### PR TITLE
fix: use Python 3.11 on Render (3.12.0 causes startup hang)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,4 @@
 fastapi==0.135.1
-starlette==0.52.1
 uvicorn[standard]==0.30.6
 pydantic==2.9.2
 pytest==8.3.3

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: PYTHON_VERSION
-        value: 3.12.0
+        value: 3.11.0
 
   # --- Expo Web static frontend ---
   - type: web


### PR DESCRIPTION
## Summary
- Change `PYTHON_VERSION` in `render.yaml` from `3.12.0` to `3.11.0`
- Revert experimental starlette pin (was a debug attempt, not the fix)

## Root cause
Python 3.12.0 on Render causes the service container to never become healthy — it consistently times out at exactly 15 minutes (Render's health check ceiling), while the build itself succeeds. Python 3.11 deploys successfully.

**Evidence from deploy bisection:**
| Deploy | Python | starlette | Result |
|--------|--------|-----------|--------|
| d960d5e | 3.12.0 | any | ✅ live (last working, pre-2026-03-22T18:29) |
| b7884f0 → 4c44c7d | 3.12.0 | any | ❌ 15-min timeout (×5 attempts) |
| e43fc6f (debug) | 3.12.0 | 0.52.1, clear cache | ❌ 15-min timeout |
| e43fc6f (debug) | **3.11.0** | 0.52.1, clear cache | ✅ **live** |

The correlation with a transitive dep released between 16:37–21:25 UTC on 2026-03-22 is likely, but Python 3.11 sidesteps the issue cleanly.

## Test plan
- [ ] CI passes on this PR
- [ ] After merging to dev → main, Render auto-deploys and backend goes live

🤖 Generated with [Claude Code](https://claude.com/claude-code)