### PR TITLE
fix(ci): use direct Render URL for backend health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
   backend-health:
     uses: wcmchenry3-stack/.github/.github/workflows/called-backend-health.yml@main
     with:
-      backend-url: 'https://dev-games-api.buffingchi.com'
+      # Direct Render origin intentionally used here instead of dev-games-api.buffingchi.com.
+      # Cloudflare Bot Fight Mode blocks GHA runner IPs (Azure cloud ranges) before
+      # the WAF skip rule fires — health checks must bypass the proxy.
+      # See wcmchenry3-stack/.github#45.
+      backend-url: 'https://yahtzee-api.onrender.com'
       health-path: '/health'
       probe-path: '/yacht/state'
       probe-expected-status: '400'


### PR DESCRIPTION
## Summary
- Changes `backend-url` from `dev-games-api.buffingchi.com` to `https://yahtzee-api.onrender.com`
- Adds comment explaining why we use the direct Render origin instead of the custom domain

## Why
Cloudflare Bot Fight Mode (enabled 2026-04-04) blocks GitHub Actions runner IPs (Azure cloud ranges) before the WAF custom-rule skip phase can fire, causing HTTP 403 on health checks routed through the Cloudflare proxy. The direct Render origin bypasses the proxy entirely — health checks should test whether Render is alive, not whether Cloudflare is routing correctly.

## Test plan
- [ ] CI passes on this PR (backend-health job returns 200)

Closes wcmchenry3-stack/.github#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)