### PR TITLE
feat(ci): add backend health + Expo compat checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,21 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-gate-main-source.yml@main
     secrets: inherit
 
+  backend-health:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-backend-health.yml@main
+    with:
+      backend-url: 'https://yahtzee-api.onrender.com'
+      health-path: '/health'
+      probe-path: '/game/state'
+      probe-expected-status: '400'
+    secrets: inherit
+
+  expo-compat:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-expo-compat.yml@main
+    with:
+      working-directory: frontend
+    secrets: inherit
+
   secret-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-secret-scan.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `backend-health` job to CI: checks `/health` returns 200 and `/game/state` returns 400 (confirms routing is live)
- Add `expo-compat` job to CI: runs `npx expo install --check` to prevent SDK version mismatches

Both consume new shared workflows from `wcmchenry3-stack/.github`.

## Context
Derived from lessons learned during the iOS white screen saga (PRs #77-#98):
- The Sentry 8.x upgrade (PR #91) was incompatible with Expo SDK 55 — `npx expo install --check` would have flagged it immediately
- Backend health validation ensures deployed services are reachable before merging

Refs: wcmchenry3-stack/.github#9, wcmchenry3-stack/.github#16

## Dependencies
- Requires wcmchenry3-stack/.github#21 to merge first (shared workflows referenced at `@main`)

## Test plan
- [ ] Merge .github PR first
- [ ] Verify `backend-health` job passes in CI
- [ ] Verify `expo-compat` job passes in CI
- [ ] Intentionally introduce an incompatible dep version to confirm expo-compat catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)