### PR TITLE
fix(ios): install Node.js in Xcode Cloud CI script

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 set -e
 
+# Install Node.js via Homebrew (not pre-installed on Xcode Cloud runners)
+brew install node
+
+# Install CocoaPods if not available
+which pod || brew install cocoapods
+
 # Navigate to frontend root (parent of ios/)
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
 
 # Install Node.js dependencies
 npm install
 
-# Install CocoaPods
+# Install CocoaPods dependencies
 cd ios
 pod install


### PR DESCRIPTION
## Summary
- Added `brew install node` to `ci_post_clone.sh` — Xcode Cloud runners don't have Node.js pre-installed
- Added fallback `brew install cocoapods` in case it's missing
- Script now installs all dependencies before `pod install`

## Test plan
- [ ] Verify Xcode Cloud build passes the `ci_post_clone.sh` step
- [ ] Verify `pod install` succeeds after node_modules are installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)