### PR TITLE
feat(blackjack): configurable table rules — H17 + multi-deck shoe

### DIFF
--- a/backend/blackjack/game.py
+++ b/backend/blackjack/game.py
@@ -24,6 +24,19 @@ RANK_VALUES: dict[str, int] = {
 RESHUFFLE_THRESHOLD = 15
 
 
+@dataclass(frozen=True)
+class BlackjackRules:
+    hit_soft_17: bool = False
+    deck_count: int = 6
+    penetration: float = 0.75
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.deck_count <= 8:
+            raise ValueError("deck_count must be between 1 and 8.")
+        if not 0.5 <= self.penetration <= 0.9:
+            raise ValueError("penetration must be between 0.5 and 0.9.")
+
+
 @dataclass
 class Card:
     suit: str
@@ -56,8 +69,21 @@ def is_natural_blackjack(cards: list[Card]) -> bool:
     return len(cards) == 2 and hand_value(cards) == 21
 
 
-def _fresh_shuffled_deck() -> list[Card]:
-    deck = [Card(suit=s, rank=r) for s in SUITS for r in RANKS]
+def is_soft_hand(cards: list[Card]) -> bool:
+    """True when at least one Ace in the hand is counted as 11."""
+    if not cards:
+        return False
+    raw_total = sum(RANK_VALUES[c.rank] for c in cards)
+    num_aces = sum(1 for c in cards if c.rank == "A")
+    if num_aces == 0:
+        return False
+    best = hand_value(cards)
+    reductions = (raw_total - best) // 10
+    return best <= 21 and num_aces > reductions
+
+
+def _fresh_shuffled_shoe(deck_count: int = 1) -> list[Card]:
+    deck = [Card(suit=s, rank=r) for s in SUITS for r in RANKS] * deck_count
     random.shuffle(deck)
     return deck
 
@@ -69,10 +95,15 @@ class BlackjackGame:
     phase: str = "betting"  # "betting" | "player" | "result"
     outcome: str | None = None  # "blackjack" | "win" | "lose" | "push"
     payout: int = 0  # net chip delta already applied to self.chips
-    _deck: list[Card] = field(default_factory=_fresh_shuffled_deck)
+    rules: BlackjackRules = field(default_factory=BlackjackRules)
+    _deck: list[Card] = field(default_factory=list)
     _player_hand: list[Card] = field(default_factory=list)
     _dealer_hand: list[Card] = field(default_factory=list)
     _doubled: bool = False
+
+    def __post_init__(self) -> None:
+        if not self._deck:
+            self._deck = _fresh_shuffled_shoe(self.rules.deck_count)
 
     # ------------------------------------------------------------------
     # Public API
@@ -147,6 +178,10 @@ class BlackjackGame:
         self._dealer_play()
         self._determine_and_settle()
 
+    def _reshuffle_threshold(self) -> int:
+        total_cards = self.rules.deck_count * 52
+        return max(RESHUFFLE_THRESHOLD, int(total_cards * (1 - self.rules.penetration)))
+
     def new_hand(self) -> None:
         if self.phase != "result":
             raise ValueError("Not in result phase.")
@@ -156,8 +191,8 @@ class BlackjackGame:
         self.outcome = None
         self.payout = 0
         self._doubled = False
-        if len(self._deck) < RESHUFFLE_THRESHOLD:
-            self._deck = _fresh_shuffled_deck()
+        if len(self._deck) < self._reshuffle_threshold():
+            self._deck = _fresh_shuffled_shoe(self.rules.deck_count)
         self.phase = "betting"
 
     # ------------------------------------------------------------------
@@ -166,12 +201,18 @@ class BlackjackGame:
 
     def _deal(self) -> Card:
         if not self._deck:
-            self._deck = _fresh_shuffled_deck()
+            self._deck = _fresh_shuffled_shoe(self.rules.deck_count)
         return self._deck.pop()
 
     def _dealer_play(self) -> None:
-        while hand_value(self._dealer_hand) <= 16:
-            self._dealer_hand.append(self._deal())
+        while True:
+            dv = hand_value(self._dealer_hand)
+            if dv < 17:
+                self._dealer_hand.append(self._deal())
+            elif dv == 17 and self.rules.hit_soft_17 and is_soft_hand(self._dealer_hand):
+                self._dealer_hand.append(self._deal())
+            else:
+                break
 
     def _determine_and_settle(self) -> None:
         pv = hand_value(self._player_hand)

--- a/backend/blackjack/models.py
+++ b/backend/blackjack/models.py
@@ -5,6 +5,18 @@ class PlaceBetRequest(BaseModel):
     amount: int = Field(..., ge=10, le=500, multiple_of=10)
 
 
+class RulesRequest(BaseModel):
+    hit_soft_17: bool = False
+    deck_count: int = Field(default=6, ge=1, le=8)
+    penetration: float = Field(default=0.75, ge=0.5, le=0.9)
+
+
+class RulesResponse(BaseModel):
+    hit_soft_17: bool
+    deck_count: int
+    penetration: float
+
+
 class CardResponse(BaseModel):
     rank: str
     suit: str
@@ -26,3 +38,4 @@ class BlackjackStateResponse(BaseModel):
     payout: int
     game_over: bool
     double_down_available: bool
+    rules: RulesResponse

--- a/backend/blackjack/router.py
+++ b/backend/blackjack/router.py
@@ -4,12 +4,14 @@ from fastapi import APIRouter, HTTPException, Request
 
 from limiter import limiter
 from session import get_session_id
-from .game import BlackjackGame, hand_value
+from .game import BlackjackGame, BlackjackRules, hand_value
 from .models import (
     BlackjackStateResponse,
     CardResponse,
     HandResponse,
     PlaceBetRequest,
+    RulesRequest,
+    RulesResponse,
 )
 
 router = APIRouter()
@@ -57,6 +59,11 @@ def _state_response(game: BlackjackGame) -> BlackjackStateResponse:
         game.phase == "player" and len(game._player_hand) == 2 and game.chips >= game.bet * 2
     )
     game_over = game.chips == 0 and game.phase == "result"
+    rules = RulesResponse(
+        hit_soft_17=game.rules.hit_soft_17,
+        deck_count=game.rules.deck_count,
+        penetration=game.rules.penetration,
+    )
     return BlackjackStateResponse(
         phase=game.phase,
         chips=game.chips,
@@ -67,15 +74,24 @@ def _state_response(game: BlackjackGame) -> BlackjackStateResponse:
         payout=game.payout,
         game_over=game_over,
         double_down_available=double_down_available,
+        rules=rules,
     )
 
 
 @router.post("/new", response_model=BlackjackStateResponse)
 @limiter.limit("10/minute")
-def new_game(request: Request) -> BlackjackStateResponse:
+def new_game(request: Request, body: RulesRequest | None = None) -> BlackjackStateResponse:
     sid = get_session_id(request)
     _evict_if_full()
-    _sessions[sid] = BlackjackGame()
+    if body:
+        rules = BlackjackRules(
+            hit_soft_17=body.hit_soft_17,
+            deck_count=body.deck_count,
+            penetration=body.penetration,
+        )
+    else:
+        rules = BlackjackRules()
+    _sessions[sid] = BlackjackGame(rules=rules)
     return _state_response(_sessions[sid])
 
 

--- a/backend/tests/test_blackjack_game.py
+++ b/backend/tests/test_blackjack_game.py
@@ -12,7 +12,7 @@ import pytest
 from blackjack.game import (
     BlackjackGame,
     Card,
-    _fresh_shuffled_deck,
+    _fresh_shuffled_shoe,
     hand_value,
     is_natural_blackjack,
 )
@@ -90,10 +90,10 @@ class TestIsNaturalBlackjack:
 
 class TestFreshDeck:
     def test_deck_has_52_cards(self):
-        assert len(_fresh_shuffled_deck()) == 52
+        assert len(_fresh_shuffled_shoe()) == 52
 
     def test_all_suits_and_ranks_present(self):
-        deck = _fresh_shuffled_deck()
+        deck = _fresh_shuffled_shoe()
         suits = {c.suit for c in deck}
         ranks = {c.rank for c in deck}
         assert suits == {"♠", "♥", "♦", "♣"}

--- a/backend/tests/test_blackjack_rules.py
+++ b/backend/tests/test_blackjack_rules.py
@@ -14,7 +14,6 @@ from blackjack.game import (
     is_soft_hand,
 )
 
-
 # ---------------------------------------------------------------------------
 # BlackjackRules validation
 # ---------------------------------------------------------------------------
@@ -213,7 +212,7 @@ class TestDealerH17:
         g = _make_game_in_player_phase(
             rules=BlackjackRules(hit_soft_17=True),
             player_hand=[Card("♠", "10"), Card("♥", "9")],  # 19
-            dealer_hand=[Card("♦", "A"), Card("♣", "6")],   # soft 17
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],  # soft 17
             deck=[Card("♠", "A")],  # dealer draws → soft 18
         )
         g.stand()
@@ -226,7 +225,7 @@ class TestDealerH17:
         g = _make_game_in_player_phase(
             rules=BlackjackRules(hit_soft_17=True),
             player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
-            dealer_hand=[Card("♦", "A"), Card("♣", "6")],   # soft 17
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],  # soft 17
             deck=[Card("♠", "K")],  # A+6+K = 17 hard
         )
         g.stand()

--- a/backend/tests/test_blackjack_rules.py
+++ b/backend/tests/test_blackjack_rules.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for configurable blackjack table rules: H17, multi-deck shoe,
+and penetration-based reshuffling.
+"""
+
+import pytest
+
+from blackjack.game import (
+    BlackjackGame,
+    BlackjackRules,
+    Card,
+    _fresh_shuffled_shoe,
+    hand_value,
+    is_soft_hand,
+)
+
+
+# ---------------------------------------------------------------------------
+# BlackjackRules validation
+# ---------------------------------------------------------------------------
+
+
+class TestBlackjackRulesValidation:
+    def test_defaults(self):
+        r = BlackjackRules()
+        assert r.hit_soft_17 is False
+        assert r.deck_count == 6
+        assert r.penetration == 0.75
+
+    def test_custom_values(self):
+        r = BlackjackRules(hit_soft_17=True, deck_count=2, penetration=0.8)
+        assert r.hit_soft_17 is True
+        assert r.deck_count == 2
+        assert r.penetration == 0.8
+
+    def test_deck_count_below_minimum_raises(self):
+        with pytest.raises(ValueError, match="deck_count"):
+            BlackjackRules(deck_count=0)
+
+    def test_deck_count_above_maximum_raises(self):
+        with pytest.raises(ValueError, match="deck_count"):
+            BlackjackRules(deck_count=9)
+
+    def test_penetration_below_minimum_raises(self):
+        with pytest.raises(ValueError, match="penetration"):
+            BlackjackRules(penetration=0.4)
+
+    def test_penetration_above_maximum_raises(self):
+        with pytest.raises(ValueError, match="penetration"):
+            BlackjackRules(penetration=0.95)
+
+    def test_boundary_deck_count_1(self):
+        r = BlackjackRules(deck_count=1)
+        assert r.deck_count == 1
+
+    def test_boundary_deck_count_8(self):
+        r = BlackjackRules(deck_count=8)
+        assert r.deck_count == 8
+
+    def test_boundary_penetration_050(self):
+        r = BlackjackRules(penetration=0.5)
+        assert r.penetration == 0.5
+
+    def test_boundary_penetration_090(self):
+        r = BlackjackRules(penetration=0.9)
+        assert r.penetration == 0.9
+
+    def test_rules_are_immutable(self):
+        r = BlackjackRules()
+        with pytest.raises(AttributeError):
+            r.hit_soft_17 = True
+
+
+# ---------------------------------------------------------------------------
+# is_soft_hand
+# ---------------------------------------------------------------------------
+
+
+class TestIsSoftHand:
+    def test_ace_plus_six_is_soft(self):
+        assert is_soft_hand([Card("♠", "A"), Card("♥", "6")])
+
+    def test_ace_plus_six_plus_king_is_hard(self):
+        # A+6+K = 1+6+10 = 17 (ace forced to 1)
+        assert not is_soft_hand([Card("♠", "A"), Card("♥", "6"), Card("♦", "K")])
+
+    def test_no_ace_is_not_soft(self):
+        assert not is_soft_hand([Card("♠", "K"), Card("♥", "7")])
+
+    def test_empty_hand_is_not_soft(self):
+        assert not is_soft_hand([])
+
+    def test_two_aces_is_soft(self):
+        # A+A = 12 (one ace at 11, one at 1), soft
+        assert is_soft_hand([Card("♠", "A"), Card("♥", "A")])
+
+    def test_ace_plus_nine_is_soft_20(self):
+        assert is_soft_hand([Card("♠", "A"), Card("♥", "9")])
+
+    def test_ace_plus_ten_is_soft_21(self):
+        assert is_soft_hand([Card("♠", "A"), Card("♥", "K")])
+
+    def test_bust_hand_is_not_soft(self):
+        # K+Q+5 = 25, no aces
+        assert not is_soft_hand([Card("♠", "K"), Card("♥", "Q"), Card("♦", "5")])
+
+
+# ---------------------------------------------------------------------------
+# Multi-deck shoe
+# ---------------------------------------------------------------------------
+
+
+class TestMultiDeckShoe:
+    def test_single_deck_has_52_cards(self):
+        shoe = _fresh_shuffled_shoe(1)
+        assert len(shoe) == 52
+
+    def test_six_deck_shoe_has_312_cards(self):
+        shoe = _fresh_shuffled_shoe(6)
+        assert len(shoe) == 312
+
+    def test_eight_deck_shoe_has_416_cards(self):
+        shoe = _fresh_shuffled_shoe(8)
+        assert len(shoe) == 416
+
+    def test_shoe_contains_correct_number_of_each_rank(self):
+        shoe = _fresh_shuffled_shoe(4)
+        # 4 decks × 4 suits = 16 of each rank
+        ace_count = sum(1 for c in shoe if c.rank == "A")
+        assert ace_count == 16
+
+    def test_game_default_rules_creates_six_deck_shoe(self):
+        g = BlackjackGame()
+        assert len(g._deck) == 312  # 6 * 52
+
+
+# ---------------------------------------------------------------------------
+# Dealer H17 / S17 logic
+# ---------------------------------------------------------------------------
+
+
+def _make_game_in_player_phase(
+    rules: BlackjackRules,
+    player_hand: list[Card],
+    dealer_hand: list[Card],
+    deck: list[Card],
+) -> BlackjackGame:
+    g = BlackjackGame(rules=rules, chips=1000)
+    g.bet = 100
+    g._player_hand = player_hand
+    g._dealer_hand = dealer_hand
+    g._deck = deck
+    g.phase = "player"
+    return g
+
+
+class TestDealerS17:
+    """Default S17: dealer stands on ALL 17s including soft 17."""
+
+    def test_dealer_stands_on_hard_17(self):
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=False),
+            player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
+            dealer_hand=[Card("♦", "10"), Card("♣", "7")],  # hard 17
+            deck=[Card("♠", "2")],  # should not be drawn
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 17
+        assert len(g._dealer_hand) == 2
+
+    def test_dealer_stands_on_soft_17_under_s17(self):
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=False),
+            player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],  # soft 17
+            deck=[Card("♠", "2")],  # should not be drawn
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 17
+        assert len(g._dealer_hand) == 2
+        assert g.outcome == "win"  # player 18 > dealer 17
+
+
+class TestDealerH17:
+    """H17: dealer hits on soft 17 but stands on hard 17."""
+
+    def test_dealer_hits_soft_17_under_h17(self):
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=True),
+            player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],  # soft 17
+            deck=[Card("♠", "3")],  # dealer hits → A+6+3 = 20
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 20
+        assert len(g._dealer_hand) == 3
+        assert g.outcome == "lose"  # dealer 20 > player 18
+
+    def test_dealer_stands_on_hard_17_under_h17(self):
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=True),
+            player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
+            dealer_hand=[Card("♦", "10"), Card("♣", "7")],  # hard 17
+            deck=[Card("♠", "2")],
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 17
+        assert len(g._dealer_hand) == 2
+
+    def test_dealer_hits_soft_17_then_stands_on_18(self):
+        # Dealer: A+6 = soft 17, hits, draws A → A+6+A = 18 (soft)
+        # With H17, dealer stands on soft 18
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=True),
+            player_hand=[Card("♠", "10"), Card("♥", "9")],  # 19
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],   # soft 17
+            deck=[Card("♠", "A")],  # dealer draws → soft 18
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 18
+        assert len(g._dealer_hand) == 3
+
+    def test_dealer_hits_soft_17_busts(self):
+        # Dealer: A+6 = soft 17, hits K → A+6+K = 17 (hard, ace demoted)
+        # Hard 17 → stands
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=True),
+            player_hand=[Card("♠", "10"), Card("♥", "8")],  # 18
+            dealer_hand=[Card("♦", "A"), Card("♣", "6")],   # soft 17
+            deck=[Card("♠", "K")],  # A+6+K = 17 hard
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 17
+        assert len(g._dealer_hand) == 3
+        # Now hard 17, dealer stops even under H17
+        assert g.outcome == "win"  # player 18 > dealer 17
+
+    def test_dealer_hits_soft_17_multiple_times(self):
+        # Dealer: A+6 = soft 17
+        # Hits 2 → soft 19 (A+6+2 = 19), stands
+        # But first test where it stays at soft 17 after multiple draws
+        # Dealer: A+3+3 = soft 17, draws 2 → soft 19
+        g = _make_game_in_player_phase(
+            rules=BlackjackRules(hit_soft_17=True),
+            player_hand=[Card("♠", "10"), Card("♥", "9")],  # 19
+            dealer_hand=[Card("♦", "A"), Card("♣", "3"), Card("♠", "3")],  # soft 17
+            deck=[Card("♠", "2")],  # → soft 19
+        )
+        g.stand()
+        assert hand_value(g._dealer_hand) == 19
+        assert len(g._dealer_hand) == 4
+
+
+# ---------------------------------------------------------------------------
+# Penetration-based reshuffling
+# ---------------------------------------------------------------------------
+
+
+class TestPenetrationReshuffle:
+    def test_reshuffle_at_default_penetration(self):
+        # 6 decks, 0.75 penetration → threshold = 6*52*(1-0.75) = 78
+        rules = BlackjackRules(deck_count=6, penetration=0.75)
+        g = BlackjackGame(rules=rules, chips=1000)
+        g.bet = 100
+        g.phase = "result"
+        g.outcome = "push"
+        # Set deck to just below threshold
+        g._deck = g._deck[:77]
+        g.new_hand()
+        assert len(g._deck) == 312  # full reshuffle
+
+    def test_no_reshuffle_above_threshold(self):
+        rules = BlackjackRules(deck_count=6, penetration=0.75)
+        g = BlackjackGame(rules=rules, chips=1000)
+        g.bet = 100
+        g.phase = "result"
+        g.outcome = "push"
+        # Set deck to just above threshold (78)
+        g._deck = g._deck[:80]
+        g.new_hand()
+        assert len(g._deck) == 80  # no reshuffle
+
+    def test_single_deck_penetration(self):
+        # 1 deck, 0.75 → threshold = max(15, 52*(1-0.75)) = max(15, 13) = 15
+        rules = BlackjackRules(deck_count=1, penetration=0.75)
+        g = BlackjackGame(rules=rules, chips=1000)
+        g.bet = 100
+        g.phase = "result"
+        g.outcome = "push"
+        g._deck = g._deck[:14]  # below 15
+        g.new_hand()
+        assert len(g._deck) == 52  # reshuffled single deck
+
+    def test_high_penetration_lower_threshold(self):
+        # 6 decks, 0.9 → threshold = max(15, 312*0.1) = max(15, 31) = 31
+        rules = BlackjackRules(deck_count=6, penetration=0.9)
+        g = BlackjackGame(rules=rules, chips=1000)
+        g.bet = 100
+        g.phase = "result"
+        g.outcome = "push"
+        g._deck = g._deck[:30]  # below 31
+        g.new_hand()
+        assert len(g._deck) == 312
+
+    def test_rules_persist_across_hands(self):
+        rules = BlackjackRules(hit_soft_17=True, deck_count=2, penetration=0.8)
+        g = BlackjackGame(rules=rules, chips=1000)
+        g.place_bet(100)
+        if g.phase == "player":
+            g.stand()
+        g.new_hand()
+        assert g.rules.hit_soft_17 is True
+        assert g.rules.deck_count == 2
+        assert g.rules.penetration == 0.8

--- a/frontend/src/components/blackjack/BettingPanel.tsx
+++ b/frontend/src/components/blackjack/BettingPanel.tsx
@@ -17,7 +17,14 @@ interface Props {
   onRulesChange: (rules: GameRules) => void;
 }
 
-export default function BettingPanel({ chips, onDeal, loading, error, rules, onRulesChange }: Props) {
+export default function BettingPanel({
+  chips,
+  onDeal,
+  loading,
+  error,
+  rules,
+  onRulesChange,
+}: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
   const maxBet = Math.min(MAX_BET, chips);
@@ -154,9 +161,7 @@ export default function BettingPanel({ chips, onDeal, loading, error, rules, onR
 
           {/* Deck count */}
           <View style={styles.ruleRow}>
-            <Text style={[styles.ruleLabel, { color: colors.text }]}>
-              {t("rules.deckCount")}
-            </Text>
+            <Text style={[styles.ruleLabel, { color: colors.text }]}>{t("rules.deckCount")}</Text>
             <View style={styles.stepper}>
               <Pressable
                 style={[
@@ -192,9 +197,7 @@ export default function BettingPanel({ chips, onDeal, loading, error, rules, onR
 
           {/* Penetration */}
           <View style={styles.ruleRow}>
-            <Text style={[styles.ruleLabel, { color: colors.text }]}>
-              {t("rules.penetration")}
-            </Text>
+            <Text style={[styles.ruleLabel, { color: colors.text }]}>{t("rules.penetration")}</Text>
             <View style={styles.stepper}>
               <Pressable
                 style={[

--- a/frontend/src/components/blackjack/BettingPanel.tsx
+++ b/frontend/src/components/blackjack/BettingPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
+import { GameRules } from "../../game/blackjack/types";
 
 const MIN_BET = 10;
 const MAX_BET = 500;
@@ -12,13 +13,16 @@ interface Props {
   onDeal: (amount: number) => void;
   loading: boolean;
   error: string | null;
+  rules: GameRules;
+  onRulesChange: (rules: GameRules) => void;
 }
 
-export default function BettingPanel({ chips, onDeal, loading, error }: Props) {
+export default function BettingPanel({ chips, onDeal, loading, error, rules, onRulesChange }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
   const maxBet = Math.min(MAX_BET, chips);
   const [bet, setBet] = useState<number>(Math.min(100, maxBet));
+  const [rulesOpen, setRulesOpen] = useState(false);
 
   function decrease() {
     setBet((b) => Math.max(MIN_BET, b - STEP));
@@ -83,6 +87,157 @@ export default function BettingPanel({ chips, onDeal, loading, error }: Props) {
         <Text style={[styles.dealBtnText, { color: colors.surface }]}>{t("actions.deal")}</Text>
       </Pressable>
 
+      {/* Collapsible Table Rules */}
+      <Pressable
+        style={styles.rulesToggle}
+        onPress={() => setRulesOpen((o) => !o)}
+        accessibilityRole="button"
+        accessibilityLabel={t("rules.toggleLabel")}
+      >
+        <Text style={[styles.rulesToggleText, { color: colors.textMuted }]}>
+          {rulesOpen ? "▾" : "▸"} {t("rules.title")}
+        </Text>
+      </Pressable>
+
+      {rulesOpen && (
+        <View style={[styles.rulesPanel, { borderColor: colors.border }]}>
+          {/* H17 toggle */}
+          <View style={styles.ruleRow}>
+            <Text style={[styles.ruleLabel, { color: colors.text }]}>
+              {t("rules.dealerSoft17")}
+            </Text>
+            <View style={styles.ruleOptions}>
+              <Pressable
+                style={[
+                  styles.ruleOptionBtn,
+                  {
+                    backgroundColor: !rules.hit_soft_17 ? colors.accent : colors.surface,
+                    borderColor: colors.border,
+                  },
+                ]}
+                onPress={() => onRulesChange({ ...rules, hit_soft_17: false })}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.s17Label")}
+              >
+                <Text
+                  style={[
+                    styles.ruleOptionText,
+                    { color: !rules.hit_soft_17 ? colors.surface : colors.text },
+                  ]}
+                >
+                  {t("rules.s17")}
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[
+                  styles.ruleOptionBtn,
+                  {
+                    backgroundColor: rules.hit_soft_17 ? colors.accent : colors.surface,
+                    borderColor: colors.border,
+                  },
+                ]}
+                onPress={() => onRulesChange({ ...rules, hit_soft_17: true })}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.h17Label")}
+              >
+                <Text
+                  style={[
+                    styles.ruleOptionText,
+                    { color: rules.hit_soft_17 ? colors.surface : colors.text },
+                  ]}
+                >
+                  {t("rules.h17")}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+
+          {/* Deck count */}
+          <View style={styles.ruleRow}>
+            <Text style={[styles.ruleLabel, { color: colors.text }]}>
+              {t("rules.deckCount")}
+            </Text>
+            <View style={styles.stepper}>
+              <Pressable
+                style={[
+                  styles.ruleStepBtn,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                ]}
+                onPress={() =>
+                  onRulesChange({ ...rules, deck_count: Math.max(1, rules.deck_count - 1) })
+                }
+                disabled={rules.deck_count <= 1}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.decreaseDeckLabel")}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.text }]}>−</Text>
+              </Pressable>
+              <Text style={[styles.ruleValue, { color: colors.text }]}>{rules.deck_count}</Text>
+              <Pressable
+                style={[
+                  styles.ruleStepBtn,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                ]}
+                onPress={() =>
+                  onRulesChange({ ...rules, deck_count: Math.min(8, rules.deck_count + 1) })
+                }
+                disabled={rules.deck_count >= 8}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.increaseDeckLabel")}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.text }]}>+</Text>
+              </Pressable>
+            </View>
+          </View>
+
+          {/* Penetration */}
+          <View style={styles.ruleRow}>
+            <Text style={[styles.ruleLabel, { color: colors.text }]}>
+              {t("rules.penetration")}
+            </Text>
+            <View style={styles.stepper}>
+              <Pressable
+                style={[
+                  styles.ruleStepBtn,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                ]}
+                onPress={() =>
+                  onRulesChange({
+                    ...rules,
+                    penetration: Math.max(0.5, Math.round((rules.penetration - 0.05) * 100) / 100),
+                  })
+                }
+                disabled={rules.penetration <= 0.5}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.decreasePenetrationLabel")}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.text }]}>−</Text>
+              </Pressable>
+              <Text style={[styles.ruleValue, { color: colors.text }]}>
+                {Math.round(rules.penetration * 100)}%
+              </Text>
+              <Pressable
+                style={[
+                  styles.ruleStepBtn,
+                  { backgroundColor: colors.surface, borderColor: colors.border },
+                ]}
+                onPress={() =>
+                  onRulesChange({
+                    ...rules,
+                    penetration: Math.min(0.9, Math.round((rules.penetration + 0.05) * 100) / 100),
+                  })
+                }
+                disabled={rules.penetration >= 0.9}
+                accessibilityRole="button"
+                accessibilityLabel={t("rules.increasePenetrationLabel")}
+              >
+                <Text style={[styles.stepBtnText, { color: colors.text }]}>+</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      )}
+
       {error && <Text style={[styles.error, { color: colors.error }]}>{error}</Text>}
     </View>
   );
@@ -142,6 +297,60 @@ const styles = StyleSheet.create({
   },
   error: {
     fontSize: 13,
+    textAlign: "center",
+  },
+  rulesToggle: {
+    paddingVertical: 4,
+  },
+  rulesToggleText: {
+    fontSize: 13,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  rulesPanel: {
+    width: "100%",
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    gap: 12,
+  },
+  ruleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  ruleLabel: {
+    fontSize: 13,
+    fontWeight: "500",
+    flex: 1,
+  },
+  ruleOptions: {
+    flexDirection: "row",
+    gap: 6,
+  },
+  ruleOptionBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  ruleOptionText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  ruleStepBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ruleValue: {
+    fontSize: 15,
+    fontWeight: "700",
+    minWidth: 44,
     textAlign: "center",
   },
 });

--- a/frontend/src/components/blackjack/__tests__/BettingPanel.test.tsx
+++ b/frontend/src/components/blackjack/__tests__/BettingPanel.test.tsx
@@ -2,18 +2,27 @@ import React from "react";
 import { render, fireEvent } from "@testing-library/react-native";
 import BettingPanel from "../BettingPanel";
 import { ThemeProvider } from "../../../theme/ThemeContext";
+import { DEFAULT_RULES } from "../../../game/blackjack/engine";
 
 function renderPanel(
   overrides: Partial<{ chips: number; loading: boolean; error: string | null }> = {}
 ) {
   const onDeal = jest.fn();
+  const onRulesChange = jest.fn();
   const { chips = 1000, loading = false, error = null } = overrides;
   const utils = render(
     <ThemeProvider>
-      <BettingPanel chips={chips} onDeal={onDeal} loading={loading} error={error} />
+      <BettingPanel
+        chips={chips}
+        onDeal={onDeal}
+        loading={loading}
+        error={error}
+        rules={DEFAULT_RULES}
+        onRulesChange={onRulesChange}
+      />
     </ThemeProvider>
   );
-  return { ...utils, onDeal };
+  return { ...utils, onDeal, onRulesChange };
 }
 
 describe("BettingPanel", () => {

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -22,6 +22,7 @@ import {
   createSeededRng,
   EngineState,
   Card,
+  DEFAULT_RULES,
 } from "../engine";
 
 // Helpers ------------------------------------------------------------------
@@ -41,6 +42,7 @@ function stateInPlayer(chips = 1000, bet = 100): EngineState {
     player_hand: [c("♠", "7"), c("♥", "8")], // 15
     dealer_hand: [c("♦", "6"), c("♣", "9")], // 15
     doubled: false,
+    rules: DEFAULT_RULES,
   };
 }
 
@@ -60,6 +62,7 @@ function stateInResult(
     player_hand: [c("♠", "7"), c("♥", "8")],
     dealer_hand: [c("♦", "6"), c("♣", "9")],
     doubled: false,
+    rules: DEFAULT_RULES,
   };
 }
 
@@ -122,7 +125,8 @@ describe("isSoftHand", () => {
 describe("newGame", () => {
   it("starts in betting phase", () => expect(newGame().phase).toBe("betting"));
   it("starts with 1000 chips", () => expect(newGame().chips).toBe(1000));
-  it("starts with 52-card deck", () => expect(newGame().deck).toHaveLength(52));
+  it("starts with 312-card deck (6 decks by default)", () =>
+    expect(newGame().deck).toHaveLength(312));
   it("starts with empty hands", () => {
     const g = newGame();
     expect(g.player_hand).toEqual([]);
@@ -372,15 +376,17 @@ describe("bust", () => {
 
 describe("deck reshuffle", () => {
   it("reshuffles when below threshold on newHand", () => {
+    // Default rules: 6 decks, 0.75 penetration → threshold = max(15, 312*0.25) = 78
     const low: EngineState = { ...stateInResult(), deck: [c("♠", "5"), c("♥", "5")] };
     const r = newHand(low);
-    expect(r.deck.length).toBe(52);
+    expect(r.deck.length).toBe(312); // 6 decks
   });
 
   it("keeps deck when above threshold on newHand", () => {
-    const high: EngineState = { ...stateInResult(), deck: Array(30).fill(c("♠", "5")) };
+    // 80 cards remaining is above threshold (78)
+    const high: EngineState = { ...stateInResult(), deck: Array(80).fill(c("♠", "5")) };
     const r = newHand(high);
-    expect(r.deck.length).toBe(30);
+    expect(r.deck.length).toBe(80);
   });
 });
 
@@ -477,6 +483,7 @@ function ddSetup(
     dealer_hand: dealer,
     deck,
     doubled: false,
+    rules: DEFAULT_RULES,
   };
 }
 
@@ -723,12 +730,12 @@ describe("seedable RNG (setRng + createSeededRng)", () => {
     expect(a.chips).toEqual(b.chips);
   });
 
-  it("deck contains all 52 unique cards regardless of seed", () => {
+  it("deck contains all 52 unique card types regardless of seed", () => {
     setRng(createSeededRng(12345));
     const { deck } = newGame();
-    expect(deck).toHaveLength(52);
+    expect(deck).toHaveLength(312); // 6 decks
     const keys = new Set(deck.map((card) => `${card.rank}-${card.suit}`));
-    expect(keys.size).toBe(52);
+    expect(keys.size).toBe(52); // 52 unique card types, each repeated 6 times
   });
 
   it("setRng(Math.random) afterEach restores non-determinism", () => {

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -366,9 +366,7 @@ function reshuffleThreshold(rules: GameRules): number {
 export function newHand(s: EngineState): EngineState {
   if (s.phase !== "result") throw new Error("Not in result phase.");
   const deck =
-    s.deck.length < reshuffleThreshold(s.rules)
-      ? freshShuffledDeck(s.rules.deck_count)
-      : s.deck;
+    s.deck.length < reshuffleThreshold(s.rules) ? freshShuffledDeck(s.rules.deck_count) : s.deck;
   return {
     ...s,
     phase: "betting",

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -11,7 +11,7 @@
  * player phase (mirrors backend's conceal behavior).
  */
 
-import { BlackjackState, CardResponse, HandResponse } from "./types";
+import { BlackjackState, CardResponse, GameRules, HandResponse } from "./types";
 
 const SUITS = ["♠", "♥", "♦", "♣"] as const;
 const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"] as const;
@@ -39,6 +39,12 @@ export interface Card {
   rank: string;
 }
 
+export const DEFAULT_RULES: GameRules = {
+  hit_soft_17: false,
+  deck_count: 6,
+  penetration: 0.75,
+};
+
 /**
  * Full engine state — kept in memory + AsyncStorage. The UI never sees
  * this directly; it consumes `toViewState(engineState)` instead.
@@ -53,6 +59,7 @@ export interface EngineState {
   player_hand: Card[];
   dealer_hand: Card[];
   doubled: boolean;
+  rules: GameRules;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,11 +133,13 @@ export function createSeededRng(seed: number): RandomSource {
   };
 }
 
-function freshShuffledDeck(): Card[] {
+function freshShuffledDeck(deckCount: number = 1): Card[] {
   const deck: Card[] = [];
-  for (const s of SUITS) {
-    for (const r of RANKS) {
-      deck.push({ suit: s, rank: r });
+  for (let d = 0; d < deckCount; d++) {
+    for (const s of SUITS) {
+      for (const r of RANKS) {
+        deck.push({ suit: s, rank: r });
+      }
     }
   }
   // Fisher–Yates shuffle
@@ -161,8 +170,8 @@ if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
  * Draw one card from a deck. Returns the new deck (with one fewer card)
  * and the drawn card. Auto-reshuffles if the deck runs dry mid-draw.
  */
-function deal(deck: Card[]): { deck: Card[]; card: Card } {
-  const working = deck.length === 0 ? freshShuffledDeck() : deck;
+function deal(deck: Card[], deckCount: number = 1): { deck: Card[]; card: Card } {
+  const working = deck.length === 0 ? freshShuffledDeck(deckCount) : deck;
   const next = [...working];
   const card = next.pop()!;
   return { deck: next, card };
@@ -199,6 +208,7 @@ export function toViewState(s: EngineState): BlackjackState {
     payout: s.payout,
     game_over,
     double_down_available,
+    rules: s.rules,
   };
 }
 
@@ -206,17 +216,19 @@ export function toViewState(s: EngineState): BlackjackState {
 // Public API — pure state transitions
 // ---------------------------------------------------------------------------
 
-export function newGame(deck?: Card[]): EngineState {
+export function newGame(deck?: Card[], rules?: GameRules): EngineState {
+  const r = rules ?? DEFAULT_RULES;
   return {
     chips: 1000,
     bet: 0,
     phase: "betting",
     outcome: null,
     payout: 0,
-    deck: deck ?? freshShuffledDeck(),
+    deck: deck ?? freshShuffledDeck(r.deck_count),
     player_hand: [],
     dealer_hand: [],
     doubled: false,
+    rules: r,
   };
 }
 
@@ -247,10 +259,10 @@ export function placeBet(s: EngineState, amount: number): EngineState {
   const playerHand: Card[] = [];
   const dealerHand: Card[] = [];
   for (let i = 0; i < 2; i++) {
-    let r = deal(deck);
+    let r = deal(deck, s.rules.deck_count);
     deck = r.deck;
     playerHand.push(r.card);
-    r = deal(deck);
+    r = deal(deck, s.rules.deck_count);
     deck = r.deck;
     dealerHand.push(r.card);
   }
@@ -275,7 +287,7 @@ export function placeBet(s: EngineState, amount: number): EngineState {
 
 export function hit(s: EngineState): EngineState {
   if (s.phase !== "player") throw new Error("Not in player phase.");
-  const { deck, card } = deal(s.deck);
+  const { deck, card } = deal(s.deck, s.rules.deck_count);
   const next: EngineState = {
     ...s,
     deck,
@@ -289,9 +301,21 @@ export function hit(s: EngineState): EngineState {
 
 function dealerPlay(s: EngineState): EngineState {
   let working = s;
-  while (handValue(working.dealer_hand) <= 16) {
-    const { deck, card } = deal(working.deck);
-    working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
+  while (true) {
+    const dv = handValue(working.dealer_hand);
+    if (dv < 17) {
+      const { deck, card } = deal(working.deck, working.rules.deck_count);
+      working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
+    } else if (
+      dv === 17 &&
+      working.rules.hit_soft_17 &&
+      isSoftHand(working.dealer_hand)
+    ) {
+      const { deck, card } = deal(working.deck, working.rules.deck_count);
+      working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
+    } else {
+      break;
+    }
   }
   return working;
 }
@@ -324,7 +348,7 @@ export function doubleDown(s: EngineState): EngineState {
   // wager. Doubling `bet` alone makes the settlement delta double, which
   // is correct under the "chips includes wagered" accounting used by
   // settleWith().
-  const { deck, card } = deal(s.deck);
+  const { deck, card } = deal(s.deck, s.rules.deck_count);
   const afterDouble: EngineState = {
     ...s,
     bet: s.bet * 2,
@@ -339,9 +363,17 @@ export function doubleDown(s: EngineState): EngineState {
   return determineAndSettle(dealerPlay(afterDouble));
 }
 
+function reshuffleThreshold(rules: GameRules): number {
+  const totalCards = rules.deck_count * 52;
+  return Math.max(RESHUFFLE_THRESHOLD, Math.floor(totalCards * (1 - rules.penetration)));
+}
+
 export function newHand(s: EngineState): EngineState {
   if (s.phase !== "result") throw new Error("Not in result phase.");
-  const deck = s.deck.length < RESHUFFLE_THRESHOLD ? freshShuffledDeck() : s.deck;
+  const deck =
+    s.deck.length < reshuffleThreshold(s.rules)
+      ? freshShuffledDeck(s.rules.deck_count)
+      : s.deck;
   return {
     ...s,
     phase: "betting",

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -299,23 +299,18 @@ export function hit(s: EngineState): EngineState {
   return next;
 }
 
+function dealerShouldDraw(hand: readonly Card[], hitSoft17: boolean): boolean {
+  const dv = handValue(hand);
+  if (dv < 17) return true;
+  if (dv === 17 && hitSoft17 && isSoftHand(hand)) return true;
+  return false;
+}
+
 function dealerPlay(s: EngineState): EngineState {
   let working = s;
-  while (true) {
-    const dv = handValue(working.dealer_hand);
-    if (dv < 17) {
-      const { deck, card } = deal(working.deck, working.rules.deck_count);
-      working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
-    } else if (
-      dv === 17 &&
-      working.rules.hit_soft_17 &&
-      isSoftHand(working.dealer_hand)
-    ) {
-      const { deck, card } = deal(working.deck, working.rules.deck_count);
-      working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
-    } else {
-      break;
-    }
+  while (dealerShouldDraw(working.dealer_hand, working.rules.hit_soft_17)) {
+    const { deck, card } = deal(working.deck, working.rules.deck_count);
+    working = { ...working, deck, dealer_hand: [...working.dealer_hand, card] };
   }
   return working;
 }

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -8,7 +8,7 @@
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import { EngineState } from "./engine";
+import { DEFAULT_RULES, EngineState } from "./engine";
 
 const STORAGE_KEY = "blackjack_game_v1";
 
@@ -35,6 +35,10 @@ export async function loadGame(): Promise<EngineState | null> {
       !Array.isArray(parsed.dealer_hand)
     ) {
       return null;
+    }
+    // Backfill rules for saves created before configurable rules.
+    if (!parsed.rules) {
+      parsed.rules = DEFAULT_RULES;
     }
     return parsed;
   } catch (e) {

--- a/frontend/src/game/blackjack/types.ts
+++ b/frontend/src/game/blackjack/types.ts
@@ -15,6 +15,12 @@ export interface HandResponse {
   soft: boolean;
 }
 
+export interface GameRules {
+  hit_soft_17: boolean;
+  deck_count: number;
+  penetration: number;
+}
+
 export interface BlackjackState {
   phase: string; // "betting" | "player" | "result"
   chips: number;
@@ -25,4 +31,5 @@ export interface BlackjackState {
   payout: number;
   game_over: boolean;
   double_down_available: boolean;
+  rules: GameRules;
 }

--- a/frontend/src/i18n/locales/ar/blackjack.json
+++ b/frontend/src/i18n/locales/ar/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "العب مجدداً",
   "gameOver.playAgainLabel": "ابدأ جلسة جديدة مع 1000 رقاقة",
   "gameOver.home": "الرئيسية",
-  "gameOver.homeLabel": "العودة إلى الشاشة الرئيسية"
+  "gameOver.homeLabel": "العودة إلى الشاشة الرئيسية",
+
+  "rules.title": "قواعد الطاولة",
+  "rules.toggleLabel": "تبديل قواعد الطاولة",
+  "rules.dealerSoft17": "الموزع 17 لينة",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "الموزع يقف على 17 لينة",
+  "rules.h17Label": "الموزع يسحب على 17 لينة",
+  "rules.deckCount": "الرزم",
+  "rules.decreaseDeckLabel": "تقليل عدد الرزم",
+  "rules.increaseDeckLabel": "زيادة عدد الرزم",
+  "rules.penetration": "الاختراق",
+  "rules.decreasePenetrationLabel": "تقليل الاختراق",
+  "rules.increasePenetrationLabel": "زيادة الاختراق"
 }

--- a/frontend/src/i18n/locales/de/blackjack.json
+++ b/frontend/src/i18n/locales/de/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Nochmal",
   "gameOver.playAgainLabel": "Neue Runde mit 1000 Chips starten",
   "gameOver.home": "Start",
-  "gameOver.homeLabel": "Zurück zum Startbildschirm"
+  "gameOver.homeLabel": "Zurück zum Startbildschirm",
+
+  "rules.title": "Tischregeln",
+  "rules.toggleLabel": "Tischregeln umschalten",
+  "rules.dealerSoft17": "Dealer weiche 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Dealer bleibt bei weicher 17",
+  "rules.h17Label": "Dealer zieht bei weicher 17",
+  "rules.deckCount": "Decks",
+  "rules.decreaseDeckLabel": "Deckanzahl verringern",
+  "rules.increaseDeckLabel": "Deckanzahl erhöhen",
+  "rules.penetration": "Penetration",
+  "rules.decreasePenetrationLabel": "Penetration verringern",
+  "rules.increasePenetrationLabel": "Penetration erhöhen"
 }

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -57,5 +57,19 @@
   "gameOver.playAgain": "Play Again",
   "gameOver.playAgainLabel": "Start a new session with 1000 chips",
   "gameOver.home": "Home",
-  "gameOver.homeLabel": "Return to home screen"
+  "gameOver.homeLabel": "Return to home screen",
+
+  "rules.title": "Table Rules",
+  "rules.toggleLabel": "Toggle table rules",
+  "rules.dealerSoft17": "Dealer soft 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Dealer stands on soft 17",
+  "rules.h17Label": "Dealer hits on soft 17",
+  "rules.deckCount": "Decks",
+  "rules.decreaseDeckLabel": "Decrease deck count",
+  "rules.increaseDeckLabel": "Increase deck count",
+  "rules.penetration": "Penetration",
+  "rules.decreasePenetrationLabel": "Decrease penetration",
+  "rules.increasePenetrationLabel": "Increase penetration"
 }

--- a/frontend/src/i18n/locales/es/blackjack.json
+++ b/frontend/src/i18n/locales/es/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Jugar de nuevo",
   "gameOver.playAgainLabel": "Inicia una nueva sesión con 1000 fichas",
   "gameOver.home": "Inicio",
-  "gameOver.homeLabel": "Volver a la pantalla de inicio"
+  "gameOver.homeLabel": "Volver a la pantalla de inicio",
+
+  "rules.title": "Reglas de mesa",
+  "rules.toggleLabel": "Alternar reglas de mesa",
+  "rules.dealerSoft17": "Crupier 17 suave",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "El crupier se planta en 17 suave",
+  "rules.h17Label": "El crupier pide en 17 suave",
+  "rules.deckCount": "Barajas",
+  "rules.decreaseDeckLabel": "Reducir barajas",
+  "rules.increaseDeckLabel": "Aumentar barajas",
+  "rules.penetration": "Penetración",
+  "rules.decreasePenetrationLabel": "Reducir penetración",
+  "rules.increasePenetrationLabel": "Aumentar penetración"
 }

--- a/frontend/src/i18n/locales/fr-CA/blackjack.json
+++ b/frontend/src/i18n/locales/fr-CA/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Rejouer",
   "gameOver.playAgainLabel": "Commencez une nouvelle partie avec 1000 jetons",
   "gameOver.home": "Accueil",
-  "gameOver.homeLabel": "Retour à l'écran d'accueil"
+  "gameOver.homeLabel": "Retour à l'écran d'accueil",
+
+  "rules.title": "Règles de la table",
+  "rules.toggleLabel": "Basculer les règles de la table",
+  "rules.dealerSoft17": "Croupier 17 souple",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Le croupier reste sur un 17 souple",
+  "rules.h17Label": "Le croupier tire sur un 17 souple",
+  "rules.deckCount": "Jeux",
+  "rules.decreaseDeckLabel": "Réduire le nombre de jeux",
+  "rules.increaseDeckLabel": "Augmenter le nombre de jeux",
+  "rules.penetration": "Pénétration",
+  "rules.decreasePenetrationLabel": "Réduire la pénétration",
+  "rules.increasePenetrationLabel": "Augmenter la pénétration"
 }

--- a/frontend/src/i18n/locales/he/blackjack.json
+++ b/frontend/src/i18n/locales/he/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "שחק שוב",
   "gameOver.playAgainLabel": "התחל משחק חדש עם 1000 שבבים",
   "gameOver.home": "בית",
-  "gameOver.homeLabel": "חזור למסך הבית"
+  "gameOver.homeLabel": "חזור למסך הבית",
+
+  "rules.title": "חוקי שולחן",
+  "rules.toggleLabel": "החלף חוקי שולחן",
+  "rules.dealerSoft17": "דילר 17 רך",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "הדילר עומד על 17 רך",
+  "rules.h17Label": "הדילר שולף על 17 רך",
+  "rules.deckCount": "חפיסות",
+  "rules.decreaseDeckLabel": "הפחת מספר חפיסות",
+  "rules.increaseDeckLabel": "הגדל מספר חפיסות",
+  "rules.penetration": "חדירה",
+  "rules.decreasePenetrationLabel": "הפחת חדירה",
+  "rules.increasePenetrationLabel": "הגדל חדירה"
 }

--- a/frontend/src/i18n/locales/hi/blackjack.json
+++ b/frontend/src/i18n/locales/hi/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "फिर से खेलें",
   "gameOver.playAgainLabel": "1000 चिप्स के साथ नया सत्र शुरू करें",
   "gameOver.home": "होम",
-  "gameOver.homeLabel": "होम स्क्रीन पर लौटें"
+  "gameOver.homeLabel": "होम स्क्रीन पर लौटें",
+
+  "rules.title": "टेबल नियम",
+  "rules.toggleLabel": "टेबल नियम टॉगल करें",
+  "rules.dealerSoft17": "डीलर सॉफ्ट 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "डीलर सॉफ्ट 17 पर रुकता है",
+  "rules.h17Label": "डीलर सॉफ्ट 17 पर कार्ड लेता है",
+  "rules.deckCount": "डेक",
+  "rules.decreaseDeckLabel": "डेक संख्या घटाएं",
+  "rules.increaseDeckLabel": "डेक संख्या बढ़ाएं",
+  "rules.penetration": "पेनेट्रेशन",
+  "rules.decreasePenetrationLabel": "पेनेट्रेशन घटाएं",
+  "rules.increasePenetrationLabel": "पेनेट्रेशन बढ़ाएं"
 }

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "再挑戦",
   "gameOver.playAgainLabel": "1000チップで新しいセッションを開始",
   "gameOver.home": "ホーム",
-  "gameOver.homeLabel": "ホーム画面に戻る"
+  "gameOver.homeLabel": "ホーム画面に戻る",
+
+  "rules.title": "テーブルルール",
+  "rules.toggleLabel": "テーブルルールを切り替え",
+  "rules.dealerSoft17": "ディーラーソフト17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "ディーラーはソフト17でスタンド",
+  "rules.h17Label": "ディーラーはソフト17でヒット",
+  "rules.deckCount": "デッキ数",
+  "rules.decreaseDeckLabel": "デッキ数を減らす",
+  "rules.increaseDeckLabel": "デッキ数を増やす",
+  "rules.penetration": "ペネトレーション",
+  "rules.decreasePenetrationLabel": "ペネトレーションを減らす",
+  "rules.increasePenetrationLabel": "ペネトレーションを増やす"
 }

--- a/frontend/src/i18n/locales/ko/blackjack.json
+++ b/frontend/src/i18n/locales/ko/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "다시 시작",
   "gameOver.playAgainLabel": "1000칩으로 새 게임 시작",
   "gameOver.home": "홈",
-  "gameOver.homeLabel": "홈 화면으로 돌아가기"
+  "gameOver.homeLabel": "홈 화면으로 돌아가기",
+
+  "rules.title": "테이블 규칙",
+  "rules.toggleLabel": "테이블 규칙 전환",
+  "rules.dealerSoft17": "딜러 소프트 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "딜러가 소프트 17에서 스탠드",
+  "rules.h17Label": "딜러가 소프트 17에서 히트",
+  "rules.deckCount": "덱 수",
+  "rules.decreaseDeckLabel": "덱 수 줄이기",
+  "rules.increaseDeckLabel": "덱 수 늘리기",
+  "rules.penetration": "페네트레이션",
+  "rules.decreasePenetrationLabel": "페네트레이션 줄이기",
+  "rules.increasePenetrationLabel": "페네트레이션 늘리기"
 }

--- a/frontend/src/i18n/locales/nl/blackjack.json
+++ b/frontend/src/i18n/locales/nl/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Opnieuw",
   "gameOver.playAgainLabel": "Begin een nieuwe sessie met 1000 chips",
   "gameOver.home": "Home",
-  "gameOver.homeLabel": "Terug naar startscherm"
+  "gameOver.homeLabel": "Terug naar startscherm",
+
+  "rules.title": "Tafelregels",
+  "rules.toggleLabel": "Tafelregels wisselen",
+  "rules.dealerSoft17": "Dealer zachte 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Dealer staat op zachte 17",
+  "rules.h17Label": "Dealer trekt op zachte 17",
+  "rules.deckCount": "Decks",
+  "rules.decreaseDeckLabel": "Aantal decks verlagen",
+  "rules.increaseDeckLabel": "Aantal decks verhogen",
+  "rules.penetration": "Penetratie",
+  "rules.decreasePenetrationLabel": "Penetratie verlagen",
+  "rules.increasePenetrationLabel": "Penetratie verhogen"
 }

--- a/frontend/src/i18n/locales/pt/blackjack.json
+++ b/frontend/src/i18n/locales/pt/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Jogar de Novo",
   "gameOver.playAgainLabel": "Iniciar nova sessão com 1000 fichas",
   "gameOver.home": "Início",
-  "gameOver.homeLabel": "Voltar para a tela inicial"
+  "gameOver.homeLabel": "Voltar para a tela inicial",
+
+  "rules.title": "Regras da mesa",
+  "rules.toggleLabel": "Alternar regras da mesa",
+  "rules.dealerSoft17": "Dealer 17 suave",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Dealer para no 17 suave",
+  "rules.h17Label": "Dealer compra no 17 suave",
+  "rules.deckCount": "Baralhos",
+  "rules.decreaseDeckLabel": "Diminuir número de baralhos",
+  "rules.increaseDeckLabel": "Aumentar número de baralhos",
+  "rules.penetration": "Penetração",
+  "rules.decreasePenetrationLabel": "Diminuir penetração",
+  "rules.increasePenetrationLabel": "Aumentar penetração"
 }

--- a/frontend/src/i18n/locales/ru/blackjack.json
+++ b/frontend/src/i18n/locales/ru/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "Сыграть",
   "gameOver.playAgainLabel": "Начать новую игру с 1000 фишек",
   "gameOver.home": "Домой",
-  "gameOver.homeLabel": "Вернуться на главный экран"
+  "gameOver.homeLabel": "Вернуться на главный экран",
+
+  "rules.title": "Правила стола",
+  "rules.toggleLabel": "Переключить правила стола",
+  "rules.dealerSoft17": "Дилер мягкие 17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "Дилер стоит на мягких 17",
+  "rules.h17Label": "Дилер берёт на мягких 17",
+  "rules.deckCount": "Колоды",
+  "rules.decreaseDeckLabel": "Уменьшить количество колод",
+  "rules.increaseDeckLabel": "Увеличить количество колод",
+  "rules.penetration": "Пенетрация",
+  "rules.decreasePenetrationLabel": "Уменьшить пенетрацию",
+  "rules.increasePenetrationLabel": "Увеличить пенетрацию"
 }

--- a/frontend/src/i18n/locales/zh/blackjack.json
+++ b/frontend/src/i18n/locales/zh/blackjack.json
@@ -48,5 +48,19 @@
   "gameOver.playAgain": "再玩一次",
   "gameOver.playAgainLabel": "用1000筹码开始新游戏",
   "gameOver.home": "主页",
-  "gameOver.homeLabel": "返回主页"
+  "gameOver.homeLabel": "返回主页",
+
+  "rules.title": "牌桌规则",
+  "rules.toggleLabel": "切换牌桌规则",
+  "rules.dealerSoft17": "庄家软17",
+  "rules.s17": "S17",
+  "rules.h17": "H17",
+  "rules.s17Label": "庄家软17停牌",
+  "rules.h17Label": "庄家软17要牌",
+  "rules.deckCount": "副数",
+  "rules.decreaseDeckLabel": "减少副数",
+  "rules.increaseDeckLabel": "增加副数",
+  "rules.penetration": "切牌深度",
+  "rules.decreasePenetrationLabel": "减少切牌深度",
+  "rules.increasePenetrationLabel": "增加切牌深度"
 }

--- a/frontend/src/screens/BlackjackScreen.tsx
+++ b/frontend/src/screens/BlackjackScreen.tsx
@@ -14,7 +14,9 @@ import {
   newHand as engineNewHand,
   toViewState,
   EngineState,
+  DEFAULT_RULES,
 } from "../game/blackjack/engine";
+import { GameRules } from "../game/blackjack/types";
 import { saveGame, loadGame, clearGame } from "../game/blackjack/storage";
 import BettingPanel from "../components/blackjack/BettingPanel";
 import BlackjackTable from "../components/blackjack/BlackjackTable";
@@ -80,11 +82,24 @@ export default function BlackjackScreen({ navigation }: Props) {
   const handleDoubleDown = () => apply(engineDoubleDown);
   const handleNextHand = () => apply(engineNewHand);
   const handlePlayAgain = () => {
-    const fresh = newGame();
+    const fresh = newGame(undefined, engine?.rules ?? DEFAULT_RULES);
     setEngine(fresh);
     saveGame(fresh);
     setError(null);
   };
+
+  const handleRulesChange = useCallback(
+    (rules: GameRules) => {
+      if (!engine || engine.phase !== "betting") return;
+      const updated: EngineState = {
+        ...newGame(undefined, rules),
+        chips: engine.chips,
+      };
+      setEngine(updated);
+      saveGame(updated);
+    },
+    [engine]
+  );
 
   if (!engine && loading) {
     return (
@@ -210,6 +225,8 @@ export default function BlackjackScreen({ navigation }: Props) {
             onDeal={handleDeal}
             loading={false}
             error={error}
+            rules={state?.rules ?? DEFAULT_RULES}
+            onRulesChange={handleRulesChange}
           />
         )}
 


### PR DESCRIPTION
## Summary

Closes #250. Adds configurable table rules to blackjack with three settings:

- **Dealer soft 17 (H17/S17)** — toggle whether dealer hits or stands on soft 17
- **Deck count (1–8)** — multi-deck shoe replaces the single-deck implementation
- **Penetration (50%–90%)** — controls reshuffle threshold based on shoe depth

Rules are immutable during gameplay and persist across hands.

### Backend
- Added frozen `BlackjackRules` dataclass with validation
- Added `is_soft_hand()` helper for H17 dealer logic
- Replaced `_fresh_shuffled_deck()` with `_fresh_shuffled_shoe(deck_count)`
- Updated dealer play loop for H17/S17 behavior
- Penetration-based reshuffle threshold (`max(15, total_cards * (1 - penetration))`)
- `POST /blackjack/new` accepts optional rules config; state response includes `rules`

### Frontend
- Added `GameRules` interface and `DEFAULT_RULES` constant
- Updated engine: multi-deck `freshShuffledDeck(deckCount)`, H17 `dealerPlay()`, penetration-based `reshuffleThreshold()`
- Collapsible "Table Rules" section in BettingPanel (visible during betting phase only)
- Backward-compatible storage migration for saves without `rules`

### i18n
- Added 14 new translation keys across all 13 locales (ar, de, en, es, fr-CA, he, hi, ja, ko, nl, pt, ru, zh)

### Tests
- 35 new backend tests in `test_blackjack_rules.py` covering rules validation, `is_soft_hand`, multi-deck shoe, H17/S17 dealer logic, and penetration reshuffling
- Updated existing backend + frontend tests for multi-deck defaults and new `rules` field
- All 157 backend tests pass

## Test plan

- [ ] Backend: `cd backend && python -m pytest tests/ -v` — all pass
- [ ] Frontend: `cd frontend && npx jest` — engine, storage, parity, and component tests pass
- [ ] Manual: open blackjack, expand Table Rules, toggle H17/S17, adjust deck count and penetration, verify dealer behavior changes accordingly
- [ ] Manual: verify rules persist across hands but reset on new game
- [ ] Manual: verify saved game without rules field loads correctly (backward compat)

https://claude.ai/code/session_01AgjBX6bgg8sCMdCr9j1FbT