### PR TITLE
feat(ci): selective Playwright E2E scope per changed game (GH #239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,73 @@ jobs:
       working-directory: frontend
     secrets: inherit
 
+  detect-e2e-scope:
+    name: Detect E2E scope
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.scope.outputs.projects }}
+      label: ${{ steps.scope.outputs.label }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            yacht:
+              - 'frontend/src/screens/GameScreen*'
+              - 'frontend/src/components/Die*'
+              - 'frontend/src/components/DiceRow*'
+              - 'frontend/src/components/Scorecard*'
+              - 'frontend/src/components/ScoreRow*'
+              - 'frontend/src/game/yacht/**'
+              - 'backend/games/yacht*'
+            blackjack:
+              - 'frontend/src/screens/BlackjackScreen*'
+              - 'frontend/src/components/blackjack/**'
+              - 'frontend/src/game/blackjack/**'
+              - 'backend/games/blackjack*'
+            twenty48:
+              - 'frontend/src/screens/Twenty48Screen*'
+              - 'frontend/src/components/twenty48/**'
+              - 'frontend/src/game/twenty48/**'
+              - 'backend/games/twenty48*'
+            pachisi:
+              - 'frontend/src/screens/PachisiScreen*'
+              - 'frontend/src/components/pachisi/**'
+              - 'frontend/src/game/pachisi/**'
+              - 'backend/games/pachisi*'
+            shared:
+              - 'frontend/App.tsx'
+              - 'frontend/app.json'
+              - 'frontend/src/theme/**'
+              - 'frontend/src/components/OfflineBanner*'
+              - 'frontend/src/components/LanguageSwitcher*'
+              - 'backend/main.py'
+              - 'e2e/**'
+              - '.github/workflows/**'
+
+      - id: scope
+        run: |
+          # Push events or PRs targeting main always run the full suite
+          if [[ "${{ github.event_name }}" == "push" ]] || \
+             [[ "${{ github.base_ref }}" == "main" ]] || \
+             [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
+            echo "projects=yacht blackjack twenty48 pachisi cross" >> "$GITHUB_OUTPUT"
+            echo "label=full suite (push/main/shared change)" >> "$GITHUB_OUTPUT"
+          else
+            projects="cross"
+            [[ "${{ steps.filter.outputs.yacht }}"     == "true" ]] && projects="$projects yacht"
+            [[ "${{ steps.filter.outputs.blackjack }}" == "true" ]] && projects="$projects blackjack"
+            [[ "${{ steps.filter.outputs.twenty48 }}"  == "true" ]] && projects="$projects twenty48"
+            [[ "${{ steps.filter.outputs.pachisi }}"   == "true" ]] && projects="$projects pachisi"
+            echo "projects=$projects" >> "$GITHUB_OUTPUT"
+            echo "label=selective: $projects" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
     name: Playwright E2E
-    needs: [test-python, test-frontend]
+    needs: [test-python, test-frontend, detect-e2e-scope]
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.48.2-jammy
@@ -126,8 +190,12 @@ jobs:
         run: npx playwright install chromium --with-deps
         working-directory: e2e
 
-      - name: Run Playwright tests
-        run: npx playwright test
+      - name: Run Playwright tests (${{ needs.detect-e2e-scope.outputs.label }})
+        run: |
+          PROJECTS="${{ needs.detect-e2e-scope.outputs.projects }}"
+          ARGS=""
+          for p in $PROJECTS; do ARGS="$ARGS --project $p"; done
+          npx playwright test $ARGS
         working-directory: e2e
         env:
           CI: "true"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,12 +4,22 @@ import { join } from "path";
 /**
  * Playwright E2E configuration.
  *
+ * Named projects allow CI to run only the impacted game suite on dev PRs
+ * while always running the full suite on main PRs / pushes.
+ *
+ * Projects:
+ *   yacht      — yacht-*.spec.ts
+ *   blackjack  — blackjack-*.spec.ts
+ *   twenty48   — twenty48-*.spec.ts
+ *   pachisi    — pachisi-*.spec.ts
+ *   cross      — accessibility.spec.ts, cascade-flow.spec.ts, ui-preferences.spec.ts
+ *
+ * In CI the e2e job passes --project flags based on dorny/paths-filter output.
+ * Locally, `npx playwright test` runs all projects (no --project flag needed).
+ *
  * The webServer serves the pre-built Expo Web static export from
  * frontend/dist/.  In CI the build step runs separately before this job.
  * Locally, run `cd frontend && npx expo export --platform web` once first.
- *
- * The Yacht backend API (http://localhost:8000) is mocked via
- * page.route() in each test — no live backend is required.
  */
 export default defineConfig({
   testDir: "./tests",
@@ -19,7 +29,9 @@ export default defineConfig({
   },
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [["github"], ["html", { outputFolder: "playwright-report" }]] : "list",
+  reporter: process.env.CI
+    ? [["github"], ["html", { outputFolder: "playwright-report" }]]
+    : "list",
   use: {
     baseURL: "http://localhost:8081",
     trace: "on-first-retry",
@@ -27,7 +39,32 @@ export default defineConfig({
   },
   projects: [
     {
-      name: "chromium",
+      name: "yacht",
+      testMatch: "yacht-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "blackjack",
+      testMatch: "blackjack-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "twenty48",
+      testMatch: "twenty48-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "pachisi",
+      testMatch: "pachisi-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "cross",
+      testMatch: [
+        "accessibility.spec.ts",
+        "cascade-flow.spec.ts",
+        "ui-preferences.spec.ts",
+      ],
       use: { ...devices["Desktop Chrome"] },
     },
   ],


### PR DESCRIPTION
## Summary

- Adds 5 named Playwright projects (`yacht`, `blackjack`, `twenty48`, `pachisi`, `cross`) to `playwright.config.ts`
- Adds a `detect-e2e-scope` CI job that uses `dorny/paths-filter` to map changed file paths to game projects
- On `dev` PRs, only the impacted game suite + `cross` tests run; on `main` PRs / push events / shared-code changes, the full suite runs
- Step name in CI logs shows scope label (e.g., `selective: cross twenty48`) for clear visibility

## Scope Rules

| Trigger | Suite run |
|---|---|
| Push event (any branch) | Full suite |
| PR targeting `main` | Full suite |
| Shared code changed (`App.tsx`, `theme/`, `e2e/**`, CI ymls) | Full suite |
| PR to `dev`, game-specific change | `cross` + impacted game(s) only |

## Test plan
- [ ] Verify CI run on this PR shows selective scope (only `cross` + `twenty48` since only `playwright.config.ts` and `ci.yml` changed — both in `e2e/**` / `.github/workflows/**` → shared → full suite)
- [ ] Verify a future twenty48-only PR triggers `cross + twenty48` only
- [ ] Verify `cross` project always runs even when no game files changed

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)