### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions (closes #316)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       projects: ${{ steps.scope.outputs.projects }}
       label: ${{ steps.scope.outputs.label }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -170,9 +170,9 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-jammy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -204,7 +204,7 @@ jobs:
           CI: "true"
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: playwright-report
@@ -215,8 +215,8 @@ jobs:
     name: i18n completeness check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -244,7 +244,7 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6 (3 remaining instances)
- Bump `actions/setup-node` v4 → v6 (3 instances)  
- Bump `actions/upload-artifact` v4 → v7
- Prepares for GitHub's Node.js 20 deprecation deadline (June 2, 2026)

**Note:** The `wcmchenry3-stack/.github` reusable workflows also need updating in a separate PR to that repo.

## Test plan
- [ ] All CI jobs pass with upgraded action versions
- [ ] No Node.js 20 deprecation warnings in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)