### PR TITLE
test(yacht): deterministic dice for score-verification e2e tests

### DIFF
--- a/frontend/src/game/yacht/__tests__/engine.test.ts
+++ b/frontend/src/game/yacht/__tests__/engine.test.ts
@@ -11,6 +11,8 @@ import {
   possibleScores,
   calculateScore,
   computeDerived,
+  setRng,
+  createSeededRng,
   Category,
   CATEGORIES,
 } from "../engine";
@@ -480,5 +482,75 @@ describe("joker rule — possibleScores", () => {
     const ps = possibleScores(g);
     expect(ps.twos).toBe(10);
     expect(ps.full_house).toBe(0);
+  });
+});
+
+// --- Seedable RNG ---------------------------------------------------------
+
+describe("seedable RNG (setRng + createSeededRng)", () => {
+  afterEach(() => {
+    // Restore default RNG so subsequent tests aren't affected.
+    setRng(Math.random);
+  });
+
+  it("same seed produces identical first roll", () => {
+    setRng(createSeededRng(42));
+    const a = roll(newGame(), [false, false, false, false, false]);
+    setRng(createSeededRng(42));
+    const b = roll(newGame(), [false, false, false, false, false]);
+    expect(a.dice).toEqual(b.dice);
+  });
+
+  it("different seeds produce different rolls", () => {
+    setRng(createSeededRng(1));
+    const a = roll(newGame(), [false, false, false, false, false]);
+    setRng(createSeededRng(999));
+    const b = roll(newGame(), [false, false, false, false, false]);
+    expect(a.dice).not.toEqual(b.dice);
+  });
+
+  it("same seed replays an identical 3-roll turn", () => {
+    const held = [false, false, false, false, false];
+
+    setRng(createSeededRng(7));
+    let a = roll(newGame(), held);
+    a = roll(a, held);
+    a = roll(a, held);
+
+    setRng(createSeededRng(7));
+    let b = roll(newGame(), held);
+    b = roll(b, held);
+    b = roll(b, held);
+
+    expect(a.dice).toEqual(b.dice);
+    expect(a.rolls_used).toEqual(b.rolls_used);
+  });
+
+  it("held dice are preserved across seeded re-rolls", () => {
+    setRng(createSeededRng(123));
+    let g = roll(newGame(), [false, false, false, false, false]);
+    const firstRoll = [...g.dice];
+    // Hold dice 0 and 1, reroll the rest with a seeded continuation.
+    g = roll(g, [true, true, false, false, false]);
+    expect(g.dice[0]).toBe(firstRoll[0]);
+    expect(g.dice[1]).toBe(firstRoll[1]);
+  });
+
+  it("seeded dice are always in 1..6", () => {
+    setRng(createSeededRng(999_999));
+    for (let i = 0; i < 20; i++) {
+      const g = roll(newGame(), [false, false, false, false, false]);
+      for (const d of g.dice) {
+        expect(d).toBeGreaterThanOrEqual(1);
+        expect(d).toBeLessThanOrEqual(6);
+      }
+    }
+  });
+
+  it("setRng(Math.random) afterEach restores non-determinism", () => {
+    // Two fresh rolls from Math.random almost never match across 5 dice.
+    const a = roll(newGame(), [false, false, false, false, false]);
+    const b = roll(newGame(), [false, false, false, false, false]);
+    expect(a.dice).not.toEqual(b.dice);
   });
 });

--- a/frontend/src/game/yacht/engine.ts
+++ b/frontend/src/game/yacht/engine.ts
@@ -62,6 +62,51 @@ const FACE_TO_UPPER: Record<number, Category> = {
 };
 
 // ---------------------------------------------------------------------------
+// Seedable RNG
+//
+// Die rolls go through `_rng` so tests and e2e flows can pin the dice
+// sequence with `setRng(createSeededRng(seed))`. Default is Math.random for
+// normal gameplay. Tests that call setRng must restore Math.random in
+// afterEach to avoid leaking determinism into later tests.
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+/**
+ * LCG (same parameters as Cascade's, Twenty48's, and Blackjack's seeded
+ * RNGs). Deterministic for a given seed. Not cryptographic — testing only.
+ */
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (1664525 * state + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// E2E test hook — exposed only when __DEV__ is true OR EXPO_PUBLIC_TEST_HOOKS
+// is set (production e2e builds). Metro strips `if (__DEV__)` branches from
+// production bundles; the EXPO_PUBLIC_TEST_HOOKS env var opts in explicitly
+// for Playwright/Maestro flows that need deterministic dice against a
+// production-shaped bundle. Call `globalThis.__yacht_setSeed(n)` before
+// the next `newGame()` to pin the roll sequence.
+const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
+const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
+if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
+  (globalThis as unknown as { __yacht_setSeed?: (seed: number) => void }).__yacht_setSeed = (
+    seed: number
+  ) => {
+    setRng(createSeededRng(seed));
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Pure scoring functions
 // ---------------------------------------------------------------------------
 
@@ -260,7 +305,7 @@ export function roll(state: GameState, heldInput: readonly boolean[]): GameState
 
   const nextDice = [...state.dice];
   for (let i = 0; i < 5; i++) {
-    if (!held[i]) nextDice[i] = 1 + Math.floor(Math.random() * 6);
+    if (!held[i]) nextDice[i] = 1 + Math.floor(_rng() * 6);
   }
 
   return withDerived({


### PR DESCRIPTION
## Summary

Third and final game to get the seeded-RNG seam (after #206 twenty48 and #187 blackjack). After #156 shipped the Yacht offline engine, \`roll()\` used unseeded \`Math.random()\`, blocking score/joker/bonus e2e assertions — \`yacht-full-game.spec.ts\` can only check UI transitions, not specific score values.

Closes #179.

## Changes (\`frontend/src/game/yacht/engine.ts\`)

- Module-level \`_rng: RandomSource\` defaulting to \`Math.random\`.
- \`setRng(fn)\` exported for tests.
- \`createSeededRng(seed)\` — same LCG parameters as the other games for cross-module consistency.
- \`Math.random()\` in \`roll()\` → \`_rng()\`.

## E2E hook

- \`globalThis.__yacht_setSeed(n)\` exposed when \`__DEV__\` is true OR \`EXPO_PUBLIC_TEST_HOOKS=1\`.
- Verified stripped from production bundles: 0 matches when unset, 1 match when \`EXPO_PUBLIC_TEST_HOOKS=1\`.

## New Unit Tests (6)

| Test | Assertion |
|---|---|
| same seed → identical first roll | roll-level determinism |
| different seeds → different rolls | seed spread |
| same seed replays identical 3-roll turn | multi-roll continuation |
| held dice preserved across seeded re-rolls | hold semantics correct with seed |
| all seeded dice in 1..6 | output range correct |
| \`setRng(Math.random)\` afterEach restores non-determinism | no cross-test leakage |

## Test Plan

- [x] \`npx jest\` — 602/602 pass (6 new)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` / \`format:check\` — clean
- [x] Prod bundle strip verified (0 → 1 via env flag)

## Unlocks

E2E tests for: score-verification (roll [5,5,5,5,5] → Yacht scores 50), joker rule bonuses, upper-bonus threshold, any specific scoring scenario. Also "replay this exact game" reproducible debugging.

## Cross-Game Pattern Complete

All three solo offline games now have consistent seedable RNG infrastructure:

| Game | PR | Hook |
|---|---|---|
| Twenty48 | #221 | \`globalThis.__twenty48_setSeed(n)\` |
| Blackjack | #222 | \`globalThis.__blackjack_setSeed(n)\` |
| Yacht | this | \`globalThis.__yacht_setSeed(n)\` |

Identical LCG parameters, identical \`setRng\`/\`createSeededRng\`/\`RandomSource\` exports, identical strip behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)