### PR TITLE
fix(infra): set healthCheckPath /health on gaming-app-api

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,7 @@ services:
     rootDir: backend
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT --timeout-keep-alive 5 --limit-max-requests 10000
+    healthCheckPath: /health
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.0


### PR DESCRIPTION
Closes #218

## Summary
- Adds `healthCheckPath: /health` to the `gaming-app-api` service in `render.yaml`
- The `/health` endpoint (`backend/main.py:168`) already exists, returns `200 {"status":"ok"}`, and is rate-limited at 120/min — safe for Render's probe interval
- Without an explicit health check path, Render had no deterministic liveness probe; hypothesis is this caused the post-deploy SIGTERM with no auto-restart

## Test plan
- [ ] CI passes on this PR
- [ ] After merge + deploy, confirm Render dashboard shows health check passing against `/health`
- [ ] Optionally: trigger a manual restart via Render dashboard and confirm service auto-recovers within ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)