### PR TITLE
fix: wire game.canvasLabel i18n key to GameCanvas aria-label

### DIFF
--- a/frontend/src/components/fruit-merge/GameCanvas.tsx
+++ b/frontend/src/components/fruit-merge/GameCanvas.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../game/fruit-merge/engine";
 import { FruitSet, FruitDefinition } from "../../theme/fruitSets";
 import { useTheme } from "../../theme/ThemeContext";
+import { useTranslation } from "react-i18next";
 
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
@@ -38,6 +39,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const rafRef = useRef<number>(0);
     const pointerXRef = useRef<number | null>(null);
     const { colors } = useTheme();
+    const { t } = useTranslation("fruit-merge");
 
     // Refs for props that change frequently — prevent engine re-creation
     const nextDefRef = useRef(nextDef);
@@ -247,7 +249,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           ref={canvasRef}
           width={width}
           height={height}
-          aria-label="Fruit Merge game — drop fruits onto the stack to merge matching ones. Tap or click to drop."
+          aria-label={t("game.canvasLabel")}
           role="application"
           style={{ display: "block", cursor: "crosshair" }}
         />


### PR DESCRIPTION
## Summary
- `GameCanvas.tsx` had a hardcoded English `aria-label` on the `<canvas>` element (violating global hard rule 11 — i18n required on all user-facing strings)
- The translation key `"game.canvasLabel"` already existed in all 13 locale `fruit-merge.json` files; it just wasn't wired up
- Adds `useTranslation("fruit-merge")` to the component and replaces the literal with `t("game.canvasLabel")`

## Root Cause
Identified during a post-merge consistency review of PRs 35, 38, and 39. The hardcoded string predates those PRs — it was present from when the accessibility work was added (PR 30) but the translation key was never connected to the component.

## Test plan
- [ ] `npx eslint src/components/fruit-merge/GameCanvas.tsx` passes with no warnings
- [ ] `npm test -- --runInBand --testPathPattern=fruit-merge` — all 35 tests pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)