### PR TITLE
refactor(api): rename Yacht endpoints /game/* → /yacht/*

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,8 +45,7 @@ if _sentry_dsn:
 # ---------------------------------------------------------------------------
 
 app = FastAPI(title="Gaming App API")
-# Yacht still uses /game/* prefix for backwards compat — rename tracked in #161.
-app.include_router(yacht_router, prefix="/game")
+app.include_router(yacht_router, prefix="/yacht")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
 app.include_router(ludo_router, prefix="/ludo")

--- a/backend/perf/check_thresholds.py
+++ b/backend/perf/check_thresholds.py
@@ -21,11 +21,11 @@ from pathlib import Path
 # Order matters: more specific patterns first.
 ENDPOINT_TO_SCENARIO: list[tuple[str, str]] = [
     ("/cascade/", "leaderboard"),
-    ("/game/new", "game_flow"),
-    ("/game/roll", "game_flow"),
-    ("/game/score", "game_flow"),
-    ("/game/state", "stateless_reads"),
-    ("/game/possible-scores", "stateless_reads"),
+    ("/yacht/new", "game_flow"),
+    ("/yacht/roll", "game_flow"),
+    ("/yacht/score", "game_flow"),
+    ("/yacht/state", "stateless_reads"),
+    ("/yacht/possible-scores", "stateless_reads"),
 ]
 
 

--- a/backend/perf/scenarios/game_flow.py
+++ b/backend/perf/scenarios/game_flow.py
@@ -38,7 +38,7 @@ class GameFlowTasks(SequentialTaskSet):
 
     @task
     def new_game(self):
-        with self.client.post("/game/new", headers=self._headers, name="POST /game/new") as resp:
+        with self.client.post("/yacht/new", headers=self._headers, name="POST /yacht/new") as resp:
             resp.raise_for_status()
         self._round = 0
 
@@ -97,7 +97,7 @@ class GameFlowTasks(SequentialTaskSet):
     @task
     def verify_game_over(self):
         with self.client.get(
-            "/game/state", headers=self._headers, name="GET /game/state (final)"
+            "/yacht/state", headers=self._headers, name="GET /yacht/state (final)"
         ) as resp:
             resp.raise_for_status()
             data = resp.json()
@@ -109,24 +109,24 @@ class GameFlowTasks(SequentialTaskSet):
         held = [False, False, False, False, False]
 
         with self.client.post(
-            "/game/roll",
+            "/yacht/roll",
             json={"held": held},
             headers=self._headers,
-            name="POST /game/roll",
+            name="POST /yacht/roll",
         ) as resp:
             resp.raise_for_status()
 
         with self.client.get(
-            "/game/possible-scores",
+            "/yacht/possible-scores",
             headers=self._headers,
-            name="GET /game/possible-scores",
+            name="GET /yacht/possible-scores",
         ) as resp:
             resp.raise_for_status()
 
         with self.client.post(
-            "/game/score",
+            "/yacht/score",
             json={"category": CATEGORIES[round_index]},
             headers=self._headers,
-            name="POST /game/score",
+            name="POST /yacht/score",
         ) as resp:
             resp.raise_for_status()

--- a/backend/perf/scenarios/rate_limit_test.py
+++ b/backend/perf/scenarios/rate_limit_test.py
@@ -5,7 +5,7 @@ Intentionally hammers endpoints to verify 429 responses fire correctly
 and include the required Retry-After header.
 
 Usage:
-  # Verify 429 fires on /game/new (10/minute limit):
+  # Verify 429 fires on /yacht/new (10/minute limit):
   locust -f perf/locustfile.py --headless --users 1 --spawn-rate 1 \
          --run-time 30s --host http://localhost:8000 RateLimitVerifyUser
 
@@ -28,13 +28,13 @@ class RateLimitTasks(SequentialTaskSet):
 
     @task
     def exhaust_new_game_limit(self):
-        """POST /game/new 12 times; the 11th or 12th must return 429."""
+        """POST /yacht/new 12 times; the 11th or 12th must return 429."""
         hit_429 = False
         for _ in range(12):
             with self.client.post(
-                "/game/new",
+                "/yacht/new",
                 headers=self._headers,
-                name="POST /game/new (rate test)",
+                name="POST /yacht/new (rate test)",
                 catch_response=True,
             ) as resp:
                 if resp.status_code == 429:

--- a/backend/perf/scenarios/stateless_reads.py
+++ b/backend/perf/scenarios/stateless_reads.py
@@ -22,7 +22,9 @@ class StatelessReadTasks(TaskSet):
 
     @task(3)
     def get_state(self):
-        with self.client.get("/yacht/state", headers=self._headers, name="GET /yacht/state") as resp:
+        with self.client.get(
+            "/yacht/state", headers=self._headers, name="GET /yacht/state"
+        ) as resp:
             resp.raise_for_status()
 
     @task(1)

--- a/backend/perf/scenarios/stateless_reads.py
+++ b/backend/perf/scenarios/stateless_reads.py
@@ -5,7 +5,7 @@ Simulates a client keeping the tab open and polling for game state.
 These endpoints should be the fastest in the system — they establish
 the latency floor for SLO calibration.
 
-Requires an active game: run after POST /game/new.
+Requires an active game: run after POST /yacht/new.
 """
 
 import uuid
@@ -18,19 +18,19 @@ class StatelessReadTasks(TaskSet):
         """Ensure a game exists before polling."""
         self._session_id = str(uuid.uuid4())
         self._headers = {"X-Session-ID": self._session_id}
-        self.client.post("/game/new", headers=self._headers, name="POST /game/new (setup)")
+        self.client.post("/yacht/new", headers=self._headers, name="POST /yacht/new (setup)")
 
     @task(3)
     def get_state(self):
-        with self.client.get("/game/state", headers=self._headers, name="GET /game/state") as resp:
+        with self.client.get("/yacht/state", headers=self._headers, name="GET /yacht/state") as resp:
             resp.raise_for_status()
 
     @task(1)
     def get_possible_scores(self):
         # possible-scores returns empty dict before rolling — that's valid (200)
         with self.client.get(
-            "/game/possible-scores",
+            "/yacht/possible-scores",
             headers=self._headers,
-            name="GET /game/possible-scores",
+            name="GET /yacht/possible-scores",
         ) as resp:
             resp.raise_for_status()

--- a/backend/perf/thresholds.json
+++ b/backend/perf/thresholds.json
@@ -7,11 +7,11 @@
       "p95_ms": 500,
       "error_rate_pct": 0.0,
       "endpoints": [
-        "POST /game/new",
-        "POST /game/roll",
-        "GET /game/possible-scores",
-        "POST /game/score",
-        "GET /game/state (final)"
+        "POST /yacht/new",
+        "POST /yacht/roll",
+        "GET /yacht/possible-scores",
+        "POST /yacht/score",
+        "GET /yacht/state (final)"
       ]
     },
     "leaderboard": {
@@ -30,8 +30,8 @@
       "p95_ms": 200,
       "error_rate_pct": 0.0,
       "endpoints": [
-        "GET /game/state",
-        "GET /game/possible-scores"
+        "GET /yacht/state",
+        "GET /yacht/possible-scores"
       ]
     }
   }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -21,7 +21,7 @@ def reset_game():
 
 
 def _new_game() -> dict:
-    res = client.post("/game/new", headers=SESSION_HEADERS)
+    res = client.post("/yacht/new", headers=SESSION_HEADERS)
     assert res.status_code == 200
     return res.json()
 
@@ -29,16 +29,16 @@ def _new_game() -> dict:
 def _roll(held: list[bool] = None) -> dict:
     if held is None:
         held = [False] * 5
-    res = client.post("/game/roll", json={"held": held}, headers=SESSION_HEADERS)
+    res = client.post("/yacht/roll", json={"held": held}, headers=SESSION_HEADERS)
     return res
 
 
 def _score(category: str) -> dict:
-    return client.post("/game/score", json={"category": category}, headers=SESSION_HEADERS)
+    return client.post("/yacht/score", json={"category": category}, headers=SESSION_HEADERS)
 
 
 # ---------------------------------------------------------------------------
-# POST /game/new
+# POST /yacht/new
 # ---------------------------------------------------------------------------
 
 
@@ -64,33 +64,33 @@ class TestNewGame:
         assert state["scores"]["chance"] is None
 
     def test_400_missing_session_id(self):
-        res = client.post("/game/new")
+        res = client.post("/yacht/new")
         assert res.status_code == 400
 
     def test_400_invalid_session_id(self):
-        res = client.post("/game/new", headers={"X-Session-ID": "not-a-uuid"})
+        res = client.post("/yacht/new", headers={"X-Session-ID": "not-a-uuid"})
         assert res.status_code == 400
 
 
 # ---------------------------------------------------------------------------
-# GET /game/state
+# GET /yacht/state
 # ---------------------------------------------------------------------------
 
 
 class TestGetState:
     def test_404_without_game(self):
-        res = client.get("/game/state", headers=SESSION_HEADERS)
+        res = client.get("/yacht/state", headers=SESSION_HEADERS)
         assert res.status_code == 404
 
     def test_returns_current_state(self):
         _new_game()
-        res = client.get("/game/state", headers=SESSION_HEADERS)
+        res = client.get("/yacht/state", headers=SESSION_HEADERS)
         assert res.status_code == 200
         assert res.json()["round"] == 1
 
 
 # ---------------------------------------------------------------------------
-# POST /game/roll
+# POST /yacht/roll
 # ---------------------------------------------------------------------------
 
 
@@ -109,7 +109,7 @@ class TestRoll:
 
     def test_invalid_held_length(self):
         _new_game()
-        res = client.post("/game/roll", json={"held": [False, False]}, headers=SESSION_HEADERS)
+        res = client.post("/yacht/roll", json={"held": [False, False]}, headers=SESSION_HEADERS)
         assert res.status_code == 422
 
     def test_400_after_three_rolls(self):
@@ -130,7 +130,7 @@ class TestRoll:
 
 
 # ---------------------------------------------------------------------------
-# POST /game/score
+# POST /yacht/score
 # ---------------------------------------------------------------------------
 
 
@@ -195,30 +195,30 @@ class TestScore:
         for cat in categories:
             _roll()
             _score(cat)
-        state = client.get("/game/state", headers=SESSION_HEADERS).json()
+        state = client.get("/yacht/state", headers=SESSION_HEADERS).json()
         assert state["game_over"] is True
 
 
 # ---------------------------------------------------------------------------
-# GET /game/possible-scores
+# GET /yacht/possible-scores
 # ---------------------------------------------------------------------------
 
 
 class TestPossibleScores:
     def test_404_without_game(self):
-        res = client.get("/game/possible-scores", headers=SESSION_HEADERS)
+        res = client.get("/yacht/possible-scores", headers=SESSION_HEADERS)
         assert res.status_code == 404
 
     def test_empty_before_rolling(self):
         _new_game()
-        res = client.get("/game/possible-scores", headers=SESSION_HEADERS)
+        res = client.get("/yacht/possible-scores", headers=SESSION_HEADERS)
         assert res.status_code == 200
         assert res.json()["possible_scores"] == {}
 
     def test_returns_scores_after_roll(self):
         _new_game()
         _roll()
-        res = client.get("/game/possible-scores", headers=SESSION_HEADERS)
+        res = client.get("/yacht/possible-scores", headers=SESSION_HEADERS)
         assert res.status_code == 200
         ps = res.json()["possible_scores"]
         assert len(ps) == 13
@@ -228,7 +228,7 @@ class TestPossibleScores:
         _roll()
         _score("chance")
         _roll()
-        ps = client.get("/game/possible-scores", headers=SESSION_HEADERS).json()["possible_scores"]
+        ps = client.get("/yacht/possible-scores", headers=SESSION_HEADERS).json()["possible_scores"]
         assert "chance" not in ps
         assert len(ps) == 12
 
@@ -242,14 +242,14 @@ class TestSessionIsolation:
     def test_two_sessions_are_independent(self):
         sid1 = str(uuid.uuid4())
         sid2 = str(uuid.uuid4())
-        client.post("/game/new", headers={"X-Session-ID": sid1})
-        client.post("/game/new", headers={"X-Session-ID": sid2})
+        client.post("/yacht/new", headers={"X-Session-ID": sid1})
+        client.post("/yacht/new", headers={"X-Session-ID": sid2})
         client.post(
-            "/game/roll",
+            "/yacht/roll",
             json={"held": [False] * 5},
             headers={"X-Session-ID": sid1},
         )
-        state2 = client.get("/game/state", headers={"X-Session-ID": sid2}).json()
+        state2 = client.get("/yacht/state", headers={"X-Session-ID": sid2}).json()
         assert state2["rolls_used"] == 0
 
     def test_session_lru_eviction(self):
@@ -259,7 +259,7 @@ class TestSessionIsolation:
         # Patch _MAX_SESSIONS to 3 so we can trigger eviction without rate limit
         with mock.patch.object(m, "_MAX_SESSIONS", 3):
             for _ in range(4):
-                client.post("/game/new", headers={"X-Session-ID": str(uuid.uuid4())})
+                client.post("/yacht/new", headers={"X-Session-ID": str(uuid.uuid4())})
         assert len(m._sessions) <= 3
 
     def test_evicted_session_returns_404(self):
@@ -267,9 +267,9 @@ class TestSessionIsolation:
         import unittest.mock as mock
 
         first_sid = str(uuid.uuid4())
-        client.post("/game/new", headers={"X-Session-ID": first_sid})
+        client.post("/yacht/new", headers={"X-Session-ID": first_sid})
         with mock.patch.object(m, "_MAX_SESSIONS", 3):
             for _ in range(3):
-                client.post("/game/new", headers={"X-Session-ID": str(uuid.uuid4())})
-        res = client.get("/game/state", headers={"X-Session-ID": first_sid})
+                client.post("/yacht/new", headers={"X-Session-ID": str(uuid.uuid4())})
+        res = client.get("/yacht/state", headers={"X-Session-ID": first_sid})
         assert res.status_code == 404

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -46,13 +46,13 @@ def _sid() -> str:
 
 
 def _new_game(client, session_id):
-    return client.post("/game/new", headers={"X-Session-ID": session_id})
+    return client.post("/yacht/new", headers={"X-Session-ID": session_id})
 
 
 def _roll(client, session_id, held=None):
     if held is None:
         held = [False] * 5
-    return client.post("/game/roll", json={"held": held}, headers={"X-Session-ID": session_id})
+    return client.post("/yacht/roll", json={"held": held}, headers={"X-Session-ID": session_id})
 
 
 # ---------------------------------------------------------------------------
@@ -64,7 +64,7 @@ def _roll(client, session_id, held=None):
 def test_security_headers_present(client_default):
     sid = _sid()
     _new_game(client_default, sid)
-    res = client_default.get("/game/state", headers={"X-Session-ID": sid})
+    res = client_default.get("/yacht/state", headers={"X-Session-ID": sid})
     assert res.headers.get("x-content-type-options") == "nosniff"
     assert res.headers.get("x-frame-options") == "DENY"
     assert res.headers.get("referrer-policy") == "strict-origin-when-cross-origin"
@@ -74,7 +74,7 @@ def test_security_headers_present(client_default):
 def test_csp_header_present_on_get(client_default):
     sid = _sid()
     _new_game(client_default, sid)
-    res = client_default.get("/game/state", headers={"X-Session-ID": sid})
+    res = client_default.get("/yacht/state", headers={"X-Session-ID": sid})
     csp = res.headers.get("content-security-policy", "")
     assert "default-src 'none'" in csp
     assert "frame-ancestors 'none'" in csp
@@ -92,7 +92,7 @@ def test_csp_header_present_on_post(client_default):
 def test_server_header_suppressed(client_default):
     sid = _sid()
     _new_game(client_default, sid)
-    res = client_default.get("/game/state", headers={"X-Session-ID": sid})
+    res = client_default.get("/yacht/state", headers={"X-Session-ID": sid})
     assert "server" not in res.headers
 
 
@@ -106,7 +106,7 @@ def test_cors_allowed_origin_localhost(client_default):
     sid = _sid()
     _new_game(client_default, sid)
     res = client_default.get(
-        "/game/state",
+        "/yacht/state",
         headers={"Origin": "http://localhost:8081", "X-Session-ID": sid},
     )
     assert res.headers.get("access-control-allow-origin") == "http://localhost:8081"
@@ -117,7 +117,7 @@ def test_cors_blocked_unknown_origin(client_default):
     sid = _sid()
     _new_game(client_default, sid)
     res = client_default.get(
-        "/game/state",
+        "/yacht/state",
         headers={"Origin": "https://evil.example.com", "X-Session-ID": sid},
     )
     assert "access-control-allow-origin" not in res.headers
@@ -128,7 +128,7 @@ def test_cors_prod_allows_frontend(client_prod):
     sid = _sid()
     _new_game(client_prod, sid)
     res = client_prod.get(
-        "/game/state",
+        "/yacht/state",
         headers={
             "Origin": "https://dev-games.buffingchi.com",
             "X-Session-ID": sid,
@@ -142,7 +142,7 @@ def test_cors_prod_blocks_localhost(client_prod):
     sid = _sid()
     _new_game(client_prod, sid)
     res = client_prod.get(
-        "/game/state",
+        "/yacht/state",
         headers={"Origin": "http://localhost:8081", "X-Session-ID": sid},
     )
     assert "access-control-allow-origin" not in res.headers
@@ -156,7 +156,7 @@ def test_cors_prod_blocks_localhost(client_prod):
 @pytest.mark.security
 def test_cors_post_new_game_allowed_origin(client_default):
     res = client_default.post(
-        "/game/new",
+        "/yacht/new",
         headers={"Origin": "http://localhost:8081", "X-Session-ID": _sid()},
     )
     assert res.headers.get("access-control-allow-origin") == "http://localhost:8081"
@@ -165,7 +165,7 @@ def test_cors_post_new_game_allowed_origin(client_default):
 @pytest.mark.security
 def test_cors_post_new_game_blocked_origin(client_default):
     res = client_default.post(
-        "/game/new",
+        "/yacht/new",
         headers={"Origin": "https://evil.example.com", "X-Session-ID": _sid()},
     )
     assert "access-control-allow-origin" not in res.headers
@@ -178,7 +178,7 @@ def test_cors_post_roll_allowed(client_default):
     _roll(client_default, sid)
     # Add Origin for this check
     res2 = client_default.post(
-        "/game/roll",
+        "/yacht/roll",
         json={"held": [False] * 5},
         headers={"Origin": "http://localhost:8081", "X-Session-ID": sid},
     )
@@ -191,7 +191,7 @@ def test_cors_post_score_allowed(client_default):
     _new_game(client_default, sid)
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score",
+        "/yacht/score",
         json={"category": "chance"},
         headers={"Origin": "http://localhost:8081", "X-Session-ID": sid},
     )
@@ -206,7 +206,7 @@ def test_cors_post_score_allowed(client_default):
 @pytest.mark.security
 def test_cors_preflight_allowed_origin(client_default):
     res = client_default.options(
-        "/game/new",
+        "/yacht/new",
         headers={
             "Origin": "http://localhost:8081",
             "Access-Control-Request-Method": "POST",
@@ -220,7 +220,7 @@ def test_cors_preflight_allowed_origin(client_default):
 @pytest.mark.security
 def test_cors_preflight_blocked_origin(client_default):
     res = client_default.options(
-        "/game/new",
+        "/yacht/new",
         headers={
             "Origin": "https://attacker.example.com",
             "Access-Control-Request-Method": "POST",
@@ -234,7 +234,7 @@ def test_cors_null_origin_blocked(client_default):
     sid = _sid()
     _new_game(client_default, sid)
     res = client_default.get(
-        "/game/state",
+        "/yacht/state",
         headers={"Origin": "null", "X-Session-ID": sid},
     )
     assert "access-control-allow-origin" not in res.headers
@@ -251,7 +251,7 @@ def test_unknown_category_error_is_fixed_string(client_default):
     _new_game(client_default, sid)
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score",
+        "/yacht/score",
         json={"category": "bogus_xyz_123"},
         headers={"X-Session-ID": sid},
     )
@@ -267,7 +267,7 @@ def test_xss_payload_not_reflected_in_error(client_default):
     _new_game(client_default, sid)
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score",
+        "/yacht/score",
         json={"category": payload},
         headers={"X-Session-ID": sid},
     )
@@ -280,10 +280,10 @@ def test_duplicate_category_error_is_fixed_string(client_default):
     sid = _sid()
     _new_game(client_default, sid)
     _roll(client_default, sid)
-    client_default.post("/game/score", json={"category": "chance"}, headers={"X-Session-ID": sid})
+    client_default.post("/yacht/score", json={"category": "chance"}, headers={"X-Session-ID": sid})
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score", json={"category": "chance"}, headers={"X-Session-ID": sid}
+        "/yacht/score", json={"category": "chance"}, headers={"X-Session-ID": sid}
     )
     assert res.status_code == 400
     assert "already scored" in res.json()["detail"]
@@ -299,7 +299,7 @@ def test_duplicate_category_error_is_fixed_string(client_default):
 def test_oversized_body_returns_413(client_default):
     sid = _sid()
     res = client_default.post(
-        "/game/score",
+        "/yacht/score",
         content=b"x" * 2000,
         headers={
             "Content-Type": "application/json",
@@ -316,7 +316,7 @@ def test_normal_body_not_rejected(client_default):
     _new_game(client_default, sid)
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score", json={"category": "chance"}, headers={"X-Session-ID": sid}
+        "/yacht/score", json={"category": "chance"}, headers={"X-Session-ID": sid}
     )
     assert res.status_code == 200
 
@@ -328,9 +328,9 @@ def test_normal_body_not_rejected(client_default):
 
 @pytest.mark.security
 def test_rate_limit_returns_429_after_threshold(client_default):
-    """POST /game/new has a 10/minute limit; 11th request must be 429."""
+    """POST /yacht/new has a 10/minute limit; 11th request must be 429."""
     responses = [
-        client_default.post("/game/new", headers={"X-Session-ID": _sid()}) for _ in range(11)
+        client_default.post("/yacht/new", headers={"X-Session-ID": _sid()}) for _ in range(11)
     ]
     assert any(r.status_code == 429 for r in responses)
 
@@ -339,7 +339,7 @@ def test_rate_limit_returns_429_after_threshold(client_default):
 def test_rate_limit_429_has_retry_after(client_default):
     """429 responses must include Retry-After header."""
     responses = [
-        client_default.post("/game/new", headers={"X-Session-ID": _sid()}) for _ in range(11)
+        client_default.post("/yacht/new", headers={"X-Session-ID": _sid()}) for _ in range(11)
     ]
     rate_limited = [r for r in responses if r.status_code == 429]
     assert rate_limited, "Expected at least one 429"
@@ -367,13 +367,13 @@ def test_cascade_score_strict_limit(client_default):
 
 @pytest.mark.security
 def test_missing_session_id_returns_400(client_default):
-    res = client_default.post("/game/new")
+    res = client_default.post("/yacht/new")
     assert res.status_code == 400
 
 
 @pytest.mark.security
 def test_invalid_uuid_session_id_returns_400(client_default):
-    res = client_default.post("/game/new", headers={"X-Session-ID": "not-a-uuid"})
+    res = client_default.post("/yacht/new", headers={"X-Session-ID": "not-a-uuid"})
     assert res.status_code == 400
 
 
@@ -383,7 +383,7 @@ def test_two_sessions_are_isolated(client_default):
     _new_game(client_default, sid1)
     _new_game(client_default, sid2)
     _roll(client_default, sid1)
-    state2 = client_default.get("/game/state", headers={"X-Session-ID": sid2}).json()
+    state2 = client_default.get("/yacht/state", headers={"X-Session-ID": sid2}).json()
     assert state2["rolls_used"] == 0
 
 
@@ -408,7 +408,7 @@ def test_score_category_fuzz_never_500(client_default, category):
     _new_game(client_default, sid)
     _roll(client_default, sid)
     res = client_default.post(
-        "/game/score",
+        "/yacht/score",
         json={"category": category},
         headers={"X-Session-ID": sid},
     )
@@ -430,7 +430,7 @@ def test_roll_held_fuzz_never_500(client_default, held):
     sid = _sid()
     _new_game(client_default, sid)
     res = client_default.post(
-        "/game/roll",
+        "/yacht/roll",
         json={"held": held},
         headers={"X-Session-ID": sid},
     )

--- a/backend/tests/test_simulation.py
+++ b/backend/tests/test_simulation.py
@@ -174,14 +174,14 @@ class TestAPISimulation:
 
     def _new(self) -> dict:
         self._rl_reset()
-        res = client.post("/game/new", headers=SESSION_HEADERS)
+        res = client.post("/yacht/new", headers=SESSION_HEADERS)
         assert res.status_code == 200
         return res.json()
 
     def _roll(self, held: list[bool] | None = None) -> dict:
         self._rl_reset()
         res = client.post(
-            "/game/roll",
+            "/yacht/roll",
             json={"held": held or [False] * 5},
             headers=SESSION_HEADERS,
         )
@@ -191,7 +191,7 @@ class TestAPISimulation:
     def _score(self, category: str) -> dict:
         self._rl_reset()
         res = client.post(
-            "/game/score",
+            "/yacht/score",
             json={"category": category},
             headers=SESSION_HEADERS,
         )
@@ -200,13 +200,13 @@ class TestAPISimulation:
 
     def _state(self) -> dict:
         self._rl_reset()
-        res = client.get("/game/state", headers=SESSION_HEADERS)
+        res = client.get("/yacht/state", headers=SESSION_HEADERS)
         assert res.status_code == 200
         return res.json()
 
     def _possible(self) -> dict:
         self._rl_reset()
-        res = client.get("/game/possible-scores", headers=SESSION_HEADERS)
+        res = client.get("/yacht/possible-scores", headers=SESSION_HEADERS)
         assert res.status_code == 200
         return res.json()["possible_scores"]
 
@@ -278,7 +278,7 @@ class TestAPISimulation:
             self._roll()
             self._score(cat)
         res = client.post(
-            "/game/roll",
+            "/yacht/roll",
             json={"held": [False] * 5},
             headers=SESSION_HEADERS,
         )
@@ -293,7 +293,7 @@ class TestAPISimulation:
         # Need a roll_used > 0 to reach the game_over check (not the must-roll check)
         # Manually set rolls_used won't work via API — the endpoint raises game_over first
         res = client.post(
-            "/game/score",
+            "/yacht/score",
             json={"category": "chance"},
             headers=SESSION_HEADERS,
         )

--- a/backend/yacht/router.py
+++ b/backend/yacht/router.py
@@ -1,8 +1,4 @@
-"""Yacht game routes.
-
-Mounted by main.py with prefix=`/game` for backwards compatibility.
-Renaming the prefix to `/yacht` is tracked in issue #161.
-"""
+"""Yacht game routes. Mounted by main.py with prefix=`/yacht`."""
 
 from collections import OrderedDict
 
@@ -33,7 +29,7 @@ def _evict_if_full() -> None:
 def _get_game(session_id: str) -> YachtGame:
     game = _sessions.get(session_id)
     if game is None:
-        raise HTTPException(status_code=404, detail="No game in progress. POST /game/new first.")
+        raise HTTPException(status_code=404, detail="No game in progress. POST /yacht/new first.")
     return game
 
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,7 +45,7 @@ backend/tests/
 - `possible_scores()` only returns unfilled categories
 
 **test_api.py**
-- `POST /game/new`, `GET /game/state`, `POST /game/roll`, `POST /game/score`, `GET /game/possible-scores`
+- `POST /yacht/new`, `GET /yacht/state`, `POST /yacht/roll`, `POST /yacht/score`, `GET /yacht/possible-scores`
 
 **test_cascade_api.py**
 - `POST /cascade/score` — valid submission (201), invalid payloads (422)

--- a/e2e/tests/helpers/api-mock.ts
+++ b/e2e/tests/helpers/api-mock.ts
@@ -51,16 +51,16 @@ function rolledState(round = 1): GameState {
 
 /**
  * Install a stateful full-game mock.
- * - POST /game/new          → fresh state round=1
- * - POST /game/roll         → state with dice + rolls_used=1
- * - GET  /game/possible-scores → all 13 categories with value 15
- * - POST /game/score        → advances round; game_over when round > 13
+ * - POST /yacht/new          → fresh state round=1
+ * - POST /yacht/roll         → state with dice + rolls_used=1
+ * - GET  /yacht/possible-scores → all 13 categories with value 15
+ * - POST /yacht/score        → advances round; game_over when round > 13
  */
 export async function installYachtGameMock(page: Page): Promise<void> {
   let round = 1;
   const scored: Record<string, number> = {};
 
-  await page.route(`${API_BASE}/game/new`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/new`, async (route: Route) => {
     round = 1;
     Object.keys(scored).forEach((k) => delete scored[k]);
     await route.fulfill({
@@ -70,7 +70,7 @@ export async function installYachtGameMock(page: Page): Promise<void> {
     });
   });
 
-  await page.route(`${API_BASE}/game/roll`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/roll`, async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -78,7 +78,7 @@ export async function installYachtGameMock(page: Page): Promise<void> {
     });
   });
 
-  await page.route(`${API_BASE}/game/possible-scores`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/possible-scores`, async (route: Route) => {
     const unfilled = CATEGORIES.filter((c) => !(c in scored));
     const possible = Object.fromEntries(unfilled.map((c) => [c, 15]));
     await route.fulfill({
@@ -88,7 +88,7 @@ export async function installYachtGameMock(page: Page): Promise<void> {
     });
   });
 
-  await page.route(`${API_BASE}/game/score`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/score`, async (route: Route) => {
     const body = JSON.parse((await route.request().postData()) ?? "{}");
     const cat: string = body.category ?? CATEGORIES[round - 1];
     scored[cat] = 15;
@@ -113,13 +113,13 @@ export async function installYachtGameMock(page: Page): Promise<void> {
 }
 
 /**
- * Install a mock that returns a 503 for the first /game/new call,
+ * Install a mock that returns a 503 for the first /yacht/new call,
  * then succeeds on subsequent calls.
  */
 export async function installFlakyNewGameMock(page: Page): Promise<void> {
   let attempt = 0;
 
-  await page.route(`${API_BASE}/game/new`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/new`, async (route: Route) => {
     attempt++;
     if (attempt === 1) {
       await route.fulfill({
@@ -137,7 +137,7 @@ export async function installFlakyNewGameMock(page: Page): Promise<void> {
   });
 
   // Also install roll/score for after the retry succeeds
-  await page.route(`${API_BASE}/game/roll`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/roll`, async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -145,7 +145,7 @@ export async function installFlakyNewGameMock(page: Page): Promise<void> {
     });
   });
 
-  await page.route(`${API_BASE}/game/possible-scores`, async (route: Route) => {
+  await page.route(`${API_BASE}/yacht/possible-scores`, async (route: Route) => {
     const possible = Object.fromEntries(CATEGORIES.map((c) => [c, 15]));
     await route.fulfill({
       status: 200,

--- a/e2e/tests/yacht-errors.spec.ts
+++ b/e2e/tests/yacht-errors.spec.ts
@@ -43,7 +43,7 @@ test.describe("Yacht — error recovery", () => {
     await installYachtGameMock(page);
 
     // Override score endpoint to return 400
-    await page.route(`${API_BASE}/game/score`, async (route) => {
+    await page.route(`${API_BASE}/yacht/score`, async (route) => {
       await route.fulfill({
         status: 400,
         contentType: "application/json",

--- a/frontend/src/game/yacht/__tests__/api.test.ts
+++ b/frontend/src/game/yacht/__tests__/api.test.ts
@@ -16,30 +16,30 @@ describe("yacht api — endpoints", () => {
     } as Response);
   }
 
-  it("newGame POSTs to /game/new", async () => {
+  it("newGame POSTs to /yacht/new", async () => {
     respondWith({ dice: [1, 2, 3, 4, 5] });
     await api.newGame();
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/game/new"),
+      expect.stringContaining("/yacht/new"),
       expect.objectContaining({ method: "POST" })
     );
   });
 
-  it("getState GETs /game/state", async () => {
+  it("getState GETs /yacht/state", async () => {
     respondWith({ dice: [1, 1, 1, 1, 1] });
     await api.getState();
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/game/state"),
+      expect.stringContaining("/yacht/state"),
       expect.any(Object)
     );
   });
 
-  it("roll POSTs held array to /game/roll", async () => {
+  it("roll POSTs held array to /yacht/roll", async () => {
     const held = [true, false, true, false, false];
     respondWith({ dice: [1, 2, 3, 4, 5] });
     await api.roll(held);
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/game/roll"),
+      expect.stringContaining("/yacht/roll"),
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ held }),
@@ -47,11 +47,11 @@ describe("yacht api — endpoints", () => {
     );
   });
 
-  it("score POSTs category to /game/score", async () => {
+  it("score POSTs category to /yacht/score", async () => {
     respondWith({ dice: [1, 2, 3, 4, 5] });
     await api.score("ones");
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/game/score"),
+      expect.stringContaining("/yacht/score"),
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ category: "ones" }),
@@ -59,11 +59,11 @@ describe("yacht api — endpoints", () => {
     );
   });
 
-  it("possibleScores GETs /game/possible-scores", async () => {
+  it("possibleScores GETs /yacht/possible-scores", async () => {
     respondWith({ possible_scores: { ones: 3 } });
     await api.possibleScores();
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/game/possible-scores"),
+      expect.stringContaining("/yacht/possible-scores"),
       expect.any(Object)
     );
   });

--- a/frontend/src/game/yacht/api.ts
+++ b/frontend/src/game/yacht/api.ts
@@ -1,8 +1,5 @@
 /**
  * Yacht API client.
- *
- * Note: paths still use the legacy `/game/` prefix rather than `/yacht/`;
- * renaming is tracked in #161.
  */
 
 import { createGameClient } from "../_shared/httpClient";
@@ -11,23 +8,23 @@ import { GameState, PossibleScores } from "./types";
 const request = createGameClient({ apiTag: "gaming-app" });
 
 export const api = {
-  newGame: () => request<GameState>("/game/new", { method: "POST" }),
+  newGame: () => request<GameState>("/yacht/new", { method: "POST" }),
 
-  getState: () => request<GameState>("/game/state"),
+  getState: () => request<GameState>("/yacht/state"),
 
   roll: (held: boolean[]) =>
-    request<GameState>("/game/roll", {
+    request<GameState>("/yacht/roll", {
       method: "POST",
       body: JSON.stringify({ held }),
     }),
 
   score: (category: string) =>
-    request<GameState>("/game/score", {
+    request<GameState>("/yacht/score", {
       method: "POST",
       body: JSON.stringify({ category }),
     }),
 
-  possibleScores: () => request<PossibleScores>("/game/possible-scores"),
+  possibleScores: () => request<PossibleScores>("/yacht/possible-scores"),
 };
 
 // Re-export types for import-site convenience.


### PR DESCRIPTION
## Summary

Normalizes Yacht's API paths to match every other game's convention:

| Before | After |
|--------|-------|
| `POST /game/new` | `POST /yacht/new` |
| `GET /game/state` | `GET /yacht/state` |
| `POST /game/roll` | `POST /yacht/roll` |
| `POST /game/score` | `POST /yacht/score` |
| `GET /game/possible-scores` | `GET /yacht/possible-scores` |

The `/game/` prefix was a leftover from when this was a Yacht-only app. Every other game uses its own name (`/cascade/*`, `/blackjack/*`, etc.) — Yacht was the odd one out.

Closes #161.

## Breaking Change

This is a **clean cut** (no dual-route window). Safe because:
- Frontend + backend deploy together
- No external API consumers
- Pre-stable app

Any cached/stale client calling `/game/*` will get 404 after deploy.

## Changes

- `backend/main.py` — `prefix="/game"` → `prefix="/yacht"`
- `backend/yacht/router.py` — error message ("POST /game/new first." → "POST /yacht/new first.") and docstring
- `frontend/src/game/yacht/api.ts` — all 5 endpoint paths
- Backend tests: `test_api.py`, `test_security.py`, `test_simulation.py`
- Perf scenarios: `game_flow.py`, `stateless_reads.py`, `rate_limit_test.py`, `thresholds.json`, `check_thresholds.py`
- E2E: `yacht-errors.spec.ts`, `helpers/api-mock.ts`
- Docs: `TESTING.md`
- Removed stale `#161`-tracking comments

## Depends On (shipped)

- #154 — backend Yacht normalized into `backend/yacht/` package
- #153 — frontend unified game module pattern

## Test Plan

- [x] `python -m pytest tests/` — 399/399 pass, 97.03% coverage
- [x] `npx jest` — 413/413 pass
- [x] `npx playwright test` — 31/31 pass
- [x] `npm run lint` / `format:check` / `black --check` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)