### PR TITLE
feat(typography): add Space Grotesk + Manrope fonts (closes #307)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,12 @@
 import "./src/i18n/i18n";
 import React, { Suspense } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
+import { useFonts } from "expo-font";
+import {
+  SpaceGrotesk_400Regular,
+  SpaceGrotesk_700Bold,
+} from "@expo-google-fonts/space-grotesk";
+import { Manrope_400Regular, Manrope_600SemiBold, Manrope_700Bold } from "@expo-google-fonts/manrope";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer } from "@react-navigation/native";
@@ -75,6 +81,22 @@ function AppInner() {
 }
 
 function App() {
+  const [fontsLoaded] = useFonts({
+    SpaceGrotesk_400Regular,
+    SpaceGrotesk_700Bold,
+    Manrope_400Regular,
+    Manrope_600SemiBold,
+    Manrope_700Bold,
+  });
+
+  if (!fontsLoaded) {
+    return (
+      <View style={{ flex: 1 }}>
+        <ActivityIndicator style={{ flex: 1 }} />
+      </View>
+    );
+  }
+
   return (
     <SafeAreaProvider>
       <GestureHandlerRootView style={{ flex: 1 }}>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -2,11 +2,12 @@ import "./src/i18n/i18n";
 import React, { Suspense } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
 import { useFonts } from "expo-font";
+import { SpaceGrotesk_400Regular, SpaceGrotesk_700Bold } from "@expo-google-fonts/space-grotesk";
 import {
-  SpaceGrotesk_400Regular,
-  SpaceGrotesk_700Bold,
-} from "@expo-google-fonts/space-grotesk";
-import { Manrope_400Regular, Manrope_600SemiBold, Manrope_700Bold } from "@expo-google-fonts/manrope";
+  Manrope_400Regular,
+  Manrope_600SemiBold,
+  Manrope_700Bold,
+} from "@expo-google-fonts/manrope";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer } from "@react-navigation/native";

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@dimforge/rapier2d-compat": "^0.19.3",
+        "@expo-google-fonts/manrope": "^0.4.2",
+        "@expo-google-fonts/space-grotesk": "^0.4.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.5.2",
         "@react-navigation/native": "^7.1.34",
@@ -1625,6 +1627,18 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@expo-google-fonts/manrope": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/manrope/-/manrope-0.4.2.tgz",
+      "integrity": "sha512-BZsKe8d9BJrVnIQIZcTS7/Kac0TbXnqs/+8EBSiQxrmK6GoCO6eTkmr50D1weIk/EoF20pTmAkpWICnovATr/g==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/space-grotesk": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/space-grotesk/-/space-grotesk-0.4.1.tgz",
+      "integrity": "sha512-ZVQYw4Ok/pgcSJiufP8oRZE3AVxS9xtmKEUfsurbHkHNdMc/GA1gDXP9G4Cr7KL4KqSc0haexR2TuMigotCn4Q==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,8 @@
   },
   "dependencies": {
     "@dimforge/rapier2d-compat": "^0.19.3",
+    "@expo-google-fonts/manrope": "^0.4.2",
+    "@expo-google-fonts/space-grotesk": "^0.4.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.5.2",
     "@react-navigation/native": "^7.1.34",

--- a/frontend/src/theme/typography.ts
+++ b/frontend/src/theme/typography.ts
@@ -1,0 +1,7 @@
+export const typography = {
+  heading: "SpaceGrotesk_700Bold",
+  headingLight: "SpaceGrotesk_400Regular",
+  body: "Manrope_400Regular",
+  bodyMedium: "Manrope_600SemiBold",
+  label: "Manrope_700Bold",
+};


### PR DESCRIPTION
## Summary
- Install @expo-google-fonts/space-grotesk and @expo-google-fonts/manrope
- Create typography.ts with font family constants
- Load fonts in App.tsx with useFonts hook

Part of BC Arcade branding overhaul.

## Test plan
- [ ] App loads without crash (fonts load before render)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)