### PR TITLE
fix(cascade): port fruit rendering and collision fixes to mobile

### DIFF
--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -67,7 +67,6 @@ function FruitBodySkia({
   color,
   image,
   angle,
-  bgColor,
   sprite,
 }: {
   x: number;
@@ -76,7 +75,6 @@ function FruitBodySkia({
   color: string;
   image: SkImage | null;
   angle: number;
-  bgColor: string;
   sprite: SpriteInfo | null;
 }) {
   if (image) {
@@ -102,11 +100,14 @@ function FruitBodySkia({
       ih = radius * 2;
     }
 
+    // Sprite is drawn clipped to the fruit's circle. No opaque background fill:
+    // on web the sprite edges are hard-thresholded via cleanImage(), but on mobile
+    // we keep the raw alpha so sprite edges blend naturally with whatever is
+    // behind (canvas background or adjacent fruits). Filling a bg circle here
+    // would obscure adjacent fruits with a dark ring where sprite alpha fades.
     return (
       <Group transform={[{ translateX: x }, { translateY: y }, { rotate: angle }]}>
         <Group clip={clipPath} invertClip={false}>
-          {/* Opaque background fill — anything transparent in the sprite shows this */}
-          <Circle cx={0} cy={0} r={radius} color={bgColor} />
           <SkiaImage image={image} x={ix} y={iy} width={iw} height={ih} fit="fill" />
         </Group>
       </Group>
@@ -324,7 +325,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                 color={nextDef.color}
                 image={images[nextDef.tier] ?? null}
                 angle={0}
-                bgColor={colors.fruitBackground}
                 sprite={spriteInfoByTier[nextDef.tier] ?? null}
               />
             </Group>
@@ -341,7 +341,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                 color={def.color}
                 image={images[body.tier] ?? null}
                 angle={body.angle}
-                bgColor={colors.fruitBackground}
                 sprite={spriteInfoByTier[body.tier] ?? null}
               />
             );


### PR DESCRIPTION
## Summary

Fixes the mobile Cascade game to render fruit sprites and collision boundaries that match the web version (closes #149).

Previously, all the fruit rendering fixes only touched the web code paths (`.web.tsx` / `engine.ts` via Rapier). Mobile's `.native.ts` + Skia renderer was untouched and still used plain circles with no sprite clipping or boundary-escape handling.

### engine.native.ts (Matter.js physics)
- Switched from `Matter.Bodies.circle` to `Matter.Bodies.fromVertices`, using the same convex-hull vertex data (`fruit-vertices.json`) the web Rapier engine uses. Falls back to a circle if vertex data is unavailable.
- Ported the boundary-escape detection loop from `engine.ts` — fruits that leave the play area are removed and reported via the new `onBoundaryEscape` callback.

### GameCanvas.tsx (Skia renderer)
- Sprites are now clipped to the fruit's circular boundary via a Skia clip path.
- Sprite image is positioned using the `spriteOffset` / `spriteScale` metadata from `fruit-vertices.json`, matching the web renderer's alignment.
- Added Sentry logging for boundary escape events, matching the web Sentry integration.
- **No opaque background fill behind the sprite.** The web clears sprite edges with `cleanImage()` (alpha-threshold), but on mobile the raw PNG alpha is kept, so a bg Circle would reveal a dark ring at every fruit-to-fruit contact point. Dropping the bg lets sprite edges blend naturally with whatever's behind (canvas background for a lone fruit, adjacent fruit where they touch).

## Test plan

- [ ] Run the mobile app (iOS / Android) and verify fruits render as sprite images (not plain circles)
- [ ] Verify collision shapes match each sprite's silhouette (watch how e.g. the dragonfruit stacks against its neighbors)
- [ ] Verify no dark ring of background color appears around fruits where they touch
- [ ] Verify a fruit that somehow escapes the play area is removed and a Sentry warning is logged
- [ ] Confirm web build still renders correctly (no regression in `engine.ts` / `GameCanvas.web.tsx`)
- [ ] `python -m pytest backend/tests/ -v`

https://claude.ai/code/session_016Tys9nWaRQayeL7euSpMu5