### PR TITLE
feat(ios): iOS prebuild and Xcode Cloud setup

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Navigate to frontend root (parent of ios/)
+cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
+
+# Install Node.js dependencies
+npm install
+
+# Install CocoaPods
+cd ios
+pod install


### PR DESCRIPTION
## Summary
- Ran `npx expo prebuild --platform ios --clean` to regenerate native iOS project
- Removed `/ios` from `.gitignore` so Xcode Cloud can access project files
- Added `ci_post_clone.sh` for Xcode Cloud to install node_modules and CocoaPods
- Excluded `ios/` from prettier and eslint checks (generated Xcode files)

## Test plan
- [ ] Verify Xcode Cloud build succeeds on dev after merge
- [ ] Confirm TestFlight submission works with the regenerated native directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)