### PR TITLE
fix(cascade): expand sprite clip to full bounding circle so Uranus rings render

### DIFF
--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -36,7 +36,7 @@ import {
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
 } from "../../game/cascade/engine";
-import { getSpriteInfo, SpriteInfo } from "../../game/cascade/fruitVertices";
+import { getSpriteInfo, spriteClipRadius, SpriteInfo } from "../../game/cascade/fruitVertices";
 import { FruitDefinition, FruitSet } from "../../theme/fruitSets";
 import { useTheme } from "../../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
@@ -87,9 +87,11 @@ function FruitBodySkia({
   sprite: SpriteInfo | null;
 }) {
   if (image) {
-    // Build a circular clip path
+    // Clip to the sprite's full bounding circle so ring imagery on ringed
+    // planets (Uranus, Saturn) is not truncated at the physics radius.
+    const clipR = sprite ? spriteClipRadius(sprite, radius) : radius;
     const clipPath = Skia.Path.Make();
-    clipPath.addCircle(0, 0, radius);
+    clipPath.addCircle(0, 0, clipR);
 
     // Compute image draw rect using sprite alignment info
     let ix: number, iy: number, iw: number, ih: number;

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -115,9 +115,14 @@ function drawFruitBody(
     ctx.beginPath();
     ctx.arc(0, 0, clipR, 0, Math.PI * 2);
     ctx.clip();
-    // Opaque bg fill first — anything transparent in the sprite shows this
+    // Opaque bg fill within the physics circle — anything transparent in the
+    // sprite body shows this. Deliberately a circle (not fillRect) so the fill
+    // stays inside radius r and never bleeds into adjacent fruit sprites when
+    // the clip radius is expanded beyond r for ringed planets.
     ctx.fillStyle = bgColor;
-    ctx.fillRect(-r, -r, r * 2, r * 2);
+    ctx.beginPath();
+    ctx.arc(0, 0, r, 0, Math.PI * 2);
+    ctx.fill();
     if (sprite) {
       const ix = sprite.offsetX * r;
       const iy = sprite.offsetY * r;

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -18,7 +18,7 @@ import {
 } from "../../game/cascade/engine";
 import * as Sentry from "@sentry/react-native";
 import { FruitDefinition, FruitSet } from "../../theme/fruitSets";
-import { getSpriteInfo, SpriteInfo } from "../../game/cascade/fruitVertices";
+import { getSpriteInfo, spriteClipRadius, SpriteInfo } from "../../game/cascade/fruitVertices";
 import { useTheme } from "../../theme/ThemeContext";
 import { useTranslation } from "react-i18next";
 
@@ -108,8 +108,12 @@ function drawFruitBody(
     ctx.save();
     ctx.translate(x, y);
     ctx.rotate(angle);
+    // Clip to the sprite's full bounding circle so ring imagery on ringed
+    // planets (Uranus, Saturn) is not truncated at the physics radius.
+    // For sprites without an extended bounding rect this equals r exactly.
+    const clipR = sprite ? spriteClipRadius(sprite, r) : r;
     ctx.beginPath();
-    ctx.arc(0, 0, r, 0, Math.PI * 2);
+    ctx.arc(0, 0, clipR, 0, Math.PI * 2);
     ctx.clip();
     // Opaque bg fill first — anything transparent in the sprite shows this
     ctx.fillStyle = bgColor;

--- a/frontend/src/game/cascade/__tests__/fruitVertices.test.ts
+++ b/frontend/src/game/cascade/__tests__/fruitVertices.test.ts
@@ -46,7 +46,7 @@ jest.mock("../../../../assets/cosmos-vertices.json", () => ({
   ]),
 }));
 
-import { getVerticesForFruit, getSpriteInfo } from "../fruitVertices";
+import { getVerticesForFruit, getSpriteInfo, spriteClipRadius } from "../fruitVertices";
 
 describe("getVerticesForFruit", () => {
   // --- fruits set ---
@@ -117,5 +117,69 @@ describe("getVerticesForFruit", () => {
 
   it("returns null sprite info for unknown set", () => {
     expect(getSpriteInfo("unknown_set", "ruby")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spriteClipRadius — GH #264 Uranus/Saturn ring clipping fix
+// ---------------------------------------------------------------------------
+
+describe("spriteClipRadius", () => {
+  it("returns sqrt(2)*scale*r for a centred sprite (offsetX=offsetY=0)", () => {
+    // All four corners are equidistant from origin at sqrt(sx^2 + sy^2)*r
+    const r = 68;
+    const sx = 1.251069;
+    const result = spriteClipRadius({ offsetX: 0, offsetY: 0, scaleX: sx, scaleY: sx }, r);
+    expect(result).toBeCloseTo(Math.hypot(sx, sx) * r, 4);
+  });
+
+  it("returns a value greater than r for a unit-scale centred sprite", () => {
+    // Even scale=1 with no offset gives sqrt(2)*r ≈ 1.414*r, ensuring the
+    // full image bounding box is visible (corners are at distance sqrt(2)*r)
+    const r = 100;
+    expect(spriteClipRadius({ offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 }, r)).toBeGreaterThan(
+      r
+    );
+  });
+
+  it("uses the farthest corner — positive offset increases the clip radius", () => {
+    const r = 100;
+    const base = spriteClipRadius({ offsetX: 0, offsetY: 0, scaleX: 1, scaleY: 1 }, r);
+    const shifted = spriteClipRadius({ offsetX: 0.2, offsetY: 0.2, scaleX: 1, scaleY: 1 }, r);
+    expect(shifted).toBeGreaterThan(base);
+  });
+
+  it("scales linearly with r", () => {
+    const sprite = { offsetX: 0.05, offsetY: 0.16, scaleX: 1.25, scaleY: 1.25 };
+    const r1 = spriteClipRadius(sprite, 68);
+    const r2 = spriteClipRadius(sprite, 136);
+    expect(r2).toBeCloseTo(r1 * 2, 4);
+  });
+
+  it("Uranus parameters — clip radius is substantially larger than physics radius", () => {
+    // Uranus: tier 7, physics radius=68, spriteScale=1.251069, spriteOffset=[0.054368, 0.155773]
+    const uranusSprite = {
+      offsetX: 0.054368,
+      offsetY: 0.155773,
+      scaleX: 1.251069,
+      scaleY: 1.251069,
+    };
+    const clipR = spriteClipRadius(uranusSprite, 68);
+    // Rings extend well beyond the 68px physics radius
+    expect(clipR).toBeGreaterThan(68);
+    // Farthest corner: sqrt((0.054368+1.251069)^2 + (0.155773+1.251069)^2) * 68 ≈ 130px
+    expect(clipR).toBeCloseTo(Math.hypot(0.054368 + 1.251069, 0.155773 + 1.251069) * 68, 1);
+  });
+
+  it("Saturn parameters — clip radius exceeds physics radius", () => {
+    // Saturn: tier 8, physics radius=76, spriteScale=1.135885, spriteOffset=[0.047144, 0.058236]
+    const saturnSprite = {
+      offsetX: 0.047144,
+      offsetY: 0.058236,
+      scaleX: 1.135885,
+      scaleY: 1.135885,
+    };
+    const clipR = spriteClipRadius(saturnSprite, 76);
+    expect(clipR).toBeGreaterThan(76);
   });
 });

--- a/frontend/src/game/cascade/fruitVertices.ts
+++ b/frontend/src/game/cascade/fruitVertices.ts
@@ -116,6 +116,30 @@ export function getVerticesForFruit(setId: string, nameKey: string): VertexPoint
 }
 
 /**
+ * Minimum circular clip radius (px) that fully encompasses the sprite rect.
+ *
+ * The sprite is drawn as an axis-aligned rectangle centred at
+ * (offsetX, offsetY)*r with half-extents (scaleX, scaleY)*r. For most
+ * planets this equals `sqrt(2)*scaleX*r`; for ringed planets (Uranus,
+ * Saturn) whose rings push the image beyond the physics radius, this
+ * returns a value larger than `r` so the ring imagery is not clipped.
+ *
+ * Physics collision always uses the unmodified `r` — this is render-only.
+ */
+export function spriteClipRadius(sprite: SpriteInfo, r: number): number {
+  const { offsetX: ox, offsetY: oy, scaleX: sx, scaleY: sy } = sprite;
+  // Distance from origin to each corner of the sprite bounding rect
+  return (
+    Math.max(
+      Math.hypot(ox + sx, oy + sy),
+      Math.hypot(ox - sx, oy + sy),
+      Math.hypot(ox + sx, oy - sy),
+      Math.hypot(ox - sx, oy - sy)
+    ) * r
+  );
+}
+
+/**
  * Return sprite rendering info so the image aligns with the collision hull.
  * Returns null for sets without PNG assets.
  */


### PR DESCRIPTION
## Summary
- Closes #264
- `spriteClipRadius()` computes the minimum enclosing circle for the sprite's axis-aligned bounding rectangle, using all four corners — not just the physics radius
- Both renderers updated: web (`GameCanvas.web.tsx` canvas 2D `ctx.arc`) and native (`GameCanvas.tsx` Skia `addCircle`)
- Physics collision is unchanged — `def.radius` still drives Matter.js bodies

## Root cause
The clip path in both renderers was hardcoded to `def.radius` (68 px for Uranus). Uranus's rings push the sprite to ~130 px from center (`hypot(offsetX + scaleX, offsetY + scaleY) * r`), so everything beyond 68 px was cut off.

## Test plan
- [ ] 6 new unit tests in `fruitVertices.test.ts` covering `spriteClipRadius` (centred sprite, unit scale > r, offset increases radius, linear scaling, Uranus params, Saturn params)
- [ ] All 790 existing tests still pass
- [ ] Manually verify Uranus and Saturn ring imagery is fully visible in Cosmos theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)