### PR TITLE
fix(deploy): query Render API at build time for API service URL

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -14,10 +14,20 @@ app.include_router(fruit_merge_router, prefix="/fruit-merge")
 app.include_router(blackjack_router, prefix="/blackjack")
 app.include_router(ludo_router, prefix="/ludo")
 
-# CORS — scoped to known origins; set ALLOWED_ORIGINS env var (comma-separated) in production
+
+# CORS — scoped to known origins; set ALLOWED_ORIGINS env var (comma-separated) in production.
+# Render's fromService with property: url returns a bare subdomain slug (e.g. "yahtzee-frontend-xyz")
+# rather than a full URL, so we normalise it to https://<slug>.onrender.com when needed.
+def _normalise_origin(origin: str) -> str:
+    origin = origin.strip()
+    if "://" not in origin:
+        return f"https://{origin}.onrender.com"
+    return origin
+
+
 _raw = os.environ.get("ALLOWED_ORIGINS", "")
 _allowed_origins: list[str] = (
-    [o.strip() for o in _raw.split(",") if o.strip()]
+    [_normalise_origin(o) for o in _raw.split(",") if o.strip()]
     if _raw
     else ["http://localhost:8081", "http://localhost:19006"]
 )

--- a/frontend/scripts/fetch-render-env.js
+++ b/frontend/scripts/fetch-render-env.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Pre-build script: queries the Render API for the API backend's public URL
+ * and writes EXPO_PUBLIC_API_URL to .env so Expo bakes the correct value
+ * into the static bundle at build time.
+ *
+ * Required env vars (set in Render dashboard, not render.yaml):
+ *   RENDER_API_KEY          — Render API key (sensitive, never commit)
+ *
+ * Optional env vars:
+ *   RENDER_API_SERVICE_NAME — name of the API service to look up (default: "yahtzee-api")
+ *
+ * Usage (called automatically by render.yaml buildCommand):
+ *   node scripts/fetch-render-env.js
+ */
+
+import { writeFileSync } from "fs";
+
+const API_KEY = process.env.RENDER_API_KEY;
+const SERVICE_NAME = process.env.RENDER_API_SERVICE_NAME ?? "yahtzee-api";
+
+if (!API_KEY) {
+  console.error(
+    "Error: RENDER_API_KEY is not set.\n" +
+      "Add it as a secret env var on the yahtzee-frontend service in the Render dashboard."
+  );
+  process.exit(1);
+}
+
+const res = await fetch("https://api.render.com/v1/services?limit=50", {
+  headers: { Authorization: `Bearer ${API_KEY}` },
+});
+
+if (!res.ok) {
+  console.error(`Render API request failed: ${res.status} ${res.statusText}`);
+  process.exit(1);
+}
+
+const services = await res.json();
+const match = services.find((s) => s.service?.name === SERVICE_NAME);
+
+if (!match) {
+  const names = services.map((s) => s.service?.name).join(", ");
+  console.error(`Service "${SERVICE_NAME}" not found. Available services: ${names}`);
+  process.exit(1);
+}
+
+const url = match.service?.serviceDetails?.url;
+if (!url || !url.startsWith("http")) {
+  console.error(`Service "${SERVICE_NAME}" has no valid public URL: ${JSON.stringify(url)}`);
+  process.exit(1);
+}
+
+writeFileSync(".env", `EXPO_PUBLIC_API_URL=${url}\n`);
+console.log(`✓ EXPO_PUBLIC_API_URL=${url}`);

--- a/frontend/src/__tests__/renderConfig.test.ts
+++ b/frontend/src/__tests__/renderConfig.test.ts
@@ -3,13 +3,12 @@
  *
  * render.yaml deployment config guard
  * ------------------------------------
- * Verifies that EXPO_PUBLIC_API_URL is set to a hardcoded full HTTPS URL
- * rather than a bare hostname from a fromService reference.
+ * Verifies that the frontend build uses fetch-render-env.js to dynamically
+ * resolve the API URL via the Render API, rather than hardcoding it or using
+ * Render's fromService reference (which returns a bare slug, not a full URL).
  *
  * Regression test for the production bug where all API-dependent games
- * (Yahtzee, Blackjack, Ludo) failed with ERR_NAME_NOT_RESOLVED because
- * Render's fromService resolved to the internal hostname "yahtzee-api"
- * instead of the public URL "https://yahtzee-api.onrender.com".
+ * (Yahtzee, Blackjack, Ludo) failed with ERR_NAME_NOT_RESOLVED.
  */
 
 import * as fs from "fs";
@@ -19,12 +18,18 @@ const renderYamlPath = path.resolve(__dirname, "../../../render.yaml");
 const renderYaml = fs.readFileSync(renderYamlPath, "utf-8");
 
 describe("render.yaml deployment configuration", () => {
-  it("EXPO_PUBLIC_API_URL is set to a hardcoded full HTTPS URL", () => {
-    // Match: EXPO_PUBLIC_API_URL followed by value: https://...
-    const valueMatch = renderYaml.match(/EXPO_PUBLIC_API_URL[\s\S]*?value:\s*(https?:\/\/\S+)/);
-    expect(valueMatch).not.toBeNull();
-    const url = valueMatch![1];
-    expect(url).toMatch(/^https:\/\/.+/);
+  it("frontend buildCommand runs fetch-render-env.js before expo export", () => {
+    // The script queries the Render API at build time so the URL is always correct.
+    // Find the line that contains expo export and assert the script precedes it.
+    const scriptIdx = renderYaml.indexOf("fetch-render-env.js");
+    const exportIdx = renderYaml.indexOf("expo export");
+    expect(scriptIdx).toBeGreaterThan(-1);
+    expect(exportIdx).toBeGreaterThan(scriptIdx);
+  });
+
+  it("EXPO_PUBLIC_API_URL is not hardcoded in render.yaml", () => {
+    // The value must come from the Render API at build time, not be baked into render.yaml.
+    expect(renderYaml).not.toMatch(/EXPO_PUBLIC_API_URL[\s\S]*?value:\s*https?:\/\//);
   });
 
   it("no fromService env var uses property: host (internal-only hostname)", () => {

--- a/render.yaml
+++ b/render.yaml
@@ -10,15 +10,23 @@ services:
       - key: PYTHON_VERSION
         value: 3.11.0
       - key: ALLOWED_ORIGINS
-        value: https://yahtzee-frontend.onrender.com
+        fromService:
+          name: yahtzee-frontend
+          type: web
+          property: url
 
   # --- Expo Web static frontend ---
   - type: web
     name: yahtzee-frontend
     runtime: static
     rootDir: frontend
-    buildCommand: npm ci && npx expo export --platform web
+    # fetch-render-env.js queries the Render API for the API service's public URL
+    # and writes EXPO_PUBLIC_API_URL to .env before Expo bakes it into the bundle.
+    # RENDER_API_KEY must be set as a secret env var in the Render dashboard.
+    buildCommand: npm ci && node scripts/fetch-render-env.js && npx expo export --platform web
     staticPublishPath: dist
     envVars:
-      - key: EXPO_PUBLIC_API_URL
-        value: https://yahtzee-api.onrender.com
+      - key: RENDER_API_SERVICE_NAME
+        value: yahtzee-api
+      - key: RENDER_API_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- Replaces hardcoded/`fromService` URL with a pre-build script (`fetch-render-env.js`) that queries the Render API for the verified public URL of `yahtzee-api` and writes it to `.env` before `expo export` runs
- `ALLOWED_ORIGINS` in the backend now normalises bare slugs from Render's `fromService` (e.g. `yahtzee-frontend-6yz5`) to full `https://<slug>.onrender.com` URLs
- `RENDER_API_KEY` stored as a secret in the Render dashboard (`sync: false` in render.yaml — never committed)

## Root cause
Render's `fromService` with `property: url` returns a bare subdomain slug (`yahtzee-api-fql1`) rather than a full URL. The frontend was building with `EXPO_PUBLIC_API_URL=yahtzee-api-fql1`, which is not browser-resolvable — causing `ERR_NAME_NOT_RESOLVED` on all API calls.

## Immediate fix (already applied via Render API)
- `EXPO_PUBLIC_API_URL` on `yahtzee-frontend` set to `https://yahtzee-api-fql1.onrender.com` ✓
- `ALLOWED_ORIGINS` on `yahtzee-api` set to `https://yahtzee-frontend-6yz5.onrender.com` ✓  
- Redeploy of `yahtzee-frontend` triggered ✓

## Test plan
- [ ] CI passes (renderConfig tests assert `fetch-render-env.js` is in buildCommand)
- [ ] After merge → deploy: network tab shows calls to `https://yahtzee-api-fql1.onrender.com/...`
- [ ] Yahtzee, Blackjack, and Ludo all load without `ERR_NAME_NOT_RESOLVED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)