### PR TITLE
tests: add `announceEvent` to mocked GameCanvas in FruitMergeScreen tests

### DIFF
--- a/frontend/src/screens/__tests__/FruitMergeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/FruitMergeScreen.test.tsx
@@ -21,6 +21,7 @@ const mockDrop = jest.fn();
 const mockReset = jest.fn();
 
 jest.mock("../../components/fruit-merge/GameCanvas", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const ReactMod = require("react");
   const MockCanvas = ReactMod.forwardRef(
     (
@@ -34,6 +35,7 @@ jest.mock("../../components/fruit-merge/GameCanvas", () => {
       ReactMod.useImperativeHandle(ref, () => ({
         drop: mockDrop,
         reset: mockReset,
+        announceEvent: jest.fn(),
       }));
       // Expose callbacks as data-* props on a View so tests can reach them
       return ReactMod.createElement("View", {


### PR DESCRIPTION
### Motivation

- The `GameCanvas` imperative API gained an `announceEvent` method and tests need the mock to provide it so component refs match the runtime API.

### Description

- Updated the `frontend/src/screens/__tests__/FruitMergeScreen.test.tsx` mock for `../../components/fruit-merge/GameCanvas` to expose `announceEvent` via `useImperativeHandle` so the test ref shape matches the real component.
- Added an eslint disable comment for `@typescript-eslint/no-require-imports` around the `require("react")` used inside the test mock.

### Testing

- Ran the unit test `FruitMergeScreen.test.tsx` under Jest and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2116eada08328b1495bcbf7007d20)