### PR TITLE
fix(docs): update privacy policy to disclose Sentry

### DIFF
--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -13,16 +13,16 @@
 </head>
 <body>
   <h1>Privacy Policy</h1>
-  <p><strong>Gaming App</strong> — Last updated: March 28, 2026</p>
+  <p><strong>Gaming App</strong> — Last updated: April 3, 2026</p>
 
   <h2>Overview</h2>
-  <p>Gaming App is a collection of classic and casual games including Yacht, Cascade, Blackjack, and Ludo. Your privacy is important to us. This policy explains what data the app does and does not collect.</p>
+  <p>Gaming App is a collection of classic and casual games including Yacht, Blackjack, 2048, Cascade, and Ludo. Your privacy is important to us. This policy explains what data the app does and does not collect.</p>
 
   <h2>Data We Do Not Collect</h2>
   <ul>
     <li>We do not collect personal information (name, email, phone number, etc.).</li>
     <li>We do not require user accounts or registration.</li>
-    <li>We do not use analytics, advertising, or tracking services.</li>
+    <li>We do not use advertising or tracking services.</li>
     <li>We do not use cookies or device identifiers for tracking.</li>
   </ul>
 
@@ -32,8 +32,17 @@
   <h2>Network Requests</h2>
   <p>The app communicates with our game server to process game logic (dice rolls, card dealing, move validation, etc.). These requests contain only game-state information and no personal data. No data from these requests is stored on our servers beyond the duration of a game session.</p>
 
+  <h2>Error Reporting</h2>
+  <p>The app uses <strong>Sentry</strong> (<a href="https://sentry.io/privacy/">sentry.io</a>) for crash reporting and error monitoring. When an error occurs, Sentry may receive:</p>
+  <ul>
+    <li>Error messages and stack traces</li>
+    <li>Device type, operating system version, and app version</li>
+    <li>An anonymized session identifier</li>
+  </ul>
+  <p>Sentry does <strong>not</strong> receive your name, email, gameplay data, or any other personal information. This data is used solely to identify and fix bugs. Sentry retains error data for 90 days.</p>
+
   <h2>Third-Party Services</h2>
-  <p>The app does not share data with any third parties.</p>
+  <p>Other than Sentry for error reporting (described above), the app does not share data with any third parties.</p>
 
   <h2>Children's Privacy</h2>
   <p>The app does not knowingly collect any personal information from children or any other users.</p>


### PR DESCRIPTION
## Summary
- Adds **Error Reporting** section disclosing Sentry usage (what data it receives, what it doesn't, 90-day retention)
- Updates **Third-Party Services** to reference Sentry instead of claiming no third parties
- Removes false "no analytics" claim (kept "no advertising or tracking")
- Adds 2048 to the game list, updates date

Closes #143

## Test plan
- [ ] Open `docs/privacy-policy.html` in a browser and verify it renders correctly
- [ ] Verify Sentry disclosure matches actual SDK config in `backend/main.py` and `frontend/App.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)