### PR TITLE
feat: add Yahtzee UI test coverage (Phase 3)

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,88 @@
+import { api } from "../client";
+
+describe("api client", () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+  });
+
+  function respondWith<T>(data: T, ok = true) {
+    mockFetch.mockResolvedValueOnce({
+      ok,
+      statusText: "Bad Request",
+      json: () => Promise.resolve(data),
+    } as Response);
+  }
+
+  it("newGame POSTs to /game/new", async () => {
+    respondWith({ dice: [1, 2, 3, 4, 5] });
+    await api.newGame();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/game/new"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("getState GETs /game/state", async () => {
+    respondWith({ dice: [1, 1, 1, 1, 1] });
+    await api.getState();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/game/state"),
+      expect.any(Object)
+    );
+  });
+
+  it("roll POSTs held array to /game/roll", async () => {
+    const held = [true, false, true, false, false];
+    respondWith({ dice: [1, 2, 3, 4, 5] });
+    await api.roll(held);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/game/roll"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ held }),
+      })
+    );
+  });
+
+  it("score POSTs category to /game/score", async () => {
+    respondWith({ dice: [1, 2, 3, 4, 5] });
+    await api.score("ones");
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/game/score"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ category: "ones" }),
+      })
+    );
+  });
+
+  it("possibleScores GETs /game/possible-scores", async () => {
+    respondWith({ possible_scores: { ones: 3 } });
+    await api.possibleScores();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/game/possible-scores"),
+      expect.any(Object)
+    );
+  });
+
+  it("throws Error with detail when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: "Bad Request",
+      json: () => Promise.resolve({ detail: "Game not found" }),
+    } as Response);
+    await expect(api.getState()).rejects.toThrow("Game not found");
+  });
+
+  it("falls back to statusText when error body has no detail", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("parse error")),
+    } as Response);
+    await expect(api.getState()).rejects.toThrow("Internal Server Error");
+  });
+});

--- a/frontend/src/components/__tests__/DiceRow.test.tsx
+++ b/frontend/src/components/__tests__/DiceRow.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import DiceRow from "../DiceRow";
+import { ThemeProvider } from "../../theme/ThemeContext";
+
+function renderDiceRow(overrides: Partial<React.ComponentProps<typeof DiceRow>> = {}) {
+  const defaults = {
+    dice: [1, 2, 3, 4, 5],
+    rollsUsed: 0,
+    gameOver: false,
+    onRoll: jest.fn().mockResolvedValue(undefined),
+    resetHeld: false,
+  };
+  const props = { ...defaults, ...overrides };
+  return render(
+    <ThemeProvider>
+      <DiceRow {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe("DiceRow", () => {
+  it("roll button is enabled when rollsUsed < 3 and not game over", () => {
+    const { getByRole } = renderDiceRow({ rollsUsed: 1 });
+    expect(getByRole("button", { name: /roll/i })).not.toBeDisabled();
+  });
+
+  it("roll button is disabled when rollsUsed === 3", () => {
+    const { getByRole } = renderDiceRow({ rollsUsed: 3 });
+    expect(getByRole("button", { name: /roll/i })).toBeDisabled();
+  });
+
+  it("roll button is disabled when game is over", () => {
+    const { getByRole } = renderDiceRow({ gameOver: true });
+    expect(getByRole("button", { name: /roll/i })).toBeDisabled();
+  });
+
+  it("pressing roll calls onRoll with held state", async () => {
+    const onRoll = jest.fn().mockResolvedValue(undefined);
+    const { getByRole } = renderDiceRow({ rollsUsed: 1, onRoll });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    expect(onRoll).toHaveBeenCalledWith([false, false, false, false, false]);
+  });
+
+  it("dice are disabled before the first roll (rollsUsed === 0)", () => {
+    const { getAllByRole } = renderDiceRow({ rollsUsed: 0 });
+    // Die uses accessibilityRole="togglebutton"
+    const dice = getAllByRole("togglebutton");
+    dice.forEach((die) => expect(die).toBeDisabled());
+  });
+
+  it("toggling a die after first roll includes it in the held array passed to onRoll", async () => {
+    const onRoll = jest.fn().mockResolvedValue(undefined);
+    const { getAllByRole, getByRole } = renderDiceRow({ rollsUsed: 1, onRoll });
+    // Hold die at index 0
+    fireEvent.press(getAllByRole("togglebutton")[0]);
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    expect(onRoll).toHaveBeenCalledWith([true, false, false, false, false]);
+  });
+
+  it("resetHeld prop change clears all held dice", async () => {
+    const onRoll = jest.fn().mockResolvedValue(undefined);
+    const { getAllByRole, getByRole, rerender } = renderDiceRow({
+      rollsUsed: 1,
+      onRoll,
+      resetHeld: false,
+    });
+    // Hold die 0
+    fireEvent.press(getAllByRole("togglebutton")[0]);
+    // Simulate resetHeld toggle (e.g., after scoring)
+    rerender(
+      <ThemeProvider>
+        <DiceRow
+          dice={[1, 2, 3, 4, 5]}
+          rollsUsed={1}
+          gameOver={false}
+          onRoll={onRoll}
+          resetHeld={true}
+        />
+      </ThemeProvider>
+    );
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    expect(onRoll).toHaveBeenCalledWith([false, false, false, false, false]);
+  });
+});

--- a/frontend/src/components/__tests__/Scorecard.test.tsx
+++ b/frontend/src/components/__tests__/Scorecard.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import Scorecard from "../Scorecard";
+import { ThemeProvider } from "../../theme/ThemeContext";
+
+const ALL_CATEGORIES = [
+  "ones",
+  "twos",
+  "threes",
+  "fours",
+  "fives",
+  "sixes",
+  "three_of_a_kind",
+  "four_of_a_kind",
+  "full_house",
+  "small_straight",
+  "large_straight",
+  "yahtzee",
+  "chance",
+];
+
+const emptyScores = Object.fromEntries(ALL_CATEGORIES.map((k) => [k, null]));
+
+function renderScorecard(overrides: Partial<React.ComponentProps<typeof Scorecard>> = {}) {
+  const defaults = {
+    scores: emptyScores,
+    possibleScores: {},
+    rollsUsed: 0,
+    gameOver: false,
+    upperSubtotal: 0,
+    upperBonus: 0,
+    totalScore: 0,
+    onScore: jest.fn(),
+  };
+  const props = { ...defaults, ...overrides };
+  return render(
+    <ThemeProvider>
+      <Scorecard {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe("Scorecard", () => {
+  it("renders all 13 category rows", () => {
+    const { getAllByRole } = renderScorecard();
+    // Each category is a Pressable button
+    const rows = getAllByRole("button");
+    expect(rows.length).toBe(13);
+  });
+
+  it("displays the total score", () => {
+    const { getByText } = renderScorecard({ totalScore: 142 });
+    expect(getByText("142")).toBeTruthy();
+  });
+
+  it("shows potential scores when rollsUsed > 0", () => {
+    const { getByText } = renderScorecard({
+      rollsUsed: 1,
+      possibleScores: { ones: 3, twos: 6 },
+    });
+    expect(getByText("3")).toBeTruthy();
+    expect(getByText("6")).toBeTruthy();
+  });
+
+  it("does not show potential scores when rollsUsed === 0", () => {
+    const { queryByText } = renderScorecard({
+      rollsUsed: 0,
+      possibleScores: { ones: 3 },
+    });
+    // The value "3" should not appear as a potential score
+    expect(queryByText("3")).toBeNull();
+  });
+
+  it("calls onScore with the correct category key when a row is pressed", () => {
+    const onScore = jest.fn();
+    const { getByRole } = renderScorecard({
+      rollsUsed: 1,
+      possibleScores: { ones: 3 },
+      onScore,
+    });
+    fireEvent.press(getByRole("button", { name: /ones/i }));
+    expect(onScore).toHaveBeenCalledWith("ones");
+  });
+
+  it("does not call onScore when rollsUsed === 0", () => {
+    const onScore = jest.fn();
+    const { getByRole } = renderScorecard({ rollsUsed: 0, onScore });
+    fireEvent.press(getByRole("button", { name: /ones/i }));
+    expect(onScore).not.toHaveBeenCalled();
+  });
+
+  it("does not call onScore for an already-scored category", () => {
+    const onScore = jest.fn();
+    const { getByRole } = renderScorecard({
+      rollsUsed: 1,
+      scores: { ...emptyScores, ones: 3 },
+      possibleScores: { twos: 6 },
+      onScore,
+    });
+    fireEvent.press(getByRole("button", { name: /ones/i }));
+    expect(onScore).not.toHaveBeenCalled();
+  });
+
+  it("shows bonus progress text when upperBonus === 0", () => {
+    const { getByText } = renderScorecard({ upperSubtotal: 21, upperBonus: 0 });
+    // Bonus progress includes the subtotal
+    expect(getByText(/21/)).toBeTruthy();
+  });
+
+  it("shows bonus achieved text when upperBonus > 0", () => {
+    const { getByText } = renderScorecard({ upperSubtotal: 63, upperBonus: 35 });
+    // bonus.achieved = "{{subtotal}} / 63 ✓" — the ✓ is unique to the achieved state
+    expect(getByText(/✓/)).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
+import GameScreen from "../GameScreen";
+import { ThemeProvider } from "../../theme/ThemeContext";
+
+// ---------------------------------------------------------------------------
+// Mock the API client
+// ---------------------------------------------------------------------------
+jest.mock("../../api/client", () => ({
+  api: {
+    roll: jest.fn(),
+    score: jest.fn(),
+    possibleScores: jest.fn(),
+  },
+}));
+
+import { api } from "../../api/client";
+const mockApi = api as jest.Mocked<typeof api>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    dice: [1, 2, 3, 4, 5],
+    held: [false, false, false, false, false],
+    rolls_used: 0,
+    round: 1,
+    scores: {
+      ones: null,
+      twos: null,
+      threes: null,
+      fours: null,
+      fives: null,
+      sixes: null,
+      three_of_a_kind: null,
+      four_of_a_kind: null,
+      full_house: null,
+      small_straight: null,
+      large_straight: null,
+      yahtzee: null,
+      chance: null,
+    },
+    game_over: false,
+    upper_subtotal: 0,
+    upper_bonus: 0,
+    total_score: 0,
+    ...overrides,
+  };
+}
+
+const mockNavigation = { navigate: jest.fn(), goBack: jest.fn() } as unknown as Parameters<
+  typeof GameScreen
+>[0]["navigation"];
+
+function renderScreen(stateOverrides: Record<string, unknown> = {}) {
+  const initialState = makeState(stateOverrides);
+  return render(
+    <ThemeProvider>
+      <GameScreen
+        navigation={mockNavigation}
+        route={{ params: { initialState } } as Parameters<typeof GameScreen>[0]["route"]}
+      />
+    </ThemeProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApi.possibleScores.mockResolvedValue({ possible_scores: {} });
+});
+
+describe("GameScreen", () => {
+  it("renders the round header", () => {
+    const { getByText } = renderScreen();
+    expect(getByText(/round.*1/i)).toBeTruthy();
+  });
+
+  it("calls api.roll when the roll button is pressed", async () => {
+    mockApi.roll.mockResolvedValue(makeState({ rolls_used: 1 }));
+    const { getByRole } = renderScreen();
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    expect(mockApi.roll).toHaveBeenCalledWith([false, false, false, false, false]);
+  });
+
+  it("updates displayed state after a successful roll", async () => {
+    mockApi.roll.mockResolvedValue(makeState({ rolls_used: 1, round: 2 }));
+    const { getByRole } = renderScreen();
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    await waitFor(() => {
+      expect(getByRole("button", { name: /roll dice/i })).toBeTruthy();
+    });
+  });
+
+  it("shows an error message when api.roll throws", async () => {
+    mockApi.roll.mockRejectedValue(new Error("Network error"));
+    const { getByRole, findByText } = renderScreen();
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+    expect(await findByText("Network error")).toBeTruthy();
+  });
+
+  it("calls api.score when a scorecard category is pressed after rolling", async () => {
+    mockApi.roll.mockResolvedValue(makeState({ rolls_used: 1, dice: [1, 1, 1, 1, 1] }));
+    mockApi.score.mockResolvedValue(makeState({ rolls_used: 0, round: 2 }));
+    mockApi.possibleScores.mockResolvedValue({ possible_scores: { ones: 5 } });
+
+    const { getByRole } = renderScreen();
+
+    // Roll first to enable scoring
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /roll dice/i }));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+
+    expect(mockApi.score).toHaveBeenCalledWith("ones");
+  });
+
+  it("game over modal is not visible initially", () => {
+    const { queryByText } = renderScreen();
+    expect(queryByText(/game over/i)).toBeNull();
+  });
+
+  it("game over modal appears when game_over is true", () => {
+    const { getByText } = renderScreen({ game_over: true, total_score: 250 });
+    expect(getByText(/game over/i)).toBeTruthy();
+    expect(getByText("250")).toBeTruthy();
+  });
+
+  it("play again button navigates home", async () => {
+    const { getByRole } = renderScreen({ game_over: true, total_score: 100 });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    expect(mockNavigation.navigate).toHaveBeenCalledWith("Home");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `api/__tests__/client.test.ts` — 7 unit tests for every API method (correct HTTP verb, URL, body, error propagation)
- Add `components/__tests__/DiceRow.test.tsx` — 6 tests covering roll button states, die hold toggle, and `resetHeld` behavior
- Add `components/__tests__/Scorecard.test.tsx` — 8 tests for category rendering, potential scores, `onScore` callback, and bonus display
- Add `screens/__tests__/GameScreen.test.tsx` — 7 integration tests for full roll/score flow, error display, and game-over modal

Total test count increases from 77 → 108 (+31).

## Test plan
- [ ] `npm test -- --runInBand` → 108 tests, all passing
- [ ] CI lint + test checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)