### PR TITLE
feat(cascade): fixed physics world with uniform visual scaling (#261)

### DIFF
--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -65,8 +65,9 @@ interface Props {
   onMerge: (event: MergeEvent) => void;
   onGameOver: () => void;
   onTap: (x: number) => void;
-  width: number;
-  height: number;
+  width: number; // world width (px) — physics coordinate space
+  height: number; // world height (px) — physics coordinate space
+  scale: number; // display scale: canvas CSS size = world * scale
 }
 
 function FruitBodySkia({
@@ -121,7 +122,7 @@ function FruitBodySkia({
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height }, ref) => {
+  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height, scale }, ref) => {
     const { colors } = useTheme();
     const { t } = useTranslation("cascade");
 
@@ -267,88 +268,93 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const panGesture = Gesture.Pan()
       .runOnJS(true)
       .minDistance(0)
-      .onBegin((e) => setPointerX(e.x))
-      .onChange((e) => setPointerX(e.x))
+      .onBegin((e) => setPointerX(e.x / scale))
+      .onChange((e) => setPointerX(e.x / scale))
       .onEnd((e) => {
-        if (pointerX !== null) onTap(e.x);
+        if (pointerX !== null) onTap(e.x / scale);
       })
       .onFinalize(() => setPointerX(null));
     const tapGesture = Gesture.Tap()
       .runOnJS(true)
       .onEnd((e, ok) => {
-        if (ok) onTap(e.x);
+        if (ok) onTap(e.x / scale);
       });
     const composed = Gesture.Exclusive(panGesture, tapGesture);
+
+    const displayW = Math.round(width * scale);
+    const displayH = Math.round(height * scale);
 
     return (
       <GestureDetector gesture={composed}>
         <Canvas
-          style={{ width, height, borderRadius: 12, overflow: "hidden" }}
+          style={{ width: displayW, height: displayH, borderRadius: 12, overflow: "hidden" }}
           accessibilityLabel={t("game.canvasLabel")}
           accessibilityRole="none"
         >
-          <Fill color={colors.fruitBackground} />
-          <Rect x={0} y={0} width={WALL_THICKNESS} height={height} color={colors.border} />
-          <Rect
-            x={width - WALL_THICKNESS}
-            y={0}
-            width={WALL_THICKNESS}
-            height={height}
-            color={colors.border}
-          />
-          <Rect
-            x={0}
-            y={height - WALL_THICKNESS}
-            width={width}
-            height={WALL_THICKNESS}
-            color={colors.border}
-          />
-          <Path path={dangerPath} color="rgba(239,68,68,0.4)" style="stroke" strokeWidth={1}>
-            <DashPathEffect intervals={[6, 4]} phase={0} />
-          </Path>
-          {ghostCx !== null && guidePath !== null && (
-            <Group opacity={0.7}>
-              <Path
-                path={guidePath}
-                color="rgba(255,255,255,0.25)"
-                style="stroke"
-                strokeWidth={1.5}
-              >
-                <DashPathEffect intervals={[4, 6]} phase={0} />
-              </Path>
-              <Circle
-                cx={ghostCx + 2}
-                cy={DROP_Y + 3}
-                r={nextDef.radius + 1}
-                color="rgba(0,0,0,0.25)"
-              />
-              <FruitBodySkia
-                x={ghostCx}
-                y={DROP_Y}
-                radius={nextDef.radius}
-                color={nextDef.color}
-                image={images[nextDef.tier] ?? null}
-                angle={0}
-                sprite={spriteInfoByTier[nextDef.tier] ?? null}
-              />
-            </Group>
-          )}
-          {bodies.map((body) => {
-            const def = fruitSet.fruits[body.tier];
-            if (!def) return null;
-            return (
-              <FruitBodySkia
-                key={body.id}
-                x={body.x}
-                y={body.y}
-                radius={def.radius}
-                color={def.color}
-                image={images[body.tier] ?? null}
-                angle={body.angle}
-                sprite={spriteInfoByTier[body.tier] ?? null}
-              />
-            );
-          })}
+          <Group transform={[{ scale }]}>
+            <Fill color={colors.fruitBackground} />
+            <Rect x={0} y={0} width={WALL_THICKNESS} height={height} color={colors.border} />
+            <Rect
+              x={width - WALL_THICKNESS}
+              y={0}
+              width={WALL_THICKNESS}
+              height={height}
+              color={colors.border}
+            />
+            <Rect
+              x={0}
+              y={height - WALL_THICKNESS}
+              width={width}
+              height={WALL_THICKNESS}
+              color={colors.border}
+            />
+            <Path path={dangerPath} color="rgba(239,68,68,0.4)" style="stroke" strokeWidth={1}>
+              <DashPathEffect intervals={[6, 4]} phase={0} />
+            </Path>
+            {ghostCx !== null && guidePath !== null && (
+              <Group opacity={0.7}>
+                <Path
+                  path={guidePath}
+                  color="rgba(255,255,255,0.25)"
+                  style="stroke"
+                  strokeWidth={1.5}
+                >
+                  <DashPathEffect intervals={[4, 6]} phase={0} />
+                </Path>
+                <Circle
+                  cx={ghostCx + 2}
+                  cy={DROP_Y + 3}
+                  r={nextDef.radius + 1}
+                  color="rgba(0,0,0,0.25)"
+                />
+                <FruitBodySkia
+                  x={ghostCx}
+                  y={DROP_Y}
+                  radius={nextDef.radius}
+                  color={nextDef.color}
+                  image={images[nextDef.tier] ?? null}
+                  angle={0}
+                  sprite={spriteInfoByTier[nextDef.tier] ?? null}
+                />
+              </Group>
+            )}
+            {bodies.map((body) => {
+              const def = fruitSet.fruits[body.tier];
+              if (!def) return null;
+              return (
+                <FruitBodySkia
+                  key={body.id}
+                  x={body.x}
+                  y={body.y}
+                  radius={def.radius}
+                  color={def.color}
+                  image={images[body.tier] ?? null}
+                  angle={body.angle}
+                  sprite={spriteInfoByTier[body.tier] ?? null}
+                />
+              );
+            })}
+          </Group>
         </Canvas>
       </GestureDetector>
     );

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -52,8 +52,9 @@ interface Props {
   onMerge: (event: MergeEvent) => void;
   onGameOver: () => void;
   onTap: (x: number) => void;
-  width: number;
-  height: number;
+  width: number; // world width (px) — physics coordinate space
+  height: number; // world height (px) — physics coordinate space
+  scale: number; // display scale: canvas CSS size = world * scale
 }
 
 function clamp(value: number, min: number, max: number) {
@@ -172,7 +173,7 @@ function drawCollisionOverlay(
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height }, ref) => {
+  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height, scale }, ref) => {
     const { colors } = useTheme();
     const { t } = useTranslation("cascade");
 
@@ -185,6 +186,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const nextDefRef = useRef(nextDef);
     const bodiesRef = useRef<BodySnapshot[]>([]);
     const pointerXRef = useRef<number | null>(null);
+    const scaleRef = useRef(scale);
     const htmlImagesRef = useRef<(CanvasImageSource | null)[]>([]);
     const spriteInfoRef = useRef<(SpriteInfo | null)[]>([]);
     const lastFrameTimeRef = useRef<number>(0); // tracks last RAF timestamp for elapsed-time physics
@@ -204,6 +206,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       nextDefRef.current = nextDef;
     }, [nextDef]);
+    useEffect(() => {
+      scaleRef.current = scale;
+    }, [scale]);
 
     // Load HTMLImageElements for the current fruit set via expo-asset
     useEffect(() => {
@@ -260,7 +265,15 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       const fs = fruitSetRef.current;
       const dangerY = height * DANGER_LINE_RATIO;
 
-      ctx.clearRect(0, 0, width, height);
+      const s = scaleRef.current;
+      const displayW = width * s;
+      const displayH = height * s;
+
+      ctx.clearRect(0, 0, displayW, displayH);
+
+      // Apply uniform scale: all drawing coords are in world units
+      ctx.save();
+      ctx.scale(s, s);
 
       // Background
       ctx.fillStyle = c.fruitBackground;
@@ -343,6 +356,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       ctx.fillRect(0, 0, WALL_THICKNESS, height);
       ctx.fillRect(width - WALL_THICKNESS, 0, WALL_THICKNESS, height);
       ctx.fillRect(0, height - WALL_THICKNESS, width, WALL_THICKNESS);
+
+      ctx.restore(); // undo ctx.scale(s, s)
     }, [width, height]); // width/height trigger engine reset anyway, so deps here are stable
 
     // Keep latest draw in a ref so the RAF loop never needs to be torn down
@@ -485,13 +500,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       .runOnJS(true)
       .minDistance(0)
       .onBegin((e) => {
-        pointerXRef.current = e.x;
+        pointerXRef.current = e.x / scaleRef.current;
       })
       .onChange((e) => {
-        pointerXRef.current = e.x;
+        pointerXRef.current = e.x / scaleRef.current;
       })
       .onEnd((e) => {
-        if (pointerXRef.current !== null) onTap(e.x);
+        if (pointerXRef.current !== null) onTap(e.x / scaleRef.current);
       })
       .onFinalize(() => {
         pointerXRef.current = null;
@@ -499,21 +514,24 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const tapGesture = Gesture.Tap()
       .runOnJS(true)
       .onEnd((e, ok) => {
-        if (ok) onTap(e.x);
+        if (ok) onTap(e.x / scaleRef.current);
       });
     const composed = Gesture.Exclusive(panGesture, tapGesture);
+
+    const displayW = Math.round(width * scale);
+    const displayH = Math.round(height * scale);
 
     return (
       <GestureDetector gesture={composed}>
         <View
-          style={{ width, height, borderRadius: 12, overflow: "hidden" }}
+          style={{ width: displayW, height: displayH, borderRadius: 12, overflow: "hidden" }}
           accessibilityLabel={t("game.canvasLabel")}
           accessibilityRole="image"
         >
           <canvas
             ref={canvasRef}
-            width={width}
-            height={height}
+            width={displayW}
+            height={displayH}
             style={{ display: "block", borderRadius: 12 }}
           />
         </View>

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -4,6 +4,8 @@ import { getVerticesForFruit } from "./fruitVertices";
 
 // Re-export shared types so imports from './engine' resolve correctly on native
 export {
+  WORLD_W,
+  WORLD_H,
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
   GAME_OVER_GRACE_MS,

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -1,5 +1,11 @@
 import { FruitDefinition, FruitTier } from "../../theme/fruitSets";
 
+// --- Canonical physics world dimensions (px) ---
+// Physics always runs at this fixed size. The renderer scales the canvas to fit
+// the device container — see CascadeScreen for the scale computation.
+export const WORLD_W = 400;
+export const WORLD_H = 700;
+
 // --- Layout constants ---
 export const WALL_THICKNESS = 16;
 /** 18% from top — game over if settled fruit crosses this */

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -3,6 +3,8 @@ import { getVerticesForFruit } from "./fruitVertices";
 
 // Re-export all shared types and constants so existing imports from './engine' keep working
 export {
+  WORLD_W,
+  WORLD_H,
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
   GAME_OVER_GRACE_MS,

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "../theme/ThemeContext";
 import { FruitSetProvider, useFruitSet } from "../theme/FruitSetContext";
 import { FruitQueue } from "../game/cascade/fruitQueue";
 import { ControlledSpawnSelector, createSeededRng } from "../game/cascade/spawnSelector";
-import { MergeEvent } from "../game/cascade/engine";
+import { MergeEvent, WORLD_W, WORLD_H } from "../game/cascade/engine";
 import { scoreForMerge } from "../game/cascade/scoring";
 import GameCanvas, { GameCanvasHandle } from "../components/cascade/GameCanvas";
 import NextFruitPreview from "../components/cascade/NextFruitPreview";
@@ -19,9 +19,6 @@ type Props = {
   navigation: NativeStackNavigationProp<RootStackParamList, "Cascade">;
 };
 
-// Max container width — keeps the game portrait-shaped on wide screens
-const MAX_CANVAS_WIDTH = 400;
-
 function CascadeGame({ navigation }: Props) {
   const { t } = useTranslation(["cascade", "common"]);
   const { colors, theme, toggle } = useTheme();
@@ -30,7 +27,7 @@ function CascadeGame({ navigation }: Props) {
   const [score, setScore] = useState(0);
   const [gameOver, setGameOver] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
-  const [canvasHeight, setCanvasHeight] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
   const [, setQueueVersion] = useState(0);
 
   const canvasRef = useRef<GameCanvasHandle>(null);
@@ -71,7 +68,7 @@ function CascadeGame({ navigation }: Props) {
   const onLayout = useCallback((e: LayoutChangeEvent) => {
     const { width, height } = e.nativeEvent.layout;
     setContainerWidth(Math.floor(width));
-    setCanvasHeight(Math.floor(height));
+    setContainerHeight(Math.floor(height));
   }, []);
 
   const handleMerge = useCallback(
@@ -179,8 +176,12 @@ function CascadeGame({ navigation }: Props) {
   const currentDef = activeFruitSet.fruits[queue.peek()];
   const nextDef = activeFruitSet.fruits[queue.peekNext()];
 
-  // Clamp canvas width to MAX_CANVAS_WIDTH
-  const canvasWidth = Math.min(containerWidth, MAX_CANVAS_WIDTH);
+  // Uniform scale so the fixed physics world fits the available container.
+  // Uses the smaller of the two axes so the canvas always letterboxes cleanly.
+  const scale =
+    containerWidth > 0 && containerHeight > 0
+      ? Math.min(containerWidth / WORLD_W, containerHeight / WORLD_H)
+      : 0;
 
   return (
     <View style={[styles.screen, { backgroundColor: colors.background }]}>
@@ -221,7 +222,7 @@ function CascadeGame({ navigation }: Props) {
 
       {/* Canvas — portrait-constrained, centered */}
       <View style={styles.canvasOuter} onLayout={onLayout}>
-        {canvasWidth > 0 && canvasHeight > 0 && (
+        {scale > 0 && (
           <GameCanvas
             ref={canvasRef}
             fruitSet={activeFruitSet}
@@ -229,8 +230,9 @@ function CascadeGame({ navigation }: Props) {
             onMerge={handleMerge}
             onGameOver={handleGameOver}
             onTap={handleTap}
-            width={canvasWidth}
-            height={canvasHeight}
+            width={WORLD_W}
+            height={WORLD_H}
+            scale={scale}
           />
         )}
       </View>


### PR DESCRIPTION
## Summary
- Adds `WORLD_W=400` / `WORLD_H=700` canonical constants to `engine.shared.ts` — physics always runs at this fixed world size regardless of device screen
- `CascadeScreen` computes `scale = min(containerW/WORLD_W, containerH/WORLD_H)` and passes it down to `GameCanvas` alongside the fixed world dimensions
- `GameCanvas.web.tsx`: applies `ctx.scale(s, s)` once per frame so all drawing remains in world coordinates; gesture X divided by scale converts back to world coords; canvas element sized to `displayW × displayH`
- `GameCanvas.tsx` (Skia/native): canvas style sized to `displayW × displayH`; all drawing wrapped in `<Group transform={[{ scale }]}>` for uniform scaling; gesture X divided by scale

## Test plan
- [ ] All 221 cascade unit tests pass (`npx jest --testPathPattern="cascade"`)
- [ ] Manual: game renders correctly at different browser window widths (letterboxes cleanly)
- [ ] Manual: tap/drop lands where the ghost fruit indicator shows
- [ ] CI green on all jobs

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)