### PR TITLE
test(blackjack): backend ↔ frontend parity harness (#172)

### DIFF
--- a/backend/tests/fixtures/blackjack_parity.json
+++ b/backend/tests/fixtures/blackjack_parity.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "natural_blackjack",
+    "description": "Player dealt A+K (natural 21); dealer has 2+5. Pays 3:2.",
+    "deck": [
+      { "suit": "♥", "rank": "5" },
+      { "suit": "♣", "rank": "K" },
+      { "suit": "♦", "rank": "2" },
+      { "suit": "♠", "rank": "A" }
+    ],
+    "actions": ["bet:100"],
+    "expected": {
+      "phase": "result",
+      "outcome": "blackjack",
+      "chips": 1150,
+      "payout": 150,
+      "bet": 100
+    }
+  },
+  {
+    "id": "push_both_blackjack",
+    "description": "Both player and dealer dealt natural 21. Push — chips unchanged.",
+    "deck": [
+      { "suit": "♦", "rank": "K" },
+      { "suit": "♣", "rank": "K" },
+      { "suit": "♥", "rank": "A" },
+      { "suit": "♠", "rank": "A" }
+    ],
+    "actions": ["bet:100"],
+    "expected": {
+      "phase": "result",
+      "outcome": "push",
+      "chips": 1000,
+      "payout": 0,
+      "bet": 100
+    }
+  },
+  {
+    "id": "dealer_bust",
+    "description": "Player stands on 18; dealer hits from 15 and busts with 25.",
+    "deck": [
+      { "suit": "♥", "rank": "10" },
+      { "suit": "♦", "rank": "9" },
+      { "suit": "♣", "rank": "8" },
+      { "suit": "♥", "rank": "6" },
+      { "suit": "♠", "rank": "10" }
+    ],
+    "actions": ["bet:100", "stand"],
+    "expected": {
+      "phase": "result",
+      "outcome": "win",
+      "chips": 1100,
+      "payout": 100,
+      "bet": 100
+    }
+  },
+  {
+    "id": "player_bust",
+    "description": "Player holds 13, hits, draws 10 and busts with 23.",
+    "deck": [
+      { "suit": "♥", "rank": "10" },
+      { "suit": "♣", "rank": "8" },
+      { "suit": "♦", "rank": "4" },
+      { "suit": "♥", "rank": "6" },
+      { "suit": "♠", "rank": "9" }
+    ],
+    "actions": ["bet:100", "hit"],
+    "expected": {
+      "phase": "result",
+      "outcome": "lose",
+      "chips": 900,
+      "payout": -100,
+      "bet": 100
+    }
+  },
+  {
+    "id": "push_equal_values",
+    "description": "Player stands on 18; dealer also reaches 18. Push.",
+    "deck": [
+      { "suit": "♦", "rank": "9" },
+      { "suit": "♣", "rank": "8" },
+      { "suit": "♥", "rank": "9" },
+      { "suit": "♠", "rank": "10" }
+    ],
+    "actions": ["bet:100", "stand"],
+    "expected": {
+      "phase": "result",
+      "outcome": "push",
+      "chips": 1000,
+      "payout": 0,
+      "bet": 100
+    }
+  },
+  {
+    "id": "double_down_win",
+    "description": "Player doubles 11 → 21; dealer hits 15 → 18. Player wins double bet.",
+    "deck": [
+      { "suit": "♠", "rank": "3" },
+      { "suit": "♣", "rank": "10" },
+      { "suit": "♣", "rank": "8" },
+      { "suit": "♦", "rank": "2" },
+      { "suit": "♥", "rank": "7" },
+      { "suit": "♠", "rank": "9" }
+    ],
+    "actions": ["bet:100", "double_down"],
+    "expected": {
+      "phase": "result",
+      "outcome": "win",
+      "chips": 1200,
+      "payout": 200,
+      "bet": 200
+    }
+  },
+  {
+    "id": "double_down_lose",
+    "description": "Player doubles 11 → 16; dealer stands on 17. Player loses double bet.",
+    "deck": [
+      { "suit": "♣", "rank": "5" },
+      { "suit": "♦", "rank": "7" },
+      { "suit": "♦", "rank": "2" },
+      { "suit": "♥", "rank": "K" },
+      { "suit": "♠", "rank": "9" }
+    ],
+    "actions": ["bet:100", "double_down"],
+    "expected": {
+      "phase": "result",
+      "outcome": "lose",
+      "chips": 800,
+      "payout": -200,
+      "bet": 200
+    }
+  },
+  {
+    "id": "double_down_bust",
+    "description": "Player doubles 14 → draws K → 24. Busts; loses double bet.",
+    "deck": [
+      { "suit": "♣", "rank": "K" },
+      { "suit": "♣", "rank": "8" },
+      { "suit": "♦", "rank": "5" },
+      { "suit": "♥", "rank": "7" },
+      { "suit": "♠", "rank": "9" }
+    ],
+    "actions": ["bet:100", "double_down"],
+    "expected": {
+      "phase": "result",
+      "outcome": "lose",
+      "chips": 800,
+      "payout": -200,
+      "bet": 200
+    }
+  }
+]

--- a/backend/tests/test_blackjack_parity.py
+++ b/backend/tests/test_blackjack_parity.py
@@ -1,0 +1,68 @@
+"""
+Backend ↔ frontend parity test harness for Blackjack (issue #172).
+
+Loads backend/tests/fixtures/blackjack_parity.json and runs every scenario
+through the Python engine.  The same JSON file is consumed by the Jest suite
+(frontend/src/game/blackjack/__tests__/parity.test.ts), so a divergence
+between the two implementations surfaces as a fixture failure in one suite.
+
+Deck layout note
+----------------
+Each fixture supplies a ``deck`` array ordered so that ``list.pop()``
+(equivalent to TypeScript's ``Array.prototype.pop()``) yields cards in deal
+order: player[0], dealer[0], player[1], dealer[1], then any hit/double cards.
+That is, the *last* element of the array is dealt first.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from blackjack.game import BlackjackGame, Card
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "blackjack_parity.json"
+
+
+def _load_fixtures() -> list[dict]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _make_deck(raw: list[dict]) -> list[Card]:
+    return [Card(suit=c["suit"], rank=c["rank"]) for c in raw]
+
+
+def _run_action(game: BlackjackGame, action: str) -> None:
+    if action.startswith("bet:"):
+        game.place_bet(int(action.split(":")[1]))
+    elif action == "hit":
+        game.hit()
+    elif action == "stand":
+        game.stand()
+    elif action == "double_down":
+        game.double_down()
+    elif action == "new_hand":
+        game.new_hand()
+    else:
+        raise ValueError(f"Unknown action: {action!r}")
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    _load_fixtures(),
+    ids=[f["id"] for f in _load_fixtures()],
+)
+def test_parity_scenario(fixture: dict) -> None:
+    game = BlackjackGame(_deck=_make_deck(fixture["deck"]))
+
+    for action in fixture["actions"]:
+        _run_action(game, action)
+
+    exp = fixture["expected"]
+    assert game.phase == exp["phase"], f"[{fixture['id']}] phase mismatch"
+    assert game.outcome == exp["outcome"], f"[{fixture['id']}] outcome mismatch"
+    assert game.chips == exp["chips"], f"[{fixture['id']}] chips mismatch"
+    assert game.payout == exp["payout"], f"[{fixture['id']}] payout mismatch"
+    assert game.bet == exp["bet"], f"[{fixture['id']}] bet mismatch"

--- a/frontend/src/game/blackjack/__tests__/parity.test.ts
+++ b/frontend/src/game/blackjack/__tests__/parity.test.ts
@@ -14,13 +14,9 @@
  */
 
 import { Card, EngineState, doubleDown, hit, newGame, placeBet, stand } from "../engine";
-
-// JSON import — resolveJsonModule is enabled via expo/tsconfig.base.
-// The path goes 5 levels up from frontend/src/game/blackjack/__tests__/ to
-// the repo root, then into backend/tests/fixtures/.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const fixtures =
-  require("../../../../../backend/tests/fixtures/blackjack_parity.json") as ParityFixture[];
+// resolveJsonModule is enabled via expo/tsconfig.base.
+// Path: 5 levels up from __tests__/ to repo root, then into backend/tests/fixtures/.
+import fixtureData from "../../../../../backend/tests/fixtures/blackjack_parity.json";
 
 interface ParityFixture {
   id: string;
@@ -45,6 +41,8 @@ function runAction(state: EngineState, action: string): EngineState {
   if (action === "double_down") return doubleDown(state);
   throw new Error(`Unknown action: ${action}`);
 }
+
+const fixtures = fixtureData as ParityFixture[];
 
 test.each(fixtures.map((f) => [f.id, f] as [string, ParityFixture]))(
   "parity: %s",

--- a/frontend/src/game/blackjack/__tests__/parity.test.ts
+++ b/frontend/src/game/blackjack/__tests__/parity.test.ts
@@ -19,7 +19,8 @@ import { Card, EngineState, doubleDown, hit, newGame, placeBet, stand } from "..
 // The path goes 5 levels up from frontend/src/game/blackjack/__tests__/ to
 // the repo root, then into backend/tests/fixtures/.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const fixtures = require("../../../../../backend/tests/fixtures/blackjack_parity.json") as ParityFixture[];
+const fixtures =
+  require("../../../../../backend/tests/fixtures/blackjack_parity.json") as ParityFixture[];
 
 interface ParityFixture {
   id: string;
@@ -60,5 +61,5 @@ test.each(fixtures.map((f) => [f.id, f] as [string, ParityFixture]))(
     expect(state.chips).toBe(exp.chips);
     expect(state.payout).toBe(exp.payout);
     expect(state.bet).toBe(exp.bet);
-  },
+  }
 );

--- a/frontend/src/game/blackjack/__tests__/parity.test.ts
+++ b/frontend/src/game/blackjack/__tests__/parity.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Frontend ↔ backend parity test harness for Blackjack (issue #172).
+ *
+ * Loads the same fixture file consumed by the Python suite
+ * (backend/tests/fixtures/blackjack_parity.json) and runs every scenario
+ * through the TypeScript engine.  A divergence between the two
+ * implementations will surface as a failure here or in pytest.
+ *
+ * Deck layout note
+ * ----------------
+ * Each fixture supplies a `deck` array ordered so that `Array.prototype.pop()`
+ * yields cards in deal order: player[0], dealer[0], player[1], dealer[1],
+ * then any hit/double cards.  The *last* element is dealt first.
+ */
+
+import { Card, EngineState, doubleDown, hit, newGame, placeBet, stand } from "../engine";
+
+// JSON import — resolveJsonModule is enabled via expo/tsconfig.base.
+// The path goes 5 levels up from frontend/src/game/blackjack/__tests__/ to
+// the repo root, then into backend/tests/fixtures/.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fixtures = require("../../../../../backend/tests/fixtures/blackjack_parity.json") as ParityFixture[];
+
+interface ParityFixture {
+  id: string;
+  description: string;
+  deck: Card[];
+  actions: string[];
+  expected: {
+    phase: string;
+    outcome: string | null;
+    chips: number;
+    payout: number;
+    bet: number;
+  };
+}
+
+function runAction(state: EngineState, action: string): EngineState {
+  if (action.startsWith("bet:")) {
+    return placeBet(state, parseInt(action.split(":")[1], 10));
+  }
+  if (action === "hit") return hit(state);
+  if (action === "stand") return stand(state);
+  if (action === "double_down") return doubleDown(state);
+  throw new Error(`Unknown action: ${action}`);
+}
+
+test.each(fixtures.map((f) => [f.id, f] as [string, ParityFixture]))(
+  "parity: %s",
+  (_id, fixture) => {
+    let state = newGame(fixture.deck);
+
+    for (const action of fixture.actions) {
+      state = runAction(state, action);
+    }
+
+    const exp = fixture.expected;
+    expect(state.phase).toBe(exp.phase);
+    expect(state.outcome).toBe(exp.outcome);
+    expect(state.chips).toBe(exp.chips);
+    expect(state.payout).toBe(exp.payout);
+    expect(state.bet).toBe(exp.bet);
+  },
+);

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -186,14 +186,14 @@ export function toViewState(s: EngineState): BlackjackState {
 // Public API — pure state transitions
 // ---------------------------------------------------------------------------
 
-export function newGame(): EngineState {
+export function newGame(deck?: Card[]): EngineState {
   return {
     chips: 1000,
     bet: 0,
     phase: "betting",
     outcome: null,
     payout: 0,
-    deck: freshShuffledDeck(),
+    deck: deck ?? freshShuffledDeck(),
     player_hand: [],
     dealer_hand: [],
     doubled: false,


### PR DESCRIPTION
## Summary

- Closes #172
- Adds `backend/tests/fixtures/blackjack_parity.json` — 8 shared deterministic scenarios (natural BJ, dealer bust, player bust, push, DD win/loss/bust)
- Both `pytest` and `jest` consume the same JSON; drift between the Python and TypeScript engines will surface as a CI failure in either suite
- Extends `newGame()` with an optional `deck?: Card[]` parameter for stacked-deck injection without touching the seeded RNG

## Test plan

- [ ] `backend/tests/test_blackjack_parity.py` — 8 parametrized pytest cases pass
- [ ] `frontend/src/game/blackjack/__tests__/parity.test.ts` — 8 `test.each` cases pass
- [ ] Existing blackjack engine + storage tests still pass (no regressions)
- [ ] CI green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)