### PR TITLE
fix(cascade): display leaderboard rank instead of score

### DIFF
--- a/backend/cascade/models.py
+++ b/backend/cascade/models.py
@@ -9,6 +9,9 @@ class ScoreSubmitRequest(BaseModel):
 class ScoreEntry(BaseModel):
     player_name: str
     score: int
+    # 1-indexed position in the sorted leaderboard. A submit that didn't make
+    # the top 10 will have rank == 11 (the truncated-off position).
+    rank: int
 
 
 class LeaderboardResponse(BaseModel):

--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -12,9 +12,18 @@ LEADERBOARD_LIMIT = 10
 @router.post("/score", response_model=ScoreEntry, status_code=201)
 @limiter.limit("5/minute")
 def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
-    entry = ScoreEntry(player_name=body.player_name, score=body.score)
+    entry = ScoreEntry(player_name=body.player_name, score=body.score, rank=0)
     _leaderboard.append(entry)
+    # Stable sort: ties preserve insertion order, so a new tied entry ranks
+    # *below* an older tied entry. This is the existing behavior.
     _leaderboard.sort(key=lambda e: e.score, reverse=True)
+    # Identity check — can't use .index() because two tied entries compare
+    # equal by Pydantic field equality.
+    rank = next(i for i, e in enumerate(_leaderboard) if e is entry) + 1
+    entry.rank = rank
+    # Renumber remaining entries since a mid-list insert shifts ranks below.
+    for i, e in enumerate(_leaderboard):
+        e.rank = i + 1
     del _leaderboard[LEADERBOARD_LIMIT:]
     return entry
 

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -29,6 +29,7 @@ class TestSubmitScore:
         body = res.json()
         assert body["player_name"] == "Alice"
         assert body["score"] == 500
+        assert body["rank"] == 1  # first entry
 
     def test_missing_player_name_returns_422(self):
         res = client.post("/cascade/score", json={"score": 100})
@@ -83,3 +84,86 @@ class TestGetScores:
         scores = client.get("/cascade/scores").json()["scores"]
         assert len(scores) == 10
         assert scores[0]["score"] == 140  # top score kept
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 500).json()["rank"] == 1
+
+    def test_lower_score_ranked_lower(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 500)
+        limiter.reset()
+        body = _submit("Bob", 200).json()
+        assert body["rank"] == 2
+
+    def test_highest_score_takes_rank_1(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 200)
+        limiter.reset()
+        body = _submit("Bob", 500).json()
+        assert body["rank"] == 1
+
+    def test_middle_insert(self):
+        from limiter import limiter
+
+        for name, score in [("A", 500), ("B", 300), ("C", 100)]:
+            limiter.reset()
+            _submit(name, score)
+        limiter.reset()
+        body = _submit("Middle", 400).json()
+        # 500, 400, 300, 100 → Middle is rank 2
+        assert body["rank"] == 2
+
+    def test_new_tie_ranks_below_existing(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 500)
+        limiter.reset()
+        body = _submit("Tied", 500).json()
+        # Stable sort: older entry stays first, new entry takes rank 2.
+        assert body["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        """Submit 10 high scores then an 11th lower one — rank should be 11."""
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000)
+        limiter.reset()
+        body = _submit("Lowly", 1).json()
+        assert body["rank"] == 11
+
+    def test_middle_insert_renumbers_tail(self):
+        """Inserting into the middle shifts everyone below by one rank."""
+        from limiter import limiter
+
+        for name, score in [("A", 500), ("B", 300), ("C", 100)]:
+            limiter.reset()
+            _submit(name, score)
+        limiter.reset()
+        _submit("Middle", 400)
+        scores = client.get("/cascade/scores").json()["scores"]
+        # A@500 rank=1, Middle@400 rank=2, B@300 rank=3, C@100 rank=4
+        ranks_by_name = {s["player_name"]: s["rank"] for s in scores}
+        assert ranks_by_name == {"A": 1, "Middle": 2, "B": 3, "C": 4}
+
+    def test_leaderboard_returns_sequential_ranks(self):
+        from limiter import limiter
+
+        for name, score in [("A", 500), ("B", 300), ("C", 100)]:
+            limiter.reset()
+            _submit(name, score)
+        scores = client.get("/cascade/scores").json()["scores"]
+        assert [s["rank"] for s in scores] == [1, 2, 3]

--- a/frontend/src/components/cascade/GameOverOverlay.tsx
+++ b/frontend/src/components/cascade/GameOverOverlay.tsx
@@ -143,7 +143,7 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
             </Text>
           ) : (
             <Text style={[styles.saved, { color: colors.bonus }]}>
-              {t("gameOver.savedConfirmation", { rank: submitted!.score.toLocaleString() })}
+              {t("gameOver.savedConfirmation", { rank: submitted!.rank })}
             </Text>
           )}
 

--- a/frontend/src/components/cascade/__tests__/GameOverOverlay.test.tsx
+++ b/frontend/src/components/cascade/__tests__/GameOverOverlay.test.tsx
@@ -84,22 +84,24 @@ describe("GameOverOverlay", () => {
   });
 
   it("pressing save after entering a name calls the API", async () => {
-    mockSubmitScore.mockResolvedValueOnce({ name: "Alice", score: 1234, rank: 1 });
+    mockSubmitScore.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 1 });
     renderOverlay(1234);
     fireEvent.changeText(screen.getByLabelText("Your name"), "Alice");
     fireEvent.press(screen.getByLabelText("Save score"));
     await waitFor(() => expect(mockSubmitScore).toHaveBeenCalledWith("Alice", 1234));
   });
 
-  it("shows saved confirmation after successful submit", async () => {
-    mockSubmitScore.mockResolvedValueOnce({ name: "Alice", score: 1234, rank: 2 });
+  it("shows saved confirmation with the leaderboard rank (#2), not the score", async () => {
+    // Regression guard for #195: previously the score was displayed where
+    // rank belonged ("Saved! #1234" for a score=1234 / rank=2).
+    mockSubmitScore.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 2 });
     renderOverlay(1234);
 
     fireEvent.changeText(screen.getByLabelText("Your name"), "Alice");
     fireEvent.press(screen.getByLabelText("Save score"));
 
     await waitFor(() => {
-      expect(screen.getByText(/Saved!/i)).toBeTruthy();
+      expect(screen.getByText("Saved! #2")).toBeTruthy();
     });
     expect(mockSubmitScore).toHaveBeenCalledWith("Alice", 1234);
   });

--- a/frontend/src/game/cascade/__tests__/api.test.ts
+++ b/frontend/src/game/cascade/__tests__/api.test.ts
@@ -17,7 +17,7 @@ describe("cascadeApi — endpoints", () => {
   }
 
   it("submitScore POSTs player_name and score to /cascade/score", async () => {
-    respondWith({ player_name: "Alice", score: 500 });
+    respondWith({ player_name: "Alice", score: 500, rank: 1 });
     await cascadeApi.submitScore("Alice", 500);
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/cascade/score"),
@@ -26,6 +26,12 @@ describe("cascadeApi — endpoints", () => {
         body: JSON.stringify({ player_name: "Alice", score: 500 }),
       })
     );
+  });
+
+  it("submitScore returns rank from response", async () => {
+    respondWith({ player_name: "Alice", score: 500, rank: 3 });
+    const entry = await cascadeApi.submitScore("Alice", 500);
+    expect(entry.rank).toBe(3);
   });
 
   it("getLeaderboard GETs /cascade/scores", async () => {

--- a/frontend/src/game/cascade/types.ts
+++ b/frontend/src/game/cascade/types.ts
@@ -5,6 +5,8 @@
 export interface ScoreEntry {
   player_name: string;
   score: number;
+  /** 1-indexed position in the leaderboard after this submission. */
+  rank: number;
 }
 
 export interface LeaderboardResponse {


### PR DESCRIPTION
## Summary

After saving a Cascade score, the "Saved!" banner displayed the **score** formatted as a rank, not the actual leaderboard position. A player scoring 500 who finished 3rd saw "Saved! #500" instead of "Saved! #3".

Closes #195.

## Root Cause Chain

1. i18n template \`gameOver.savedConfirmation\` = \`"Saved! #{{rank}}"\` expected a rank.
2. \`GameOverOverlay.tsx\` passed \`submitted.score\` under the \`rank\` interpolation key.
3. Backend \`ScoreEntry\` didn't include a \`rank\` field — so even a fixed frontend wouldn't have the data.

## Fix

### Backend
- Add \`rank: int\` to \`ScoreEntry\` (Pydantic model).
- Compute rank via identity lookup in the sorted leaderboard (can't use \`.index()\` — tied entries are field-equal under Pydantic).
- Renumber \`rank\` on existing entries after a mid-list insert.
- Rank is computed BEFORE the top-10 trim, so submissions that don't make the leaderboard still get a meaningful \`rank == 11\`.

### Frontend
- Add \`rank: number\` to \`ScoreEntry\` type.
- \`GameOverOverlay.tsx\` passes \`submitted.rank\` to the i18n template.

## New Tests

**Backend (8 new):**
- First submission → rank 1
- Lower/higher scores → correct ordering
- Middle insert → correct rank + tail renumbering
- New tie ranks below existing (stable sort)
- Off-leaderboard submission → rank 11
- GET returns sequential ranks 1..N

**Frontend (1 new + 1 strengthened):**
- \`api.test.ts\`: rank round-trips from mocked response
- \`GameOverOverlay.test.tsx\`: regression guard — asserts exact text \`"Saved! #2"\` for a score=1234/rank=2 entry (would have printed \`"Saved! #1,234"\` under the bug)

## Test Plan

- [x] Backend: 425/425 pytest pass, 97.55% coverage
- [x] Frontend: 584/584 jest pass
- [x] Lint/prettier/black all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)