### PR TITLE
feat(ci): add Xcode build validation (Phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
         run: node scripts/check-i18n-strings.js
         working-directory: frontend
 
+  ios-build-check:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-ios-build-check.yml@main
+    with:
+      working-directory: frontend
+      workspace-name: 'GamingApp.xcworkspace'
+      scheme: 'GamingApp'
+    secrets: inherit
+
   openai-policy:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
Add `ios-build-check` job to CI pipeline — runs `xcodebuild` on a macOS runner to validate the committed iOS project compiles.

## What it does
- Runs `npm ci` to install JS deps
- Removes stale `Podfile.lock` and runs `pod install` (with retry)
- Runs `xcodebuild build` with `GamingApp.xcworkspace` / `GamingApp` scheme
- `CODE_SIGNING_ALLOWED=NO` — just validates compilation, no certificates needed
- Uploads build logs on failure

## Dependencies
- Requires wcmchenry3-stack/.github#24 to merge first

Refs: wcmchenry3-stack/.github#13

## Test plan
- [ ] Merge .github PR first
- [ ] Verify ios-build-check job runs and passes
- [ ] Confirm build logs uploaded as artifact on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)