### PR TITLE
fix(cascade): improve fruit drop UX with aim-then-release gesture

### DIFF
--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -213,17 +213,21 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       );
     }
 
+    const panGesture = Gesture.Pan()
+      .runOnJS(true)
+      .minDistance(0)
+      .onBegin((e) => setPointerX(e.x))
+      .onChange((e) => setPointerX(e.x))
+      .onEnd((e) => {
+        if (pointerX !== null) onTap(e.x);
+      })
+      .onFinalize(() => setPointerX(null));
     const tapGesture = Gesture.Tap()
       .runOnJS(true)
       .onEnd((e, ok) => {
         if (ok) onTap(e.x);
       });
-    const panGesture = Gesture.Pan()
-      .runOnJS(true)
-      .onBegin((e) => setPointerX(e.x))
-      .onChange((e) => setPointerX(e.x))
-      .onFinalize(() => setPointerX(null));
-    const composed = Gesture.Simultaneous(tapGesture, panGesture);
+    const composed = Gesture.Exclusive(panGesture, tapGesture);
 
     return (
       <GestureDetector gesture={composed}>
@@ -252,10 +256,16 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             <DashPathEffect intervals={[6, 4]} phase={0} />
           </Path>
           {ghostCx !== null && guidePath !== null && (
-            <Group opacity={0.4}>
-              <Path path={guidePath} color="rgba(255,255,255,0.12)" style="stroke" strokeWidth={1}>
+            <Group opacity={0.7}>
+              <Path path={guidePath} color="rgba(255,255,255,0.25)" style="stroke" strokeWidth={1.5}>
                 <DashPathEffect intervals={[4, 6]} phase={0} />
               </Path>
+              <Circle
+                cx={ghostCx + 2}
+                cy={DROP_Y + 3}
+                r={nextDef.radius + 1}
+                color="rgba(0,0,0,0.25)"
+              />
               <FruitBodySkia
                 x={ghostCx}
                 y={DROP_Y}

--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -257,7 +257,12 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           </Path>
           {ghostCx !== null && guidePath !== null && (
             <Group opacity={0.7}>
-              <Path path={guidePath} color="rgba(255,255,255,0.25)" style="stroke" strokeWidth={1.5}>
+              <Path
+                path={guidePath}
+                color="rgba(255,255,255,0.25)"
+                style="stroke"
+                strokeWidth={1.5}
+              >
                 <DashPathEffect intervals={[4, 6]} phase={0} />
               </Path>
               <Circle

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -178,14 +178,19 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           width - WALL_THICKNESS - nd.radius
         );
         ctx.save();
-        ctx.globalAlpha = 0.4;
-        ctx.strokeStyle = "rgba(255,255,255,0.12)";
-        ctx.lineWidth = 1;
+        ctx.globalAlpha = 0.7;
+        ctx.strokeStyle = "rgba(255,255,255,0.25)";
+        ctx.lineWidth = 1.5;
         ctx.setLineDash([4, 6]);
         ctx.beginPath();
         ctx.moveTo(ghostCx, dangerY);
         ctx.lineTo(ghostCx, height - WALL_THICKNESS);
         ctx.stroke();
+        // Drop shadow
+        ctx.fillStyle = "rgba(0,0,0,0.25)";
+        ctx.beginPath();
+        ctx.arc(ghostCx + 2, DROP_Y + 3, nd.radius + 1, 0, Math.PI * 2);
+        ctx.fill();
         drawFruitBody(
           ctx,
           nd,
@@ -279,23 +284,27 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       [initEngine, width]
     );
 
-    const tapGesture = Gesture.Tap()
-      .runOnJS(true)
-      .onEnd((e, ok) => {
-        if (ok) onTap(e.x);
-      });
     const panGesture = Gesture.Pan()
       .runOnJS(true)
+      .minDistance(0)
       .onBegin((e) => {
         pointerXRef.current = e.x;
       })
       .onChange((e) => {
         pointerXRef.current = e.x;
       })
+      .onEnd((e) => {
+        if (pointerXRef.current !== null) onTap(e.x);
+      })
       .onFinalize(() => {
         pointerXRef.current = null;
       });
-    const composed = Gesture.Simultaneous(tapGesture, panGesture);
+    const tapGesture = Gesture.Tap()
+      .runOnJS(true)
+      .onEnd((e, ok) => {
+        if (ok) onTap(e.x);
+      });
+    const composed = Gesture.Exclusive(panGesture, tapGesture);
 
     return (
       <GestureDetector gesture={composed}>

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -84,7 +84,7 @@ function CascadeGame({ navigation }: Props) {
 
       setTimeout(() => {
         droppingRef.current = false;
-      }, 400);
+      }, 200);
     },
     [gameOver, activeFruitSet]
   );

--- a/frontend/src/screens/__tests__/CascadeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/CascadeScreen.test.tsx
@@ -4,7 +4,7 @@
  * GameCanvas (which uses HTMLCanvas + Matter.js) is mocked out entirely.
  * We focus on the state and ref logic in CascadeGame:
  *   - score starts at 0
- *   - handleTap cooldown blocks double-drops within 400ms
+ *   - handleTap cooldown blocks double-drops within 200ms
  *   - handleTap is blocked when game is over
  *   - handleRestart resets score and calls canvas.reset
  */
@@ -124,7 +124,7 @@ describe("CascadeGame", () => {
     expect(mockDrop).toHaveBeenCalledTimes(1);
   });
 
-  it("second tap within 400ms cooldown is ignored", () => {
+  it("second tap within 200ms cooldown is ignored", () => {
     const renderer = renderScreen();
     const canvas = findCanvas(renderer);
 
@@ -136,7 +136,7 @@ describe("CascadeGame", () => {
     expect(mockDrop).toHaveBeenCalledTimes(1);
   });
 
-  it("tap succeeds again after the 400ms cooldown expires", () => {
+  it("tap succeeds again after the 200ms cooldown expires", () => {
     const renderer = renderScreen();
     const canvas = findCanvas(renderer);
 
@@ -144,7 +144,7 @@ describe("CascadeGame", () => {
       canvas.props.__onTap(150);
     });
     act(() => {
-      jest.advanceTimersByTime(401);
+      jest.advanceTimersByTime(201);
     });
     act(() => {
       canvas.props.__onTap(150);


### PR DESCRIPTION
## Summary
- Replace `Gesture.Simultaneous(tap, pan)` with `Gesture.Exclusive(pan, tap)` — pan-to-aim-then-release is now primary, quick-tap is fallback. Eliminates tap-vs-pan ambiguity causing accidental drops.
- Increase ghost preview opacity (`0.4` → `0.7`), add drop shadow beneath ghost fruit, brighten guide line
- Reduce drop cooldown from `400ms` → `200ms` for snappier feel

Closes #120

## Test plan
- [ ] Web: drag to position → release to drop works reliably
- [ ] Web: quick tap still drops immediately
- [ ] Ghost preview is clearly visible with drop shadow
- [ ] Guide line is bright and easy to follow
- [ ] No double-drops occur with rapid interaction
- [ ] CI passes (lint, type check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)