### PR TITLE
fix(radii): rescale tier radii so T10 fits 3-wide and all tiers grow consistently

### DIFF
--- a/e2e/tests/cascade-gameplay.spec.ts
+++ b/e2e/tests/cascade-gameplay.spec.ts
@@ -60,11 +60,11 @@ test.describe("Cascade — merge and score behavior", () => {
   test("two tier-10 (watermelon) fruits merge → score = 256, no tier-11 spawned", async ({
     page,
   }) => {
-    // Tier-10 radius=98; valid x range in a 400px canvas is [114, 286].
-    // Use the extreme ends (min/max clamp) for least initial overlap (~12%)
-    // so Rapier contact detection fires reliably.
-    await spawnTierAt(page, 10, 114);
-    await spawnTierAt(page, 10, 286);
+    // Tier-10 radius=61; valid x range in a 400px canvas is [77, 323].
+    // Place 107px apart (r1+r2=122) for ~12% initial overlap so Rapier
+    // contact detection fires reliably without suppressing contact events.
+    await spawnTierAt(page, 10, 147);
+    await spawnTierAt(page, 10, 253);
     await fastForward(page, 2000);
 
     const state = await getState(page);

--- a/e2e/tests/cascade-gameplay.spec.ts
+++ b/e2e/tests/cascade-gameplay.spec.ts
@@ -60,11 +60,11 @@ test.describe("Cascade — merge and score behavior", () => {
   test("two tier-10 (watermelon) fruits merge → score = 256, no tier-11 spawned", async ({
     page,
   }) => {
-    // Tier-10 radius=61; valid x range in a 400px canvas is [77, 323].
-    // Place 107px apart (r1+r2=122) for ~12% initial overlap so Rapier
+    // Tier-10 radius=89; valid x range in a 400px canvas is [105, 295].
+    // Place 156px apart (r1+r2=178) for ~12% initial overlap so Rapier
     // contact detection fires reliably without suppressing contact events.
-    await spawnTierAt(page, 10, 147);
-    await spawnTierAt(page, 10, 253);
+    await spawnTierAt(page, 10, 122);
+    await spawnTierAt(page, 10, 278);
     await fastForward(page, 2000);
 
     const state = await getState(page);

--- a/frontend/src/theme/fruitSets.ts
+++ b/frontend/src/theme/fruitSets.ts
@@ -81,16 +81,16 @@ export interface FruitSet {
 // Radii scale with tier — same across all sets so physics is skin-agnostic
 const RADII: Record<FruitTier, number> = {
   0: 18,
-  1: 20,
-  2: 23,
-  3: 26,
-  4: 29,
-  5: 33,
-  6: 36,
-  7: 42,
-  8: 51,
-  9: 56,
-  10: 61,
+  1: 25,
+  2: 33,
+  3: 38,
+  4: 44,
+  5: 49,
+  6: 54,
+  7: 62,
+  8: 75,
+  9: 82,
+  10: 89,
 };
 
 // Score doubles each tier (cherry merge = 1, watermelon merge = 1024)

--- a/frontend/src/theme/fruitSets.ts
+++ b/frontend/src/theme/fruitSets.ts
@@ -81,16 +81,16 @@ export interface FruitSet {
 // Radii scale with tier — same across all sets so physics is skin-agnostic
 const RADII: Record<FruitTier, number> = {
   0: 18,
-  1: 25,
-  2: 33,
-  3: 38,
-  4: 44,
-  5: 52,
-  6: 60,
-  7: 68,
-  8: 76,
-  9: 86,
-  10: 98,
+  1: 20,
+  2: 23,
+  3: 26,
+  4: 29,
+  5: 33,
+  6: 36,
+  7: 42,
+  8: 51,
+  9: 56,
+  10: 61,
 };
 
 // Score doubles each tier (cherry merge = 1, watermelon merge = 1024)


### PR DESCRIPTION
Closes #294

## Summary
- T10 (Watermelon/Sun) drops from 98→61px so exactly 3 fit side-by-side in the 368px bin interior (3×2×61=366px)
- Tiers 1–10 rebalanced so each tier's full-sprite visual size is ≥10% larger than the previous
- Fixes the coconut (T7) → dragonfruit (T8) visual regression: the dragonfruit's inflated bounding box (spikes) gives it a smaller `spriteScale` (1.319 vs coconut's 1.441), requiring a larger radius ratio (r8/r7 = 51/42 = 1.214) to compensate
- No baked PNGs or vertices JSON changes needed — `bakedClipR` is geometrically independent of physics radius

## New RADII
| Tier | Old | New |
|------|-----|-----|
| 0 | 18 | 18 |
| 1 | 25 | 20 |
| 2 | 33 | 23 |
| 3 | 38 | 26 |
| 4 | 44 | 29 |
| 5 | 52 | 33 |
| 6 | 60 | 36 |
| 7 | 68 | 42 |
| 8 | 76 | 51 |
| 9 | 86 | 56 |
| 10 | 98 | 61 |

## Test plan
- [ ] Verify 3 T10 fruits drop into an empty bin and land side-by-side without clipping walls
- [ ] Play through fruits theme and cosmos theme — each tier visually larger than the previous
- [ ] Confirm dragonfruit/pineapple appear clearly larger than coconut in-game
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)