### PR TITLE
fix: use valid Render fromService property 'host'

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
-const BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
+const _apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
+const BASE_URL = _apiUrl.startsWith("http") ? _apiUrl : `https://${_apiUrl}`;
 
 export interface GameState {
   dice: number[];

--- a/render.yaml
+++ b/render.yaml
@@ -22,4 +22,4 @@ services:
         fromService:
           name: yahtzee-api
           type: web
-          property: onlineUrl
+          property: host


### PR DESCRIPTION
onlineUrl is not a valid Render blueprint property. Switch to 'host' which returns the bare hostname. client.ts now prepends https:// when the env var has no protocol (Render) and passes localhost URLs through unchanged (local dev).