### PR TITLE
chore(android): bump version to 1.0.5

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 5
+        versionName "1.0.5"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gaming App",
     "slug": "gaming-app",
-    "version": "1.0.0",
+    "version": "1.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",


### PR DESCRIPTION
## Summary
- Bump versionCode 1 → 5 and versionName 1.0.0 → 1.0.5 in build.gradle
- Align app.json version to 1.0.5 for Play Store release

## Test plan
- [ ] ./gradlew assembleDebug passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)