### PR TITLE
fix(ios): Xcode Cloud build — write .xcode.env.local for node

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -1,18 +1,36 @@
 #!/bin/sh
 set -e
 
-# Install Node.js via Homebrew (not pre-installed on Xcode Cloud runners)
+echo "=== Xcode Cloud: ci_post_clone.sh ==="
+
+# -------------------------------------------------------
+# 1. Install Node.js (not pre-installed on Xcode Cloud)
+# -------------------------------------------------------
 brew install node
+echo "Node: $(node --version) at $(which node)"
 
-# Install CocoaPods if not available
-which pod || brew install cocoapods
+# -------------------------------------------------------
+# 2. Tell Xcode build phases where to find node
+#    Build phases source .xcode.env / .xcode.env.local
+#    to locate NODE_BINARY. Without this, the "Bundle
+#    React Native code and images" phase fails.
+# -------------------------------------------------------
+NODE_PATH=$(which node)
+cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
+echo "export NODE_BINARY=$NODE_PATH" > .xcode.env.local
+echo "Wrote .xcode.env.local -> NODE_BINARY=$NODE_PATH"
 
-# Navigate to frontend root (parent of ios/)
+# -------------------------------------------------------
+# 3. Install JavaScript dependencies
+# -------------------------------------------------------
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
-
-# Install Node.js dependencies
 npm install
 
-# Install CocoaPods dependencies
-cd ios
+# -------------------------------------------------------
+# 4. Install CocoaPods dependencies
+# -------------------------------------------------------
+cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
+which pod || brew install cocoapods
 pod install
+
+echo "=== ci_post_clone.sh complete ==="


### PR DESCRIPTION
## Summary
- Fixed `PhaseScriptExecution` failure (exit code 65) in Xcode Cloud builds
- Root cause: the "Bundle React Native code and images" build phase couldn't find `node` because `.xcode.env.local` (gitignored) didn't exist on the CI runner
- `ci_post_clone.sh` now writes `.xcode.env.local` with the correct `NODE_BINARY` path after installing Node.js via Homebrew

## What the script does
1. `brew install node` — installs Node.js
2. Writes `export NODE_BINARY=/opt/homebrew/bin/node` to `.xcode.env.local`
3. `npm install` — installs JS dependencies
4. `pod install` — installs CocoaPods

## Test plan
- [ ] Xcode Cloud build passes `ci_post_clone.sh` step
- [ ] Xcode Cloud build passes `xcodebuild archive` step (no more PhaseScriptExecution failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)