### PR TITLE
fix(blackjack): double down chip-accounting bug

### DIFF
--- a/backend/blackjack/game.py
+++ b/backend/blackjack/game.py
@@ -127,10 +127,16 @@ class BlackjackGame:
             raise ValueError("Not in player phase.")
         if len(self._player_hand) != 2:
             raise ValueError("Double down only allowed on initial two cards.")
-        if self.chips < self.bet:
+        # chips represents stack+wagered (place_bet does not deduct); the free
+        # stack is chips-bet. Doubling requires another `bet` of free stack,
+        # so the true requirement is chips >= 2*bet.
+        if self.chips < self.bet * 2:
             raise ValueError("Insufficient chips to double down.")
 
-        self.chips -= self.bet  # deduct extra bet now
+        # Don't subtract from chips here — that would double-count the extra
+        # wager. Doubling `bet` alone makes the settlement delta double,
+        # which is the correct outcome under the "chips includes wagered"
+        # accounting used by _settle_with().
         self.bet *= 2
         self._doubled = True
 

--- a/backend/blackjack/router.py
+++ b/backend/blackjack/router.py
@@ -54,7 +54,7 @@ def _state_response(game: BlackjackGame) -> BlackjackStateResponse:
     dealer_hand = _hand_response(game._dealer_hand, conceal_hole=concealing)
     player_hand = _hand_response(game._player_hand)
     double_down_available = (
-        game.phase == "player" and len(game._player_hand) == 2 and game.chips >= game.bet
+        game.phase == "player" and len(game._player_hand) == 2 and game.chips >= game.bet * 2
     )
     game_over = game.chips == 0 and game.phase == "result"
     return BlackjackStateResponse(

--- a/backend/tests/test_blackjack_game.py
+++ b/backend/tests/test_blackjack_game.py
@@ -278,10 +278,17 @@ class TestDoubleDown:
             g.double_down()
 
     def test_double_down_requires_sufficient_chips(self):
+        # chips=150, bet=100 → free stack is chips-bet=50, not enough to double.
+        # Real requirement is chips >= 2*bet (200 here).
         g = _in_player_phase(chips=150, bet=100)
-        g.chips = 50  # not enough to cover bet again
         with pytest.raises(ValueError, match="Insufficient chips"):
             g.double_down()
+
+    def test_double_down_accepts_exact_2x_bet(self):
+        # chips=200, bet=100 → chips == 2*bet, boundary allowed.
+        g = _in_player_phase(chips=200, bet=100)
+        g.double_down()  # should not raise
+        assert g.bet == 200
 
     def test_double_down_doubles_the_bet(self):
         g = _in_player_phase(chips=500, bet=100)
@@ -293,15 +300,21 @@ class TestDoubleDown:
         g.double_down()
         assert g.phase == "result"
 
-    def test_double_down_deducts_extra_chips_before_settle(self):
+    def test_double_down_applies_2x_payout(self):
+        # Under the "chips includes wagered" accounting, DD doubles the bet
+        # and the settlement delta doubles with it. Start 300 / bet 100:
+        #   win:  300 + 200 = 500  (net +200)
+        #   lose: 300 - 200 = 100  (net -200)
+        #   push: 300 + 0   = 300  (net 0)
         g = _in_player_phase(chips=300, bet=100)
         g.double_down()
-        # chips = 300 - 100 (extra) ± payout
+        assert g.bet == 200
         if g.outcome == "win":
-            assert g.chips == 300 - 100 + 200  # net +100
+            assert g.chips == 500
         elif g.outcome == "lose":
-            assert g.chips == 300 - 100 - 200  # net -200 → 0 (floor)
-        # push: 300 - 100 + 0 = 200
+            assert g.chips == 100
+        elif g.outcome == "push":
+            assert g.chips == 300
         assert g.chips >= 0
 
 

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -290,9 +290,16 @@ describe("double down", () => {
     expect(() => doubleDown(three)).toThrow(/initial two cards/);
   });
 
-  it("requires sufficient chips", () => {
-    const broke: EngineState = { ...stateInPlayer(150, 100), chips: 50 };
+  it("requires chips >= 2*bet (free stack = chips - bet)", () => {
+    // chips=150, bet=100 → only 50 free; needs another 100 to double.
+    const broke: EngineState = stateInPlayer(150, 100);
     expect(() => doubleDown(broke)).toThrow(/Insufficient chips/);
+  });
+
+  it("accepts exact 2*bet (boundary)", () => {
+    // chips=200, bet=100 → chips == 2*bet, allowed.
+    const r = doubleDown(stateInPlayer(200, 100));
+    expect(r.bet).toBe(200);
   });
 
   it("doubles the bet", () => {
@@ -305,11 +312,17 @@ describe("double down", () => {
     expect(r.phase).toBe("result");
   });
 
-  it("deducts extra chips before settling", () => {
+  it("applies 2x payout delta", () => {
+    // Under "chips includes wagered" accounting, doubling the bet doubles
+    // the settlement delta. Start 300 / bet 100:
+    //   win:  300 + 200 = 500
+    //   lose: 300 - 200 = 100
+    //   push: 300 + 0   = 300
     const r = doubleDown(stateInPlayer(300, 100));
-    // Start 300, deduct 100 extra = 200, then ±payout
-    if (r.outcome === "win") expect(r.chips).toBe(300 - 100 + 200);
-    if (r.outcome === "push") expect(r.chips).toBe(200);
+    expect(r.bet).toBe(200);
+    if (r.outcome === "win") expect(r.chips).toBe(500);
+    if (r.outcome === "lose") expect(r.chips).toBe(100);
+    if (r.outcome === "push") expect(r.chips).toBe(300);
     expect(r.chips).toBeGreaterThanOrEqual(0);
   });
 });
@@ -371,10 +384,14 @@ describe("toViewState", () => {
     expect(toViewState(stateInResult()).game_over).toBe(false);
   });
 
-  it("double_down_available only in player phase with 2 cards and enough chips", () => {
+  it("double_down_available only in player phase with 2 cards and chips >= 2*bet", () => {
+    // chips=500, bet=100 → chips >= 200 ✓
     expect(toViewState(stateInPlayer(500, 100)).double_down_available).toBe(true);
-    const broke: EngineState = { ...stateInPlayer(50, 100) };
-    expect(toViewState(broke).double_down_available).toBe(false);
+    // boundary: chips=200, bet=100 ✓
+    expect(toViewState(stateInPlayer(200, 100)).double_down_available).toBe(true);
+    // chips=150, bet=100 → not enough free stack
+    expect(toViewState(stateInPlayer(150, 100)).double_down_available).toBe(false);
+    // 3 cards → not available
     const three: EngineState = {
       ...stateInPlayer(500, 100),
       player_hand: [c("♠", "5"), c("♥", "5"), c("♦", "5")],

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -122,7 +122,7 @@ function handResponse(cards: readonly Card[], concealHole: boolean): HandRespons
 export function toViewState(s: EngineState): BlackjackState {
   const concealing = s.phase === "player";
   const double_down_available =
-    s.phase === "player" && s.player_hand.length === 2 && s.chips >= s.bet;
+    s.phase === "player" && s.player_hand.length === 2 && s.chips >= s.bet * 2;
   const game_over = s.chips === 0 && s.phase === "result";
   return {
     phase: s.phase,
@@ -250,13 +250,18 @@ export function doubleDown(s: EngineState): EngineState {
   if (s.player_hand.length !== 2) {
     throw new Error("Double down only allowed on initial two cards.");
   }
-  if (s.chips < s.bet) throw new Error("Insufficient chips to double down.");
+  // chips represents stack+wagered (placeBet does not deduct); the free
+  // stack is chips-bet. Doubling requires another `bet` of free stack,
+  // so the true requirement is chips >= 2*bet.
+  if (s.chips < s.bet * 2) throw new Error("Insufficient chips to double down.");
 
-  // Deduct extra bet now + double the bet
+  // Don't subtract from chips here — that would double-count the extra
+  // wager. Doubling `bet` alone makes the settlement delta double, which
+  // is correct under the "chips includes wagered" accounting used by
+  // settleWith().
   const { deck, card } = deal(s.deck);
   const afterDouble: EngineState = {
     ...s,
-    chips: s.chips - s.bet,
     bet: s.bet * 2,
     doubled: true,
     deck,


### PR DESCRIPTION
## Summary

Double down had a chip-accounting bug in both engines (backend and the new offline engine from #169). The extra wager was double-counted, so DD offered no upside on a win and over-debited on a loss.

Closes #170.

## The Invariant

\`place_bet()\` sets \`bet\` but doesn't deduct from \`chips\`. So throughout a hand, \`chips\` represents stack+wagered. Settlement applies a net delta:

| Outcome | delta |
|---|---|
| win | +bet |
| lose | -bet |
| push | 0 |
| blackjack | ceil(1.5*bet) |

## The Bug

\`doubleDown()\` did BOTH \`chips -= bet\` AND \`bet *= 2\`. That broke the invariant.

**Trace (chips=1000, bet=100):**

| Step | chips | bet |
|---|---|---|
| After placeBet | 1000 | 100 |
| After DD code | 900 | 200 |
| Win → delta=+200 | 1100 | — |

Expected: 1200. Actual: 1100. Net +100 instead of +200. DD offered no bonus vs. a regular win.

## Precondition Bug

\`chips >= bet\` is wrong because chips already *includes* the wagered bet. Free stack is \`chips - bet\`. To double, need another bet of free stack → real rule is \`chips >= 2*bet\`.

Example: chips=150, bet=100. Free stack=50. Needs another 100 to DD. Old check: 150 >= 100 ✓ (wrong — allows). New check: 150 >= 200 ✗ (correct — denies).

## Fix

Both engines and both state projections:
- Remove \`chips -= bet\` in \`doubleDown()\`. Doubling \`bet\` alone makes the delta double.
- Change \`chips >= bet\` to \`chips >= 2*bet\` in the sufficiency check and in the \`double_down_available\` flag computed by \`toViewState()\` / \`_state_response()\`.

## Locations

- \`backend/blackjack/game.py:125-142\` — \`double_down()\`
- \`backend/blackjack/router.py:56-58\` — \`double_down_available\`
- \`frontend/src/game/blackjack/engine.ts:248-285\` — \`doubleDown()\`
- \`frontend/src/game/blackjack/engine.ts:122-127\` — \`toViewState()\`

## Test Updates

Tests that encoded the buggy math now encode the correct math:

| Test | Change |
|---|---|
| \`test_double_down_requires_sufficient_chips\` | chips=150/bet=100 now correctly fails under \`chips >= 2*bet\`; removed redundant \`g.chips = 50\` override |
| \`test_double_down_accepts_exact_2x_bet\` | NEW — boundary case chips=200/bet=100 allowed |
| \`test_double_down_applies_2x_payout\` | renamed from \`test_double_down_deducts_extra_chips_before_settle\` — asserts correct math (chips=500 on win, 100 on loss, 300 on push, starting 300/100) |
| \`toViewState / double_down_available\` | added boundary case chips=200/bet=100 ✓ and chips=150/bet=100 ✗ |

## Test Plan

- [x] Backend: \`pytest tests/\` — 400/400 pass
- [x] Frontend: \`npx jest\` — 566/566 pass
- [x] Black + ruff clean
- [x] Eslint + prettier clean
- [ ] Manual: start blackjack, bet 100, double down on any valid hand, verify chip delta is 2× a normal win/loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)