### PR TITLE
Clamp fruit bodies inside playfield bounds to prevent falling off map

### DIFF
--- a/frontend/src/game/fruit-merge/__tests__/engine.test.ts
+++ b/frontend/src/game/fruit-merge/__tests__/engine.test.ts
@@ -1,5 +1,12 @@
 import Matter from "matter-js";
-import { createEngine, spawnFruitAt, FruitBody, DANGER_LINE_RATIO, EngineSetup } from "../engine";
+import {
+  createEngine,
+  spawnFruitAt,
+  FruitBody,
+  DANGER_LINE_RATIO,
+  EngineSetup,
+  WALL_THICKNESS,
+} from "../engine";
 import { FRUIT_SETS } from "../../../theme/fruitSets";
 
 const fruitSet = FRUIT_SETS["fruits"];
@@ -305,5 +312,38 @@ describe("game-over detection", () => {
     fireUpdate(engine);
 
     expect(onGameOver).not.toHaveBeenCalled();
+  });
+});
+
+describe("world boundary clamping", () => {
+  it("keeps fruits above the floor if they drift below the playfield", () => {
+    const { engine, world } = setup();
+    const def = fruitSet.fruits[1];
+    const body = spawnFruitAt(world, def, fruitSet.id, 150, 100);
+
+    Matter.Body.setPosition(body, { x: 150, y: H + 20 });
+    Matter.Body.setVelocity(body, { x: 0, y: 12 });
+    fireUpdate(engine);
+
+    expect(body.position.y).toBeLessThanOrEqual(H - def.radius);
+    expect(body.velocity.y).toBeLessThanOrEqual(0);
+  });
+
+  it("keeps fruits inside the left and right walls", () => {
+    const { engine, world } = setup();
+    const def = fruitSet.fruits[1];
+    const body = spawnFruitAt(world, def, fruitSet.id, 150, 100);
+
+    Matter.Body.setPosition(body, { x: WALL_THICKNESS - 8, y: 200 });
+    Matter.Body.setVelocity(body, { x: -5, y: 0 });
+    fireUpdate(engine);
+    expect(body.position.x).toBeGreaterThanOrEqual(WALL_THICKNESS + def.radius);
+    expect(body.velocity.x).toBeGreaterThanOrEqual(0);
+
+    Matter.Body.setPosition(body, { x: W - WALL_THICKNESS + 8, y: 200 });
+    Matter.Body.setVelocity(body, { x: 5, y: 0 });
+    fireUpdate(engine);
+    expect(body.position.x).toBeLessThanOrEqual(W - WALL_THICKNESS - def.radius);
+    expect(body.velocity.x).toBeLessThanOrEqual(0);
   });
 });

--- a/frontend/src/game/fruit-merge/engine.ts
+++ b/frontend/src/game/fruit-merge/engine.ts
@@ -95,6 +95,9 @@ export function createEngine(
 
   // Game-over: a settled fruit (alive > grace period) above the danger line
   const dangerY = H * DANGER_LINE_RATIO;
+  const leftBoundary = WALL_THICKNESS;
+  const rightBoundary = W - WALL_THICKNESS;
+  const floorY = H;
   let gameOverFired = false;
 
   Matter.Events.on(engine, "afterUpdate", () => {
@@ -102,6 +105,33 @@ export function createEngine(
     const now = Date.now();
     for (const body of Matter.Composite.allBodies(world)) {
       const fb = body as FruitBody;
+      if (fb.fruitTier !== undefined && !fb.isStatic) {
+        const radius = fb.circleRadius ?? 0;
+        let correctedX: number | null = null;
+        let correctedY: number | null = null;
+
+        if (body.position.x - radius < leftBoundary) {
+          correctedX = leftBoundary + radius;
+        } else if (body.position.x + radius > rightBoundary) {
+          correctedX = rightBoundary - radius;
+        }
+
+        if (body.position.y + radius > floorY) {
+          correctedY = floorY - radius;
+        }
+
+        if (correctedX !== null || correctedY !== null) {
+          Matter.Body.setPosition(body, {
+            x: correctedX ?? body.position.x,
+            y: correctedY ?? body.position.y,
+          });
+          Matter.Body.setVelocity(body, {
+            x: correctedX !== null ? 0 : body.velocity.x,
+            y: correctedY !== null && body.velocity.y > 0 ? 0 : body.velocity.y,
+          });
+        }
+      }
+
       if (
         fb.fruitTier === undefined ||
         fb.isStatic ||


### PR DESCRIPTION
### Motivation
- A fruit (notably the blueberry) could fall or be pushed outside the playfield and disappear under certain edge-case collisions, causing it to drop off the map. 
- The engine needs to ensure dynamic fruit bodies remain inside the left/right walls and above the floor so rendering and physics remain consistent.

### Description
- Added boundary clamping in `createEngine`'s `afterUpdate` tick to snap dynamic fruit bodies back inside the left/right walls and above the floor when they drift out of bounds (`frontend/src/game/fruit-merge/engine.ts`).
- When a clamp occurs the corresponding velocity component is zeroed (horizontal velocity set to `0` when clamped against a side wall; downward velocity prevented when clamped to the floor) to avoid immediate re-tunneling out of bounds.
- Added unit tests that verify floor clamping and left/right wall clamping and their velocity corrections (`frontend/src/game/fruit-merge/__tests__/engine.test.ts`).
- Changes touch `frontend/src/game/fruit-merge/engine.ts` and `frontend/src/game/fruit-merge/__tests__/engine.test.ts`.

### Testing
- Ran the focused test file with `npm test -- --runTestsByPath src/game/fruit-merge/__tests__/engine.test.ts` and the suite passed.
- Test summary: `PASS src/game/fruit-merge/__tests__/engine.test.ts` with all tests passing (20 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21def1a808328a5a6be2f7cc9a168)