### PR TITLE
fix(cascade): quick wins — dead i18n keys, boundary escape tests, backend coverage

### DIFF
--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -210,7 +210,7 @@ class TestTieBreak:
 
         scores = client.get("/cascade/scores").json()["scores"]
         assert scores[0]["player_name"] == "Alice"  # older entry is rank 1
-        assert scores[1]["player_name"] == "Bob"    # newer entry is rank 2
+        assert scores[1]["player_name"] == "Bob"  # newer entry is rank 2
         assert body["rank"] == 2  # confirmed in submission response too
 
 

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -167,3 +167,82 @@ class TestSubmitRank:
             _submit(name, score)
         scores = client.get("/cascade/scores").json()["scores"]
         assert [s["rank"] for s in scores] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter (#204)
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        """POST /cascade/score is limited to 5/minute; 6th call must 429."""
+        from limiter import limiter
+
+        # 5 allowed submissions
+        for i in range(5):
+            res = _submit(f"Player{i}", i * 10)
+            assert res.status_code == 201
+
+        # 6th should be rate-limited
+        res = _submit("Excess", 999)
+        assert res.status_code == 429
+
+        # Cleanup: reset so other tests aren't affected
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering (#204)
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        """When two entries share the same score, insertion order decides rank.
+        The first-inserted entry wins (stable sort on score descending)."""
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)
+        limiter.reset()
+        body = _submit("Bob", 100).json()
+
+        scores = client.get("/cascade/scores").json()["scores"]
+        assert scores[0]["player_name"] == "Alice"  # older entry is rank 1
+        assert scores[1]["player_name"] == "Bob"    # newer entry is rank 2
+        assert body["rank"] == 2  # confirmed in submission response too
+
+
+# ---------------------------------------------------------------------------
+# Duplicate player names (#204)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateNames:
+    def test_duplicate_name_both_entries_kept(self):
+        """Policy: append-only. Two submissions from the same name both appear
+        on the leaderboard (neither overwrites the other)."""
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)
+        limiter.reset()
+        _submit("Alice", 200)
+
+        scores = client.get("/cascade/scores").json()["scores"]
+        alice_entries = [s for s in scores if s["player_name"] == "Alice"]
+        assert len(alice_entries) == 2
+
+    def test_duplicate_name_ordered_by_score(self):
+        """Both Alice entries appear, higher score ranked first."""
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)
+        limiter.reset()
+        _submit("Alice", 200)
+
+        scores = client.get("/cascade/scores").json()["scores"]
+        alice_scores = [s["score"] for s in scores if s["player_name"] == "Alice"]
+        assert alice_scores == [200, 100]  # descending

--- a/frontend/src/game/cascade/__tests__/engine.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.test.ts
@@ -280,6 +280,89 @@ describe("game-over detection", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Boundary escape
+// ---------------------------------------------------------------------------
+
+describe("boundary escape", () => {
+  // tier-0 radius = 18px, margin = 2 * 18 = 36px
+  // SCALE = 0.01: physics coord = pixel * 0.01
+  const RADIUS = fruitSet.fruits[0].radius; // 18
+  const MARGIN = RADIUS * 2; // 36
+
+  async function buildEscapeEngine() {
+    const onBoundaryEscape = jest.fn();
+    const onGameOver = jest.fn();
+    const handle = await createEngine(W, H, fruitSet, jest.fn(), onGameOver, onBoundaryEscape);
+    return { handle, onBoundaryEscape, onGameOver };
+  }
+
+  it("fires onBoundaryEscape and removes body when fruit escapes below floor", async () => {
+    const { handle, onBoundaryEscape } = await buildEscapeEngine();
+    handle.drop(fruitSet.fruits[0], fruitSet.id, 150, 300);
+    handle.step(); // register body (handle 0)
+    const world = getWorld();
+    const body = world._bodies.get(0)!;
+    // Place below floor: py > H + margin
+    body._y = (H + MARGIN + 10) * 0.01;
+    handle.step();
+    expect(onBoundaryEscape).toHaveBeenCalledTimes(1);
+    expect(onBoundaryEscape).toHaveBeenCalledWith(expect.objectContaining({ tier: 0 }));
+    // Body removed from world
+    expect(world._bodies.has(0)).toBe(false);
+  });
+
+  it("fires onBoundaryEscape and removes body when fruit escapes through left wall", async () => {
+    const { handle, onBoundaryEscape } = await buildEscapeEngine();
+    handle.drop(fruitSet.fruits[0], fruitSet.id, 150, 300);
+    handle.step();
+    const world = getWorld();
+    const body = world._bodies.get(0)!;
+    // Place left of left wall: px < -margin
+    body._x = (-MARGIN - 10) * 0.01;
+    handle.step();
+    expect(onBoundaryEscape).toHaveBeenCalledTimes(1);
+    expect(world._bodies.has(0)).toBe(false);
+  });
+
+  it("fires onBoundaryEscape and removes body when fruit escapes through right wall", async () => {
+    const { handle, onBoundaryEscape } = await buildEscapeEngine();
+    handle.drop(fruitSet.fruits[0], fruitSet.id, 150, 300);
+    handle.step();
+    const world = getWorld();
+    const body = world._bodies.get(0)!;
+    // Place right of right wall: px > W + margin
+    body._x = (W + MARGIN + 10) * 0.01;
+    handle.step();
+    expect(onBoundaryEscape).toHaveBeenCalledTimes(1);
+    expect(world._bodies.has(0)).toBe(false);
+  });
+
+  it("does NOT fire onBoundaryEscape for a fruit inside the escape margin", async () => {
+    const { handle, onBoundaryEscape } = await buildEscapeEngine();
+    handle.drop(fruitSet.fruits[0], fruitSet.id, 150, 300);
+    handle.step();
+    const world = getWorld();
+    const body = world._bodies.get(0)!;
+    // Place just inside the right margin: px = W + radius (< W + 2*radius)
+    body._x = (W + RADIUS) * 0.01;
+    handle.step();
+    expect(onBoundaryEscape).not.toHaveBeenCalled();
+    expect(world._bodies.has(0)).toBe(true);
+  });
+
+  it("escape does not trigger game-over", async () => {
+    const { handle, onBoundaryEscape, onGameOver } = await buildEscapeEngine();
+    handle.drop(fruitSet.fruits[0], fruitSet.id, 150, 300);
+    handle.step();
+    const world = getWorld();
+    world._bodies.get(0)!._y = (H + MARGIN + 10) * 0.01;
+    handle.step();
+    expect(onBoundaryEscape).toHaveBeenCalledTimes(1);
+    expect(onGameOver).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cleanup
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/i18n/locales/ar/cascade.json
+++ b/frontend/src/i18n/locales/ar/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "تم الحفظ! #{{rank}}",
   "gameOver.playAgain": "العب مجددًا",
   "gameOver.playAgainButton": "العب مرة أخرى",
-  "game.engineUnsupported": "هذه اللعبة غير مدعومة على هذا الجهاز.",
-  "game.webOnly": "ويب فقط",
   "gameOver.savedLocally": "تم الحفظ محليًا — سيتم الإرسال عند الاتصال"
 }

--- a/frontend/src/i18n/locales/de/cascade.json
+++ b/frontend/src/i18n/locales/de/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Gespeichert! #{{rank}}",
   "gameOver.playAgain": "Nochmal spielen",
   "gameOver.playAgainButton": "Nochmal!",
-  "game.engineUnsupported": "Dieses Spiel wird auf diesem Gerät nicht unterstützt.",
-  "game.webOnly": "Nur Web",
   "gameOver.savedLocally": "Lokal gespeichert — wird online übermittelt"
 }

--- a/frontend/src/i18n/locales/en/cascade.json
+++ b/frontend/src/i18n/locales/en/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Saved! #{{rank}}",
   "gameOver.savedLocally": "Saved locally — will submit when online",
   "gameOver.playAgain": "Play again",
-  "gameOver.playAgainButton": "Play Again",
-  "game.engineUnsupported": "This game is not supported on this device.",
-  "game.webOnly": "Web Only"
+  "gameOver.playAgainButton": "Play Again"
 }

--- a/frontend/src/i18n/locales/es/cascade.json
+++ b/frontend/src/i18n/locales/es/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "¡Guardado! #{{rank}}",
   "gameOver.playAgain": "Jugar de nuevo",
   "gameOver.playAgainButton": "Jugar otra vez",
-  "game.engineUnsupported": "Este juego no está disponible en este dispositivo.",
-  "game.webOnly": "Solo Web",
   "gameOver.savedLocally": "Guardado localmente — se enviará al estar en línea"
 }

--- a/frontend/src/i18n/locales/fr-CA/cascade.json
+++ b/frontend/src/i18n/locales/fr-CA/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Enregistré! #{{rank}}",
   "gameOver.playAgain": "Rejouer",
   "gameOver.playAgainButton": "Rejouer",
-  "game.engineUnsupported": "Ce jeu n'est pas disponible sur cet appareil.",
-  "game.webOnly": "Web uniquement",
   "gameOver.savedLocally": "Enregistré localement — sera envoyé une fois en ligne"
 }

--- a/frontend/src/i18n/locales/he/cascade.json
+++ b/frontend/src/i18n/locales/he/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "נשמר! #{{rank}}",
   "gameOver.playAgain": "שחק שוב",
   "gameOver.playAgainButton": "שחק שוב",
-  "game.engineUnsupported": "משחק זה אינו נתמך במכשיר זה.",
-  "game.webOnly": "אינטרנט בלבד",
   "gameOver.savedLocally": "נשמר מקומית — יישלח כשמחובר"
 }

--- a/frontend/src/i18n/locales/hi/cascade.json
+++ b/frontend/src/i18n/locales/hi/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "सेव्ड! #{{rank}}",
   "gameOver.playAgain": "फिर से खेलें",
   "gameOver.playAgainButton": "फिर से खेलें",
-  "game.engineUnsupported": "यह गेम इस डिवाइस पर समर्थित नहीं है।",
-  "game.webOnly": "केवल वेब",
   "gameOver.savedLocally": "स्थानीय रूप से सहेजा गया — ऑनलाइन होने पर भेजा जाएगा"
 }

--- a/frontend/src/i18n/locales/ja/cascade.json
+++ b/frontend/src/i18n/locales/ja/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "保存完了！#{{rank}}",
   "gameOver.playAgain": "もう一度プレイ",
   "gameOver.playAgainButton": "再挑戦",
-  "game.engineUnsupported": "このゲームはこのデバイスではサポートされていません。",
-  "game.webOnly": "Webのみ",
   "gameOver.savedLocally": "ローカルに保存しました — オンライン時に送信されます"
 }

--- a/frontend/src/i18n/locales/ko/cascade.json
+++ b/frontend/src/i18n/locales/ko/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "저장 완료! #{{rank}}",
   "gameOver.playAgain": "다시 하기",
   "gameOver.playAgainButton": "다시 플레이",
-  "game.engineUnsupported": "이 게임은 이 기기에서 지원되지 않습니다.",
-  "game.webOnly": "웹 전용",
   "gameOver.savedLocally": "로컬에 저장됨 — 온라인 시 전송됩니다"
 }

--- a/frontend/src/i18n/locales/nl/cascade.json
+++ b/frontend/src/i18n/locales/nl/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Opgeslagen! #{{rank}}",
   "gameOver.playAgain": "Opnieuw spelen",
   "gameOver.playAgainButton": "Nog een keer",
-  "game.engineUnsupported": "Dit spel wordt niet ondersteund op dit apparaat.",
-  "game.webOnly": "Alleen web",
   "gameOver.savedLocally": "Lokaal opgeslagen — wordt online verzonden"
 }

--- a/frontend/src/i18n/locales/pt/cascade.json
+++ b/frontend/src/i18n/locales/pt/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Salvo! #{{rank}}",
   "gameOver.playAgain": "Jogar de novo",
   "gameOver.playAgainButton": "Jogar Novamente",
-  "game.engineUnsupported": "Este jogo não é suportado neste dispositivo.",
-  "game.webOnly": "Apenas Web",
   "gameOver.savedLocally": "Salvo localmente — será enviado quando online"
 }

--- a/frontend/src/i18n/locales/ru/cascade.json
+++ b/frontend/src/i18n/locales/ru/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "Сохранено! №{{rank}}",
   "gameOver.playAgain": "Играть снова",
   "gameOver.playAgainButton": "Играть ещё",
-  "game.engineUnsupported": "Эта игра не поддерживается на данном устройстве.",
-  "game.webOnly": "Только веб",
   "gameOver.savedLocally": "Сохранено локально — будет отправлено онлайн"
 }

--- a/frontend/src/i18n/locales/zh/cascade.json
+++ b/frontend/src/i18n/locales/zh/cascade.json
@@ -24,7 +24,5 @@
   "gameOver.savedConfirmation": "已保存！第{{rank}}名",
   "gameOver.playAgain": "再玩一次",
   "gameOver.playAgainButton": "再来一局",
-  "game.engineUnsupported": "此游戏在本设备上不受支持。",
-  "game.webOnly": "仅限网页",
   "gameOver.savedLocally": "已在本地保存 — 联网后将提交"
 }


### PR DESCRIPTION
Closes #196, #201, #204

## Summary
- **#196** — Remove `game.engineUnsupported` and `game.webOnly` from all 13 locale JSON files; keys were never referenced anywhere in the codebase
- **#201** — Add 5 boundary escape unit tests to `engine.test.ts`: escape below floor, left/right wall, inside-margin no-op, and escape-doesn't-trigger-game-over
- **#204** — Add 4 backend tests to `test_cascade_api.py`: rate limiter returns 429 on 6th submission, tie-break ordering (older entry wins on equal score), duplicate name append-only policy documented and asserted

## Test plan
- [ ] All 26 frontend engine tests pass (`jest src/game/cascade/__tests__/engine.test.ts`)
- [ ] All 21 cascade backend tests pass (`pytest tests/test_cascade_api.py`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)