### PR TITLE
fix(yacht): Play Again reset + Dismiss navigation (GH #225)

### DIFF
--- a/e2e/tests/yacht-errors.spec.ts
+++ b/e2e/tests/yacht-errors.spec.ts
@@ -8,6 +8,7 @@
  * navigation.
  *
  * GH #184 — extended with 5 additional error / guard cases.
+ * GH #225 — regression tests for "Play Again" reset bug.
  */
 
 import { test, expect } from "@playwright/test";
@@ -190,5 +191,123 @@ test.describe("Yacht — error paths and navigation", () => {
         .click();
       await expect(page.getByText("Round 2 / 13")).toBeVisible();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #225 — "Play Again" reset regression tests
+// ---------------------------------------------------------------------------
+
+const CATEGORY_LABELS_IN_ORDER = [
+  "Ones",
+  "Twos",
+  "Threes",
+  "Fours",
+  "Fives",
+  "Sixes",
+  "Three of a Kind",
+  "Four of a Kind",
+  "Full House (25)",
+  "Sm. Straight (30)",
+  "Lg. Straight (40)",
+  "Yacht! (50)",
+  "Chance",
+];
+
+test.describe("Yacht — Play Again reset regression (GH #225)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("yacht_game_v1"));
+    await page.goto("/");
+  });
+
+  /** Helper: play a full 13-round game and reach the game-over modal. */
+  async function playFullGame(page: Parameters<Parameters<typeof test>[1]>[0]) {
+    await page.getByRole("button", { name: "Play Yacht" }).click();
+    for (let round = 0; round < 13; round++) {
+      await page
+        .getByText(`Round ${round + 1} / 13`)
+        .waitFor({ timeout: 15000 });
+      await page.getByRole("button", { name: /Roll/i }).click();
+      await page.getByText(CATEGORY_LABELS_IN_ORDER[round]).first().click();
+    }
+    await page.getByText("Game Over!").waitFor({ timeout: 10000 });
+  }
+
+  test("Play Again resets to Round 1 / 13", async ({ page }) => {
+    await playFullGame(page);
+
+    await page.getByRole("button", { name: /start a new game/i }).click();
+
+    await expect(page.getByText("Round 1 / 13")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("Play Again clears all scored categories", async ({ page }) => {
+    await playFullGame(page);
+    await page.getByRole("button", { name: /start a new game/i }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // No category should show a filled score — they should all be "not available"
+    // (before the first roll, canScore is false so all show "not available")
+    await expect(
+      page.getByRole("button", { name: /Chance: not available/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Ones: not available/ }),
+    ).toBeVisible();
+  });
+
+  test("Play Again allows rolling and scoring immediately", async ({
+    page,
+  }) => {
+    await playFullGame(page);
+    await page.getByRole("button", { name: /start a new game/i }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const rollBtn = page.getByRole("button", { name: /Roll/i });
+    await expect(rollBtn).not.toBeDisabled();
+    await rollBtn.click();
+    await expect(
+      page.getByRole("button", { name: /Chance: potential score/ }),
+    ).toBeVisible();
+  });
+
+  test("localStorage is updated with round-1 state after Play Again", async ({
+    page,
+  }) => {
+    await playFullGame(page);
+    await page.getByRole("button", { name: /start a new game/i }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("yacht_game_v1"),
+    );
+    expect(stored).not.toBeNull();
+    const state = JSON.parse(stored!);
+    expect(state.round).toBe(1);
+    expect(state.game_over).toBe(false);
+    // All scores should be null
+    for (const v of Object.values(state.scores)) {
+      expect(v).toBeNull();
+    }
+  });
+
+  test("Dismiss navigates back to HomeScreen", async ({ page }) => {
+    await playFullGame(page);
+
+    await page.getByRole("button", { name: /dismiss/i }).click();
+
+    // After dismiss the user lands on HomeScreen
+    await expect(page.getByText("Gaming App").first()).toBeVisible({
+      timeout: 10000,
+    });
   });
 });

--- a/e2e/tests/yacht-errors.spec.ts
+++ b/e2e/tests/yacht-errors.spec.ts
@@ -120,7 +120,9 @@ test.describe("Yacht — error paths and navigation", () => {
     await expect(rollBtn).not.toBeDisabled();
   });
 
-  test("all score rows are disabled after game over", async ({ page }) => {
+  test("game-over modal shows final score and both action buttons", async ({
+    page,
+  }) => {
     const CATEGORY_LABELS_IN_ORDER = [
       "Ones",
       "Twos",
@@ -146,14 +148,13 @@ test.describe("Yacht — error paths and navigation", () => {
       await page.getByText(CATEGORY_LABELS_IN_ORDER[round]).first().click();
     }
 
-    // Dismiss the game-over modal to inspect the scorecard
+    // Modal should show final score and both action buttons
     await expect(page.getByText("Game Over!")).toBeVisible();
-    await page.getByRole("button", { name: /dismiss/i }).click();
-
-    // All scored rows should be disabled (game_over=true blocks canScore)
-    const chanceRow = page.getByRole("button", { name: /Chance: scored/ });
-    await expect(chanceRow).toBeVisible();
-    await expect(chanceRow).toBeDisabled();
+    await expect(page.getByText(/Final Score/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /start a new game/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /dismiss/i })).toBeVisible();
   });
 
   test("scratching a category (scoring 0) is not reversible", async ({

--- a/e2e/tests/yacht-full-game.spec.ts
+++ b/e2e/tests/yacht-full-game.spec.ts
@@ -53,7 +53,9 @@ test.describe("Yacht — full 13-round game journey", () => {
     await rollBtn.click();
 
     // After rolling, a die button with an accessible "Die N: showing X" label appears
-    await expect(page.getByRole("button", { name: /Die 1: showing \d/ })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Die 1: showing \d/ }),
+    ).toBeVisible();
   });
 
   test("scoring a category advances the round", async ({ page }) => {
@@ -79,7 +81,9 @@ test.describe("Yacht — full 13-round game journey", () => {
     await expect(page.getByText(/Final Score/i)).toBeVisible();
   });
 
-  test("Play Again from game-over modal starts a new game in place", async ({ page }) => {
+  test("Play Again from game-over modal starts a new game in place", async ({
+    page,
+  }) => {
     await page.getByRole("button", { name: "Play Yacht" }).click();
 
     for (let round = 0; round < 13; round++) {
@@ -94,7 +98,7 @@ test.describe("Yacht — full 13-round game journey", () => {
     await expect(page.getByRole("button", { name: /Roll/i })).toBeVisible();
   });
 
-  test("No Thanks dismisses game-over modal and keeps score visible", async ({ page }) => {
+  test("No Thanks navigates back to HomeScreen", async ({ page }) => {
     await page.getByRole("button", { name: "Play Yacht" }).click();
 
     for (let round = 0; round < 13; round++) {
@@ -105,6 +109,9 @@ test.describe("Yacht — full 13-round game journey", () => {
     await expect(page.getByText("Game Over!")).toBeVisible();
     await page.getByRole("button", { name: /dismiss/i }).click();
 
-    await expect(page.getByText("Game Over!")).not.toBeVisible();
+    // Dismiss now navigates back to HomeScreen rather than hiding the modal in-place.
+    await expect(page.getByText("Gaming App").first()).toBeVisible({
+      timeout: 10000,
+    });
   });
 });

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -59,8 +59,8 @@ export default function GameScreen({ navigation, route }: Props) {
     }
   }
 
-  const startNewGame = useCallback(() => {
-    clearGame();
+  const startNewGame = useCallback(async () => {
+    await clearGame();
     setGameState(newGame());
     setResetHeld((r) => !r);
     setError(null);
@@ -171,7 +171,7 @@ export default function GameScreen({ navigation, route }: Props) {
             </Pressable>
             <Pressable
               style={[styles.modalDismissButton]}
-              onPress={() => setGameState((s) => ({ ...s, game_over: false }))}
+              onPress={() => navigation.goBack()}
               accessibilityRole="button"
               accessibilityLabel={t("gameOver.dismissLabel")}
             >

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react-native";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
 import GameScreen from "../GameScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+import { saveGame, clearGame } from "../../game/yacht/storage";
 
 // ---------------------------------------------------------------------------
 // Mock yacht storage — no-op persistence
 // ---------------------------------------------------------------------------
 jest.mock("../../game/yacht/storage", () => ({
   saveGame: jest.fn(),
-  clearGame: jest.fn(),
+  clearGame: jest.fn().mockResolvedValue(undefined),
   loadGame: jest.fn().mockResolvedValue(null),
 }));
 
@@ -117,11 +118,130 @@ describe("GameScreen", () => {
     expect(getByText(/round.*1/i)).toBeTruthy();
   });
 
-  it("dismiss button closes modal and keeps final score", async () => {
-    const { getByRole, queryByText } = renderScreen({ game_over: true, total_score: 200 });
+  it("dismiss button navigates back to HomeScreen", async () => {
+    const { getByRole } = renderScreen({ game_over: true, total_score: 200 });
     await act(async () => {
       fireEvent.press(getByRole("button", { name: /dismiss/i }));
     });
+    expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #225 — "Play Again" reset correctness
+// ---------------------------------------------------------------------------
+
+describe("GameScreen — Play Again reset (GH #225)", () => {
+  // Build a fully-completed game state: all 13 categories filled, game_over true.
+  function makeGameOverState(): Record<string, unknown> {
+    return {
+      dice: [0, 0, 0, 0, 0],
+      held: [false, false, false, false, false],
+      rolls_used: 0,
+      round: 14, // engine advances past 13 after the last score
+      scores: {
+        ones: 3,
+        twos: 6,
+        threes: 9,
+        fours: 12,
+        fives: 15,
+        sixes: 18,
+        three_of_a_kind: 20,
+        four_of_a_kind: 0,
+        full_house: 25,
+        small_straight: 30,
+        large_straight: 40,
+        yacht: 50,
+        chance: 21,
+      },
+      game_over: true,
+      upper_subtotal: 63,
+      upper_bonus: 35,
+      yacht_bonus_count: 0,
+      yacht_bonus_total: 0,
+      total_score: 284,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Play Again resets round to 1", async () => {
+    const { getByRole, getByText } = renderScreen(makeGameOverState());
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    expect(getByText(/round.*1/i)).toBeTruthy();
+  });
+
+  it("Play Again resets all score categories to null", async () => {
+    const { getByRole, queryByText } = renderScreen(makeGameOverState());
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    // After reset, no category should show a filled score — modal is gone too
     expect(queryByText(/game over/i)).toBeNull();
+    // Total score should be 0
+    expect(queryByText("284")).toBeNull();
+  });
+
+  it("Play Again calls clearGame before saveGame to avoid the race condition", async () => {
+    const callOrder: string[] = [];
+    (clearGame as jest.Mock).mockImplementation(async () => {
+      callOrder.push("clearGame");
+    });
+    (saveGame as jest.Mock).mockImplementation(async () => {
+      callOrder.push("saveGame");
+    });
+
+    // Mount and flush the initial useEffect (which calls saveGame with the
+    // game-over state). We only care about the ordering triggered by "Play Again".
+    const { getByRole } = renderScreen(makeGameOverState());
+    await act(async () => {
+      await Promise.resolve(); // flush initial saveGame from useEffect
+    });
+    callOrder.length = 0; // reset tracker — only track calls from "Play Again" onward
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+
+    // clearGame must have been called
+    expect(clearGame).toHaveBeenCalled();
+    // saveGame must have been called (via useEffect on the new state)
+    await waitFor(() => expect(saveGame).toHaveBeenCalled());
+    // clearGame MUST appear before saveGame in the call order
+    const clearIdx = callOrder.indexOf("clearGame");
+    const saveIdx = callOrder.indexOf("saveGame");
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(saveIdx).toBeGreaterThan(clearIdx);
+  });
+
+  it("Play Again saves a fresh state (round:1, game_over:false, scores null)", async () => {
+    const { getByRole } = renderScreen(makeGameOverState());
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+
+    await waitFor(() => expect(saveGame).toHaveBeenCalled());
+    const savedState = (saveGame as jest.Mock).mock.calls.at(-1)?.[0];
+    expect(savedState.round).toBe(1);
+    expect(savedState.game_over).toBe(false);
+    // Every score category should be null
+    for (const v of Object.values(savedState.scores)) {
+      expect(v).toBeNull();
+    }
+  });
+
+  it("Play Again resets total_score to 0", async () => {
+    const { getByRole } = renderScreen(makeGameOverState());
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+
+    await waitFor(() => expect(saveGame).toHaveBeenCalled());
+    const savedState = (saveGame as jest.Mock).mock.calls.at(-1)?.[0];
+    expect(savedState.total_score).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause 1 fixed**: `startNewGame()` now `await`s `clearGame()` before calling `setGameState(newGame())`. Previously the race between `clearGame()` and the `saveGame` useEffect could delete the freshly-written round-1 state.
- **Root cause 2 fixed**: The "No Thanks" / Dismiss button now calls `navigation.goBack()` instead of `setGameState({...s, game_over: false})`. The old handler left the game stuck at round 14 with all categories filled and no way to recover without navigating away.

## New test coverage
**GameScreen.test.tsx** (5 new tests in `GH #225` describe block):
- Play Again resets round to 1
- Play Again resets all score categories to null
- Play Again calls `clearGame` before `saveGame` (ordering/race condition verified)
- Play Again saves a fresh state (round:1, game_over:false, scores null)
- Play Again resets total_score to 0

**e2e/tests/yacht-errors.spec.ts** (5 new e2e regression tests):
- Play Again resets to Round 1 / 13 after a full game
- Play Again clears all scored categories
- Play Again allows rolling and scoring immediately
- localStorage is updated with round-1 state after Play Again
- Dismiss navigates back to HomeScreen

## Test plan
- [ ] All 19 CI checks pass
- [ ] `GameScreen.test.tsx` — 12/12 tests pass locally ✓
- [ ] Playwright E2E regression tests pass (Play Again + Dismiss flows)

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)