### PR TITLE
test(blackjack): expand double-down coverage

### DIFF
--- a/backend/tests/test_blackjack_game.py
+++ b/backend/tests/test_blackjack_game.py
@@ -346,3 +346,223 @@ class TestDeckReshuffle:
         g.new_hand()
         # After dealing 4 cards the deck should still be large
         assert len(g._deck) > 40
+
+
+# ---------------------------------------------------------------------------
+# Double down — deterministic scenarios (rigged decks)
+#
+# _deal() pops from the end of _deck, so the LAST element is drawn first.
+# For DD tests the dealer is stacked onto the deck AFTER the DD card:
+#     deck = [..., dealer_hit_2, dealer_hit_1, DD_card]
+#                                                ^ popped first
+# ---------------------------------------------------------------------------
+
+
+def _dd_setup(chips: int, bet: int, player, dealer, deck) -> BlackjackGame:
+    """Build a player-phase game with exact hands and deck contents."""
+    g = BlackjackGame(chips=chips)
+    g.bet = bet
+    g._player_hand = list(player)
+    g._dealer_hand = list(dealer)
+    g._deck = list(deck)
+    g.phase = "player"
+    return g
+
+
+class TestDoubleDownDeterministic:
+    """DD with rigged decks so outcomes are fixed, not random."""
+
+    def test_dd_win_pays_net_plus_2x_bet(self):
+        # Player 10+5=15; DD card 6 → 21. Dealer 6+8=14, hits a 10 → 24 bust.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "6"), Card("♣", "8")],
+            deck=[Card("♠", "10"), Card("♠", "6")],  # dealer hit, then DD card
+        )
+        g.double_down()
+        assert g.outcome == "win"
+        assert g.bet == 200
+        assert g.chips == 500 + 200  # net +2*bet
+
+    def test_dd_loss_debits_net_minus_2x_bet(self):
+        # Player 10+5=15; DD card 2 → 17. Dealer 9+9=18, stands. Player loses.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "2")],
+        )
+        g.double_down()
+        assert g.outcome == "lose"
+        assert g.chips == 500 - 200  # net -2*bet
+
+    def test_dd_push_returns_zero_delta(self):
+        # Player 10+5=15; DD card 3 → 18. Dealer 9+9=18, stands. Push.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "3")],
+        )
+        g.double_down()
+        assert g.outcome == "push"
+        assert g.chips == 500  # net 0
+
+    def test_dd_to_21_is_even_money_not_blackjack(self):
+        # 6+5=11, DD card K → 21. Not a natural BJ (that needs exactly 2 initial
+        # cards). Should pay even money on the doubled bet, i.e. +2*bet — NOT
+        # the 3:2 blackjack payout (which would be ceil(1.5*200)=300).
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "6"), Card("♥", "5")],
+            dealer=[Card("♦", "10"), Card("♣", "8")],  # 18, stands
+            deck=[Card("♠", "K")],
+        )
+        g.double_down()
+        assert g.outcome == "win"
+        assert g.chips == 500 + 200  # +2*bet, not +1.5*2*bet=300
+
+    def test_dd_bust_settles_immediately_dealer_untouched(self):
+        # Player 10+10=20, DD card 5 → 25 bust. Dealer must NOT draw.
+        dealer_initial = [Card("♦", "6"), Card("♣", "7")]
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "K"), Card("♥", "Q")],
+            dealer=dealer_initial,
+            deck=[Card("♠", "2"), Card("♠", "5")],  # 2 is "would-be dealer hit"
+        )
+        g.double_down()
+        assert g.outcome == "lose"
+        assert g.chips == 500 - 200
+        # Dealer hand should be untouched (2 cards, same ranks).
+        assert len(g._dealer_hand) == 2
+        assert [(c.rank, c.suit) for c in g._dealer_hand] == [
+            (c.rank, c.suit) for c in dealer_initial
+        ]
+        # The would-be dealer hit card should still be in the deck.
+        assert any(c.rank == "2" for c in g._deck)
+
+    def test_dd_sufficiency_exact_2x_boundary_allowed(self):
+        g = _dd_setup(
+            chips=200,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "3")],  # → 18 push
+        )
+        g.double_down()
+        assert g.bet == 200
+        # push: chips unchanged at 200
+        assert g.chips == 200
+
+    def test_dd_sufficiency_below_2x_rejected(self):
+        # chips = 2*bet - 10 (190) → not enough free stack
+        g = _dd_setup(
+            chips=190,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "2")],
+        )
+        with pytest.raises(ValueError, match="Insufficient chips"):
+            g.double_down()
+
+    def test_dd_exact_2x_loss_reaches_zero_and_game_over(self):
+        # chips == 2*bet, DD loss → chips 0, phase result (game_over by view).
+        g = _dd_setup(
+            chips=200,
+            bet=100,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "2")],  # → 17, dealer 18, lose
+        )
+        g.double_down()
+        assert g.outcome == "lose"
+        assert g.chips == 0
+        assert g.phase == "result"
+
+    def test_dd_refused_after_third_card(self):
+        # Same wording as existing "requires two cards" test but spelled out
+        # for completeness: once the player hits, DD is off the table.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "5"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "8")],
+            deck=[Card("♠", "3")],
+        )
+        g.hit()  # player hand now 3 cards: 5+5+3=13
+        with pytest.raises(ValueError, match="initial two cards"):
+            g.double_down()
+
+    def test_dd_with_soft_17_ace_counts_as_one_on_bust(self):
+        # Player A+6 = 17 soft. DD card K → A+6+K: 11+6+10=27>21, ace demotes
+        # to 1+6+10=17. No bust; still valid. Dealer 9+9=18, stands. Lose.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "A"), Card("♥", "6")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "K")],
+        )
+        g.double_down()
+        assert g.outcome == "lose"
+        assert hand_value(g._player_hand) == 17
+        assert g.chips == 500 - 200
+
+    def test_dd_with_soft_18_can_stay_21_with_3(self):
+        # Player A+7 = 18 soft. DD card 3 → A+7+3: 11+7+3=21 (ace stays 11).
+        # Dealer 10+8=18 stands. Player wins.
+        g = _dd_setup(
+            chips=500,
+            bet=100,
+            player=[Card("♠", "A"), Card("♥", "7")],
+            dealer=[Card("♦", "10"), Card("♣", "8")],
+            deck=[Card("♠", "3")],
+        )
+        g.double_down()
+        assert hand_value(g._player_hand) == 21
+        assert g.outcome == "win"
+        assert g.chips == 500 + 200
+
+
+@pytest.mark.parametrize(
+    "chips,bet",
+    [
+        (200, 100),  # exact DD boundary
+        (1000, 500),  # max bet, exact DD boundary
+        (20, 10),  # min bet, exact DD boundary
+    ],
+)
+class TestDoubleDownParamBoundary:
+    """Exact 2*bet boundary across a spread of (chips, bet) pairs."""
+
+    def test_dd_at_boundary_allowed_push_leaves_chips_intact(self, chips, bet):
+        g = _dd_setup(
+            chips=chips,
+            bet=bet,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "3")],  # → 18 push against dealer 18
+        )
+        g.double_down()
+        assert g.outcome == "push"
+        assert g.chips == chips
+
+    def test_dd_at_boundary_loss_reaches_zero(self, chips, bet):
+        g = _dd_setup(
+            chips=chips,
+            bet=bet,
+            player=[Card("♠", "10"), Card("♥", "5")],
+            dealer=[Card("♦", "9"), Card("♣", "9")],
+            deck=[Card("♠", "2")],  # → 17 vs dealer 18 → lose
+        )
+        g.double_down()
+        assert g.outcome == "lose"
+        assert g.chips == 0

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -399,3 +399,223 @@ describe("toViewState", () => {
     expect(toViewState(three).double_down_available).toBe(false);
   });
 });
+
+// --- Double down — deterministic scenarios (rigged decks) -----------------
+//
+// deal() pops from the end of `deck`, so the LAST element is drawn first.
+// Stack order for DD tests:
+//     deck = [..., dealer_hit_2, dealer_hit_1, DD_card]
+//                                               ^ popped first
+
+function ddSetup(
+  chips: number,
+  bet: number,
+  player: Card[],
+  dealer: Card[],
+  deck: Card[]
+): EngineState {
+  return {
+    chips,
+    bet,
+    phase: "player",
+    outcome: null,
+    payout: 0,
+    player_hand: player,
+    dealer_hand: dealer,
+    deck,
+    doubled: false,
+  };
+}
+
+describe("double down — deterministic scenarios", () => {
+  it("DD win pays net +2*bet (dealer busts)", () => {
+    // Player 10+5=15, DD card 6 → 21. Dealer 6+8=14, hits 10 → 24 bust.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "6"), c("♣", "8")],
+      [c("♠", "10"), c("♠", "6")] // dealer hit, then DD card (popped first)
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("win");
+    expect(r.bet).toBe(200);
+    expect(r.chips).toBe(500 + 200); // net +2*bet
+  });
+
+  it("DD loss debits net -2*bet", () => {
+    // Player 10+5=15, DD card 2 → 17. Dealer 9+9=18 stands.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "2")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("lose");
+    expect(r.chips).toBe(500 - 200);
+  });
+
+  it("DD push returns zero delta", () => {
+    // Player 10+5=15, DD card 3 → 18. Dealer 9+9=18 stands. Push.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "3")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("push");
+    expect(r.chips).toBe(500);
+  });
+
+  it("DD to 21 is even money, not the 3:2 blackjack payout", () => {
+    // 6+5=11, DD card K → 21 (3 cards — not a natural). Pays +2*bet,
+    // NOT ceil(1.5 * 200) = 300.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "6"), c("♥", "5")],
+      [c("♦", "10"), c("♣", "8")], // 18, stands
+      [c("♠", "K")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("win");
+    expect(r.chips).toBe(500 + 200); // not +300
+  });
+
+  it("DD bust settles immediately — dealer hand untouched", () => {
+    // Player 10+10=20, DD card 5 → 25 bust. Dealer MUST NOT draw.
+    const dealerInitial = [c("♦", "6"), c("♣", "7")];
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "K"), c("♥", "Q")],
+      dealerInitial,
+      [c("♠", "2"), c("♠", "5")] // 2 is "would-be dealer hit"
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("lose");
+    expect(r.chips).toBe(500 - 200);
+    expect(r.dealer_hand).toEqual(dealerInitial);
+    // The unused dealer-hit card should still be in the deck.
+    expect(r.deck.some((card) => card.rank === "2")).toBe(true);
+  });
+
+  it("sufficiency boundary: chips == 2*bet is allowed", () => {
+    const g = ddSetup(
+      200,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "3")] // push
+    );
+    const r = doubleDown(g);
+    expect(r.bet).toBe(200);
+    expect(r.chips).toBe(200);
+  });
+
+  it("sufficiency boundary: chips == 2*bet - 10 rejected", () => {
+    const g = ddSetup(
+      190,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "2")]
+    );
+    expect(() => doubleDown(g)).toThrow(/Insufficient chips/);
+  });
+
+  it("exact 2*bet loss → chips 0 and game_over via view state", () => {
+    const g = ddSetup(
+      200,
+      100,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "2")] // → 17, dealer 18 → lose
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("lose");
+    expect(r.chips).toBe(0);
+    expect(r.phase).toBe("result");
+    expect(toViewState(r).game_over).toBe(true);
+  });
+
+  it("DD refused after a hit (3rd card)", () => {
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "5"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "8")],
+      [c("♠", "3")]
+    );
+    const afterHit = hit(g);
+    expect(() => doubleDown(afterHit)).toThrow(/initial two cards/);
+  });
+
+  it("DD with soft 17 (A+6) — ace demotes when DD card busts", () => {
+    // A+6 = 17 soft. DD card K → 11+6+10=27 > 21, ace demotes: 1+6+10 = 17.
+    // Dealer 9+9=18 stands → lose.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "A"), c("♥", "6")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "K")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("lose");
+    expect(r.chips).toBe(500 - 200);
+    // Confirm the final player total is 17 via the engine's handValue
+    expect(handValue(r.player_hand)).toBe(17);
+  });
+
+  it("DD with soft 18 (A+7) — 3 brings it to hard 21 (ace stays 11)", () => {
+    // A+7=18, DD card 3 → 11+7+3=21. Dealer 10+8=18 stands → win.
+    const g = ddSetup(
+      500,
+      100,
+      [c("♠", "A"), c("♥", "7")],
+      [c("♦", "10"), c("♣", "8")],
+      [c("♠", "3")]
+    );
+    const r = doubleDown(g);
+    expect(handValue(r.player_hand)).toBe(21);
+    expect(r.outcome).toBe("win");
+    expect(r.chips).toBe(500 + 200);
+  });
+});
+
+describe.each([
+  [200, 100],
+  [1000, 500],
+  [20, 10],
+])("double down — boundary at chips=%i, bet=%i", (chips, bet) => {
+  it("DD at exact 2*bet with push leaves chips intact", () => {
+    const g = ddSetup(
+      chips,
+      bet,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "3")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("push");
+    expect(r.chips).toBe(chips);
+  });
+
+  it("DD at exact 2*bet with loss reaches zero", () => {
+    const g = ddSetup(
+      chips,
+      bet,
+      [c("♠", "10"), c("♥", "5")],
+      [c("♦", "9"), c("♣", "9")],
+      [c("♠", "2")]
+    );
+    const r = doubleDown(g);
+    expect(r.outcome).toBe("lose");
+    expect(r.chips).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds deterministic test coverage (stacked decks, no randomness) for blackjack double down. Companion to #170.

17 tests per engine × 2 = **34 new tests total**, mirrored between backend and frontend.

Closes #171.

## Scenarios Covered

### Economics
- **DD win → net +2×bet** (rigged dealer bust)
- **DD loss → net -2×bet** (rigged dealer 18 vs player 17)
- **DD push → zero delta**
- **DD to 21 is even money, NOT 3:2** (3-card 21 is a regular win, not a natural blackjack)

### Bust behavior
- **DD bust settles immediately** — dealer hand stays at 2 cards, the would-be dealer hit card remains in the deck. Regression guard against accidentally running \`dealer_play\` after a DD bust.

### Sufficiency boundaries
- \`chips == 2*bet\` allowed
- \`chips == 2*bet - 10\` rejected
- Exact 2*bet + loss → chips 0, phase result, \`game_over=true\` in view state

### Edge cases
- DD refused after a hit (3rd card)
- **Soft 17** (A+6) + DD card that busts → ace demotes to 1, final 17
- **Soft 18** (A+7) + 3 → hard 21 (ace stays 11, player wins)

### Parametrized boundary sweep
- (chips=200, bet=100)
- (chips=1000, bet=500)
- (chips=20, bet=10)

Each pair verifies: push→no change, loss→0. Backend uses \`@pytest.mark.parametrize\`, frontend uses \`describe.each\`.

## Why

The DD codepath is the most error-prone branch in the game (it doubles both the wager and the risk). These tests lock it down before future Split, Insurance, and Surrender features interact with it.

## Test Plan

- [x] Backend: \`pytest tests/\` — 417/417 pass, 97.13% coverage
- [x] Frontend: \`npx jest\` — 583/583 pass
- [x] Black + ruff clean
- [x] Eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)