### PR TITLE
fix: hardcode ZAP scan URL to fix workflow file validation errors

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -10,6 +10,6 @@ jobs:
   zap-scan:
     uses: wcmchenry3-stack/.github/.github/workflows/called-zap-scheduled.yml@main
     with:
-      target-url: ${{ secrets.SITE_URL }}
+      target-url: 'https://dev-games.buffingchi.com'
       artifact-name: 'zap-weekly-gaming'
     secrets: inherit


### PR DESCRIPTION
## Summary
- `zap-scan.yml` was using `${{ secrets.SITE_URL }}` as the `target-url` input when calling the reusable `called-zap-scheduled.yml` workflow. Secrets cannot be evaluated in `with:` blocks for reusable workflow calls — the value resolves to an empty string at parse time, causing GitHub to report a workflow file validation failure on every push (0s duration, no jobs run).
- Fix: hardcode the known URL (`https://dev-games.buffingchi.com`) directly in the `with:` block.

## Test plan
- [ ] Verify no ZAP scan workflow file failures appear on next push to any branch
- [ ] Verify the weekly scheduled ZAP scan runs successfully against the hardcoded URL

Closes wcmchenry3-stack/.github#55

🤖 Generated with [Claude Code](https://claude.com/claude-code)