### PR TITLE
fix(security): resolve high severity lodash npm audit vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11634,9 +11634,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
- Ran `npm audit fix` to update lodash past the high severity code injection CVE (GHSA-r5fr-rjxr-66jc)
- Remaining 13 low severity vulnerabilities require breaking upstream changes (`jest-expo`, `@lhci/cli`) and are not addressable without major version bumps
- CI `cve-frontend` check uses `--audit-level=high`, so this should now pass

## Test plan
- [ ] Verify `npm audit --audit-level=high` exits 0
- [ ] All existing tests pass (no runtime dependency on lodash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)