### PR TITLE
docs: clarify iOS builds use Xcode directly, not EAS Build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ See [~/.claude/standards/testing.md](~/.claude/standards/testing.md) + [`docs/TE
 cd backend && python -m pytest tests/ -v
 ```
 
+## iOS Builds
+**Xcode direct — EAS Build is NOT used.** `frontend/ios/` is committed to the repo, not generated at build time.
+See [`docs/IOS.md`](docs/IOS.md). Do not suggest `eas build`, `prebuildCommand`, or treating `ios/` as ephemeral.
+
 ## Deployment
 See [`docs/RENDER.md`](docs/RENDER.md) for Render hosting setup.
 

--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -1,0 +1,41 @@
+# iOS Build — Xcode (Direct)
+
+## How iOS is built
+
+This project builds iOS **directly in Xcode**. EAS Build (Expo Application Services) is **not used**.
+
+## What this means
+
+- `frontend/ios/` is **committed to the repo** — it is NOT gitignored and NOT generated at build time
+- `expo prebuild` is **not** part of the build process
+- Builds are triggered from Xcode (locally or via CI with `xcodebuild`)
+- The workspace is `frontend/ios/GamingApp.xcworkspace`
+
+## If the ios/ folder is missing
+
+The `frontend/ios/` directory must exist in the repo. If it is missing:
+
+1. It was likely accidentally added to `.gitignore` — remove `/ios` from `frontend/.gitignore`
+2. Run `expo prebuild` once to regenerate it: `cd frontend && npx expo prebuild`
+3. Commit the generated `ios/` folder
+4. Do **not** add `prebuildCommand` to `eas.json` — EAS is not the build target
+
+## EAS status
+
+`eas.json` exists and is intentionally kept for future use. When the app goes to production,
+EAS will be used for **App Store submission** (`eas submit`), not for building.
+Builds will remain Xcode-direct even then unless explicitly decided otherwise.
+
+**Do not** treat the presence of `eas.json` as evidence that EAS Build is in use.
+
+## CI / CD
+
+The GitHub Actions `ci.yml` does not run iOS builds. iOS builds run via Xcode directly.
+If a CI iOS build step is added in future, it must call `xcodebuild` (not `eas build`).
+
+## Do not suggest
+
+- `eas build` for iOS
+- `prebuildCommand` in `eas.json`
+- Treating `ios/` as a generated/ephemeral directory
+- Removing `eas.json` — it is kept intentionally for future App Store submission

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -37,7 +37,8 @@ yarn-error.*
 *.tsbuildinfo
 
 # generated native folders
-/ios
+# NOTE: /ios is NOT ignored — iOS builds use Xcode directly, ios/ is committed
+# See docs/IOS.md
 /android
 
 .env.local


### PR DESCRIPTION
## Summary
- Adds `docs/IOS.md` documenting that iOS builds use Xcode directly and `frontend/ios/` must be committed
- Updates `CLAUDE.md` with an iOS Builds section and explicit notes to never suggest EAS Build
- Removes `/ios` from `frontend/.gitignore` so the native folder is no longer excluded
- Notes that `eas.json` is kept intentionally for future App Store submission (`eas submit`)

## Test plan
- [ ] Verify `docs/IOS.md` accurately reflects the project's iOS build approach
- [ ] Verify `frontend/.gitignore` no longer ignores `/ios`
- [ ] Run `expo prebuild` locally and confirm `frontend/ios/` is generated and committable

🤖 Generated with [Claude Code](https://claude.com/claude-code)