### PR TITLE
feat(e2e): cascade merge/score, game-over, and leaderboard e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,11 @@ jobs:
               - 'frontend/src/components/pachisi/**'
               - 'frontend/src/game/pachisi/**'
               - 'backend/games/pachisi*'
+            cascade:
+              - 'frontend/src/screens/CascadeScreen*'
+              - 'frontend/src/components/cascade/**'
+              - 'frontend/src/game/cascade/**'
+              - 'backend/games/cascade*'
             shared:
               - 'frontend/App.tsx'
               - 'frontend/app.json'
@@ -145,7 +150,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]] || \
              [[ "${{ github.base_ref }}" == "main" ]] || \
              [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
-            echo "projects=yacht blackjack twenty48 pachisi cross" >> "$GITHUB_OUTPUT"
+            echo "projects=yacht blackjack twenty48 pachisi cascade cross" >> "$GITHUB_OUTPUT"
             echo "label=full suite (push/main/shared change)" >> "$GITHUB_OUTPUT"
           else
             projects="cross"
@@ -153,6 +158,7 @@ jobs:
             [[ "${{ steps.filter.outputs.blackjack }}" == "true" ]] && projects="$projects blackjack"
             [[ "${{ steps.filter.outputs.twenty48 }}"  == "true" ]] && projects="$projects twenty48"
             [[ "${{ steps.filter.outputs.pachisi }}"   == "true" ]] && projects="$projects pachisi"
+            [[ "${{ steps.filter.outputs.cascade }}"   == "true" ]] && projects="$projects cascade"
             echo "projects=$projects" >> "$GITHUB_OUTPUT"
             echo "label=selective: $projects" >> "$GITHUB_OUTPUT"
           fi

--- a/e2e/tests/cascade-game-over.spec.ts
+++ b/e2e/tests/cascade-game-over.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * cascade-game-over.spec.ts — GH #199
+ *
+ * Game-over overlay behaviour: appearance, score save (success, offline, error),
+ * and restart flow.
+ *
+ * `triggerGameOver()` instantly sets gameOver=true without waiting for physics
+ * because `fastForward()` advances simulation steps but not Date.now(), so the
+ * danger-line grace period would never fire via physics time alone.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  gotoCascade,
+  getState,
+  triggerGameOver,
+  mockLeaderboard,
+} from "./helpers/cascade";
+
+const API_BASE = "http://localhost:8000";
+const SCORE_ENDPOINT = `${API_BASE}/cascade/score`;
+
+test.describe("Cascade — game-over overlay", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboard(page);
+    await gotoCascade(page);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Overlay appearance
+  // ---------------------------------------------------------------------------
+
+  test("game-over overlay appears after triggerGameOver()", async ({
+    page,
+  }) => {
+    await triggerGameOver(page);
+
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("overlay shows name input and Save Score button", async ({ page }) => {
+    await triggerGameOver(page);
+
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByPlaceholder("Enter your name")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Save score" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Play again" }),
+    ).toBeVisible();
+  });
+
+  test("getState().gameOver is true after triggerGameOver()", async ({
+    page,
+  }) => {
+    await triggerGameOver(page);
+    const state = await getState(page);
+    expect(state.gameOver).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Successful score submission
+  // ---------------------------------------------------------------------------
+
+  test("Save Score with valid name → shows 'Saved! #1' confirmation", async ({
+    page,
+  }) => {
+    // Override leaderboard mock for the score POST to return rank 1
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ player_name: "Tester", score: 0, rank: 1 }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(page.getByText("Saved! #1")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("Save Score button is busy (ActivityIndicator) while submitting", async ({
+    page,
+  }) => {
+    // Delay the response so we can observe the busy state
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await new Promise((r) => setTimeout(r, 800));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ player_name: "Tester", score: 0, rank: 2 }),
+      });
+    });
+
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    // During the 800 ms delay the button should report busy=true
+    await expect(
+      page.getByRole("button", { name: "Save score" }),
+    ).toHaveJSProperty("disabled", true, { timeout: 500 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Network failure → saved locally
+  // ---------------------------------------------------------------------------
+
+  test("fetch TypeError (network down) queues score locally → shows savedLocally text", async ({
+    page,
+  }) => {
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await route.abort("failed");
+    });
+
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(
+      page.getByText("Saved locally — will submit when online"),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Server error → generic error message
+  // ---------------------------------------------------------------------------
+
+  test("non-2xx response → shows error message", async ({ page }) => {
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Internal Server Error" }),
+      });
+    });
+
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(
+      page.getByText("Could not save score. Check your connection."),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Play Again (restart)
+  // ---------------------------------------------------------------------------
+
+  test("Play Again button resets game — overlay disappears and score resets to 0", async ({
+    page,
+  }) => {
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByRole("button", { name: "Play again" }).click();
+
+    // Overlay should be gone
+    await expect(
+      page.getByRole("heading", { name: "Game Over" }),
+    ).not.toBeVisible({ timeout: 3_000 });
+
+    // Score display should be back to 0
+    const state = await getState(page);
+    expect(state.score).toBe(0);
+    expect(state.gameOver).toBe(false);
+  });
+});

--- a/e2e/tests/cascade-gameplay.spec.ts
+++ b/e2e/tests/cascade-gameplay.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * cascade-gameplay.spec.ts — GH #198
+ *
+ * Merge + score behavior verified via the window test hooks.
+ * Uses spawnTierAt() to drop specific-tier fruits deterministically,
+ * and fastForward() to simulate physics without waiting for real time.
+ *
+ * Score formula: scoreForMerge(tier) = 2^(tier+1)  (tiers 0-9)
+ *                                     = 256          (tier 10 — watermelon bonus)
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  gotoCascade,
+  getState,
+  fastForward,
+  mockLeaderboard,
+  spawnTierAt,
+} from "./helpers/cascade";
+
+test.describe("Cascade — merge and score behavior", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboard(page);
+    await gotoCascade(page);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Single merge
+  // ---------------------------------------------------------------------------
+
+  test("two tier-0 fruits at same x merge → score = 2, fruitCount = 1", async ({
+    page,
+  }) => {
+    // Drop two tier-0 fruits slightly apart so physics detects overlap
+    await spawnTierAt(page, 0, 145);
+    await spawnTierAt(page, 0, 155);
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.score).toBe(2); // 2^(0+1)
+    expect(state.fruitCount).toBe(1); // two inputs → one tier-1 output
+  });
+
+  test("two tier-1 fruits merge → score = 4", async ({ page }) => {
+    await spawnTierAt(page, 1, 145);
+    await spawnTierAt(page, 1, 155);
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.score).toBe(4); // 2^(1+1)
+    expect(state.fruitCount).toBe(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Watermelon bonus
+  // ---------------------------------------------------------------------------
+
+  test("two tier-10 (watermelon) fruits merge → score = 256, no tier-11 spawned", async ({
+    page,
+  }) => {
+    await spawnTierAt(page, 10, 145);
+    await spawnTierAt(page, 10, 155);
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.score).toBe(256); // watermelon bonus
+    // Both watermelons removed, no tier-11 exists → fruitCount drops by 2
+    expect(state.fruitCount).toBe(0);
+    // No tier-11 in the engine state
+    expect(state.fruits.some((f) => f.tier === 11)).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // No merge for different tiers
+  // ---------------------------------------------------------------------------
+
+  test("tier-0 + tier-1 at same x do NOT merge → score = 0, fruitCount = 2", async ({
+    page,
+  }) => {
+    await spawnTierAt(page, 0, 150);
+    await spawnTierAt(page, 1, 150);
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.score).toBe(0);
+    expect(state.fruitCount).toBe(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cumulative score across sequential merges
+  // ---------------------------------------------------------------------------
+
+  test("sequential tier-0 merges accumulate score correctly", async ({
+    page,
+  }) => {
+    // Merge 1: two tier-0 → score += 2
+    await spawnTierAt(page, 0, 100);
+    await spawnTierAt(page, 0, 110);
+    await fastForward(page, 1500);
+
+    // Merge 2: two more tier-0 → score += 2 (total = 4)
+    await spawnTierAt(page, 0, 200);
+    await spawnTierAt(page, 0, 210);
+    await fastForward(page, 1500);
+
+    const state = await getState(page);
+    expect(state.score).toBe(4); // 2 + 2
+  });
+
+  test("mixed-tier merges accumulate score correctly", async ({ page }) => {
+    // tier-0 merge (+2), tier-2 merge (+8)
+    await spawnTierAt(page, 0, 80);
+    await spawnTierAt(page, 0, 90);
+    await fastForward(page, 1500);
+
+    await spawnTierAt(page, 2, 220);
+    await spawnTierAt(page, 2, 230);
+    await fastForward(page, 1500);
+
+    const state = await getState(page);
+    expect(state.score).toBe(10); // 2 + 8
+  });
+
+  // ---------------------------------------------------------------------------
+  // Score stays at 0 with no merges
+  // ---------------------------------------------------------------------------
+
+  test("fruits at well-separated x positions do not merge → score = 0", async ({
+    page,
+  }) => {
+    // Drop tier-0 fruits far apart (radius=18, so >36px apart = no overlap)
+    await spawnTierAt(page, 0, 50);
+    await spawnTierAt(page, 0, 250);
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.score).toBe(0);
+    expect(state.fruitCount).toBe(2);
+  });
+});

--- a/e2e/tests/cascade-leaderboard.spec.ts
+++ b/e2e/tests/cascade-leaderboard.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * cascade-leaderboard.spec.ts — GH #200
+ *
+ * Leaderboard integration: verifies that
+ *   1. GET /cascade/scores is fetched when the game screen loads.
+ *   2. POST /cascade/score is called with the correct payload when a score is
+ *      submitted from the game-over overlay.
+ *   3. The rank returned by the server is surfaced in the overlay.
+ *   4. Rank 1 vs. mid-table ranks both render correctly.
+ *
+ * All network calls are intercepted via Playwright's `page.route()` — no real
+ * backend is required.
+ */
+
+import { test, expect } from "@playwright/test";
+import { gotoCascade, triggerGameOver } from "./helpers/cascade";
+
+const API_BASE = "http://localhost:8000";
+const SCORES_ENDPOINT = `${API_BASE}/cascade/scores`;
+const SCORE_ENDPOINT = `${API_BASE}/cascade/score`;
+
+test.describe("Cascade — leaderboard API integration", () => {
+  // ---------------------------------------------------------------------------
+  // Game loads cleanly when the leaderboard endpoint returns data
+  // ---------------------------------------------------------------------------
+
+  test("game screen loads without errors when leaderboard returns populated scores", async ({
+    page,
+  }) => {
+    await page.route(`${API_BASE}/cascade/**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          scores: [
+            { player_name: "Alice", score: 1000, rank: 1 },
+            { player_name: "Bob", score: 800, rank: 2 },
+          ],
+        }),
+      });
+    });
+
+    await gotoCascade(page);
+
+    // Game should still be playable — score display and canvas are visible
+    await expect(page.getByText("Score", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("img", { name: /Cascade game/i }),
+    ).toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // POST /cascade/score payload and rank display
+  // ---------------------------------------------------------------------------
+
+  test("submitting a score POSTs the correct payload to /cascade/score", async ({
+    page,
+  }) => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    await page.route(`${API_BASE}/cascade/**`, async (route) => {
+      if (route.request().method() === "POST") {
+        capturedBody = JSON.parse(route.request().postData() ?? "{}");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ player_name: "Alice", score: 0, rank: 1 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ scores: [] }),
+        });
+      }
+    });
+
+    await gotoCascade(page);
+    await triggerGameOver(page);
+
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Alice");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(page.getByText("Saved! #1")).toBeVisible({ timeout: 5_000 });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.player_name).toBe("Alice");
+    expect(typeof capturedBody!.score).toBe("number");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rank display scenarios
+  // ---------------------------------------------------------------------------
+
+  test("rank 1 response renders 'Saved! #1'", async ({ page }) => {
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ player_name: "Alice", score: 500, rank: 1 }),
+      });
+    });
+    await page.route(SCORES_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+
+    await gotoCascade(page);
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Alice");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(page.getByText("Saved! #1")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("rank 42 response renders 'Saved! #42'", async ({ page }) => {
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ player_name: "Bob", score: 100, rank: 42 }),
+      });
+    });
+    await page.route(SCORES_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+
+    await gotoCascade(page);
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Bob");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(page.getByText("Saved! #42")).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 429 rate-limit response
+  // ---------------------------------------------------------------------------
+
+  test("429 response from server → shows generic error message", async ({
+    page,
+  }) => {
+    await page.route(SCORE_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 429,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Too Many Requests" }),
+      });
+    });
+    await page.route(SCORES_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+
+    await gotoCascade(page);
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByPlaceholder("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Save score" }).click();
+
+    await expect(
+      page.getByText("Could not save score. Check your connection."),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty name → button disabled, no request sent
+  // ---------------------------------------------------------------------------
+
+  test("Save Score button is disabled when name is empty", async ({ page }) => {
+    let postCalled = false;
+
+    await page.route(`${API_BASE}/cascade/**`, async (route) => {
+      if (route.request().method() === "POST") {
+        postCalled = true;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+
+    await gotoCascade(page);
+    await triggerGameOver(page);
+    await expect(page.getByRole("heading", { name: "Game Over" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Do NOT fill in a name — button should be disabled
+    const saveBtn = page.getByRole("button", { name: "Save score" });
+    await expect(saveBtn).toBeDisabled();
+
+    // Attempt a click anyway — no POST should fire
+    await saveBtn.click({ force: true });
+    await page.waitForTimeout(300);
+    expect(postCalled).toBe(false);
+  });
+});

--- a/e2e/tests/helpers/cascade.ts
+++ b/e2e/tests/helpers/cascade.ts
@@ -115,3 +115,21 @@ export async function triggerGameOver(page: Page): Promise<void> {
     ).__cascade_triggerGameOver?.(),
   );
 }
+
+/**
+ * Spawn a fruit of a specific tier at canvas x-coordinate `x`, bypassing
+ * the queue entirely. Enables deterministic merge/score tests.
+ */
+export async function spawnTierAt(
+  page: Page,
+  tier: number,
+  x: number,
+): Promise<void> {
+  await page.evaluate(
+    ([t, xPos]) =>
+      (
+        window as { __cascade_spawnTierAt?: (tier: number, x: number) => void }
+      ).__cascade_spawnTierAt?.(t, xPos),
+    [tier, x] as const,
+  );
+}

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -135,12 +135,19 @@ function CascadeGame({ navigation }: Props) {
     g.__cascade_triggerGameOver = () => {
       setGameOver(true);
     };
+    g.__cascade_spawnTierAt = (tier: number, x: number) => {
+      if (gameOverRef.current) return;
+      const def = activeFruitSetRef.current.fruits[tier];
+      if (!def) return;
+      canvasRef.current?.drop(def, x);
+    };
     return () => {
       delete g.__cascade_getState;
       delete g.__cascade_setSeed;
       delete g.__cascade_dropAt;
       delete g.__cascade_fastForward;
       delete g.__cascade_triggerGameOver;
+      delete g.__cascade_spawnTierAt;
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Summary
- **cascade-gameplay.spec.ts** (#198): 7 deterministic merge+score tests using `spawnTierAt()` + `fastForward()` — single merges (tier 0/1), watermelon bonus (tier 10 → score=256, fruitCount=0), cross-tier no-merge, cumulative and mixed-tier scoring
- **cascade-game-over.spec.ts** (#199): 7 game-over overlay tests — appearance, successful save with rank display, busy state during submit, network abort → savedLocally, 500 error → generic error message, Play Again restart
- **cascade-leaderboard.spec.ts** (#200): 6 leaderboard API tests — game loads with populated scores, POST payload shape, rank #1 / #42 rendering, 429 error handling, disabled Save button when name is empty
- **CascadeScreen.tsx**: added `__cascade_spawnTierAt(tier, x)` test hook (bypasses the fruit queue to drop a specific tier deterministically)
- **helpers/cascade.ts**: added `spawnTierAt(page, tier, x)` wrapping the new hook

## Test plan
- [ ] CI Playwright `cascade` project passes all 20 new tests
- [ ] `cascade-gameplay` tests: verify score increments match `scoreForMerge(tier) = 2^(tier+1)` formula
- [ ] `cascade-game-over` tests: overlay appears, name input works, route abort → savedLocally, 500 → error message, Play Again clears overlay
- [ ] `cascade-leaderboard` tests: POST payload captured correctly, rank text renders, 429 maps to error message, empty name disables button

Closes #198, #199, #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)