### PR TITLE
test(twenty48): frontend component tests for Tile, Grid, GameOverlay (#140)

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -26,11 +26,12 @@ import cascade from "./src/i18n/locales/en/cascade.json";
 import errors from "./src/i18n/locales/en/errors.json";
 import blackjack from "./src/i18n/locales/en/blackjack.json";
 import pachisi from "./src/i18n/locales/en/pachisi.json";
+import twenty48 from "./src/i18n/locales/en/twenty48.json";
 
 i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
-  ns: ["common", "yacht", "cascade", "errors", "blackjack", "pachisi"],
+  ns: ["common", "yacht", "cascade", "errors", "blackjack", "pachisi", "twenty48"],
   defaultNS: "common",
   resources: {
     en: {
@@ -40,6 +41,7 @@ i18n.use(initReactI18next).init({
       errors,
       blackjack,
       pachisi,
+      twenty48,
     },
   },
   interpolation: { escapeValue: false },

--- a/frontend/src/components/twenty48/__tests__/GameOverlay.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/GameOverlay.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import GameOverlay from "../GameOverlay";
+import { ThemeProvider } from "../../../theme/ThemeContext";
+
+function renderOverlay(
+  type: "game_over" | "win",
+  overrides: Partial<React.ComponentProps<typeof GameOverlay>> = {}
+) {
+  const props = {
+    type,
+    score: 1024,
+    onNewGame: jest.fn(),
+    onHome: jest.fn(),
+    ...overrides,
+  };
+  return render(
+    <ThemeProvider>
+      <GameOverlay {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe("GameOverlay — game over state", () => {
+  it('shows "Game Over" title', () => {
+    const { getByText } = renderOverlay("game_over");
+    expect(getByText("Game Over")).toBeTruthy();
+  });
+
+  it("does not show keep playing button", () => {
+    const { queryByText } = renderOverlay("game_over");
+    expect(queryByText("Keep Playing")).toBeNull();
+  });
+
+  it('calls onNewGame when "New Game" is pressed', () => {
+    const onNewGame = jest.fn();
+    const { getByLabelText } = renderOverlay("game_over", { onNewGame });
+    fireEvent.press(getByLabelText("Start a new 2048 game"));
+    expect(onNewGame).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onHome when "Home" is pressed', () => {
+    const onHome = jest.fn();
+    const { getByLabelText } = renderOverlay("game_over", { onHome });
+    fireEvent.press(getByLabelText("Quit and return to home screen"));
+    expect(onHome).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GameOverlay — win state", () => {
+  it('shows "You Win!" title', () => {
+    const { getByText } = renderOverlay("win");
+    expect(getByText("You Win!")).toBeTruthy();
+  });
+
+  it("shows keep playing button when onKeepPlaying is provided", () => {
+    const { getByLabelText } = renderOverlay("win", { onKeepPlaying: jest.fn() });
+    expect(getByLabelText("Continue playing after reaching 2048")).toBeTruthy();
+  });
+
+  it("calls onKeepPlaying when button is pressed", () => {
+    const onKeepPlaying = jest.fn();
+    const { getByLabelText } = renderOverlay("win", { onKeepPlaying });
+    fireEvent.press(getByLabelText("Continue playing after reaching 2048"));
+    expect(onKeepPlaying).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onNewGame when New Game is pressed from win state", () => {
+    const onNewGame = jest.fn();
+    const { getByLabelText } = renderOverlay("win", { onNewGame, onKeepPlaying: jest.fn() });
+    fireEvent.press(getByLabelText("Start a new 2048 game"));
+    expect(onNewGame).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show keep playing button when onKeepPlaying is not provided", () => {
+    const { queryByLabelText } = renderOverlay("win");
+    expect(queryByLabelText("Continue playing after reaching 2048")).toBeNull();
+  });
+});

--- a/frontend/src/components/twenty48/__tests__/Grid.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/Grid.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import Grid from "../Grid";
+import { ThemeProvider } from "../../../theme/ThemeContext";
+
+const EMPTY_BOARD = Array.from({ length: 4 }, () => Array(4).fill(0));
+
+function renderGrid(board = EMPTY_BOARD) {
+  return render(
+    <ThemeProvider>
+      <Grid board={board} />
+    </ThemeProvider>
+  );
+}
+
+describe("Grid", () => {
+  it("renders 16 cells for a 4×4 board", () => {
+    const { getAllByLabelText } = renderGrid();
+    // Each zero cell has accessibilityLabel "empty"
+    expect(getAllByLabelText("empty")).toHaveLength(16);
+  });
+
+  it("renders tiles for non-zero values", () => {
+    const board = EMPTY_BOARD.map((row) => [...row]);
+    board[0][0] = 2;
+    board[1][2] = 512;
+    const { getByText } = renderGrid(board);
+    expect(getByText("2")).toBeTruthy();
+    expect(getByText("512")).toBeTruthy();
+  });
+
+  it("does not render text for empty (zero) cells", () => {
+    const { queryByText } = renderGrid();
+    expect(queryByText("0")).toBeNull();
+  });
+
+  it("has accessibilityLabel 'Game board' on the container", () => {
+    const { getByLabelText } = renderGrid();
+    expect(getByLabelText("Game board")).toBeTruthy();
+  });
+
+  it("renders the correct count of non-zero tiles", () => {
+    const board = EMPTY_BOARD.map((row) => [...row]);
+    board[0][0] = 2;
+    board[2][3] = 4;
+    board[3][1] = 8;
+    const { getAllByLabelText } = renderGrid(board);
+    expect(getAllByLabelText("empty")).toHaveLength(13);
+    expect(getAllByLabelText("2")).toHaveLength(1);
+    expect(getAllByLabelText("4")).toHaveLength(1);
+    expect(getAllByLabelText("8")).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/twenty48/__tests__/Tile.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/Tile.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import Tile from "../Tile";
+
+describe("Tile", () => {
+  it.each([2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048])(
+    "renders correct number text for value %i",
+    (value) => {
+      const { getByText } = render(<Tile value={value} size={80} />);
+      expect(getByText(String(value))).toBeTruthy();
+    }
+  );
+
+  it("renders nothing for value 0 (empty tile)", () => {
+    const { queryByText } = render(<Tile value={0} size={80} />);
+    // No number text should appear
+    expect(queryByText("0")).toBeNull();
+  });
+
+  it("has accessibilityLabel 'empty' for value 0", () => {
+    const { getByLabelText } = render(<Tile value={0} size={80} />);
+    expect(getByLabelText("empty")).toBeTruthy();
+  });
+
+  it("has accessibilityLabel matching value for non-zero tiles", () => {
+    const { getByLabelText } = render(<Tile value={128} size={80} />);
+    expect(getByLabelText("128")).toBeTruthy();
+  });
+
+  it("uses smaller font size for 4-digit numbers", () => {
+    const { getByText } = render(<Tile value={1024} size={80} />);
+    const text = getByText("1024");
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontSize: 18 })])
+    );
+  });
+
+  it("uses smallest font size for 5-digit numbers", () => {
+    const { getByText } = render(<Tile value={16384} size={80} />);
+    const text = getByText("16384");
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontSize: 14 })])
+    );
+  });
+
+  it("uses large font size for 2-digit numbers", () => {
+    const { getByText } = render(<Tile value={64} size={80} />);
+    const text = getByText("64");
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontSize: 28 })])
+    );
+  });
+
+  it("uses medium font size for 3-digit numbers", () => {
+    const { getByText } = render(<Tile value={256} size={80} />);
+    const text = getByText("256");
+    expect(text.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ fontSize: 22 })])
+    );
+  });
+
+  it("applies known tile color for value 2", () => {
+    const { getByLabelText } = render(<Tile value={2} size={80} />);
+    const tile = getByLabelText("2");
+    expect(tile.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: "#eee4da" })])
+    );
+  });
+
+  it("applies fallback color for unknown high values", () => {
+    const { getByLabelText } = render(<Tile value={4096} size={80} />);
+    const tile = getByLabelText("4096");
+    expect(tile.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ backgroundColor: "#3c3a32" })])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #140
- Adds 34 unit tests across three new files covering all cases from the issue spec
- Registers `twenty48` in `jest.setup.ts` so translation strings resolve in tests

## Files

| File | Tests |
|------|-------|
| `Tile.test.tsx` | Number text for all tile values, empty tile, font sizes (4 buckets), tile colors, fallback color |
| `Grid.test.tsx` | 16 cells rendered, non-zero tiles, empty cells, `"Game board"` a11y label, correct tile counts |
| `GameOverlay.test.tsx` | Game Over title, win title, keep-playing button visibility, `onNewGame`/`onKeepPlaying`/`onHome` callbacks |

## Test plan

- [ ] 34 Jest tests pass locally
- [ ] Full suite (649 tests) passes with no regressions
- [ ] ESLint + Prettier clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)