### PR TITLE
test(blackjack): deterministic deck seed for verification tests

### DIFF
--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -17,6 +17,8 @@ import {
   handValue,
   isNaturalBlackjack,
   toViewState,
+  setRng,
+  createSeededRng,
   EngineState,
   Card,
 } from "../engine";
@@ -617,5 +619,71 @@ describe.each([
     const r = doubleDown(g);
     expect(r.outcome).toBe("lose");
     expect(r.chips).toBe(0);
+  });
+});
+
+// --- Seedable RNG ---------------------------------------------------------
+
+describe("seedable RNG (setRng + createSeededRng)", () => {
+  afterEach(() => {
+    // Restore default RNG so subsequent tests aren't affected.
+    setRng(Math.random);
+  });
+
+  it("same seed produces identical shuffled decks", () => {
+    setRng(createSeededRng(42));
+    const a = newGame();
+    setRng(createSeededRng(42));
+    const b = newGame();
+    expect(a.deck).toEqual(b.deck);
+  });
+
+  it("different seeds produce different decks", () => {
+    setRng(createSeededRng(1));
+    const a = newGame();
+    setRng(createSeededRng(999));
+    const b = newGame();
+    expect(a.deck).not.toEqual(b.deck);
+  });
+
+  it("same seed replays identical placeBet outcome (deal order preserved)", () => {
+    setRng(createSeededRng(7));
+    const a = placeBet(newGame(), 100);
+    setRng(createSeededRng(7));
+    const b = placeBet(newGame(), 100);
+    expect(a.player_hand).toEqual(b.player_hand);
+    expect(a.dealer_hand).toEqual(b.dealer_hand);
+    expect(a.phase).toEqual(b.phase);
+    expect(a.outcome).toEqual(b.outcome);
+  });
+
+  it("same seed replays identical stand → dealer play sequence", () => {
+    setRng(createSeededRng(123));
+    let a = placeBet(newGame(), 100);
+    if (a.phase === "player") a = stand(a);
+
+    setRng(createSeededRng(123));
+    let b = placeBet(newGame(), 100);
+    if (b.phase === "player") b = stand(b);
+
+    expect(a.player_hand).toEqual(b.player_hand);
+    expect(a.dealer_hand).toEqual(b.dealer_hand);
+    expect(a.outcome).toEqual(b.outcome);
+    expect(a.chips).toEqual(b.chips);
+  });
+
+  it("deck contains all 52 unique cards regardless of seed", () => {
+    setRng(createSeededRng(12345));
+    const { deck } = newGame();
+    expect(deck).toHaveLength(52);
+    const keys = new Set(deck.map((card) => `${card.rank}-${card.suit}`));
+    expect(keys.size).toBe(52);
+  });
+
+  it("setRng(Math.random) afterEach restores non-determinism", () => {
+    const a = newGame();
+    const b = newGame();
+    // Two fresh shuffles from Math.random almost never match across 52 cards.
+    expect(a.deck).not.toEqual(b.deck);
   });
 });

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -78,6 +78,35 @@ export function isNaturalBlackjack(cards: readonly Card[]): boolean {
   return cards.length === 2 && handValue(cards) === 21;
 }
 
+// ---------------------------------------------------------------------------
+// Seedable RNG
+//
+// The deck shuffle goes through `_rng` so tests and e2e flows can pin the
+// deal sequence with `setRng(createSeededRng(seed))`. Default is Math.random
+// for normal gameplay. Tests that call setRng must restore Math.random in
+// afterEach to avoid leaking determinism into later tests.
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+/**
+ * LCG (same parameters as Cascade's and Twenty48's seeded RNGs).
+ * Deterministic for a given seed. Not cryptographic — testing only.
+ */
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
 function freshShuffledDeck(): Card[] {
   const deck: Card[] = [];
   for (const s of SUITS) {
@@ -87,10 +116,26 @@ function freshShuffledDeck(): Card[] {
   }
   // Fisher–Yates shuffle
   for (let i = deck.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(_rng() * (i + 1));
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
   return deck;
+}
+
+// E2E test hook — exposed only when __DEV__ is true OR EXPO_PUBLIC_TEST_HOOKS
+// is set (production e2e builds). Metro strips `if (__DEV__)` branches from
+// production bundles; the EXPO_PUBLIC_TEST_HOOKS env var opts in explicitly
+// for Playwright/Maestro flows that need deterministic deals against a
+// production-shaped bundle. Call `globalThis.__blackjack_setSeed(n)` before
+// the next `newGame()` (or after) — subsequent reshuffles will draw from
+// the seeded stream too, so the entire session is reproducible.
+const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
+const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
+if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
+  (globalThis as unknown as { __blackjack_setSeed?: (seed: number) => void }).__blackjack_setSeed =
+    (seed: number) => {
+      setRng(createSeededRng(seed));
+    };
 }
 
 /**


### PR DESCRIPTION
## Summary

Mirror of #206 (twenty48 seeded RNG), for Blackjack. After #169 shipped the offline engine, \`freshShuffledDeck()\` used unseeded Fisher-Yates, which blocks score/chip-math verification in e2e and reproducible debugging ("replay this exact hand").

Closes #187.

## Changes (\`frontend/src/game/blackjack/engine.ts\`)

- Module-level \`_rng: RandomSource\` defaulting to \`Math.random\`.
- \`setRng(fn)\` exported for tests.
- \`createSeededRng(seed)\` — LCG matching Cascade's and Twenty48's seeded RNGs (same parameters for consistency across the game module family).
- \`Math.random()\` in the Fisher-Yates shuffle → \`_rng()\`.

## E2E hook

- \`globalThis.__blackjack_setSeed(n)\` exposed when \`__DEV__\` is true OR \`EXPO_PUBLIC_TEST_HOOKS=1\`.
- **Verified stripped from production bundles**: 0 matches when env unset, 1 match when \`EXPO_PUBLIC_TEST_HOOKS=1\` is set at build time.

## New Unit Tests (6)

| Test | Assertion |
|---|---|
| same seed → identical decks | deck-level determinism |
| different seeds → different decks | seed spread |
| same seed → identical \`placeBet\` outcome | player + dealer hand match |
| same seed → identical \`stand → dealer play\` sequence | full outcome reproduction |
| seeded deck still contains all 52 unique cards | shuffle integrity |
| \`setRng(Math.random)\` afterEach restores non-determinism | no cross-test leakage |

## Test Plan

- [x] \`npx jest\` — 596/596 pass (6 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` / \`format:check\` — clean
- [x] Prod bundle strip verified (0 matches → 1 match via env flag)

## Unlocks

- E2E tests for double-down payout verification (#170/#171 regression net)
- Blackjack payout ratio, bust outcomes, dealer soft-17 policy verification
- "Replay this exact hand" reproducible debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)