### PR TITLE
ci: auto-open sync PR after merges to main

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,10 @@
+name: Sync main → dev
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-sync-main-to-dev.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds workflow to auto-open a draft sync PR (main → dev) after every merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)