### PR TITLE
test(twenty48): deterministic spawn seed for e2e + reproducible unit tests

### DIFF
--- a/frontend/src/game/twenty48/__tests__/engine.test.ts
+++ b/frontend/src/game/twenty48/__tests__/engine.test.ts
@@ -5,7 +5,16 @@
  * behaviorally identical.
  */
 
-import { newGame, move, slideAndMerge, isGameOver, SIZE, Direction } from "../engine";
+import {
+  newGame,
+  move,
+  slideAndMerge,
+  isGameOver,
+  setRng,
+  createSeededRng,
+  SIZE,
+  Direction,
+} from "../engine";
 import { Twenty48State } from "../types";
 
 // Build a state with a specific board, bypassing random spawns.
@@ -334,5 +343,97 @@ describe("spawn probability", () => {
     const ratio2 = counts[2] / (counts[2] + counts[4]);
     expect(ratio2).toBeGreaterThanOrEqual(0.85);
     expect(ratio2).toBeLessThanOrEqual(0.95);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seedable RNG
+// ---------------------------------------------------------------------------
+
+describe("seedable RNG (setRng + createSeededRng)", () => {
+  afterEach(() => {
+    // Restore default RNG so subsequent tests aren't affected.
+    setRng(Math.random);
+  });
+
+  it("same seed produces identical initial boards", () => {
+    setRng(createSeededRng(42));
+    const a = newGame();
+    setRng(createSeededRng(42));
+    const b = newGame();
+    expect(a.board).toEqual(b.board);
+  });
+
+  it("different seeds usually produce different boards", () => {
+    setRng(createSeededRng(1));
+    const a = newGame();
+    setRng(createSeededRng(999));
+    const b = newGame();
+    // Two different seeds should diverge on at least one cell.
+    const flatA = a.board.flat();
+    const flatB = b.board.flat();
+    const anyDiff = flatA.some((v, i) => v !== flatB[i]);
+    expect(anyDiff).toBe(true);
+  });
+
+  it("same seed replays the exact tile sequence over 10 moves", () => {
+    // Run A
+    setRng(createSeededRng(7));
+    let a = newGame();
+    const sequenceA: number[][][] = [a.board.map((r) => [...r])];
+    const directions: Direction[] = ["left", "down", "right", "up", "left"];
+    for (const d of directions) {
+      try {
+        a = move(a, d);
+        sequenceA.push(a.board.map((r) => [...r]));
+      } catch {
+        // "no effect" — try the next direction
+      }
+    }
+
+    // Run B with same seed
+    setRng(createSeededRng(7));
+    let b = newGame();
+    const sequenceB: number[][][] = [b.board.map((r) => [...r])];
+    for (const d of directions) {
+      try {
+        b = move(b, d);
+        sequenceB.push(b.board.map((r) => [...r]));
+      } catch {
+        // same skip
+      }
+    }
+
+    expect(sequenceA).toEqual(sequenceB);
+  });
+
+  it("rng returning 0.5 spawns a 2 (not 4) — probability gate at 0.9", () => {
+    // 0.5 < 0.9 → spawns 2. First call picks the cell index (floor(0.5 * N)),
+    // second call decides 2 vs 4.
+    setRng(() => 0.5);
+    const s = newGame();
+    const nonZero = s.board.flat().filter((v) => v !== 0);
+    // newGame spawns 2 tiles; both should be 2s.
+    expect(nonZero).toEqual([2, 2]);
+  });
+
+  it("rng returning 0.95 spawns a 4 — probability gate at 0.9", () => {
+    setRng(() => 0.95);
+    const s = newGame();
+    const nonZero = s.board.flat().filter((v) => v !== 0);
+    // 0.95 >= 0.9 → spawns 4s.
+    expect(nonZero).toEqual([4, 4]);
+  });
+
+  it("setRng(Math.random) after afterEach restores non-determinism", () => {
+    // Sanity: back on default, two games should almost always differ.
+    const a = newGame();
+    const b = newGame();
+    // Not guaranteed to differ, but across 16 cells with random placement
+    // the odds of a full match are vanishingly small.
+    const flatA = a.board.flat();
+    const flatB = b.board.flat();
+    const anyDiff = flatA.some((v, i) => v !== flatB[i]);
+    expect(anyDiff).toBe(true);
   });
 });

--- a/frontend/src/game/twenty48/engine.ts
+++ b/frontend/src/game/twenty48/engine.ts
@@ -62,6 +62,51 @@ function boardsEqual(a: readonly number[][], b: readonly number[][]): boolean {
   return true;
 }
 
+// ---------------------------------------------------------------------------
+// Seedable RNG
+//
+// Both spawn decisions (which empty cell, 2 vs 4) go through `_rng` so tests
+// and e2e flows can pin the sequence with `setRng(createSeededRng(seed))`.
+// Default is Math.random for normal gameplay. After each test that calls
+// setRng, call setRng(Math.random) to restore the default.
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+/**
+ * LCG (same parameters as Cascade's seeded RNG). Deterministic for a given
+ * seed. Not cryptographic — testing only.
+ */
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// E2E test hook — exposed only when __DEV__ is true OR EXPO_PUBLIC_TEST_HOOKS
+// is set (production e2e builds). Metro strips `if (__DEV__)` branches from
+// production bundles; the EXPO_PUBLIC_TEST_HOOKS env var opts in explicitly
+// for Playwright/Maestro flows that need deterministic spawns against a
+// production-shaped bundle. Call `globalThis.__twenty48_setSeed(n)` before
+// the next `newGame()` to pin the tile sequence.
+const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
+const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
+if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
+  (globalThis as unknown as { __twenty48_setSeed?: (seed: number) => void }).__twenty48_setSeed = (
+    seed: number
+  ) => {
+    setRng(createSeededRng(seed));
+  };
+}
+
 function spawnTile(board: number[][]): void {
   const empty: Array<[number, number]> = [];
   for (let r = 0; r < SIZE; r++) {
@@ -70,8 +115,8 @@ function spawnTile(board: number[][]): void {
     }
   }
   if (empty.length === 0) return;
-  const [r, c] = empty[Math.floor(Math.random() * empty.length)];
-  board[r][c] = Math.random() < 0.9 ? 2 : 4;
+  const [r, c] = empty[Math.floor(_rng() * empty.length)];
+  board[r][c] = _rng() < 0.9 ? 2 : 4;
 }
 
 /**


### PR DESCRIPTION
## Summary

\`spawnTile()\` used \`Math.random()\` directly for both the empty-cell pick and the 2/4 probability, blocking score-verification e2e tests and reproducible edge-case unit tests. Adds a seedable RNG hook mirroring Cascade's \`createSeededRng\` pattern.

Closes #206.

## Changes (\`frontend/src/game/twenty48/engine.ts\`)

- Module-level \`_rng: RandomSource\` defaulting to \`Math.random\`.
- \`setRng(fn)\` exported for tests.
- \`createSeededRng(seed)\` exported — same LCG parameters as Cascade's implementation.
- Both \`Math.random()\` calls in \`spawnTile\` replaced with \`_rng()\`.

## E2E hook

- \`globalThis.__twenty48_setSeed(n)\` exposed when \`__DEV__\` is true OR \`EXPO_PUBLIC_TEST_HOOKS=1\` (for production-shaped e2e builds).
- **Verified stripped from normal production bundles** — \`grep -c __twenty48_setSeed\` = 0 when the env var is unset; = 1 when set.

## New Unit Tests (6)

| Test | Assertion |
|---|---|
| same seed → identical initial boards | seed reproducibility |
| different seeds usually produce different boards | seed spread |
| same seed replays exact 5-move sequence | long-term determinism |
| \`rng()=0.5\` spawns only 2s | probability gate < 0.9 |
| \`rng()=0.95\` spawns only 4s | probability gate >= 0.9 |
| \`setRng(Math.random)\` afterEach restores non-determinism | no cross-test leakage |

## Test Plan

- [x] \`npx jest\` — 590/590 pass (6 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` / \`format:check\` — clean
- [x] Verified hook stripped from production bundle when \`EXPO_PUBLIC_TEST_HOOKS\` unset (0 matches)
- [x] Verified hook present when \`EXPO_PUBLIC_TEST_HOOKS=1\` (1 match)

## Follow-up

The issue mentions "CI step: verify \`__twenty48_\` symbol is stripped from production bundles" — that could be added as a 2-line step in CI (the grep count verification above). Not included here; small enough to do separately if you want a permanent guard.

## Unlocks

Deterministic e2e tests for: score verification, win state, game-over detection, persistence. Also makes edge-case unit tests reproducible — construct specific boards by replaying a known seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)