### PR TITLE
fix(blackjack): persistent table layout + always-visible chip balance (GH #226, #227)

### DIFF
--- a/frontend/src/screens/BlackjackScreen.tsx
+++ b/frontend/src/screens/BlackjackScreen.tsx
@@ -132,8 +132,78 @@ export default function BlackjackScreen({ navigation }: Props) {
         </Text>
       )}
 
-      {/* Main content */}
-      <View style={styles.content}>
+      {/*
+       * GH #227 — Chip balance is now always visible during player and result
+       * phases. BettingPanel already shows chips during the betting phase, so
+       * this strip only appears outside of it.
+       */}
+      {state && state.phase !== "betting" && (
+        <Text
+          style={[styles.chipStrip, { color: colors.text }]}
+          accessibilityLabel={t("blackjack:chips.accessibilityLabel", { chips: state.chips })}
+        >
+          {t("blackjack:chips.display", { chips: state.chips })}
+        </Text>
+      )}
+
+      {/*
+       * GH #226 — BlackjackTable is now always rendered when state exists,
+       * including during the betting phase (where the hands are empty). This
+       * keeps the table felt visible between hands instead of wiping the screen
+       * and replacing it with the bet stepper.
+       */}
+      {state && (
+        <View style={styles.tableArea}>
+          <BlackjackTable
+            playerHand={state.player_hand}
+            dealerHand={state.dealer_hand}
+            phase={state.phase}
+          />
+        </View>
+      )}
+
+      {/* Phase-specific controls */}
+      <View style={styles.controls}>
+        {state?.phase === "result" && (
+          <>
+            <ResultBanner outcome={state.outcome!} payout={state.payout} />
+
+            <View style={styles.resultActions}>
+              <Pressable
+                style={[styles.actionBtn, { backgroundColor: colors.accent }]}
+                onPress={handleNextHand}
+                accessibilityRole="button"
+                accessibilityLabel={t("blackjack:actions.nextHandLabel")}
+              >
+                <Text style={[styles.actionBtnText, { color: colors.surface }]}>
+                  {t("blackjack:actions.nextHand")}
+                </Text>
+              </Pressable>
+
+              <Pressable
+                style={[styles.actionBtn, styles.quitBtn, { borderColor: colors.border }]}
+                onPress={() => navigation.navigate("Home")}
+                accessibilityRole="button"
+                accessibilityLabel={t("blackjack:actions.quitLabel")}
+              >
+                <Text style={[styles.actionBtnText, { color: colors.text }]}>
+                  {t("blackjack:actions.quit")}
+                </Text>
+              </Pressable>
+            </View>
+          </>
+        )}
+
+        {state?.phase === "player" && (
+          <ActionButtons
+            onHit={handleHit}
+            onStand={handleStand}
+            onDoubleDown={handleDoubleDown}
+            doubleDownAvailable={state.double_down_available}
+            loading={false}
+          />
+        )}
+
         {(!state || state.phase === "betting") && (
           <BettingPanel
             chips={state?.chips ?? 1000}
@@ -141,56 +211,6 @@ export default function BlackjackScreen({ navigation }: Props) {
             loading={false}
             error={error}
           />
-        )}
-
-        {state && state.phase !== "betting" && (
-          <>
-            <BlackjackTable
-              playerHand={state.player_hand}
-              dealerHand={state.dealer_hand}
-              phase={state.phase}
-            />
-
-            {state.phase === "result" && (
-              <>
-                <ResultBanner outcome={state.outcome!} payout={state.payout} />
-
-                <View style={styles.resultActions}>
-                  <Pressable
-                    style={[styles.actionBtn, { backgroundColor: colors.accent }]}
-                    onPress={handleNextHand}
-                    accessibilityRole="button"
-                    accessibilityLabel={t("blackjack:actions.nextHandLabel")}
-                  >
-                    <Text style={[styles.actionBtnText, { color: colors.surface }]}>
-                      {t("blackjack:actions.nextHand")}
-                    </Text>
-                  </Pressable>
-
-                  <Pressable
-                    style={[styles.actionBtn, styles.quitBtn, { borderColor: colors.border }]}
-                    onPress={() => navigation.navigate("Home")}
-                    accessibilityRole="button"
-                    accessibilityLabel={t("blackjack:actions.quitLabel")}
-                  >
-                    <Text style={[styles.actionBtnText, { color: colors.text }]}>
-                      {t("blackjack:actions.quit")}
-                    </Text>
-                  </Pressable>
-                </View>
-              </>
-            )}
-
-            {state.phase === "player" && (
-              <ActionButtons
-                onHit={handleHit}
-                onStand={handleStand}
-                onDoubleDown={handleDoubleDown}
-                doubleDownAvailable={state.double_down_available}
-                loading={false}
-              />
-            )}
-          </>
         )}
 
         {state && state.phase !== "betting" && error && (
@@ -244,14 +264,25 @@ const styles = StyleSheet.create({
     fontWeight: "500",
     textTransform: "uppercase",
     letterSpacing: 0.8,
-    marginBottom: 16,
+    marginBottom: 4,
   },
-  content: {
+  chipStrip: {
+    textAlign: "center",
+    fontSize: 20,
+    fontWeight: "700",
+    marginBottom: 12,
+  },
+  tableArea: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    padding: 24,
-    gap: 28,
+    paddingHorizontal: 24,
+  },
+  controls: {
+    alignItems: "center",
+    paddingHorizontal: 24,
+    paddingBottom: 32,
+    gap: 16,
   },
   resultActions: {
     width: "100%",

--- a/frontend/src/screens/__tests__/BlackjackScreen.test.tsx
+++ b/frontend/src/screens/__tests__/BlackjackScreen.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, act, screen, waitFor } from "@testing-library/react-
 import BlackjackScreen from "../BlackjackScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import { loadGame } from "../../game/blackjack/storage";
-import { newGame, placeBet, hit, stand } from "../../game/blackjack/engine";
+import { newGame, placeBet, stand } from "../../game/blackjack/engine";
 
 // ---------------------------------------------------------------------------
 // Mock blackjack storage — no saved game by default, no-op persistence.

--- a/frontend/src/screens/__tests__/BlackjackScreen.test.tsx
+++ b/frontend/src/screens/__tests__/BlackjackScreen.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { render, fireEvent, act, screen, waitFor } from "@testing-library/react-native";
 import BlackjackScreen from "../BlackjackScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+import { loadGame } from "../../game/blackjack/storage";
+import { newGame, placeBet, hit, stand } from "../../game/blackjack/engine";
 
 // ---------------------------------------------------------------------------
 // Mock blackjack storage — no saved game by default, no-op persistence.
@@ -66,5 +68,71 @@ describe("BlackjackScreen — header / navigation", () => {
   it("shows Blackjack title", async () => {
     renderScreen();
     await waitFor(() => expect(screen.getByText("Blackjack")).toBeTruthy());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #227 — Chip balance visible during player and result phases
+// ---------------------------------------------------------------------------
+
+describe("BlackjackScreen — chip balance visibility (GH #227)", () => {
+  it("chip balance is visible in BettingPanel during betting phase", async () => {
+    renderScreen();
+    await screen.findByText("Deal");
+    // BettingPanel renders "1000 chips" during betting
+    expect(screen.getByLabelText(/you have 1000 chips/i)).toBeTruthy();
+  });
+
+  it("chip balance remains visible after dealing (player phase)", async () => {
+    renderScreen();
+    await screen.findByText("Deal");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Deal"));
+    });
+    // After deal, either player or result phase — chips strip should be visible
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/you have \d+ chips/i)).toBeTruthy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH #226 — Persistent table layout — table visible during betting phase
+// ---------------------------------------------------------------------------
+
+describe("BlackjackScreen — persistent table layout (GH #226)", () => {
+  it("Dealer's Hand label is visible during the betting phase", async () => {
+    renderScreen();
+    await screen.findByText("Deal");
+    // Table is now always rendered; hand labels should be visible even pre-deal
+    expect(screen.getByText("Dealer's Hand")).toBeTruthy();
+    expect(screen.getByText("Your Hand")).toBeTruthy();
+  });
+
+  it("table labels remain visible after transitioning back to betting via Next Hand", async () => {
+    // Inject a result-phase state so we can press Next Hand
+    const resultState = (() => {
+      // Build a deterministic ended hand: deal, stand, which lands in result
+      let s = newGame();
+      s = placeBet(s, 100);
+      // Stand immediately (dealer will draw; eventually result phase)
+      s = stand(s);
+      return s;
+    })();
+    (loadGame as jest.Mock).mockResolvedValueOnce(resultState);
+
+    renderScreen();
+
+    // Wait until Next Hand button appears (result phase)
+    const nextHandBtn = await screen.findByText("Next Hand", {}, { timeout: 5000 });
+    await act(async () => {
+      fireEvent.press(nextHandBtn);
+    });
+
+    // Back in betting phase — table should still show hand labels
+    await waitFor(() => {
+      expect(screen.getByText("Deal")).toBeTruthy(); // BettingPanel visible
+      expect(screen.getByText("Dealer's Hand")).toBeTruthy(); // Table still visible
+    });
   });
 });


### PR DESCRIPTION
## Summary

Two UI bugs fixed in a single screen-level refactor of `BlackjackScreen.tsx`.

### GH #227 — Chip balance hidden during player-turn and result phases
`BettingPanel` was the only component rendering the chip count, and it was unmounted the moment cards were dealt. Players couldn't see their balance while deciding to Hit/Stand/Double Down or after a result.

**Fix:** Added a `chipStrip` text element rendered during `player` and `result` phases using the existing `chips.display` / `chips.accessibilityLabel` i18n keys. `BettingPanel` continues to show chips during betting — no duplication.

### GH #226 — Screen wipes between hands
Pressing **Next Hand** unmounted `BlackjackTable` and mounted `BettingPanel` in its place, creating a jarring full-viewport wipe on every hand.

**Fix:** `BlackjackTable` is now always rendered when `state` exists, including during the betting phase (where hands are empty — just the two hand labels are shown, like an empty felt). The layout is split into a `flex: 1` `tableArea` (table stays pinned) and a `controls` section pinned to the bottom. Transitioning back to betting via Next Hand keeps the table visible.

## New tests (4)
- Chip balance visible via `BettingPanel` during betting phase
- Chip balance visible via `chipStrip` after dealing (player/result phase)
- `Dealer's Hand` label visible during betting phase (table always rendered)
- Table labels still present after pressing Next Hand (transition to betting)

## Test plan
- [ ] All 19 CI checks pass
- [ ] `BlackjackScreen.test.tsx` — 8/8 tests pass locally ✓

Closes #226
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)