### PR TITLE
fix: remove stale allowed-repos input from openai-policy CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,4 @@ jobs:
 
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    with:
-      allowed-repos: wcmchenry3-stack/gaming_app
     secrets: inherit


### PR DESCRIPTION
## Summary
Removes the `with: allowed-repos:` block from the `openai-policy` job in CI.

`called-openai-policy.yml` no longer accepts `allowed-repos` as an input (removed when the workflow became universal in wcmchenry3-stack/.github#7). Passing an undefined input to a `workflow_call` causes GitHub Actions to throw `startup_failure` — no jobs run at all, blocking PR #57 (dev → main).

## Change
```diff
  openai-policy:
    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
-    with:
-      allowed-repos: wcmchenry3-stack/gaming_app
    secrets: inherit
```

## Test plan
- [ ] CI on this PR runs all jobs (no startup_failure)
- [ ] openai-policy job logs: "No changed files reference OpenAI — policy checks skipped."
- [ ] After merging to dev, re-run PR #57 — all required checks start and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)