### PR TITLE
Fix Render web build failure caused by dynamic i18n imports

### DIFF
--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -22,83 +22,83 @@ function resolveLocale(): string {
 }
 
 const localeLoaders: Record<string, Record<Namespace, () => TranslationModule>> = {
-  "en": {
-    "common": () => import("./locales/en/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/en/yahtzee.json") as TranslationModule,
+  en: {
+    common: () => import("./locales/en/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/en/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/en/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/en/errors.json") as TranslationModule,
+    errors: () => import("./locales/en/errors.json") as TranslationModule,
   },
   "fr-CA": {
-    "common": () => import("./locales/fr-CA/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/fr-CA/yahtzee.json") as TranslationModule,
+    common: () => import("./locales/fr-CA/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/fr-CA/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/fr-CA/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/fr-CA/errors.json") as TranslationModule,
+    errors: () => import("./locales/fr-CA/errors.json") as TranslationModule,
   },
-  "es": {
-    "common": () => import("./locales/es/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/es/yahtzee.json") as TranslationModule,
+  es: {
+    common: () => import("./locales/es/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/es/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/es/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/es/errors.json") as TranslationModule,
+    errors: () => import("./locales/es/errors.json") as TranslationModule,
   },
-  "hi": {
-    "common": () => import("./locales/hi/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/hi/yahtzee.json") as TranslationModule,
+  hi: {
+    common: () => import("./locales/hi/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/hi/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/hi/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/hi/errors.json") as TranslationModule,
+    errors: () => import("./locales/hi/errors.json") as TranslationModule,
   },
-  "ar": {
-    "common": () => import("./locales/ar/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/ar/yahtzee.json") as TranslationModule,
+  ar: {
+    common: () => import("./locales/ar/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/ar/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/ar/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/ar/errors.json") as TranslationModule,
+    errors: () => import("./locales/ar/errors.json") as TranslationModule,
   },
-  "zh": {
-    "common": () => import("./locales/zh/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/zh/yahtzee.json") as TranslationModule,
+  zh: {
+    common: () => import("./locales/zh/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/zh/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/zh/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/zh/errors.json") as TranslationModule,
+    errors: () => import("./locales/zh/errors.json") as TranslationModule,
   },
-  "ja": {
-    "common": () => import("./locales/ja/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/ja/yahtzee.json") as TranslationModule,
+  ja: {
+    common: () => import("./locales/ja/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/ja/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/ja/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/ja/errors.json") as TranslationModule,
+    errors: () => import("./locales/ja/errors.json") as TranslationModule,
   },
-  "ko": {
-    "common": () => import("./locales/ko/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/ko/yahtzee.json") as TranslationModule,
+  ko: {
+    common: () => import("./locales/ko/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/ko/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/ko/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/ko/errors.json") as TranslationModule,
+    errors: () => import("./locales/ko/errors.json") as TranslationModule,
   },
-  "pt": {
-    "common": () => import("./locales/pt/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/pt/yahtzee.json") as TranslationModule,
+  pt: {
+    common: () => import("./locales/pt/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/pt/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/pt/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/pt/errors.json") as TranslationModule,
+    errors: () => import("./locales/pt/errors.json") as TranslationModule,
   },
-  "he": {
-    "common": () => import("./locales/he/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/he/yahtzee.json") as TranslationModule,
+  he: {
+    common: () => import("./locales/he/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/he/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/he/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/he/errors.json") as TranslationModule,
+    errors: () => import("./locales/he/errors.json") as TranslationModule,
   },
-  "de": {
-    "common": () => import("./locales/de/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/de/yahtzee.json") as TranslationModule,
+  de: {
+    common: () => import("./locales/de/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/de/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/de/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/de/errors.json") as TranslationModule,
+    errors: () => import("./locales/de/errors.json") as TranslationModule,
   },
-  "nl": {
-    "common": () => import("./locales/nl/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/nl/yahtzee.json") as TranslationModule,
+  nl: {
+    common: () => import("./locales/nl/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/nl/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/nl/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/nl/errors.json") as TranslationModule,
+    errors: () => import("./locales/nl/errors.json") as TranslationModule,
   },
-  "ru": {
-    "common": () => import("./locales/ru/common.json") as TranslationModule,
-    "yahtzee": () => import("./locales/ru/yahtzee.json") as TranslationModule,
+  ru: {
+    common: () => import("./locales/ru/common.json") as TranslationModule,
+    yahtzee: () => import("./locales/ru/yahtzee.json") as TranslationModule,
     "fruit-merge": () => import("./locales/ru/fruit-merge.json") as TranslationModule,
-    "errors": () => import("./locales/ru/errors.json") as TranslationModule,
+    errors: () => import("./locales/ru/errors.json") as TranslationModule,
   },
 };
 


### PR DESCRIPTION
### Motivation
- Metro (used by Expo web builds) fails to statically analyze template-literal dynamic imports like `import(`./locales/${lng}/${ns}.json`)`, causing Render deploys to fail during bundling. 
- The change aims to replace the unsupported dynamic import pattern with statically analyzable import paths so the web bundler can include translation JSON files correctly. 
- Keep existing i18n behavior (supported languages, namespaces, fallback) while making loading deterministic for the bundler.

### Description
- Added `Namespace` and `TranslationModule` types and implemented a `localeLoaders` map that provides an explicit import function for every supported `locale -> namespace` pair in `frontend/src/i18n/i18n.ts`.
- Introduced `loadLocaleNamespace(lng: string, ns: string)` which looks up the loader in `localeLoaders` and falls back to English when a locale or namespace is missing.
- Replaced the previous dynamic template import usage with `resourcesToBackend(loadLocaleNamespace)` so Metro can statically resolve imports during `expo export --platform web` while preserving the original i18n initialization options.

### Testing
- Ran `npm ci && npx expo export --platform web` in `frontend/`, and the bundling/export completed successfully (`Exported: dist`).
- Verified that the Metro bundling error for `Invalid call ... import(`./locales/${lng}/${ns}.json`)` no longer occurs during the export.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c20e66a03083288ded24e86be143d1)