### PR TITLE
feat(ci): add local path check + npm ci fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-gate-main-source.yml@main
     secrets: inherit
 
+  local-path-check:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-local-path-check.yml@main
+    with:
+      scan-paths: 'frontend/ios/'
+      file-patterns: '*.xcconfig,*.pbxproj'
+    secrets: inherit
+
   secret-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-secret-scan.yml@main
     secrets: inherit

--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -37,9 +37,9 @@ echo "=== .env written ==="
 cat .env
 
 # -------------------------------------------------------
-# 4. Install JavaScript dependencies
+# 4. Install JavaScript dependencies (npm ci for lockfile integrity)
 # -------------------------------------------------------
-npm install
+npm ci
 
 # -------------------------------------------------------
 # 5. Install CocoaPods (fresh install to fix paths)


### PR DESCRIPTION
## Summary
- Add `local-path-check` job to CI: scans `frontend/ios/` xcconfig and pbxproj files for hardcoded `/Users/` paths
- Fix `ci_post_clone.sh`: use `npm ci` instead of `npm install` for lockfile integrity

## Lessons applied
- **PR #87**: Committed `ios/Pods/` had `/Users/bill.mchenry/...` paths that broke on Xcode Cloud runners
- **PR #92**: Package in `package.json` but not in `node_modules` — `npm ci` would have caught the drift

## Dependencies
- Requires wcmchenry3-stack/.github#23 to merge first

Refs: wcmchenry3-stack/.github#18, wcmchenry3-stack/.github#19

## Test plan
- [ ] Merge .github PR first
- [ ] Verify local-path-check job runs in CI
- [ ] Verify Xcode Cloud build still works with `npm ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)