### PR TITLE
ci: add ZAP weekly security scan

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -1,0 +1,15 @@
+name: ZAP Weekly Scan
+
+on:
+  schedule:
+    # Weekly Sunday at 06:00 UTC (midnight Mountain Time)
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+jobs:
+  zap-scan:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
+    with:
+      target-url: ${{ secrets.SITE_URL }}
+      artifact-name: 'zap-weekly-gaming'
+    secrets: inherit


### PR DESCRIPTION
Adds a weekly OWASP ZAP baseline scan workflow that runs every Sunday at 06:00 UTC. This follows the reusable workflow pattern used across the org, calling the shared called-zap-scheduled workflow from wcmchenry3-stack/.github.