### PR TITLE
fix(api): append .onrender.com when fromService injects a bare slug

### DIFF
--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -119,15 +119,15 @@ describe("api BASE_URL configuration", () => {
     );
   });
 
-  it("prepends https:// when EXPO_PUBLIC_API_URL is a bare hostname (Render property: host)", async () => {
-    // Render's property: host injects just the service name, e.g. "yahtzee-api".
-    // The client must still prepend https:// so the URL is at least syntactically valid.
-    process.env.EXPO_PUBLIC_API_URL = "yahtzee-api";
+  it("builds a full onrender.com URL when EXPO_PUBLIC_API_URL is a bare slug (Render fromService)", async () => {
+    // Render's fromService with property: url injects a bare subdomain slug,
+    // e.g. "yahtzee-api-fql1" — no https:// and no .onrender.com suffix.
+    process.env.EXPO_PUBLIC_API_URL = "yahtzee-api-fql1";
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { api: freshApi } = require("../client") as typeof import("../client");
     await freshApi.newGame();
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toMatch(/^https:\/\//);
+    expect(calledUrl).toMatch(/^https:\/\/yahtzee-api-fql1\.onrender\.com/);
   });
 
   it("falls back to http://localhost:8000 when EXPO_PUBLIC_API_URL is not set", async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,7 @@
 const _apiUrl = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
-const BASE_URL = _apiUrl.startsWith("http") ? _apiUrl : `https://${_apiUrl}`;
+// Render's fromService can inject a bare subdomain slug (e.g. "yahtzee-api-fql1")
+// without a protocol or the .onrender.com suffix. Normalise to a full URL.
+const BASE_URL = _apiUrl.startsWith("http") ? _apiUrl : `https://${_apiUrl}.onrender.com`;
 
 export interface GameState {
   dice: number[];


### PR DESCRIPTION
Render's fromService with property: url returns just the subdomain slug (e.g. "yahtzee-api-fql1") — no protocol, no .onrender.com suffix. The previous fix added https:// but left off the domain, producing https://yahtzee-api-fql1 which still fails DNS resolution.

Now: bare slug → https://<slug>.onrender.com (correct full URL) Full https:// URL → used as-is (works for fetch-render-env.js output too)

## Summary
<!-- What does this PR do? Focus on the why, not the how. -->
-

## Type of change
- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done
<!-- What did you run? Any coverage delta? -->
- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist
- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist *(frontend PRs only)*
- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom
