### PR TITLE
fix: move black/ruff to dev deps, fix deploy workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [dev, main]
   push:
     branches: [dev, main]
+  workflow_call:
+    secrets: inherit
 
 jobs:
   gate-main-source:

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+black==26.3.1
+ruff==0.8.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,5 +3,3 @@ uvicorn[standard]==0.30.6
 pydantic==2.9.2
 pytest==8.3.3
 httpx==0.27.2
-black==26.3.1
-ruff==0.8.4


### PR DESCRIPTION
## Summary
- Remove `black` and `ruff` from `requirements.txt` — these are linting tools and don't belong in the Render production environment; suspected cause of the backend startup timeout
- Add `requirements-dev.txt` (includes all runtime deps + black/ruff) for CI and local dev use
- Add `workflow_call: secrets: inherit` to `ci.yml` so `deploy.yml` can call it as a reusable workflow (was causing `deploy.yml` to fail instantly with "workflow file issue" on every push to main)

## Context
- Render `gaming-app-api` has failed to deploy 3 times in a row (all timing out at exactly 15 min in the update phase)
- Build succeeds each time — the crash happens at runtime startup
- The only meaningful backend change in the failing commit is `black==26.3.1` + `ruff==0.8.4` added to `requirements.txt`
- Neither tool is imported at runtime, but installing them may introduce transitive dependency version conflicts that break startup on Python 3.12 (Render uses 3.12, CI uses 3.11)

## Test plan
- [ ] CI passes on this PR (validates no test regressions)
- [ ] After merging to dev → main, verify Render `gaming-app-api` deploy succeeds
- [ ] Verify `deploy.yml` runs without the "workflow file issue" error
- [ ] Check Render dashboard logs if deploy still fails to pinpoint the exact startup error

🤖 Generated with [Claude Code](https://claude.com/claude-code)