### PR TITLE
fix: scope CORS origins and add security response headers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, HTTPException
+import os
+
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from game import YahtzeeGame
@@ -8,12 +10,30 @@ from fruit_merge.router import router as fruit_merge_router
 app = FastAPI(title="Gaming App API")
 app.include_router(fruit_merge_router, prefix="/fruit-merge")
 
+# CORS — scoped to known origins; set ALLOWED_ORIGINS env var (comma-separated) in production
+_raw = os.environ.get("ALLOWED_ORIGINS", "")
+_allowed_origins: list[str] = (
+    [o.strip() for o in _raw.split(",") if o.strip()]
+    if _raw
+    else ["http://localhost:8081", "http://localhost:19006"]
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_origins=_allowed_origins,
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type"],
 )
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next) -> Response:
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
+
 
 game: YahtzeeGame | None = None
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.pytest.ini_options]
+markers = [
+    "security: security-focused tests (CORS, headers, injection)",
+]
+
 [tool.black]
 line-length = 100
 

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,75 @@
+"""Security tests — CORS scoping and response header hardening."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client_default():
+    """Client using the default (dev) allowed origins."""
+    os.environ.pop("ALLOWED_ORIGINS", None)
+    import importlib
+    import main as m
+
+    importlib.reload(m)
+    yield TestClient(m.app)
+
+
+@pytest.fixture()
+def client_prod():
+    """Client with a production ALLOWED_ORIGINS env var."""
+    os.environ["ALLOWED_ORIGINS"] = "https://yahtzee-frontend.onrender.com"
+    import importlib
+    import main as m
+
+    importlib.reload(m)
+    yield TestClient(m.app)
+    os.environ.pop("ALLOWED_ORIGINS", None)
+    importlib.reload(m)
+
+
+# ---------------------------------------------------------------------------
+# Security headers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_security_headers_present(client_default):
+    res = client_default.get("/game/state")
+    assert res.headers.get("x-content-type-options") == "nosniff"
+    assert res.headers.get("x-frame-options") == "DENY"
+    assert res.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
+
+
+# ---------------------------------------------------------------------------
+# CORS — allowed origins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_cors_allowed_origin_localhost(client_default):
+    res = client_default.get("/game/state", headers={"Origin": "http://localhost:8081"})
+    assert res.headers.get("access-control-allow-origin") == "http://localhost:8081"
+
+
+@pytest.mark.security
+def test_cors_blocked_unknown_origin(client_default):
+    res = client_default.get("/game/state", headers={"Origin": "https://evil.example.com"})
+    assert "access-control-allow-origin" not in res.headers
+
+
+@pytest.mark.security
+def test_cors_prod_allows_frontend(client_prod):
+    res = client_prod.get(
+        "/game/state",
+        headers={"Origin": "https://yahtzee-frontend.onrender.com"},
+    )
+    assert res.headers.get("access-control-allow-origin") == "https://yahtzee-frontend.onrender.com"
+
+
+@pytest.mark.security
+def test_cors_prod_blocks_localhost(client_prod):
+    res = client_prod.get("/game/state", headers={"Origin": "http://localhost:8081"})
+    assert "access-control-allow-origin" not in res.headers

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,8 @@ services:
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.0
+      - key: ALLOWED_ORIGINS
+        value: https://yahtzee-frontend.onrender.com
 
   # --- Expo Web static frontend ---
   - type: web


### PR DESCRIPTION
## Summary

- **CORS wildcard removed**: `allow_origins=["*"]` replaced with an env-var-driven allowlist. Defaults to `localhost:8081` / `localhost:19006` for local dev; production reads `ALLOWED_ORIGINS` from the environment (set in `render.yaml` to `https://yahtzee-frontend.onrender.com`)
- **Methods and headers tightened**: `allow_methods` narrowed to `GET, POST`; `allow_headers` narrowed to `Content-Type`
- **Security response headers**: HTTP middleware adds `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin` on every response
- **`@pytest.mark.security` tests**: 5 new tests covering header presence, CORS allow for known origins, and CORS block for unknown origins — in both dev and prod configurations
- **Mark registered** in `pyproject.toml` to avoid pytest warnings

## Test plan
- [ ] `python -m pytest tests/ -v` — 88 tests pass
- [ ] `python -m pytest -m security -v` — 5 security tests pass
- [ ] After deploy: `curl -I https://yahtzee-api.onrender.com/game/state` shows `x-content-type-options`, `x-frame-options`, `referrer-policy` headers
- [ ] CORS preflight from `https://yahtzee-frontend.onrender.com` succeeds; request from unknown origin returns no `access-control-allow-origin` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)