### PR TITLE
feat(cascade): testable canvas hook for deterministic e2e gameplay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
         working-directory: frontend
         env:
           EXPO_PUBLIC_API_URL: http://localhost:8000
+          EXPO_PUBLIC_TEST_HOOKS: "1"
 
       - name: Install E2E deps
         run: npm ci

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -59,10 +59,14 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
+      name: "cascade",
+      testMatch: "cascade-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       name: "cross",
       testMatch: [
         "accessibility.spec.ts",
-        "cascade-flow.spec.ts",
         "ui-preferences.spec.ts",
       ],
       use: { ...devices["Desktop Chrome"] },

--- a/e2e/tests/helpers/cascade.ts
+++ b/e2e/tests/helpers/cascade.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared helpers for Cascade e2e tests.
+ *
+ * Requires EXPO_PUBLIC_TEST_HOOKS=1 in the frontend build (set in CI and
+ * locally via `EXPO_PUBLIC_TEST_HOOKS=1 npx expo export --platform web`).
+ *
+ * All window.__cascade_* hooks are registered in CascadeScreen.tsx and
+ * GameCanvas.web.tsx and are no-ops / undefined in production builds.
+ */
+
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+
+export interface CascadeState {
+  score: number;
+  fruitCount: number;
+  dangerRatio: number;
+  gameOver: boolean;
+  nextFruitTier: number;
+  fruits: Array<{ id: number; tier: number; x: number; y: number }>;
+}
+
+/** Mock leaderboard endpoint so tests don't depend on a running backend. */
+export async function mockLeaderboard(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/cascade/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+/** Navigate from Home to Cascade and wait for the canvas to be ready. */
+export async function gotoCascade(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Play Cascade" }).click();
+  await page
+    .getByRole("heading", { name: "Cascade" })
+    .waitFor({ timeout: 10_000 });
+  // Rapier WASM may take a moment to initialise — wait for the canvas label
+  await page
+    .getByRole("img", { name: /Cascade game/i })
+    .waitFor({ timeout: 15_000 });
+}
+
+/** Read the current engine state exposed by the test hook. */
+export async function getState(page: Page): Promise<CascadeState> {
+  return page.evaluate(
+    () =>
+      (
+        window as { __cascade_getState?: () => CascadeState }
+      ).__cascade_getState?.() ?? {
+        score: 0,
+        fruitCount: 0,
+        dangerRatio: 0,
+        gameOver: false,
+        nextFruitTier: 0,
+        fruits: [],
+      },
+  );
+}
+
+/**
+ * Seed the fruit-spawn RNG for a reproducible queue.
+ * Must be called before the first drop of a session.
+ */
+export async function setSeed(page: Page, seed: number): Promise<void> {
+  await page.evaluate(
+    (s) =>
+      (
+        window as { __cascade_setSeed?: (n: number) => void }
+      ).__cascade_setSeed?.(s),
+    seed,
+  );
+}
+
+/**
+ * Programmatically drop the next fruit at canvas x-coordinate `x`.
+ * Bypasses the 200 ms droppingRef lock so tests can drop rapidly.
+ */
+export async function dropAt(page: Page, x: number): Promise<void> {
+  await page.evaluate(
+    (xPos) =>
+      (window as { __cascade_dropAt?: (x: number) => void }).__cascade_dropAt?.(
+        xPos,
+      ),
+    x,
+  );
+}
+
+/**
+ * Fast-forward the physics simulation by `ms` milliseconds without
+ * waiting for real time. Useful for settling fruits before assertions.
+ */
+export async function fastForward(page: Page, ms: number): Promise<void> {
+  await page.evaluate(
+    (millis) =>
+      (
+        window as { __cascade_fastForward?: (ms: number) => void }
+      ).__cascade_fastForward?.(millis),
+    ms,
+  );
+}
+
+/**
+ * Immediately trigger game-over (skips danger-line buildup).
+ * Useful for testing the game-over overlay and restart flow.
+ */
+export async function triggerGameOver(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    (
+      window as { __cascade_triggerGameOver?: () => void }
+    ).__cascade_triggerGameOver?.(),
+  );
+}

--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -44,10 +44,19 @@ import { useFruitImages, getImagesForSet } from "../../theme/useFruitImages";
 
 const DROP_Y = 30;
 
+export interface CascadeEngineState {
+  fruitCount: number;
+  dangerRatio: number;
+  fruits: Array<{ id: number; tier: number; x: number; y: number }>;
+}
+
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
   reset: () => void;
   announceEvent: (message: string) => void;
+  /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
+  getEngineState?: () => CascadeEngineState;
+  fastForward?: (ms: number) => void;
 }
 
 interface Props {

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -31,10 +31,19 @@ const DROP_Y = 30;
  */
 const DEBUG_COLLISION = __DEV__;
 
+export interface CascadeEngineState {
+  fruitCount: number;
+  dangerRatio: number;
+  fruits: Array<{ id: number; tier: number; x: number; y: number }>;
+}
+
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
   reset: () => void;
   announceEvent: (message: string) => void;
+  /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
+  getEngineState?: () => CascadeEngineState;
+  fastForward?: (ms: number) => void;
 }
 
 interface Props {
@@ -416,9 +425,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       return () => cancelAnimationFrame(id);
     }, []); // intentionally empty — loop lives for component lifetime
 
-    useImperativeHandle(
-      ref,
-      () => ({
+    useImperativeHandle(ref, () => {
+      const base: GameCanvasHandle = {
         drop(def, x) {
           if (!engineRef.current) return;
           const clamped = clamp(
@@ -434,9 +442,44 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         announceEvent(message) {
           AccessibilityInfo.announceForAccessibility(message);
         },
-      }),
-      [initEngine, width]
-    );
+      };
+
+      if (process.env.EXPO_PUBLIC_TEST_HOOKS !== "1") return base;
+
+      return {
+        ...base,
+        getEngineState(): CascadeEngineState {
+          const bodies = bodiesRef.current;
+          const dangerY = height * DANGER_LINE_RATIO;
+          let dangerRatio = 0;
+          if (bodies.length > 0) {
+            const minTopY = Math.min(
+              ...bodies.map((b) => b.y - (fruitSetRef.current.fruits[b.tier]?.radius ?? 0))
+            );
+            dangerRatio = Math.max(0, Math.min(1, 1 - minTopY / dangerY));
+          }
+          return {
+            fruitCount: bodies.length,
+            dangerRatio,
+            fruits: bodies.map((b) => ({
+              id: b.id,
+              tier: b.tier,
+              x: Math.round(b.x),
+              y: Math.round(b.y),
+            })),
+          };
+        },
+        fastForward(ms: number) {
+          if (!engineRef.current) return;
+          const STEP_S = 1 / 60; // ~16.67 ms per step
+          const steps = Math.ceil(ms / (STEP_S * 1000));
+          for (let i = 0; i < steps; i++) {
+            bodiesRef.current = engineRef.current.step(STEP_S);
+          }
+          drawRef.current();
+        },
+      };
+    }, [initEngine, width, height]);
 
     const panGesture = Gesture.Pan()
       .runOnJS(true)

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -6,6 +6,7 @@ import { RootStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { FruitSetProvider, useFruitSet } from "../theme/FruitSetContext";
 import { FruitQueue } from "../game/cascade/fruitQueue";
+import { ControlledSpawnSelector, createSeededRng } from "../game/cascade/spawnSelector";
 import { MergeEvent } from "../game/cascade/engine";
 import { scoreForMerge } from "../game/cascade/scoring";
 import GameCanvas, { GameCanvasHandle } from "../components/cascade/GameCanvas";
@@ -36,6 +37,22 @@ function CascadeGame({ navigation }: Props) {
   const queueRef = useRef(new FruitQueue());
   const droppingRef = useRef(false);
   const prevFruitSetId = useRef(activeFruitSet.id);
+
+  // Refs used by test hooks to read latest state without closure staleness
+  const scoreRef = useRef(0);
+  const gameOverRef = useRef(false);
+  const activeFruitSetRef = useRef(activeFruitSet);
+
+  // Keep refs in sync with state for test hooks
+  useEffect(() => {
+    scoreRef.current = score;
+  }, [score]);
+  useEffect(() => {
+    gameOverRef.current = gameOver;
+  }, [gameOver]);
+  useEffect(() => {
+    activeFruitSetRef.current = activeFruitSet;
+  }, [activeFruitSet]);
 
   // Reset the engine when the player switches fruit set skin
   useEffect(() => {
@@ -88,6 +105,44 @@ function CascadeGame({ navigation }: Props) {
     },
     [gameOver, activeFruitSet]
   );
+
+  // -------------------------------------------------------------------------
+  // Test seam — window.__cascade_* hooks (only when EXPO_PUBLIC_TEST_HOOKS=1)
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (process.env.EXPO_PUBLIC_TEST_HOOKS !== "1") return;
+    const g = globalThis as Record<string, unknown>;
+    g.__cascade_getState = () => ({
+      score: scoreRef.current,
+      gameOver: gameOverRef.current,
+      nextFruitTier: queueRef.current.peek(),
+      ...canvasRef.current?.getEngineState?.(),
+    });
+    g.__cascade_setSeed = (seed: number) => {
+      queueRef.current = new FruitQueue(new ControlledSpawnSelector(createSeededRng(seed)));
+      setQueueVersion((v) => v + 1);
+    };
+    g.__cascade_dropAt = (x: number) => {
+      if (gameOverRef.current) return;
+      const tier = queueRef.current.consume();
+      setQueueVersion((v) => v + 1);
+      const def = activeFruitSetRef.current.fruits[tier];
+      canvasRef.current?.drop(def, x);
+    };
+    g.__cascade_fastForward = (ms: number) => {
+      canvasRef.current?.fastForward?.(ms);
+    };
+    g.__cascade_triggerGameOver = () => {
+      setGameOver(true);
+    };
+    return () => {
+      delete g.__cascade_getState;
+      delete g.__cascade_setSeed;
+      delete g.__cascade_dropAt;
+      delete g.__cascade_fastForward;
+      delete g.__cascade_triggerGameOver;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleRestart() {
     queueRef.current = new FruitQueue();


### PR DESCRIPTION
Closes #197

## Summary
- **`GameCanvas.web.tsx`**: adds `getEngineState()` and `fastForward()` to `GameCanvasHandle`, implemented when `EXPO_PUBLIC_TEST_HOOKS=1`. `getEngineState()` returns `{fruitCount, dangerRatio, fruits[]}`. `fastForward(ms)` steps physics in a tight loop without waiting for real time.
- **`GameCanvas.tsx`**: mirrors the updated interface (native stubs not needed for Playwright which runs on web).
- **`CascadeScreen.tsx`**: registers five `window.__cascade_*` hooks under the same env guard: `getState`, `setSeed`, `dropAt`, `fastForward`, `triggerGameOver`. Refs keep score/gameOver/activeFruitSet fresh in hook closures.
- **`e2e/tests/helpers/cascade.ts`** (new): Playwright wrapper — `gotoCascade`, `getState`, `setSeed`, `dropAt`, `fastForward`, `triggerGameOver`, `mockLeaderboard`.
- **`playwright.config.ts`**: adds dedicated `cascade` project (`cascade-*.spec.ts`) so gameplay specs run in CI; removes `cascade-flow.spec.ts` from `cross`.
- **`ci.yml`**: passes `EXPO_PUBLIC_TEST_HOOKS=1` to the e2e Expo build.

## Test plan
- [ ] CI green (lint, unit tests, existing cascade-flow smoke tests)
- [ ] After merge, PRs #198/#199/#200 can import from `helpers/cascade.ts` and call `dropAt`/`fastForward`/`getState` for real gameplay assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)