### PR TITLE
feat(ios): prepare app for iOS TestFlight submission

### DIFF
--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gaming App — Privacy Policy</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 700px; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; color: #333; }
+    h1 { font-size: 1.5rem; }
+    h2 { font-size: 1.15rem; margin-top: 1.5rem; }
+    p, li { font-size: 0.95rem; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p><strong>Gaming App</strong> — Last updated: March 28, 2026</p>
+
+  <h2>Overview</h2>
+  <p>Gaming App is a collection of classic and casual games including Yahtzee, Fruit Merge, Blackjack, and Ludo. Your privacy is important to us. This policy explains what data the app does and does not collect.</p>
+
+  <h2>Data We Do Not Collect</h2>
+  <ul>
+    <li>We do not collect personal information (name, email, phone number, etc.).</li>
+    <li>We do not require user accounts or registration.</li>
+    <li>We do not use analytics, advertising, or tracking services.</li>
+    <li>We do not use cookies or device identifiers for tracking.</li>
+  </ul>
+
+  <h2>Data Stored on Your Device</h2>
+  <p>The app stores game preferences (such as language and display settings) locally on your device using standard device storage. This data never leaves your device.</p>
+
+  <h2>Network Requests</h2>
+  <p>The app communicates with our game server to process game logic (dice rolls, card dealing, move validation, etc.). These requests contain only game-state information and no personal data. No data from these requests is stored on our servers beyond the duration of a game session.</p>
+
+  <h2>Third-Party Services</h2>
+  <p>The app does not share data with any third parties.</p>
+
+  <h2>Children's Privacy</h2>
+  <p>The app does not knowingly collect any personal information from children or any other users.</p>
+
+  <h2>Changes to This Policy</h2>
+  <p>We may update this policy from time to time. Any changes will be reflected on this page with an updated date.</p>
+
+  <h2>Contact</h2>
+  <p>If you have questions about this privacy policy, please contact us at: <strong>buffingchi@gmail.com</strong></p>
+</body>
+</html>

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "frontend",
-    "slug": "frontend",
+    "name": "Gaming App",
+    "slug": "gaming-app",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -12,7 +12,20 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.buffingchi.games",
+      "buildNumber": "1",
+      "privacyManifests": {
+        "NSPrivacyAccessedAPITypes": [
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+          }
+        ],
+        "NSPrivacyCollectedDataTypes": [],
+        "NSPrivacyTracking": false,
+        "NSPrivacyTrackingDomains": []
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -1,0 +1,39 @@
+{
+  "cli": {
+    "version": ">= 15.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_API_URL": "yahtzee-api"
+      },
+      "ios": {
+        "image": "latest"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "FILL_IN_YOUR_APPLE_ID",
+        "ascAppId": "FILL_IN_AFTER_ASC_SETUP",
+        "appleTeamId": "FILL_IN_YOUR_TEAM_ID"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "main": "index.ts",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Configure iOS bundle identifier (`com.buffingchi.games`), display name, build number, and Apple privacy manifests in `app.json`
- Add `eas.json` with development, preview, and production build profiles
- Add privacy policy HTML page (`docs/privacy-policy.html`) for App Store Connect and GitHub Pages hosting

## Test plan
- [ ] Run `npx expo config` in `frontend/` and verify iOS config (bundle ID, privacy manifests)
- [ ] Run `npx expo prebuild --platform ios` and confirm `ios/` directory generates without errors
- [ ] Open `ios/GamingApp.xcworkspace` in Xcode and verify signing works with Apple Developer team
- [ ] Verify `docs/privacy-policy.html` renders correctly in a browser
- [ ] Archive and upload to App Store Connect via Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)