### PR TITLE
fix(fruit-merge): handle WebAssembly unavailable on Hermes (BC_GAMES-2)

### DIFF
--- a/frontend/src/components/fruit-merge/GameCanvas.tsx
+++ b/frontend/src/components/fruit-merge/GameCanvas.tsx
@@ -12,7 +12,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { AccessibilityInfo } from "react-native";
+import { AccessibilityInfo, View, Text, StyleSheet } from "react-native";
 import {
   Canvas,
   Circle,
@@ -100,6 +100,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
     const [bodies, setBodies] = useState<BodySnapshot[]>([]);
     const [pointerX, setPointerX] = useState<number | null>(null);
+    const [engineError, setEngineError] = useState<string | null>(null);
 
     const engineRef = useRef<EngineHandle | null>(null);
     const lastFrameTimeRef = useRef<number>(0); // tracks last RAF timestamp for elapsed-time physics
@@ -121,13 +122,18 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       engineRef.current?.cleanup();
       engineRef.current = null;
       setBodies([]);
-      engineRef.current = await createEngine(
-        width,
-        height,
-        fruitSet,
-        (e) => onMergeRef.current(e),
-        () => onGameOverRef.current()
-      );
+      setEngineError(null);
+      try {
+        engineRef.current = await createEngine(
+          width,
+          height,
+          fruitSet,
+          (e) => onMergeRef.current(e),
+          () => onGameOverRef.current()
+        );
+      } catch (err) {
+        setEngineError(err instanceof Error ? err.message : String(err));
+      }
     }, [width, height, fruitSet]);
 
     useEffect(() => {
@@ -198,6 +204,14 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       p.lineTo(ghostCx, height - WALL_THICKNESS);
       return p;
     }, [ghostCx, dangerY, height]);
+
+    if (engineError) {
+      return (
+        <View style={[styles.errorContainer, { width, height }]}>
+          <Text style={styles.errorText}>{t("game.engineUnsupported")}</Text>
+        </View>
+      );
+    }
 
     const tapGesture = Gesture.Tap()
       .runOnJS(true)
@@ -279,3 +293,18 @@ export default GameCanvas;
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
 }
+
+const styles = StyleSheet.create({
+  errorContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12,
+    backgroundColor: "#1a1a2e",
+  },
+  errorText: {
+    color: "#aaa",
+    fontSize: 14,
+    textAlign: "center",
+    paddingHorizontal: 24,
+  },
+});

--- a/frontend/src/game/fruit-merge/engine.ts
+++ b/frontend/src/game/fruit-merge/engine.ts
@@ -65,6 +65,12 @@ let _rapierPromise: Promise<RapierLib> | null = null;
 async function getRapier(): Promise<RapierLib> {
   if (!_rapierPromise) {
     _rapierPromise = (async () => {
+      // Hermes (React Native's JS engine on iOS/Android) does not support WebAssembly.
+      // Fail fast with a clear message rather than letting rapier throw a cryptic
+      // ReferenceError deep inside its WASM loader.
+      if (typeof WebAssembly === "undefined") {
+        throw new Error("WebAssembly is not available in this environment (Hermes)");
+      }
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const mod = require("@dimforge/rapier2d-compat") as { default?: RapierLib } | RapierLib;
       const R = (mod as { default?: RapierLib }).default ?? (mod as RapierLib);

--- a/frontend/src/i18n/locales/ar/fruit-merge.json
+++ b/frontend/src/i18n/locales/ar/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "احفظ النتيجة",
   "gameOver.savedConfirmation": "تم الحفظ! #{{rank}}",
   "gameOver.playAgain": "العب مجددًا",
-  "gameOver.playAgainButton": "العب مرة أخرى"
+  "gameOver.playAgainButton": "العب مرة أخرى",
+  "game.engineUnsupported": "هذه اللعبة غير مدعومة على هذا الجهاز."
 }

--- a/frontend/src/i18n/locales/de/fruit-merge.json
+++ b/frontend/src/i18n/locales/de/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Punkte sichern",
   "gameOver.savedConfirmation": "Gespeichert! #{{rank}}",
   "gameOver.playAgain": "Nochmal spielen",
-  "gameOver.playAgainButton": "Nochmal!"
+  "gameOver.playAgainButton": "Nochmal!",
+  "game.engineUnsupported": "Dieses Spiel wird auf diesem Gerät nicht unterstützt."
 }

--- a/frontend/src/i18n/locales/en/fruit-merge.json
+++ b/frontend/src/i18n/locales/en/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Save Score",
   "gameOver.savedConfirmation": "Saved! #{{rank}}",
   "gameOver.playAgain": "Play again",
-  "gameOver.playAgainButton": "Play Again"
+  "gameOver.playAgainButton": "Play Again",
+  "game.engineUnsupported": "This game is not supported on this device."
 }

--- a/frontend/src/i18n/locales/es/fruit-merge.json
+++ b/frontend/src/i18n/locales/es/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Guardar",
   "gameOver.savedConfirmation": "¡Guardado! #{{rank}}",
   "gameOver.playAgain": "Jugar de nuevo",
-  "gameOver.playAgainButton": "Jugar otra vez"
+  "gameOver.playAgainButton": "Jugar otra vez",
+  "game.engineUnsupported": "Este juego no está disponible en este dispositivo."
 }

--- a/frontend/src/i18n/locales/fr-CA/fruit-merge.json
+++ b/frontend/src/i18n/locales/fr-CA/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Sauvegarder",
   "gameOver.savedConfirmation": "Enregistré! #{{rank}}",
   "gameOver.playAgain": "Rejouer",
-  "gameOver.playAgainButton": "Rejouer"
+  "gameOver.playAgainButton": "Rejouer",
+  "game.engineUnsupported": "Ce jeu n'est pas disponible sur cet appareil."
 }

--- a/frontend/src/i18n/locales/he/fruit-merge.json
+++ b/frontend/src/i18n/locales/he/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "שמור ניקוד",
   "gameOver.savedConfirmation": "נשמר! #{{rank}}",
   "gameOver.playAgain": "שחק שוב",
-  "gameOver.playAgainButton": "שחק שוב"
+  "gameOver.playAgainButton": "שחק שוב",
+  "game.engineUnsupported": "משחק זה אינו נתמך במכשיר זה."
 }

--- a/frontend/src/i18n/locales/hi/fruit-merge.json
+++ b/frontend/src/i18n/locales/hi/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "स्कोर सेव",
   "gameOver.savedConfirmation": "सेव्ड! #{{rank}}",
   "gameOver.playAgain": "फिर से खेलें",
-  "gameOver.playAgainButton": "फिर से खेलें"
+  "gameOver.playAgainButton": "फिर से खेलें",
+  "game.engineUnsupported": "यह गेम इस डिवाइस पर समर्थित नहीं है।"
 }

--- a/frontend/src/i18n/locales/ja/fruit-merge.json
+++ b/frontend/src/i18n/locales/ja/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "スコア保存",
   "gameOver.savedConfirmation": "保存完了！#{{rank}}",
   "gameOver.playAgain": "もう一度プレイ",
-  "gameOver.playAgainButton": "再挑戦"
+  "gameOver.playAgainButton": "再挑戦",
+  "game.engineUnsupported": "このゲームはこのデバイスではサポートされていません。"
 }

--- a/frontend/src/i18n/locales/ko/fruit-merge.json
+++ b/frontend/src/i18n/locales/ko/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "점수 저장",
   "gameOver.savedConfirmation": "저장 완료! #{{rank}}",
   "gameOver.playAgain": "다시 하기",
-  "gameOver.playAgainButton": "다시 플레이"
+  "gameOver.playAgainButton": "다시 플레이",
+  "game.engineUnsupported": "이 게임은 이 기기에서 지원되지 않습니다."
 }

--- a/frontend/src/i18n/locales/nl/fruit-merge.json
+++ b/frontend/src/i18n/locales/nl/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Score opslaan",
   "gameOver.savedConfirmation": "Opgeslagen! #{{rank}}",
   "gameOver.playAgain": "Opnieuw spelen",
-  "gameOver.playAgainButton": "Nog een keer"
+  "gameOver.playAgainButton": "Nog een keer",
+  "game.engineUnsupported": "Dit spel wordt niet ondersteund op dit apparaat."
 }

--- a/frontend/src/i18n/locales/pt/fruit-merge.json
+++ b/frontend/src/i18n/locales/pt/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Salvar Pontos",
   "gameOver.savedConfirmation": "Salvo! #{{rank}}",
   "gameOver.playAgain": "Jogar de novo",
-  "gameOver.playAgainButton": "Jogar Novamente"
+  "gameOver.playAgainButton": "Jogar Novamente",
+  "game.engineUnsupported": "Este jogo não é suportado neste dispositivo."
 }

--- a/frontend/src/i18n/locales/ru/fruit-merge.json
+++ b/frontend/src/i18n/locales/ru/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "Сохранить",
   "gameOver.savedConfirmation": "Сохранено! №{{rank}}",
   "gameOver.playAgain": "Играть снова",
-  "gameOver.playAgainButton": "Играть ещё"
+  "gameOver.playAgainButton": "Играть ещё",
+  "game.engineUnsupported": "Эта игра не поддерживается на данном устройстве."
 }

--- a/frontend/src/i18n/locales/zh/fruit-merge.json
+++ b/frontend/src/i18n/locales/zh/fruit-merge.json
@@ -23,5 +23,6 @@
   "gameOver.saveButton": "保存分数",
   "gameOver.savedConfirmation": "已保存！第{{rank}}名",
   "gameOver.playAgain": "再玩一次",
-  "gameOver.playAgainButton": "再来一局"
+  "gameOver.playAgainButton": "再来一局",
+  "game.engineUnsupported": "此游戏在本设备上不受支持。"
 }


### PR DESCRIPTION
## Summary
- `@dimforge/rapier2d-compat` calls into WebAssembly during init; Hermes (iOS JS engine) doesn't support it, throwing `ReferenceError: Property 'WebAssembly' doesn't exist`
- The error escaped as an unhandled promise rejection because `initEngine()` in `GameCanvas.tsx` had no error handling around `createEngine()`
- Added a `typeof WebAssembly` guard in `getRapier()` to fail fast with a clear error, and a `try/catch` in `initEngine()` to surface a localized "not supported on this device" fallback UI instead of crashing

## Test plan
- [ ] Build and run on iOS simulator (Hermes) — fruit-merge screen should show the unsupported message instead of throwing an unhandled rejection
- [ ] Verify fruit-merge game still works on web (WebAssembly available)
- [ ] Confirm BC_GAMES-2 no longer appears in Sentry after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)