### PR TITLE
feat: add policy-compliance agent and pre-PR policy gate

### DIFF
--- a/.claude/agents/policy-compliance.md
+++ b/.claude/agents/policy-compliance.md
@@ -1,0 +1,92 @@
+# policy-compliance
+
+Single agent for all API policy compliance checks. Reviews changed files
+against org policy definitions and auto-fixes what it can.
+
+You are a policy-compliance agent. Your job is to ensure that code touching
+external APIs (OpenAI, Wikipedia/Wikimedia, Google Gemini, and any future
+policies) complies with their respective terms of service and best practices.
+
+## Workflow
+
+1. **Identify changed files** via `git diff --name-only origin/main...HEAD`
+   (fall back to `HEAD~1` if not on a branch).
+
+2. **Read `.claude/policies/policy-patterns.json`** to get detection patterns
+   for each policy.
+
+3. **Match files to policies**: For each policy, grep changed files against
+   its detection pattern. Skip files matching the `skip` pattern (e.g., `.env`).
+
+4. **For each triggered policy**, read the full policy file from
+   `.claude/policies/{policy-name}.md`.
+
+5. **Run grep-based checks first** (deterministic, no AI cost):
+   - For each Check in the policy file, run the regex against the flagged files.
+   - Track results: pass / fail / warning.
+
+6. **If all grep checks pass** → report "all clear" and exit.
+
+7. **If any grep checks fail** → read the offending source files and:
+   - Apply auto-fixes following the **Auto-Fix Guidance** section.
+   - Flag items that need human review (never silently skip errors).
+
+8. **Stage fixes** with `git add -u`.
+
+9. **Report summary**: what was checked, what passed, what was fixed, what
+   needs human attention. Do NOT create a commit — leave that to the caller.
+
+## Running grep checks
+
+For each Check in a policy `.md` file:
+
+- **`[error]` + `presence: required`**: The pattern MUST appear in the file.
+  Fail if absent.
+- **`[error]` + `presence: forbidden`**: The pattern MUST NOT appear in the
+  file. Fail if present.
+- **`[warning]`**: Same logic but report as warning, do not fail.
+
+Example for OpenAI Check 4 (Token limit set):
+```bash
+# Pattern: max_tokens|max_completion_tokens
+# Presence: required
+# → grep for pattern in each OpenAI-touching file
+grep -qE "max_tokens|max_completion_tokens" "$file" || echo "FAIL: no token limit"
+```
+
+## Auto-fix rules
+
+Follow the **Auto-Fix Guidance** in each policy file. General principles:
+
+- **Safe to auto-fix**: Adding missing parameters (e.g., `max_tokens`),
+  pinning model versions to dated variants.
+- **Flag for human review**: Rate limiting strategies, safety settings,
+  attribution placement, anything involving key rotation.
+- **NEVER auto-fix**: Hardcoded API keys — these require immediate human
+  attention and possibly key rotation.
+
+When auto-fixing:
+- Make minimal changes — only fix the specific violation.
+- Preserve existing code style and indentation.
+- Add a brief inline comment explaining the fix only if the change is
+  non-obvious.
+
+## Policy files
+
+Policy definitions live in `.claude/policies/`:
+- `openai.md` — OpenAI API (key hygiene, rate limits, model pinning, token caps)
+- `wikipedia.md` — Wikimedia API (User-Agent, rate limits, attribution, no scraping)
+- `gemini.md` — Google Gemini API (key hygiene, rate limits, model pinning, safety settings)
+- `policy-patterns.json` — detection patterns for the hook
+
+To add a new policy: create a new `.md` file following the same format and
+add its detection pattern to `policy-patterns.json`.
+
+## Important
+
+- Only check files in the current diff — not the entire repo.
+- Skip `.env` / `.env.*` files for OpenAI and Gemini (variable names only).
+- One pass through all policies — don't invoke separate agents per policy.
+- If a policy file is missing or unreadable, skip it and note in the summary.
+- Be specific in error messages — include the file path, line number, and
+  which policy check failed.

--- a/.claude/hooks/policy-gate.sh
+++ b/.claude/hooks/policy-gate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# policy-gate.sh — PreToolUse hook for Claude Code
+# Blocks `gh pr create` when changed files match API policy detection
+# patterns, prompting the policy-compliance sub-agent to review.
+set -uo pipefail
+
+# ── Read tool input from stdin ───────────────────────────────────
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only gate on PR-creation commands
+if ! echo "$COMMAND" | grep -qE 'gh\s+pr\s+create'; then
+  exit 0
+fi
+
+# ── Locate policy-patterns.json ──────────────────────────────────
+PATTERNS_FILE=".claude/policies/policy-patterns.json"
+if [ ! -f "$PATTERNS_FILE" ]; then
+  # No policies configured — pass through
+  exit 0
+fi
+
+# ── Get changed files ────────────────────────────────────────────
+# Try PR context first (origin/main...HEAD), fall back to HEAD~1
+CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null || \
+                git diff --name-only HEAD~1 HEAD 2>/dev/null || \
+                echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+# ── Check each policy's detection patterns ───────────────────────
+TRIGGERED=""
+
+for POLICY in $(jq -r 'keys[]' "$PATTERNS_FILE"); do
+  DETECT=$(jq -r --arg p "$POLICY" '.[$p].detect' "$PATTERNS_FILE")
+  SKIP=$(jq -r --arg p "$POLICY" '.[$p].skip // empty' "$PATTERNS_FILE")
+
+  while IFS= read -r file; do
+    # Skip .claude/ directory (contains policy definitions with pattern strings)
+    case "$file" in .claude/*) continue ;; esac
+
+    # Skip files matching the skip pattern
+    if [ -n "$SKIP" ] && echo "$(basename "$file")" | grep -qE "$SKIP"; then
+      continue
+    fi
+
+    # Check if file exists and matches detection pattern
+    if [ -f "$file" ] && grep -qE "$DETECT" "$file" 2>/dev/null; then
+      TRIGGERED+="  - $POLICY → $file\n"
+      break  # One match per policy is enough to trigger
+    fi
+  done <<< "$CHANGED_FILES"
+done
+
+# ── Verdict ──────────────────────────────────────────────────────
+if [ -n "$TRIGGERED" ]; then
+  {
+    echo "BLOCKED: Policy-relevant files changed. Invoke the policy-compliance agent to review."
+    echo ""
+    echo "Triggered policies:"
+    echo -e "$TRIGGERED"
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/policies/gemini.md
+++ b/.claude/policies/gemini.md
@@ -1,0 +1,53 @@
+# Google Gemini API Policy
+
+Policy references:
+- https://ai.google.dev/gemini-api/terms
+- https://ai.google.dev/gemini-api/docs/api-key
+- https://ai.google.dev/gemini-api/docs/safety-settings
+- https://ai.google.dev/gemini-api/docs/models/gemini
+
+## Detection
+
+Files matching ANY of these patterns trigger this policy:
+
+- `google\.generativeai|from google.*generativeai|genai\.|GenerativeModel|GEMINI_API_KEY|GOOGLE_AI_API_KEY`
+
+Skip `.env` / `.env.*` files (variable declarations, not logic).
+
+## Checks
+
+### Check 1: API key not hardcoded [error]
+
+**Pattern**: `(GEMINI_API_KEY|GOOGLE_AI_API_KEY|api_key)\s*=\s*["'][A-Za-z0-9\-_]{20,}["']`
+**Also check**: `genai\.configure\(\s*api_key\s*=\s*["'][^"'$\{]{10,}`
+**Presence**: forbidden
+**Message**: Hardcoded Gemini API key detected. Store keys in environment variables and access via `os.environ`.
+**Reference**: https://ai.google.dev/gemini-api/docs/api-key
+
+### Check 2: Rate limit / error handling [error]
+
+**Pattern**: `retry|backoff|sleep|ResourceExhausted|429|quota|tenacity|Retry|exponential`
+**Presence**: required
+**Message**: No rate-limit or error handling found. Gemini API enforces quota limits; unhandled ResourceExhausted errors will crash production. Add retry/backoff logic.
+**Reference**: https://ai.google.dev/gemini-api/docs/troubleshooting
+
+### Check 3: Model version pinned [warning]
+
+**Pattern**: `["'](gemini-pro|gemini-1\.5-pro|gemini-1\.5-flash|gemini-2\.0-flash|gemini-2\.5-pro|gemini-2\.5-flash)["']`
+**Presence**: forbidden (prefer versioned model names with date suffixes)
+**Message**: Unversioned Gemini model alias detected. Google may update these — pin to a specific version when available.
+**Reference**: https://ai.google.dev/gemini-api/docs/models/gemini
+
+### Check 4: Safety settings configured [warning]
+
+**Pattern**: `safety_settings|HarmCategory|HarmBlockThreshold|SafetySetting`
+**Presence**: required (warning only)
+**Message**: No safety settings configured. Gemini API provides configurable safety filters — review defaults and set explicit thresholds appropriate for your use case.
+**Reference**: https://ai.google.dev/gemini-api/docs/safety-settings
+
+## Auto-Fix Guidance
+
+- **Model pinning**: Replace unversioned aliases with the latest versioned name if known. Flag for review if uncertain.
+- **Safety settings**: If a `GenerativeModel(` or `genai.GenerativeModel(` call lacks `safety_settings`, suggest adding explicit settings. Do NOT auto-insert — safety thresholds require human judgment.
+- **Rate limiting**: Flag for human review — retry strategy depends on application needs.
+- **Hardcoded keys**: NEVER auto-fix by moving the key — flag immediately. The key may be compromised.

--- a/.claude/policies/openai.md
+++ b/.claude/policies/openai.md
@@ -1,0 +1,52 @@
+# OpenAI API Policy
+
+Policy references (calibrated against CI workflow `called-openai-policy.yml`):
+- https://openai.com/policies/usage-policies
+- https://openai.com/policies/terms-of-use
+- https://platform.openai.com/docs/guides/rate-limits
+
+## Detection
+
+Files matching ANY of these patterns trigger this policy:
+
+- `from openai|import openai|openai\.com|OpenAI\(|client\.chat\.completions|client\.completions\.create|OPENAI_API_KEY`
+
+Skip `.env` / `.env.*` files (variable declarations, not logic).
+
+## Checks
+
+### Check 1: API key not hardcoded [error]
+
+**Pattern**: `sk-[a-zA-Z0-9\-_]{20,}`
+**Presence**: forbidden
+**Also check**: `(api_key|OPENAI_API_KEY)\s*=\s*["'][^"'$\{]{10,}` (string literal assignment)
+**Message**: Hardcoded OpenAI API key detected. Store keys in environment variables and access via `os.environ` or `process.env`.
+**Reference**: https://platform.openai.com/docs/api-reference/authentication
+
+### Check 2: Rate limit / error handling [error]
+
+**Pattern**: `429|RateLimitError|rate_limit|retry|backoff|sleep|Retry|exponential|tenacity|httpx\.HTTPStatusError`
+**Presence**: required
+**Message**: No rate-limit or retry handling found. OpenAI enforces token-per-minute limits; unhandled 429s will crash production. Add retry/backoff logic.
+**Reference**: https://platform.openai.com/docs/guides/rate-limits
+
+### Check 3: Model version pinned [warning]
+
+**Pattern**: `["'](gpt-4o|gpt-4|gpt-3\.5-turbo|o1|o3|o4-mini|gpt-4-turbo)["']`
+**Presence**: forbidden (unversioned aliases)
+**Message**: Unversioned model alias detected. OpenAI silently updates these — pin to a dated version (e.g., `gpt-4o-2024-11-20`).
+**Reference**: https://platform.openai.com/docs/models
+
+### Check 4: Token limit set [error]
+
+**Pattern**: `max_tokens|max_completion_tokens`
+**Presence**: required
+**Message**: No token limit found. Without a cap, large responses can exhaust quota and cause cost spikes.
+**Reference**: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens
+
+## Auto-Fix Guidance
+
+- **Model pinning**: Replace unversioned aliases with latest dated version. Check OpenAI docs for current dated versions.
+- **Token limit**: If a `client.chat.completions.create(` call lacks `max_tokens` or `max_completion_tokens`, add `max_completion_tokens=4096` as a reasonable default.
+- **Rate limiting**: If no retry logic exists, suggest adding exponential backoff. Do NOT auto-insert — flag for human review since retry strategy depends on the application.
+- **Hardcoded keys**: NEVER auto-fix by moving the key — flag immediately. The key may already be compromised.

--- a/.claude/policies/policy-patterns.json
+++ b/.claude/policies/policy-patterns.json
@@ -1,0 +1,14 @@
+{
+  "openai": {
+    "detect": "from openai|import openai|openai\\.com|OpenAI\\(|client\\.chat\\.completions|client\\.completions\\.create|OPENAI_API_KEY",
+    "skip": "^\\.env"
+  },
+  "wikipedia": {
+    "detect": "wikipedia\\.org|mediawiki|wikimedia",
+    "skip": null
+  },
+  "gemini": {
+    "detect": "google\\.generativeai|from google.*generativeai|genai\\.|GenerativeModel|GEMINI_API_KEY|GOOGLE_AI_API_KEY",
+    "skip": "^\\.env"
+  }
+}

--- a/.claude/policies/wikipedia.md
+++ b/.claude/policies/wikipedia.md
@@ -1,0 +1,50 @@
+# Wikipedia / Wikimedia API Policy
+
+Policy references (calibrated against CI workflow `called-wikipedia-policy.yml`):
+- https://www.mediawiki.org/wiki/API:Etiquette
+- https://foundation.wikimedia.org/wiki/Policy:Terms_of_Use
+- https://www.mediawiki.org/wiki/API:REST_API
+
+## Detection
+
+Files matching ANY of these patterns trigger this policy:
+
+- `wikipedia\.org|mediawiki|wikimedia`
+
+## Checks
+
+### Check 1: User-Agent header present [error]
+
+**Pattern**: `User-Agent|user_agent|userAgent`
+**Presence**: required
+**Message**: Missing User-Agent header. Wikimedia policy requires every API request to include a descriptive User-Agent (app name + contact).
+**Reference**: https://www.mediawiki.org/wiki/API:Etiquette#The_User-Agent_header
+
+### Check 2: Rate limiting present [error]
+
+**Pattern**: `sleep|throttle|ratelimit|rate_limit|RateLimit|backoff|retry|Retry|setTimeout|asyncio\.sleep`
+**Presence**: required
+**Message**: No rate-limiting code found. Wikimedia requires respectful request pacing (e.g., sleep, backoff, retry logic).
+**Reference**: https://www.mediawiki.org/wiki/API:Etiquette#Request_limit
+
+### Check 3: Attribution [warning]
+
+**Pattern**: `CC BY-SA|attribution|wikimedia|Creative Commons|licensed under`
+**Presence**: required (warning only — attribution often lives in UI templates)
+**Message**: No attribution found in this file. Wikipedia content is CC BY-SA licensed. Verify attribution exists in UI/templates.
+**Reference**: https://creativecommons.org/licenses/by-sa/4.0/
+
+### Check 4: No raw HTML scraping [error]
+
+**Pattern (forbidden)**: `BeautifulSoup|lxml\.html|from scrapy|import scrapy|html\.parser`
+**Also check**: `requests\.(get|post)\s*\([^)]*wikipedia\.org/wiki/` and `fetch\(['"]https?://[a-z]+\.wikipedia\.org/wiki/`
+**Presence**: forbidden
+**Message**: HTML-scraping library or direct wiki URL request detected. Use the official Wikimedia REST API (`/w/api.php` or `api.wikimedia.org`) instead.
+**Reference**: https://www.mediawiki.org/wiki/API:Main_page
+
+## Auto-Fix Guidance
+
+- **User-Agent**: If a `requests.get` or `requests.Session` call targets wikipedia.org without a User-Agent, the agent can add a `headers={"User-Agent": "app-name/1.0 (contact@example.com)"}` parameter. Use the repo name as the app name placeholder.
+- **Rate limiting**: Flag for human review — retry strategy depends on the application's request pattern.
+- **Attribution**: Flag for human review — attribution belongs in UI, not necessarily in the API module.
+- **HTML scraping**: Flag for human review — requires refactoring to use the API instead.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/lint-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/policy-gate.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `policy-compliance` sub-agent and `policy-gate.sh` pre-PR hook
- Covers **OpenAI**, **Wikipedia/Wikimedia**, and **Google Gemini** API policies
- Auto-detects policy-relevant files from git diff — no per-repo config needed
- Blocks `gh pr create` if policy files are touched, agent reviews and auto-fixes

## Flow
```
gh pr create → policy-gate.sh hook fires
  → No policy files in diff? → PR proceeds
  → Policy files detected? → Hook blocks
    → policy-compliance agent runs checks
    → Auto-fixes what it can, flags the rest
    → Retry PR creation
```

## Files added
| File | Purpose |
|------|---------|
| `.claude/policies/openai.md` | OpenAI API compliance rules |
| `.claude/policies/wikipedia.md` | Wikimedia API compliance rules |
| `.claude/policies/gemini.md` | Google Gemini API compliance rules |
| `.claude/policies/policy-patterns.json` | Detection patterns for hook |
| `.claude/hooks/policy-gate.sh` | Pre-PR policy gate (exit 2 on match) |
| `.claude/agents/policy-compliance.md` | Single agent for all policies |

**Extensible**: add a new policy by dropping a `.md` file + one JSON entry.

Inherited from org `.github` meta-repo pattern (see wcmchenry3-stack/.github#32, #36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)