### PR TITLE
fix: improve responsive layouts for Galaxy Fold narrow screen

### DIFF
--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Pressable, Text, StyleSheet } from "react-native";
+import { Pressable, Text, StyleSheet, useWindowDimensions } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
 
@@ -14,6 +14,10 @@ interface DieProps {
 export default function Die({ value, held, onPress, disabled, index }: DieProps) {
   const { t } = useTranslation("yacht");
   const { colors } = useTheme();
+  const { width } = useWindowDimensions();
+  // Scale dice down on narrow screens (e.g. Galaxy Fold cover: ~280dp).
+  // 5 dice × (size + 12px margin) must fit within screen width.
+  const dieSize = Math.min(56, (width - 80) / 5);
   const displayValue = value > 0 ? value : t("dice.labelBlank");
   const heldSuffix = held ? t("dice.heldSuffix") : "";
   const label = t("dice.label", { index: index + 1, value: displayValue, heldSuffix });
@@ -29,6 +33,8 @@ export default function Die({ value, held, onPress, disabled, index }: DieProps)
       style={[
         styles.die,
         {
+          width: dieSize,
+          height: dieSize,
           backgroundColor: held ? colors.heldBg : colors.dieBg,
           borderColor: held ? colors.heldBorder : colors.dieBorder,
         },
@@ -47,8 +53,6 @@ export default function Die({ value, held, onPress, disabled, index }: DieProps)
 
 const styles = StyleSheet.create({
   die: {
-    width: 56,
-    height: 56,
     borderRadius: 10,
     borderWidth: 3,
     alignItems: "center",

--- a/frontend/src/components/cascade/GameOverOverlay.tsx
+++ b/frontend/src/components/cascade/GameOverOverlay.tsx
@@ -176,7 +176,7 @@ const styles = StyleSheet.create({
     maxWidth: 360,
     borderRadius: 20,
     borderWidth: 1,
-    padding: 32,
+    padding: 24,
     alignItems: "center",
     gap: 12,
   },

--- a/frontend/src/components/cascade/ScoreDisplay.tsx
+++ b/frontend/src/components/cascade/ScoreDisplay.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 12,
     borderWidth: 1,
-    minWidth: 120,
+    minWidth: 100,
   },
   label: {
     fontSize: 10,

--- a/frontend/src/screens/BlackjackScreen.tsx
+++ b/frontend/src/screens/BlackjackScreen.tsx
@@ -301,11 +301,11 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: 24,
+    paddingHorizontal: 16,
   },
   controls: {
     alignItems: "center",
-    paddingHorizontal: 24,
+    paddingHorizontal: 16,
     paddingBottom: 32,
     gap: 16,
   },

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -269,9 +269,10 @@ const styles = StyleSheet.create({
   },
   modalBox: {
     borderRadius: 16,
-    padding: 32,
+    padding: 24,
     alignItems: "center",
-    width: 280,
+    width: "85%",
+    maxWidth: 320,
   },
   modalTitle: {
     fontSize: 28,


### PR DESCRIPTION
## Summary
- **Die.tsx** — Scale dice dynamically via `useWindowDimensions` so 5-dice row fits on ~280dp folded cover screen instead of overflowing at 340px
- **GameScreen.tsx** — Replace hardcoded modal `width: 280` with responsive `width: 85% / maxWidth: 320`; reduce padding 32→24
- **BlackjackScreen.tsx** — Reduce tableArea/controls `paddingHorizontal` 24→16 to reclaim space on narrow viewports
- **GameOverOverlay.tsx** — Reduce card padding 32→24 for narrow screens
- **ScoreDisplay.tsx** — Reduce `minWidth` 120→100 so two score boxes fit on folded Galaxy Fold

Closes #288

## Test plan
- [x] `npx jest` — 33 related tests pass (Die, GameScreen, BlackjackScreen, ScoreDisplay, GameOverOverlay)
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx prettier --check` — all files formatted
- [ ] Manual test on Galaxy Fold emulator (folded 280dp and unfolded 590dp)
- [ ] Verify dice row, modals, and score displays render without overflow on narrow screen
- [ ] Verify fold/unfold transition doesn't break layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)