### PR TITLE
fix: address Sentry issues #279, #278, #258

### DIFF
--- a/e2e/tests/cascade-leaderboard.spec.ts
+++ b/e2e/tests/cascade-leaderboard.spec.ts
@@ -156,7 +156,7 @@ test.describe("Cascade — leaderboard API integration", () => {
   // 429 rate-limit response
   // ---------------------------------------------------------------------------
 
-  test("429 response from server → shows generic error message", async ({
+  test("429 response from server → queues score locally for retry", async ({
     page,
   }) => {
     await page.route(SCORE_ENDPOINT, async (route) => {
@@ -184,7 +184,7 @@ test.describe("Cascade — leaderboard API integration", () => {
     await page.getByRole("button", { name: "Save score" }).click();
 
     await expect(
-      page.getByText("Could not save score. Check your connection."),
+      page.getByText("Saved locally"),
     ).toBeVisible({ timeout: 5_000 });
   });
 

--- a/frontend/src/components/cascade/GameOverOverlay.tsx
+++ b/frontend/src/components/cascade/GameOverOverlay.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { useTranslation } from "react-i18next";
 import { cascadeApi, ScoreEntry } from "../../game/cascade/api";
+import { ApiError } from "../../game/_shared/httpClient";
 import { useTheme } from "../../theme/ThemeContext";
 import { useNetwork } from "../../game/_shared/NetworkContext";
 import { scoreQueue } from "../../game/_shared/scoreQueue";
@@ -50,10 +51,12 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
       const entry = await cascadeApi.submitScore(playerName, score);
       setSubmitted(entry);
     } catch (e) {
-      // Network/fetch failures are TypeErrors from fetch(); treat as offline
-      // and queue for later. Application errors (non-2xx) fall through to
-      // the generic error message — those shouldn't be retried blindly.
-      if (e instanceof TypeError) {
+      // Network/fetch failures (TypeError) and transient server errors (429)
+      // are queued for automatic retry when connectivity/rate-limits allow.
+      // Permanent application errors fall through to the generic message.
+      const isTransient =
+        e instanceof TypeError || (e instanceof ApiError && e.status === 429);
+      if (isTransient) {
         try {
           await scoreQueue.enqueue("cascade", { player_name: playerName, score });
           setSavedLocally(true);

--- a/frontend/src/components/cascade/GameOverOverlay.tsx
+++ b/frontend/src/components/cascade/GameOverOverlay.tsx
@@ -54,8 +54,7 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
       // Network/fetch failures (TypeError) and transient server errors (429)
       // are queued for automatic retry when connectivity/rate-limits allow.
       // Permanent application errors fall through to the generic message.
-      const isTransient =
-        e instanceof TypeError || (e instanceof ApiError && e.status === 429);
+      const isTransient = e instanceof TypeError || (e instanceof ApiError && e.status === 429);
       if (isTransient) {
         try {
           await scoreQueue.enqueue("cascade", { player_name: playerName, score });

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -26,7 +26,19 @@ export class ApiError extends Error {
 }
 
 function resolveBaseUrl(): string {
-  const raw = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
+  const raw = process.env.EXPO_PUBLIC_API_URL;
+  if (!raw) {
+    if (__DEV__) {
+      return "http://localhost:8000";
+    }
+    Sentry.captureMessage("EXPO_PUBLIC_API_URL is not set in production build", {
+      level: "error",
+      tags: { subsystem: "httpClient", issue: "missing-env" },
+    });
+    // Fall back so the app doesn't hard-crash, but this will fail with a
+    // TypeError: Failed to fetch — which Sentry will capture separately.
+    return "http://localhost:8000";
+  }
   return raw.startsWith("http") ? raw : `https://${raw}`;
 }
 

--- a/frontend/src/game/_shared/scoreQueue.ts
+++ b/frontend/src/game/_shared/scoreQueue.ts
@@ -61,6 +61,7 @@ export class ScoreQueue {
       return Array.isArray(parsed) ? parsed : [];
     } catch (e) {
       Sentry.captureException(e, { tags: { subsystem: "scoreQueue", op: "read" } });
+      await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
       return [];
     }
   }

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -45,6 +45,7 @@ export async function loadGame(): Promise<EngineState | null> {
     return parsed;
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "blackjack.storage", op: "load" } });
+    await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
     return null;
   }
 }

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -39,6 +39,8 @@ export async function loadGame(): Promise<Twenty48State | null> {
     return parsed;
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "load" } });
+    // Remove corrupted entry so it doesn't fail on every subsequent load.
+    await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
     return null;
   }
 }

--- a/frontend/src/game/yacht/storage.ts
+++ b/frontend/src/game/yacht/storage.ts
@@ -37,6 +37,7 @@ export async function loadGame(): Promise<GameState | null> {
     return parsed;
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "yacht.storage", op: "load" } });
+    await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- **#279** — Warn in Sentry when `EXPO_PUBLIC_API_URL` is missing in production builds instead of silently falling back to `localhost:8000`
- **#278** — Clear corrupted AsyncStorage entries on `JSON.parse` failure so they don't fail repeatedly on every subsequent load
- **#258** — Treat 429 rate-limit responses as transient errors and queue cascade scores for automatic retry instead of showing a permanent error

> **#259 (SIGABRT)** — Native crash with minimal stack trace; needs Xcode/Android Studio crash logs to diagnose. No code fix possible without more data.

Closes #279, closes #278, closes #258

## Policy compliance
Reviewed by policy-compliance agent — no AI API usage, no hardcoded keys, no policy violations in changed files. The translate.js flag is a false positive (file not in this PR diff; hook uses origin/main base instead of origin/dev).

## Test plan
- [x] `npx jest --testPathPattern="(httpClient|scoreQueue|storage)"` — all 34 tests pass
- [x] `npx tsc --noEmit` — no new type errors in modified files
- [ ] Verify Sentry alert fires when EXPO_PUBLIC_API_URL is unset in a staging build
- [ ] Confirm corrupted AsyncStorage data is cleared on next load (no repeated Sentry errors)
- [ ] Confirm 429 on cascade score submission queues the score locally and retries

Generated with [Claude Code](https://claude.com/claude-code)