### PR TITLE
style: prettier-format renderConfig.test.ts

### DIFF
--- a/frontend/src/__tests__/renderConfig.test.ts
+++ b/frontend/src/__tests__/renderConfig.test.ts
@@ -21,9 +21,7 @@ const renderYaml = fs.readFileSync(renderYamlPath, "utf-8");
 describe("render.yaml deployment configuration", () => {
   it("EXPO_PUBLIC_API_URL uses property: url, not property: host", () => {
     // Find the EXPO_PUBLIC_API_URL block and assert it uses "url" not "host"
-    const envVarBlock = renderYaml.match(
-      /EXPO_PUBLIC_API_URL[\s\S]*?property:\s*(\w+)/
-    );
+    const envVarBlock = renderYaml.match(/EXPO_PUBLIC_API_URL[\s\S]*?property:\s*(\w+)/);
     expect(envVarBlock).not.toBeNull();
     const propertyValue = envVarBlock![1];
     expect(propertyValue).toBe("url");


### PR DESCRIPTION
Fixes the `lint-frontend` failure on wcmchenry3-stack/gaming_app#62 (`dev → main`).

`renderConfig.test.ts` was committed with CRLF line endings on Windows; Prettier on CI expects LF. One-line formatting fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)