### PR TITLE
feat(ci): add Maestro E2E flows for iOS + Android

### DIFF
--- a/e2e/maestro/home-screen-android.yaml
+++ b/e2e/maestro/home-screen-android.yaml
@@ -1,0 +1,10 @@
+appId: com.buffingchi.games
+---
+- launchApp
+- assertVisible:
+    text: "Gaming App"
+    timeout: 15000
+- assertVisible:
+    text: "Choose a game"
+    timeout: 5000
+- takeScreenshot: android-home-screen-verified

--- a/e2e/maestro/home-screen-ios.yaml
+++ b/e2e/maestro/home-screen-ios.yaml
@@ -1,0 +1,10 @@
+appId: com.buffingchi.games
+---
+- launchApp
+- assertVisible:
+    text: "Gaming App"
+    timeout: 15000
+- assertVisible:
+    text: "Choose a game"
+    timeout: 5000
+- takeScreenshot: home-screen-verified


### PR DESCRIPTION
## Summary
Add Maestro flow files for mobile E2E testing:
- `e2e/maestro/home-screen-ios.yaml` — validates home screen renders on iOS simulator
- `e2e/maestro/home-screen-android.yaml` — validates home screen renders on Android emulator

Both assert "Gaming App" title and "Choose a game" subtitle are visible within 15s of launch.

## Context
During PRs #77-#98, "Verify iOS app launches past splash screen" was an unchecked manual test plan item on multiple PRs. These Maestro flows automate exactly that validation.

**Note:** These flows are not yet wired into CI (the shared workflows are available but not added to ci.yml yet). They can be run on-demand or added as required checks when ready for the macOS runner cost.

## Dependencies
- Requires wcmchenry3-stack/.github#25 for the shared workflows

Refs: wcmchenry3-stack/.github#14, wcmchenry3-stack/.github#15

## Test plan
- [ ] Run locally: `maestro test e2e/maestro/home-screen-ios.yaml` (requires running simulator)
- [ ] Merge .github PR for shared workflows
- [ ] Wire into CI when ready for macOS runner costs

🤖 Generated with [Claude Code](https://claude.com/claude-code)