### PR TITLE
feat: add lint-review agent and pre-PR lint gate

### DIFF
--- a/.claude/agents/lint-review.md
+++ b/.claude/agents/lint-review.md
@@ -1,0 +1,59 @@
+# lint-review
+
+Auto-fix linting issues across Python and frontend projects.
+
+You are a lint-review agent. Your job is to fix all linting and formatting
+issues in the current repository so that CI will pass cleanly.
+
+## Workflow
+
+1. **Detect project type** by checking for marker files in the repo root.
+2. **Run auto-fix commands** (deterministic — no AI judgment needed).
+3. **Verify** by re-running checks in strict mode.
+4. **Stage the fixes** so they are included in the next commit.
+5. **Report** a short summary of what changed.
+
+## Python projects
+
+Detected when any of these exist: `pyproject.toml`, `requirements.txt`,
+`setup.py`, `setup.cfg`.
+
+```bash
+# Auto-fix
+black .
+ruff check --fix .
+
+# Verify
+black --check .
+ruff check .
+```
+
+## Frontend projects
+
+Detected when `package.json` exists.
+
+```bash
+# Auto-fix
+npx prettier --write .
+npx eslint --fix .
+
+# Verify
+npx prettier --check .
+npx eslint .
+```
+
+## After fixing
+
+1. Run `git diff --stat` to summarize what changed.
+2. Stage all modified files with `git add -u`.
+3. Print a one-line summary: how many files were fixed and by which tool.
+4. Do **not** create a commit — leave that to the caller.
+
+## Important
+
+- Only fix files already tracked by git (do not add new files).
+- If a linter is not installed, skip it and note that in your summary.
+- If auto-fix cannot resolve all issues (e.g., an eslint rule requires
+  manual intervention), list the remaining errors clearly so the caller
+  can address them.
+- Do not modify test files unless the linter explicitly flags them.

--- a/.claude/hooks/lint-gate.sh
+++ b/.claude/hooks/lint-gate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# lint-gate.sh — PreToolUse hook for Claude Code
+# Blocks `gh pr create` when linting issues exist, prompting the
+# lint-review sub-agent to auto-fix before retrying.
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if ! echo "$COMMAND" | grep -qE 'gh\s+pr\s+create'; then
+  exit 0
+fi
+
+FAIL=0
+REPORT=""
+
+if [ -f "pyproject.toml" ] || [ -f "requirements.txt" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
+  if command -v black &>/dev/null; then
+    OUT=$(black --check --quiet . 2>&1) || { FAIL=1; REPORT+="## black\n${OUT}\n\n"; }
+  fi
+  if command -v ruff &>/dev/null; then
+    OUT=$(ruff check --no-fix . 2>&1) || { FAIL=1; REPORT+="## ruff\n${OUT}\n\n"; }
+  fi
+fi
+
+if [ -f "package.json" ]; then
+  if [ -x "node_modules/.bin/eslint" ]; then
+    OUT=$(npx eslint . 2>&1) || { FAIL=1; REPORT+="## eslint\n${OUT}\n\n"; }
+  fi
+  if [ -x "node_modules/.bin/prettier" ]; then
+    OUT=$(npx prettier --check . 2>&1) || { FAIL=1; REPORT+="## prettier\n${OUT}\n\n"; }
+  fi
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  { echo "BLOCKED: Lint check failed. Invoke the lint-review agent to auto-fix."; echo ""; echo -e "$REPORT"; } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 .vscode/
 .idea/
 *.swp
+
+# Claude Code local overrides (personal, not shared)
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add Claude Code `lint-review` sub-agent and `lint-gate.sh` pre-PR hook
- Auto-detects project type (Python/frontend) and runs appropriate linters
- Blocks `gh pr create` if linting fails, then auto-fixes via sub-agent

## Flow
```
gh pr create → lint-gate.sh hook fires
  → Pass? → PR created
  → Fail? → Hook blocks → lint-review agent auto-fixes → retry
```

## Files added
| File | Purpose |
|------|---------|
| `.claude/settings.json` | Hook configuration |
| `.claude/hooks/lint-gate.sh` | Lint check gate (exit 2 on failure) |
| `.claude/agents/lint-review.md` | Auto-fix agent definition |

Inherited from org `.github` meta-repo pattern (see wcmchenry3-stack/.github#36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)