### PR TITLE
fix: ErrorBoundary to catch render errors causing white screen

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -6,6 +6,7 @@ import GameScreen from "./src/screens/GameScreen";
 import FruitMergeScreen from "./src/screens/FruitMergeScreen";
 import { GameState } from "./src/api/client";
 import { ThemeProvider } from "./src/theme/ThemeContext";
+import { ErrorBoundary } from "./src/components/ErrorBoundary";
 
 export type RootStackParamList = {
   Home: undefined;
@@ -17,14 +18,16 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
   return (
-    <ThemeProvider>
-      <NavigationContainer>
-        <Stack.Navigator screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="Game" component={GameScreen} />
-          <Stack.Screen name="FruitMerge" component={FruitMergeScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </ThemeProvider>
+    <ErrorBoundary>
+      <ThemeProvider>
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Game" component={GameScreen} />
+            <Stack.Screen name="FruitMerge" component={FruitMergeScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ThemeProvider>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // TODO: replace with Sentry.captureException(error, { extra: info })
+    // once @sentry/react-native is installed and configured
+    console.error("[ErrorBoundary] Uncaught render error:", error, info);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>Something went wrong</Text>
+          <Text style={styles.message}>
+            {this.state.error?.message ?? "An unexpected error occurred."}
+          </Text>
+          <Pressable style={styles.button} onPress={this.handleReload}>
+            <Text style={styles.buttonText}>Try again</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    backgroundColor: "#fff",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 12,
+  },
+  message: {
+    fontSize: 14,
+    color: "#666",
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: "#1a1a2e",
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "600",
+    fontSize: 14,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a class-based `ErrorBoundary` component wrapping the full app tree
- Catches unhandled render errors that were silently unmounting the tree and producing a white screen with no logs
- Logs the error + component stack via `console.error` — visible in browser devtools immediately
- Shows a user-facing fallback UI ("Something went wrong" + "Try again" button) instead of a blank screen

## Sentry follow-up
`ErrorBoundary.tsx:24` has a `TODO` comment marking the exact line to replace with `Sentry.captureException()` once `@sentry/react-native` is installed and a `SENTRY_DSN` env var is configured. That work is scoped to a separate PR.

## Test plan
- [ ] Launch the app and confirm normal flow is unaffected
- [ ] Temporarily throw in a screen component to verify the fallback UI renders and `console.error` fires
- [ ] Confirm "Try again" resets the boundary and re-renders the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)