### PR TITLE
feat: accessibility — WCAG 2.2 AA + game-specific patterns

### DIFF
--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -43,6 +43,7 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
         {dice.map((val, i) => (
           <Die
             key={i}
+            index={i}
             value={val}
             held={held[i]}
             onPress={() => toggleHeld(i)}
@@ -50,7 +51,7 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
           />
         ))}
       </View>
-      <Text style={[styles.hint, { color: colors.textMuted }]}>
+      <Text style={[styles.hint, { color: colors.textMuted }]} accessibilityLiveRegion="polite">
         {rollsUsed > 0 ? "Tap dice to hold" : "Press Roll to start your turn"}
       </Text>
       <Pressable
@@ -60,6 +61,11 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
         ]}
         onPress={handleRoll}
         disabled={!canRoll || rolling}
+        accessibilityRole="button"
+        accessibilityLabel={
+          rolling ? "Rolling" : `Roll dice, ${rollsLeft} roll${rollsLeft === 1 ? "" : "s"} left`
+        }
+        accessibilityState={{ disabled: !canRoll || rolling, busy: rolling }}
       >
         <Text style={styles.rollButtonText}>
           {rolling ? "Rolling..." : `Roll (${rollsLeft} left)`}

--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -7,15 +7,24 @@ interface DieProps {
   held: boolean;
   onPress: () => void;
   disabled: boolean;
+  index: number;
 }
 
-export default function Die({ value, held, onPress, disabled }: DieProps) {
+export default function Die({ value, held, onPress, disabled, index }: DieProps) {
   const { colors } = useTheme();
+  const displayValue = value > 0 ? value : "blank";
+  const label = `Die ${index + 1}: showing ${displayValue}${held ? ", held" : ""}`;
 
   return (
     <Pressable
       onPress={onPress}
       disabled={disabled}
+      accessibilityRole="togglebutton"
+      accessibilityState={{ checked: held, disabled }}
+      accessibilityLabel={label}
+      accessibilityHint={
+        disabled ? undefined : held ? "Double-tap to unhold" : "Double-tap to hold"
+      }
       style={[
         styles.die,
         {
@@ -25,6 +34,11 @@ export default function Die({ value, held, onPress, disabled }: DieProps) {
         disabled && styles.disabled,
       ]}
     >
+      {held && (
+        <Text style={styles.heldBadge} importantForAccessibility="no">
+          ✓
+        </Text>
+      )}
       <Text style={[styles.value, { color: colors.text }]}>{value > 0 ? value : "—"}</Text>
     </Pressable>
   );
@@ -45,6 +59,14 @@ const styles = StyleSheet.create({
   },
   value: {
     fontSize: 26,
+    fontWeight: "700",
+  },
+  heldBadge: {
+    position: "absolute",
+    top: 2,
+    right: 4,
+    fontSize: 10,
+    color: "#2563eb",
     fontWeight: "700",
   },
 });

--- a/frontend/src/components/ScoreRow.tsx
+++ b/frontend/src/components/ScoreRow.tsx
@@ -15,6 +15,13 @@ export default function ScoreRow({ label, score, potential, onSelect, canScore }
   const isFilled = score !== null;
   const isSelectable = !isFilled && canScore;
 
+  const stateText = isFilled
+    ? `scored ${score}`
+    : canScore && potential !== undefined
+      ? `potential score ${potential}, double-tap to score`
+      : "not available";
+  const accessLabel = `${label}: ${stateText}`;
+
   return (
     <Pressable
       style={[
@@ -26,6 +33,9 @@ export default function ScoreRow({ label, score, potential, onSelect, canScore }
       ]}
       onPress={isSelectable ? onSelect : undefined}
       disabled={!isSelectable}
+      accessibilityRole="button"
+      accessibilityLabel={accessLabel}
+      accessibilityState={{ disabled: !isSelectable }}
     >
       <Text style={[styles.label, { color: isFilled ? colors.textFilled : colors.text }]}>
         {label}
@@ -50,6 +60,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingHorizontal: 12,
     paddingVertical: 8,
+    minHeight: 44,
     borderBottomWidth: 1,
   },
   label: {

--- a/frontend/src/components/fruit-merge/GameCanvas.tsx
+++ b/frontend/src/components/fruit-merge/GameCanvas.tsx
@@ -15,6 +15,7 @@ import { useTheme } from "../../theme/ThemeContext";
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
   reset: () => void;
+  announceEvent: (message: string) => void;
 }
 
 interface Props {
@@ -225,6 +226,16 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         reset() {
           initEngine();
         },
+        announceEvent(message: string) {
+          const el = document.getElementById("fruit-merge-announcer");
+          if (el) {
+            // Clear first so re-announcing the same string still triggers the live region
+            el.textContent = "";
+            requestAnimationFrame(() => {
+              el.textContent = message;
+            });
+          }
+        },
       }),
       [initEngine, width]
     );
@@ -236,7 +247,23 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           ref={canvasRef}
           width={width}
           height={height}
+          aria-label="Fruit Merge game — drop fruits onto the stack to merge matching ones. Tap or click to drop."
+          role="application"
           style={{ display: "block", cursor: "crosshair" }}
+        />
+        {/* Visually hidden live region — narrates merge events and game-over for screen readers */}
+        {/* @ts-expect-error — div is a valid DOM element in Expo Web */}
+        <div
+          id="fruit-merge-announcer"
+          aria-live="polite"
+          aria-atomic="true"
+          style={{
+            position: "absolute",
+            left: -9999,
+            width: 1,
+            height: 1,
+            overflow: "hidden",
+          }}
         />
       </View>
     );

--- a/frontend/src/components/fruit-merge/GameOverOverlay.tsx
+++ b/frontend/src/components/fruit-merge/GameOverOverlay.tsx
@@ -38,14 +38,26 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
   }
 
   return (
-    <Modal transparent animationType="fade">
+    <Modal transparent animationType="fade" accessibilityViewIsModal>
       <View style={styles.backdrop}>
         <View
           style={[styles.card, { backgroundColor: colors.modalBg, borderColor: colors.border }]}
         >
-          <Text style={[styles.title, { color: colors.text }]}>Game Over</Text>
-          <Text style={[styles.score, { color: colors.accent }]}>{score.toLocaleString()}</Text>
-          <Text style={[styles.scoreLabel, { color: colors.textMuted }]}>points</Text>
+          <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+            Game Over
+          </Text>
+          <Text
+            style={[styles.score, { color: colors.accent }]}
+            accessibilityLabel={`Your score: ${score.toLocaleString()} points`}
+          >
+            {score.toLocaleString()}
+          </Text>
+          <Text
+            style={[styles.scoreLabel, { color: colors.textMuted }]}
+            importantForAccessibility="no"
+          >
+            points
+          </Text>
 
           {!submitted ? (
             <>
@@ -64,8 +76,18 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
                 onChangeText={setName}
                 maxLength={32}
                 editable={!submitting}
+                accessibilityLabel="Your name"
+                accessibilityHint="Enter your name to save your score to the leaderboard"
               />
-              {error && <Text style={[styles.error, { color: colors.error }]}>{error}</Text>}
+              {error && (
+                <Text
+                  style={[styles.error, { color: colors.error }]}
+                  accessibilityLiveRegion="assertive"
+                  accessibilityRole="alert"
+                >
+                  {error}
+                </Text>
+              )}
               <Pressable
                 style={[
                   styles.btn,
@@ -73,6 +95,9 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
                 ]}
                 onPress={handleSubmit}
                 disabled={submitting || !name.trim()}
+                accessibilityRole="button"
+                accessibilityLabel="Save score"
+                accessibilityState={{ disabled: submitting || !name.trim(), busy: submitting }}
               >
                 {submitting ? (
                   <ActivityIndicator color="#fff" />
@@ -90,6 +115,8 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
           <Pressable
             style={[styles.restartBtn, { borderColor: colors.border }]}
             onPress={onRestart}
+            accessibilityRole="button"
+            accessibilityLabel="Play again"
           >
             <Text style={[styles.restartText, { color: colors.textMuted }]}>Play Again</Text>
           </Pressable>

--- a/frontend/src/components/fruit-merge/NextFruitPreview.tsx
+++ b/frontend/src/components/fruit-merge/NextFruitPreview.tsx
@@ -12,10 +12,20 @@ export default function NextFruitPreview({ current, next }: Props) {
   const { colors } = useTheme();
   return (
     <View style={styles.row}>
-      <View style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}>
-        <Text style={styles.label}>Drop</Text>
-        <Text style={styles.emoji}>{current.emoji}</Text>
-        <Text style={[styles.name, { color: colors.text }]}>{current.name}</Text>
+      <View
+        style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        accessible
+        accessibilityLabel={`Dropping next: ${current.name}`}
+      >
+        <Text style={styles.label} importantForAccessibility="no">
+          Drop
+        </Text>
+        <Text style={styles.emoji} importantForAccessibility="no">
+          {current.emoji}
+        </Text>
+        <Text style={[styles.name, { color: colors.text }]} importantForAccessibility="no">
+          {current.name}
+        </Text>
       </View>
       <View
         style={[
@@ -23,10 +33,18 @@ export default function NextFruitPreview({ current, next }: Props) {
           styles.nextCard,
           { backgroundColor: colors.surfaceAlt, borderColor: colors.border },
         ]}
+        accessible
+        accessibilityLabel={`Coming up: ${next.name}`}
       >
-        <Text style={styles.label}>Next</Text>
-        <Text style={[styles.emoji, styles.nextEmoji]}>{next.emoji}</Text>
-        <Text style={[styles.name, { color: colors.textMuted }]}>{next.name}</Text>
+        <Text style={styles.label} importantForAccessibility="no">
+          Next
+        </Text>
+        <Text style={[styles.emoji, styles.nextEmoji]} importantForAccessibility="no">
+          {next.emoji}
+        </Text>
+        <Text style={[styles.name, { color: colors.textMuted }]} importantForAccessibility="no">
+          {next.name}
+        </Text>
       </View>
     </View>
   );

--- a/frontend/src/components/fruit-merge/ScoreDisplay.tsx
+++ b/frontend/src/components/fruit-merge/ScoreDisplay.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from "react";
-import { View, Text, Animated, StyleSheet } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { View, Text, Animated, StyleSheet, AccessibilityInfo } from "react-native";
 import { useTheme } from "../../theme/ThemeContext";
 
 interface Props {
@@ -10,23 +10,35 @@ export default function ScoreDisplay({ score }: Props) {
   const { colors } = useTheme();
   const scale = useRef(new Animated.Value(1)).current;
   const prevScore = useRef(score);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
 
   useEffect(() => {
     if (score !== prevScore.current) {
       prevScore.current = score;
-      Animated.sequence([
-        Animated.timing(scale, { toValue: 1.25, duration: 80, useNativeDriver: true }),
-        Animated.timing(scale, { toValue: 1, duration: 120, useNativeDriver: true }),
-      ]).start();
+      if (!reduceMotion) {
+        Animated.sequence([
+          Animated.timing(scale, { toValue: 1.25, duration: 80, useNativeDriver: true }),
+          Animated.timing(scale, { toValue: 1, duration: 120, useNativeDriver: true }),
+        ]).start();
+      }
     }
-  }, [score, scale]);
+  }, [score, scale, reduceMotion]);
 
   return (
     <View
       style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.border }]}
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={`Score: ${score.toLocaleString()}`}
     >
       <Text style={[styles.label, { color: colors.textMuted }]}>Score</Text>
-      <Animated.Text style={[styles.score, { color: colors.accent, transform: [{ scale }] }]}>
+      <Animated.Text
+        style={[styles.score, { color: colors.accent, transform: [{ scale }] }]}
+        importantForAccessibility="no"
+      >
         {score.toLocaleString()}
       </Animated.Text>
     </View>

--- a/frontend/src/components/fruit-merge/ThemeSelector.tsx
+++ b/frontend/src/components/fruit-merge/ThemeSelector.tsx
@@ -9,13 +9,16 @@ export default function ThemeSelector() {
   const { colors } = useTheme();
 
   return (
-    <View style={styles.row}>
+    <View style={styles.row} accessibilityRole="radiogroup" accessibilityLabel="Fruit set theme">
       {Object.values(FRUIT_SETS).map((set) => {
         const active = set.id === activeFruitSet.id;
         return (
           <Pressable
             key={set.id}
             onPress={() => setFruitSetById(set.id)}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={`${set.label} theme`}
             style={[
               styles.pill,
               {
@@ -47,6 +50,8 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     borderRadius: 20,
     borderWidth: 1,
+    minHeight: 44,
+    justifyContent: "center",
   },
   pillText: {
     fontSize: 13,

--- a/frontend/src/screens/FruitMergeScreen.tsx
+++ b/frontend/src/screens/FruitMergeScreen.tsx
@@ -53,11 +53,19 @@ function FruitMergeGame({ navigation }: Props) {
     setCanvasHeight(Math.floor(height));
   }, []);
 
-  const handleMerge = useCallback((event: MergeEvent) => {
-    setScore((s) => s + scoreForMerge(event.tier));
-  }, []);
+  const handleMerge = useCallback(
+    (event: MergeEvent) => {
+      setScore((s) => s + scoreForMerge(event.tier));
+      const merged = activeFruitSet.fruits[event.tier];
+      if (merged) {
+        canvasRef.current?.announceEvent(`Merged! ${merged.name} created.`);
+      }
+    },
+    [activeFruitSet]
+  );
 
   const handleGameOver = useCallback(() => {
+    canvasRef.current?.announceEvent("Game over.");
     setGameOver(true);
   }, []);
 
@@ -98,11 +106,23 @@ function FruitMergeGame({ navigation }: Props) {
     <View style={[styles.screen, { backgroundColor: colors.background }]}>
       {/* Header */}
       <View style={styles.header}>
-        <Pressable onPress={() => navigation.goBack()} style={styles.backBtn}>
+        <Pressable
+          onPress={() => navigation.goBack()}
+          style={styles.backBtn}
+          accessibilityRole="button"
+          accessibilityLabel="Go back to home screen"
+        >
           <Text style={[styles.backText, { color: colors.textMuted }]}>← Back</Text>
         </Pressable>
-        <Text style={[styles.title, { color: colors.text }]}>Fruit Merge</Text>
-        <Pressable onPress={toggle} style={styles.themeToggle}>
+        <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+          Fruit Merge
+        </Text>
+        <Pressable
+          onPress={toggle}
+          style={styles.themeToggle}
+          accessibilityRole="button"
+          accessibilityLabel={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+        >
           <Text style={[styles.themeToggleText, { color: colors.textMuted }]}>
             {theme === "dark" ? "Light" : "Dark"}
           </Text>
@@ -157,10 +177,10 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 10,
   },
-  backBtn: { paddingVertical: 6, paddingRight: 12 },
+  backBtn: { paddingVertical: 6, paddingRight: 12, minHeight: 44, justifyContent: "center" },
   backText: { fontSize: 15 },
   title: { fontSize: 20, fontWeight: "700" },
-  themeToggle: { paddingVertical: 6, paddingLeft: 12 },
+  themeToggle: { paddingVertical: 6, paddingLeft: 12, minHeight: 44, justifyContent: "center" },
   themeToggleText: { fontSize: 13 },
   hud: {
     flexDirection: "row",

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -62,11 +62,24 @@ export default function GameScreen({ navigation, route }: Props) {
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.headerBg }]}>
         <Text style={styles.headerText}>Round {gameState.round} / 13</Text>
-        <Pressable onPress={toggle} style={styles.themeToggle}>
+        <Pressable
+          onPress={toggle}
+          style={styles.themeToggle}
+          accessibilityRole="button"
+          accessibilityLabel={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+        >
           <Text style={styles.themeToggleText}>{theme === "dark" ? "Light" : "Dark"}</Text>
         </Pressable>
       </View>
-      {error && <Text style={[styles.errorText, { color: colors.error }]}>{error}</Text>}
+      {error && (
+        <Text
+          style={[styles.errorText, { color: colors.error }]}
+          accessibilityLiveRegion="assertive"
+          accessibilityRole="alert"
+        >
+          {error}
+        </Text>
+      )}
 
       {/* Dice */}
       <DiceRow
@@ -92,12 +105,22 @@ export default function GameScreen({ navigation, route }: Props) {
       </View>
 
       {/* Game Over Modal */}
-      <Modal visible={gameState.game_over} transparent animationType="fade">
+      <Modal
+        visible={gameState.game_over}
+        transparent
+        animationType="fade"
+        accessibilityViewIsModal
+      >
         <View style={styles.modalOverlay}>
           <View style={[styles.modalBox, { backgroundColor: colors.modalBg }]}>
-            <Text style={[styles.modalTitle, { color: colors.text }]}>Game Over!</Text>
+            <Text style={[styles.modalTitle, { color: colors.text }]} accessibilityRole="header">
+              Game Over!
+            </Text>
             <Text style={[styles.modalScore, { color: colors.textMuted }]}>Final Score</Text>
-            <Text style={[styles.modalScoreValue, { color: colors.accent }]}>
+            <Text
+              style={[styles.modalScoreValue, { color: colors.accent }]}
+              accessibilityLabel={`Final score: ${gameState.total_score}`}
+            >
               {gameState.total_score}
             </Text>
             {gameState.upper_bonus > 0 && (
@@ -108,6 +131,8 @@ export default function GameScreen({ navigation, route }: Props) {
             <Pressable
               style={[styles.modalButton, { backgroundColor: colors.accent }]}
               onPress={() => navigation.navigate("Home")}
+              accessibilityRole="button"
+              accessibilityLabel="Play again — return to home screen"
             >
               <Text style={styles.modalButtonText}>Play Again</Text>
             </Pressable>
@@ -139,6 +164,8 @@ const styles = StyleSheet.create({
     right: 16,
     paddingHorizontal: 10,
     paddingVertical: 4,
+    minHeight: 44,
+    justifyContent: "center",
   },
   themeToggleText: {
     color: "#94a3b8",

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -55,7 +55,12 @@ export default function HomeScreen({ navigation }: Props) {
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <Pressable style={styles.themeToggle} onPress={toggle}>
+      <Pressable
+        style={styles.themeToggle}
+        onPress={toggle}
+        accessibilityRole="button"
+        accessibilityLabel={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+      >
         <Text style={[styles.themeToggleText, { color: colors.textMuted }]}>
           {theme === "dark" ? "Light mode" : "Dark mode"}
         </Text>
@@ -71,6 +76,10 @@ export default function HomeScreen({ navigation }: Props) {
               style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
               onPress={game.action}
               disabled={game.loading}
+              accessibilityRole="button"
+              accessibilityLabel={`Play ${game.title}`}
+              accessibilityHint={game.description}
+              accessibilityState={{ disabled: game.loading, busy: game.loading }}
             >
               <Text style={styles.cardEmoji}>{game.emoji}</Text>
               <View style={styles.cardBody}>
@@ -108,6 +117,8 @@ const styles = StyleSheet.create({
     right: 16,
     paddingHorizontal: 12,
     paddingVertical: 6,
+    minHeight: 44,
+    justifyContent: "center",
   },
   themeToggleText: {
     fontSize: 13,

--- a/frontend/src/screens/__tests__/FruitMergeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/FruitMergeScreen.test.tsx
@@ -35,6 +35,7 @@ jest.mock("../../components/fruit-merge/GameCanvas", () => {
       ReactMod.useImperativeHandle(ref, () => ({
         drop: mockDrop,
         reset: mockReset,
+        announceEvent: jest.fn(),
       }));
       // Expose callbacks as data-* props on a View so tests can reach them
       return ReactMod.createElement("View", {


### PR DESCRIPTION
## Summary

- **Die toggle buttons**: `accessibilityRole="togglebutton"` + `accessibilityState.checked` conveys hold/unhold state; non-color ✓ badge added as secondary held indicator (fixes WCAG 1.4.1 color-only violation)
- **Score categories**: Full `accessibilityLabel` with category name + score state ("potential 14, double-tap to score"); `minHeight: 44` touch target
- **Live regions**: Dice hint text, Fruit Merge score display, and error messages announce changes to screen readers without requiring navigation
- **Modals**: `accessibilityViewIsModal` on Yahtzee game-over and Fruit Merge game-over overlays; `accessibilityRole="header"` on modal titles
- **Canvas accessibility**: `aria-label` + `role="application"` on Fruit Merge physics canvas; hidden `aria-live="polite"` div narrates merge events and game-over via `announceEvent()` ref method
- **Reduced motion**: `AccessibilityInfo.isReduceMotionEnabled()` skips `ScoreDisplay` scale pulse animation (WCAG 2.3.3)
- **Radio group semantics**: `ThemeSelector` uses `accessibilityRole="radiogroup"` / `"radio"` + `accessibilityState.selected` (not plain buttons)
- **Touch targets**: All previously sub-44px targets (back button, theme toggles, theme pills, score rows) now meet WCAG 2.5.5 minimum
- **Game canvas narration**: Merge events say "Merged! Watermelon created."; game-over says "Game over." — pushed to screen reader without visual change

## What's out of scope (documented)
- Keyboard-controlled drop targeting in Fruit Merge (requires physics architecture changes; same category as single-global-game-state constraint)

## Test plan
- [ ] All 55 existing tests pass (`npm test`)
- [ ] All 83 backend tests pass (`pytest`)
- [ ] `npx lhci autorun` accessibility score ≥ 0.90
- [ ] VoiceOver (macOS): roll dice → each die announces value + held state; hold a die → announces "Die 2: showing 4, held"; select category → announces name and potential score; game-over modal traps focus
- [ ] VoiceOver: Fruit Merge score display announces on each merge; "Game over." announced when stack overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)