### PR TITLE
fix(ios): reinstall Pods to fix hardcoded Hermes path

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -15,10 +15,6 @@ echo "npm:  $(npm --version) at $(which npm)"
 
 # -------------------------------------------------------
 # 2. Tell Xcode build phases where to find node
-#    - .xcode.env.local: sourced by "Bundle React Native
-#      code and images" phase to set NODE_BINARY
-#    - profile files: ensures login shells (bash -l) used
-#      by the [Expo] Configure project phase find node
 # -------------------------------------------------------
 NODE_BIN=$(which node)
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
@@ -36,20 +32,22 @@ cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
 npm install
 
 # -------------------------------------------------------
-# 4. Install CocoaPods dependencies
+# 4. Install CocoaPods (fresh install to fix paths)
+#    The committed Pods have hardcoded local machine paths
+#    (e.g. HERMES_CLI_PATH). Removing and reinstalling
+#    regenerates xcconfigs with correct CI runner paths.
 # -------------------------------------------------------
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
+rm -rf Pods
 which pod || brew install cocoapods
 pod install
 
 # -------------------------------------------------------
-# 5. Verify everything is in place for the build
+# 5. Verify HERMES_CLI_PATH is correct
 # -------------------------------------------------------
 echo "=== Pre-build verification ==="
-echo "node_modules exists: $(test -d "$CI_PRIMARY_REPOSITORY_PATH/frontend/node_modules" && echo YES || echo NO)"
-echo "Pods exists: $(test -d "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios/Pods" && echo YES || echo NO)"
-echo ".xcode.env.local: $(cat "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios/.xcode.env.local")"
-echo "entry file check:"
-"$NODE_BIN" -e "console.log(require('expo/scripts/resolveAppEntry'))" "$CI_PRIMARY_REPOSITORY_PATH/frontend" ios absolute || echo "WARN: entry file resolution failed"
+HERMES_PATH=$(grep HERMES_CLI_PATH "Pods/Target Support Files/Pods-GamingApp/Pods-GamingApp.release.xcconfig" || echo "NOT FOUND")
+echo "HERMES_CLI_PATH: $HERMES_PATH"
+echo "node_modules: $(test -d "$CI_PRIMARY_REPOSITORY_PATH/frontend/node_modules" && echo YES || echo NO)"
 
 echo "=== ci_post_clone.sh complete ==="


### PR DESCRIPTION
## Summary
**Root cause found**: The committed `ios/Pods/` xcconfig files contain a hardcoded path from the local dev machine:

```
HERMES_CLI_PATH = /Users/bill.mchenry/gaming_app/frontend/node_modules/hermes-compiler/hermesc/osx-bin/hermesc
```

On Xcode Cloud the runner path is `/Volumes/workspace/repository/...`, so the Hermes compiler (`hermesc`) isn't found and the "Bundle React Native code and images" phase fails.

**Fix**: `rm -rf Pods` before `pod install` in `ci_post_clone.sh`. This forces CocoaPods to regenerate all xcconfig files with correct absolute paths for the CI runner, instead of reusing the stale committed ones.

## Test plan
- [ ] `ci_post_clone.sh` completes — verify `HERMES_CLI_PATH` in the log points to `/Volumes/workspace/...` or `/usr/local/...`
- [ ] `xcodebuild archive` succeeds — no more PhaseScriptExecution failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)