### PR TITLE
fix(ios): ensure node on PATH for all Xcode build phases

### DIFF
--- a/frontend/ios/.xcode.env
+++ b/frontend/ios/.xcode.env
@@ -8,4 +8,5 @@
 # Customize the NODE_BINARY variable here.
 # For example, to use nvm with brew, add the following line
 # . "$(brew --prefix nvm)/nvm.sh" --no-use
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
 export NODE_BINARY=$(command -v node)

--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -15,14 +15,19 @@ echo "npm:  $(npm --version) at $(which npm)"
 
 # -------------------------------------------------------
 # 2. Tell Xcode build phases where to find node
-#    The "Bundle React Native code and images" phase
-#    sources .xcode.env.local to get NODE_BINARY.
-#    (Do NOT symlink node over itself — brew already
-#    placed it in /usr/local/bin.)
+#    - .xcode.env.local: sourced by "Bundle React Native
+#      code and images" phase to set NODE_BINARY
+#    - profile files: ensures login shells (bash -l) used
+#      by the [Expo] Configure project phase find node
 # -------------------------------------------------------
+NODE_BIN=$(which node)
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
-echo "export NODE_BINARY=$(which node)" > .xcode.env.local
+echo "export NODE_BINARY=$NODE_BIN" > .xcode.env.local
 cat .xcode.env.local
+
+# Ensure login shells (bash -l) can find node
+echo "export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$PATH\"" >> "$HOME/.bash_profile"
+echo "export PATH=\"/usr/local/bin:/opt/homebrew/bin:\$PATH\"" >> "$HOME/.zprofile"
 
 # -------------------------------------------------------
 # 3. Install JavaScript dependencies
@@ -36,5 +41,15 @@ npm install
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
 which pod || brew install cocoapods
 pod install
+
+# -------------------------------------------------------
+# 5. Verify everything is in place for the build
+# -------------------------------------------------------
+echo "=== Pre-build verification ==="
+echo "node_modules exists: $(test -d "$CI_PRIMARY_REPOSITORY_PATH/frontend/node_modules" && echo YES || echo NO)"
+echo "Pods exists: $(test -d "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios/Pods" && echo YES || echo NO)"
+echo ".xcode.env.local: $(cat "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios/.xcode.env.local")"
+echo "entry file check:"
+"$NODE_BIN" -e "console.log(require('expo/scripts/resolveAppEntry'))" "$CI_PRIMARY_REPOSITORY_PATH/frontend" ios absolute || echo "WARN: entry file resolution failed"
 
 echo "=== ci_post_clone.sh complete ==="


### PR DESCRIPTION
## Summary
Three fixes targeting the `PhaseScriptExecution` failure (exit code 65):

1. **`.xcode.env`** — Added `export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"` before `command -v node`. Xcode build phases run in a minimal shell that may not include Homebrew paths. This ensures the "Bundle React Native code and images" phase finds node.

2. **`ci_post_clone.sh`** — Writes PATH exports to `~/.bash_profile` and `~/.zprofile` so the `[Expo] Configure project` phase (which runs via `bash -l` login shell) can also find node.

3. **`ci_post_clone.sh`** — Added pre-build verification that logs whether `node_modules`, `Pods`, and entry file resolution are working, to help diagnose any remaining issues.

## Test plan
- [ ] `ci_post_clone.sh` passes
- [ ] `xcodebuild archive` passes — no more PhaseScriptExecution failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)