### PR TITLE
ci: add gate-main-source check and dev to PR trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,18 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [dev, main]
   push:
-    branches: [main]
+    branches: [dev, main]
 
 # TODO: Add lint-python (black/ruff) and lint-frontend (eslint/prettier) jobs
 # once linting tools are configured in backend/ and frontend/.
 
 jobs:
+  gate-main-source:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-gate-main-source.yml@main
+    secrets: inherit
+
   secret-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-secret-scan.yml@main
     secrets: inherit


### PR DESCRIPTION
## Changes
- Adds `gate-main-source` job — fails if a PR targets `main` from any branch other than `dev`
- Adds `dev` to `pull_request: branches` so CI runs on feature→dev PRs (not just main)

## Pre-Commit Checks
- [x] CI-only change — no app code modified