### PR TITLE
fix(cascade): respect safe area insets on Galaxy Fold

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -58,6 +58,13 @@ jest.mock("react-native-reanimated", () => {
   };
 });
 
+// Safe area context mock — returns zero insets in tests
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  SafeAreaView: jest.fn(({ children }: { children: unknown }) => children),
+  SafeAreaProvider: jest.fn(({ children }: { children: unknown }) => children),
+}));
+
 // Sentry mock — @sentry/react-native ships ESM that Jest can't transform
 jest.mock("@sentry/react-native", () => ({
   captureException: jest.fn(),

--- a/frontend/scripts/translate.js
+++ b/frontend/scripts/translate.js
@@ -39,7 +39,7 @@ function parseArgs() {
 
   const locale = get("--locale");
   const ns = get("--namespace");
-  const model = get("--model") ?? "gpt-4o";
+  const model = get("--model") ?? "gpt-4o-2024-11-20";
   const dryRun = has("--dry-run");
   const force = has("--force");
 

--- a/frontend/src/screens/BlackjackScreen.tsx
+++ b/frontend/src/screens/BlackjackScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../App";
@@ -32,6 +33,7 @@ type Props = {
 export default function BlackjackScreen({ navigation }: Props) {
   const { t } = useTranslation(["blackjack", "common", "errors"]);
   const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const [engine, setEngine] = useState<EngineState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -114,7 +116,7 @@ export default function BlackjackScreen({ navigation }: Props) {
   const state: BlackjackState | null = engine ? toViewState(engine) : null;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
       {/* Header */}
       <View style={styles.header}>
         <Pressable
@@ -262,7 +264,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    paddingTop: 48,
   },
   header: {
     flexDirection: "row",

--- a/frontend/src/screens/BlackjackScreen.tsx
+++ b/frontend/src/screens/BlackjackScreen.tsx
@@ -116,7 +116,18 @@ export default function BlackjackScreen({ navigation }: Props) {
   const state: BlackjackState | null = engine ? toViewState(engine) : null;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: Math.max(insets.top, 16),
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 16),
+          paddingRight: Math.max(insets.right, 16),
+        },
+      ]}
+    >
       {/* Header */}
       <View style={styles.header}>
         <Pressable

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -186,7 +186,18 @@ function CascadeGame({ navigation }: Props) {
       : 0;
 
   return (
-    <View style={[styles.screen, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
+    <View
+      style={[
+        styles.screen,
+        {
+          backgroundColor: colors.background,
+          paddingTop: Math.max(insets.top, 16),
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 16),
+          paddingRight: Math.max(insets.right, 16),
+        },
+      ]}
+    >
       {/* Header */}
       <View style={styles.header}>
         <Pressable

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { View, Text, Pressable, StyleSheet, LayoutChangeEvent } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../App";
@@ -22,6 +23,7 @@ type Props = {
 function CascadeGame({ navigation }: Props) {
   const { t } = useTranslation(["cascade", "common"]);
   const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
   const { activeFruitSet } = useFruitSet();
 
   const [score, setScore] = useState(0);
@@ -184,7 +186,7 @@ function CascadeGame({ navigation }: Props) {
       : 0;
 
   return (
-    <View style={[styles.screen, { backgroundColor: colors.background }]}>
+    <View style={[styles.screen, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
       {/* Header */}
       <View style={styles.header}>
         <Pressable
@@ -253,8 +255,6 @@ export default function CascadeScreen(props: Props) {
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
-    padding: 16,
-    paddingTop: 48,
   },
   header: {
     flexDirection: "row",

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { View, Text, StyleSheet, Modal, Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RouteProp } from "@react-navigation/native";
@@ -26,6 +27,7 @@ type Props = {
 export default function GameScreen({ navigation, route }: Props) {
   const { t } = useTranslation(["yacht", "common"]);
   const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
   const [gameState, setGameState] = useState<GameState>(route.params.initialState);
   const [possibleScores, setPossibleScores] = useState<Record<string, number>>({});
   const [resetHeld, setResetHeld] = useState(false);
@@ -94,7 +96,7 @@ export default function GameScreen({ navigation, route }: Props) {
   }, []);
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.headerBg }]}>
         <Pressable
@@ -216,7 +218,7 @@ export default function GameScreen({ navigation, route }: Props) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, paddingTop: 48 },
+  container: { flex: 1 },
   header: {
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -96,7 +96,18 @@ export default function GameScreen({ navigation, route }: Props) {
   }, []);
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: Math.max(insets.top, 16),
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 16),
+          paddingRight: Math.max(insets.right, 16),
+        },
+      ]}
+    >
       {/* Header */}
       <View style={[styles.header, { backgroundColor: colors.headerBg }]}>
         <Pressable

--- a/frontend/src/screens/PachisiScreen.tsx
+++ b/frontend/src/screens/PachisiScreen.tsx
@@ -114,7 +114,18 @@ export default function PachisiScreen({ navigation }: Props) {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: Math.max(insets.top, 16),
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 16),
+          paddingRight: Math.max(insets.right, 16),
+        },
+      ]}
+    >
       {/* Header */}
       <View style={styles.header}>
         <Pressable

--- a/frontend/src/screens/PachisiScreen.tsx
+++ b/frontend/src/screens/PachisiScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { View, Text, Pressable, StyleSheet, ActivityIndicator, ScrollView } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../App";
@@ -22,6 +23,7 @@ type Props = {
 export default function PachisiScreen({ navigation }: Props) {
   const { t } = useTranslation(["pachisi", "common", "errors"]);
   const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const [state, setState] = useState<PachisiState | null>(null);
   const [loading, setLoading] = useState(false);
@@ -112,7 +114,7 @@ export default function PachisiScreen({ navigation }: Props) {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
       {/* Header */}
       <View style={styles.header}>
         <Pressable
@@ -235,7 +237,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    paddingTop: 48,
   },
   header: {
     flexDirection: "row",

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { View, Text, Pressable, StyleSheet, ActivityIndicator, Platform } from "react-native";
 import { GestureDetector, Gesture } from "react-native-gesture-handler";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../App";
@@ -29,6 +30,7 @@ type Props = {
 export default function Twenty48Screen({ navigation }: Props) {
   const { t } = useTranslation(["twenty48", "common", "errors"]);
   const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const [state, setState] = useState<Twenty48State | null>(null);
   const [loading, setLoading] = useState(true);
@@ -187,7 +189,7 @@ export default function Twenty48Screen({ navigation }: Props) {
   const showGameOverOverlay = state?.game_over;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
       {/* Header */}
       <View style={styles.header}>
         <Pressable
@@ -275,7 +277,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    paddingTop: 48,
     alignItems: "center",
   },
   header: {

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -189,7 +189,18 @@ export default function Twenty48Screen({ navigation }: Props) {
   const showGameOverOverlay = state?.game_over;
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: Math.max(insets.top, 16), paddingBottom: Math.max(insets.bottom, 16), paddingLeft: Math.max(insets.left, 16), paddingRight: Math.max(insets.right, 16) }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: Math.max(insets.top, 16),
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 16),
+          paddingRight: Math.max(insets.right, 16),
+        },
+      ]}
+    >
       {/* Header */}
       <View style={styles.header}>
         <Pressable


### PR DESCRIPTION
## Summary
- Replace hardcoded `paddingTop: 48` with dynamic `useSafeAreaInsets()` values across **all 5 game screens**
- Ensures game containers and UI controls respect device safe areas (nav bars, notches, Dynamic Island)
- Uses `Math.max(inset, 16)` to guarantee minimum 16px padding on all sides
- Also pins `translate.js` to dated gpt-4o model version per org policy

Closes #295, #300, #301, #302, #303

### Screens fixed
| Screen | File |
|--------|------|
| Cascade | `CascadeScreen.tsx` |
| Yacht Dice | `GameScreen.tsx` |
| Blackjack | `BlackjackScreen.tsx` |
| Pachisi | `PachisiScreen.tsx` |
| 2048 | `Twenty48Screen.tsx` |

## Test plan
- [ ] Open each game on Samsung Galaxy Fold (or emulator at 280px width)
- [ ] Verify no UI is clipped by the navigation bar at the bottom
- [ ] Verify header controls (back button, theme toggle) are fully visible
- [ ] Verify layout still looks correct on standard devices (iPhone, Pixel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)