### PR TITLE
feat(nav): add persistent bottom tab bar (closes #308)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -5,12 +5,17 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
 import GameScreen from "./src/screens/GameScreen";
 import CascadeScreen from "./src/screens/CascadeScreen";
 import BlackjackScreen from "./src/screens/BlackjackScreen";
 import Twenty48Screen from "./src/screens/Twenty48Screen";
+import LeaderboardScreen from "./src/screens/LeaderboardScreen";
+import ProfileScreen from "./src/screens/ProfileScreen";
+import SettingsScreen from "./src/screens/SettingsScreen";
+import BottomTabBar from "./src/components/shared/BottomTabBar";
 import { GameState } from "./src/game/yacht/types";
 import { ThemeProvider } from "./src/theme/ThemeContext";
 import { useHtmlAttributes } from "./src/i18n/useHtmlAttributes";
@@ -32,7 +37,7 @@ if (!dsn) {
 }
 
 export type RootStackParamList = {
-  Home: undefined;
+  MainTabs: undefined;
   Game: { initialState: GameState };
   Cascade: undefined;
   Blackjack: undefined;
@@ -41,6 +46,21 @@ export type RootStackParamList = {
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator();
+
+function MainTabs() {
+  return (
+    <Tab.Navigator
+      tabBar={(props) => <BottomTabBar {...props} />}
+      screenOptions={{ headerShown: false }}
+    >
+      <Tab.Screen name="Lobby" component={HomeScreen} />
+      <Tab.Screen name="Ranks" component={LeaderboardScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}
 
 function AppCrashFallback({ resetError }: { resetError: () => void }) {
   return (
@@ -60,7 +80,7 @@ function AppInner() {
       <ThemeProvider>
         <NavigationContainer>
           <Stack.Navigator screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="MainTabs" component={MainTabs} />
             <Stack.Screen name="Game" component={GameScreen} />
             <Stack.Screen name="Cascade" component={CascadeScreen} />
             <Stack.Screen name="Blackjack" component={BlackjackScreen} />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@dimforge/rapier2d-compat": "^0.19.3",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.5.2",
+        "@react-navigation/bottom-tabs": "^7.15.9",
         "@react-navigation/native": "^7.1.34",
         "@react-navigation/native-stack": "^7.14.6",
         "@sentry/react-native": "~7.11.0",
@@ -3575,6 +3576,24 @@
       "integrity": "sha512-9ezxaHjxqTkTOLg62SGg7YhFaE+fxa/jlrWP0nwf7eGFHlGOiTAaRR2KUfiN3K05e+EMbEhgcH/c7bgaXeGyJw==",
       "license": "MIT"
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.15.9",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.9.tgz",
+      "integrity": "sha512-Ou28A1aZLj5wiFQ3F93aIsrI4NCwn3IJzkkjNo9KLFXsc0Yks+UqrVaFlffHFLsrbajuGRG/OQpnMA1ljayY5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.14",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.2.2",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
     "node_modules/@react-navigation/core": {
       "version": "7.16.2",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.16.2.tgz",
@@ -3601,9 +3620,9 @@
       "license": "MIT"
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.11.tgz",
-      "integrity": "sha512-O5KiwaVCcEVuqZgQ77xiBFSl1sha77rNMTFlLWYnom33ZHPDarV3bM9WNyVnMZxU8ZVTi02X3+ZhO0fSn5QYyg==",
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
+      "integrity": "sha512-lKqzu+su2pI/YIZmR7L7xdOs4UL+rVXKJAMpRMBrwInEy96SjIFst6QDGpE89Dunnu3VjVpjWfByo9f2GWBHDQ==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -3612,7 +3631,7 @@
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.34",
+        "@react-navigation/native": "^7.2.2",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@dimforge/rapier2d-compat": "^0.19.3",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.5.2",
+    "@react-navigation/bottom-tabs": "^7.15.9",
     "@react-navigation/native": "^7.1.34",
     "@react-navigation/native-stack": "^7.14.6",
     "@sentry/react-native": "~7.11.0",

--- a/frontend/src/components/shared/BottomTabBar.tsx
+++ b/frontend/src/components/shared/BottomTabBar.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { useTheme } from "../../theme/ThemeContext";
+
+const TAB_ITEMS: Record<string, { emoji: string; label: string }> = {
+  Lobby: { emoji: "🏠", label: "Lobby" },
+  Ranks: { emoji: "🏆", label: "Ranks" },
+  Profile: { emoji: "👤", label: "Profile" },
+  Settings: { emoji: "⚙️", label: "Settings" },
+};
+
+export default function BottomTabBar({ state, navigation }: BottomTabBarProps) {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          paddingBottom: insets.bottom || 8,
+          backgroundColor: "rgba(14, 14, 19, 0.85)",
+        },
+      ]}
+    >
+      {state.routes.map((route, index) => {
+        const focused = state.index === index;
+        const tab = TAB_ITEMS[route.name] ?? { emoji: "?", label: route.name };
+
+        return (
+          <Pressable
+            key={route.key}
+            onPress={() => navigation.navigate(route.name)}
+            style={[
+              styles.tab,
+              focused && { backgroundColor: colors.accent },
+            ]}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: focused }}
+            accessibilityLabel={tab.label}
+          >
+            <Text style={styles.emoji}>{tab.emoji}</Text>
+            <Text
+              style={[
+                styles.label,
+                { color: focused ? "#0e0e13" : "#6e6e7a" },
+              ]}
+            >
+              {tab.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    height: 72,
+    alignItems: "center",
+    justifyContent: "space-around",
+  },
+  tab: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    gap: 2,
+  },
+  emoji: { fontSize: 20 },
+  label: { fontSize: 11, fontWeight: "600" },
+});

--- a/frontend/src/components/shared/BottomTabBar.tsx
+++ b/frontend/src/components/shared/BottomTabBar.tsx
@@ -33,21 +33,13 @@ export default function BottomTabBar({ state, navigation }: BottomTabBarProps) {
           <Pressable
             key={route.key}
             onPress={() => navigation.navigate(route.name)}
-            style={[
-              styles.tab,
-              focused && { backgroundColor: colors.accent },
-            ]}
+            style={[styles.tab, focused && { backgroundColor: colors.accent }]}
             accessibilityRole="tab"
             accessibilityState={{ selected: focused }}
             accessibilityLabel={tab.label}
           >
             <Text style={styles.emoji}>{tab.emoji}</Text>
-            <Text
-              style={[
-                styles.label,
-                { color: focused ? "#0e0e13" : "#6e6e7a" },
-              ]}
-            >
+            <Text style={[styles.label, { color: focused ? "#0e0e13" : "#6e6e7a" }]}>
               {tab.label}
             </Text>
           </Pressable>

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
+import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../../App";
 import { newGame as newYachtGame } from "../game/yacht/engine";
@@ -11,7 +12,7 @@ import LanguageSwitcher from "../components/LanguageSwitcher";
 import OfflineBanner from "../components/OfflineBanner";
 
 type Props = {
-  navigation: NativeStackNavigationProp<RootStackParamList, "Home">;
+  navigation: NativeStackNavigationProp<RootStackParamList, "MainTabs">;
 };
 
 interface GameCard {
@@ -22,7 +23,8 @@ interface GameCard {
   badge?: string;
 }
 
-export default function HomeScreen({ navigation }: Props) {
+export default function HomeScreen(_props: Props) {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { t } = useTranslation([
     "common",
     "yacht",

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -11,10 +11,6 @@ import { useTheme } from "../theme/ThemeContext";
 import LanguageSwitcher from "../components/LanguageSwitcher";
 import OfflineBanner from "../components/OfflineBanner";
 
-type Props = {
-  navigation: NativeStackNavigationProp<RootStackParamList, "MainTabs">;
-};
-
 interface GameCard {
   emoji: string;
   title: string;
@@ -23,7 +19,7 @@ interface GameCard {
   badge?: string;
 }
 
-export default function HomeScreen(_props: Props) {
+export default function HomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { t } = useTranslation([
     "common",

--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../theme/ThemeContext";
+
+export default function LeaderboardScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation("common");
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
+      <Text style={[styles.icon]}>🏆</Text>
+      <Text style={[styles.title, { color: colors.text }]}>{t("screens.leaderboard", "Leaderboard")}</Text>
+      <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  icon: { fontSize: 48, marginBottom: 16 },
+  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
+  subtitle: { fontSize: 16 },
+});

--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -10,9 +10,13 @@ export default function LeaderboardScreen() {
   const { t } = useTranslation("common");
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
+    <View
+      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+    >
       <Text style={[styles.icon]}>🏆</Text>
-      <Text style={[styles.title, { color: colors.text }]}>{t("screens.leaderboard", "Leaderboard")}</Text>
+      <Text style={[styles.title, { color: colors.text }]}>
+        {t("screens.leaderboard", "Leaderboard")}
+      </Text>
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
     </View>
   );

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../theme/ThemeContext";
+
+export default function ProfileScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation("common");
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
+      <Text style={[styles.icon]}>👤</Text>
+      <Text style={[styles.title, { color: colors.text }]}>{t("screens.profile", "Profile")}</Text>
+      <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  icon: { fontSize: 48, marginBottom: 16 },
+  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
+  subtitle: { fontSize: 16 },
+});

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -10,7 +10,9 @@ export default function ProfileScreen() {
   const { t } = useTranslation("common");
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
+    <View
+      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+    >
       <Text style={[styles.icon]}>👤</Text>
       <Text style={[styles.title, { color: colors.text }]}>{t("screens.profile", "Profile")}</Text>
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -11,8 +11,12 @@ export default function SettingsScreen() {
   const { t } = useTranslation("common");
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
-      <Text style={[styles.title, { color: colors.text }]}>{t("screens.settings", "Settings")}</Text>
+    <View
+      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+    >
+      <Text style={[styles.title, { color: colors.text }]}>
+        {t("screens.settings", "Settings")}
+      </Text>
 
       <View style={[styles.row, { borderColor: colors.border }]}>
         <Text style={[styles.label, { color: colors.text }]}>{t("theme.label", "Theme")}</Text>
@@ -31,7 +35,9 @@ export default function SettingsScreen() {
       </View>
 
       <View style={[styles.row, { borderColor: colors.border }]}>
-        <Text style={[styles.label, { color: colors.text }]}>{t("settings.language", "Language")}</Text>
+        <Text style={[styles.label, { color: colors.text }]}>
+          {t("settings.language", "Language")}
+        </Text>
         <LanguageSwitcher />
       </View>
     </View>

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../theme/ThemeContext";
+import LanguageSwitcher from "../components/LanguageSwitcher";
+
+export default function SettingsScreen() {
+  const { colors, theme, toggle } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation("common");
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}>
+      <Text style={[styles.title, { color: colors.text }]}>{t("screens.settings", "Settings")}</Text>
+
+      <View style={[styles.row, { borderColor: colors.border }]}>
+        <Text style={[styles.label, { color: colors.text }]}>{t("theme.label", "Theme")}</Text>
+        <Pressable
+          onPress={toggle}
+          style={[styles.toggle, { backgroundColor: colors.surfaceAlt }]}
+          accessibilityRole="button"
+          accessibilityLabel={t("theme.switchTo", {
+            mode: theme === "dark" ? t("theme.light") : t("theme.dark"),
+          })}
+        >
+          <Text style={{ color: colors.text }}>
+            {theme === "dark" ? t("theme.light", "Light") : t("theme.dark", "Dark")}
+          </Text>
+        </Pressable>
+      </View>
+
+      <View style={[styles.row, { borderColor: colors.border }]}>
+        <Text style={[styles.label, { color: colors.text }]}>{t("settings.language", "Language")}</Text>
+        <LanguageSwitcher />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24 },
+  title: { fontSize: 24, fontWeight: "700", marginBottom: 24, marginTop: 16 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+  },
+  label: { fontSize: 16 },
+  toggle: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 8 },
+});

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { NavigationContainer } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import HomeScreen from "../HomeScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 
@@ -14,25 +12,32 @@ jest.mock("../../game/yacht/storage", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Mock navigation — capture navigate calls
+// Mock navigation
 // ---------------------------------------------------------------------------
 const mockNavigate = jest.fn();
-jest.mock("@react-navigation/native", () => {
-  const actual = jest.requireActual("@react-navigation/native");
-  return {
-    ...actual,
-    useNavigation: () => ({
-      navigate: mockNavigate,
-      goBack: jest.fn(),
-    }),
-  };
-});
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    dispatch: jest.fn(),
+    reset: jest.fn(),
+    isFocused: jest.fn().mockReturnValue(true),
+    canGoBack: jest.fn().mockReturnValue(false),
+    addListener: jest.fn(() => jest.fn()),
+    removeListener: jest.fn(),
+    setParams: jest.fn(),
+    getParent: jest.fn(),
+    getState: jest.fn(),
+    setOptions: jest.fn(),
+    getId: jest.fn(),
+  }),
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const Stack = createNativeStackNavigator();
 
 const testInsets = {
   frame: { x: 0, y: 0, width: 390, height: 844 },
@@ -43,13 +48,9 @@ function renderScreen() {
   return render(
     <SafeAreaProvider initialMetrics={testInsets}>
       <ThemeProvider>
-        <NavigationContainer>
-          <Stack.Navigator screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="Home" component={HomeScreen} />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <HomeScreen />
       </ThemeProvider>
-    </SafeAreaProvider>
+    </SafeAreaProvider>,
   );
 }
 
@@ -95,8 +96,8 @@ describe("HomeScreen — game cards", () => {
             rolls_used: 0,
             game_over: false,
           }),
-        })
-      )
+        }),
+      ),
     );
   });
 });

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -50,7 +50,7 @@ function renderScreen() {
       <ThemeProvider>
         <HomeScreen />
       </ThemeProvider>
-    </SafeAreaProvider>,
+    </SafeAreaProvider>
   );
 }
 
@@ -96,8 +96,8 @@ describe("HomeScreen — game cards", () => {
             rolls_used: 0,
             game_over: false,
           }),
-        }),
-      ),
+        })
+      )
     );
   });
 });

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import HomeScreen from "../HomeScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 
@@ -12,26 +14,40 @@ jest.mock("../../game/yacht/storage", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock navigation — capture navigate calls
+// ---------------------------------------------------------------------------
+const mockNavigate = jest.fn();
+jest.mock("@react-navigation/native", () => {
+  const actual = jest.requireActual("@react-navigation/native");
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+      goBack: jest.fn(),
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function mockNav() {
-  return {
-    navigate: jest.fn(),
-    goBack: jest.fn(),
-  } as unknown as Parameters<typeof HomeScreen>[0]["navigation"];
-}
+const Stack = createNativeStackNavigator();
 
 const testInsets = {
   frame: { x: 0, y: 0, width: 390, height: 844 },
   insets: { top: 47, bottom: 34, left: 0, right: 0 },
 };
 
-function renderScreen(nav = mockNav()) {
+function renderScreen() {
   return render(
     <SafeAreaProvider initialMetrics={testInsets}>
       <ThemeProvider>
-        <HomeScreen navigation={nav} />
+        <NavigationContainer>
+          <Stack.Navigator screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="Home" component={HomeScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
       </ThemeProvider>
     </SafeAreaProvider>
   );
@@ -47,8 +63,7 @@ beforeEach(() => {
 
 describe("HomeScreen — game cards", () => {
   it("renders active game cards (Pachisi disabled)", () => {
-    const nav = mockNav();
-    const { getByLabelText, queryByLabelText } = renderScreen(nav);
+    const { getByLabelText, queryByLabelText } = renderScreen();
     expect(getByLabelText("Play Yacht")).toBeTruthy();
     expect(getByLabelText("Play Cascade")).toBeTruthy();
     expect(getByLabelText("Play Blackjack")).toBeTruthy();
@@ -57,36 +72,29 @@ describe("HomeScreen — game cards", () => {
   });
 
   it("navigates to Blackjack when Blackjack card pressed", () => {
-    const nav = mockNav();
-    const { getByLabelText } = renderScreen(nav);
+    const { getByLabelText } = renderScreen();
     fireEvent.press(getByLabelText("Play Blackjack"));
-    expect(nav.navigate).toHaveBeenCalledWith("Blackjack");
+    expect(mockNavigate).toHaveBeenCalledWith("Blackjack");
   });
 
   it("navigates to Cascade when Cascade card pressed", () => {
-    const nav = mockNav();
-    const { getByLabelText } = renderScreen(nav);
+    const { getByLabelText } = renderScreen();
     fireEvent.press(getByLabelText("Play Cascade"));
-    expect(nav.navigate).toHaveBeenCalledWith("Cascade");
+    expect(mockNavigate).toHaveBeenCalledWith("Cascade");
   });
 
-  // Pachisi disabled — navigation test skipped
-  // it("navigates to Pachisi when Pachisi card pressed", () => {
-  //   const nav = mockNav();
-  //   const { getByLabelText } = renderScreen(nav);
-  //   fireEvent.press(getByLabelText("Play Pachisi"));
-  //   expect(nav.navigate).toHaveBeenCalledWith("Pachisi");
-  // });
-
   it("navigates to Game with a new state when Yacht card pressed (no saved game)", async () => {
-    const nav = mockNav();
-    const { getByLabelText } = renderScreen(nav);
+    const { getByLabelText } = renderScreen();
     fireEvent.press(getByLabelText("Play Yacht"));
     await waitFor(() =>
-      expect(nav.navigate).toHaveBeenCalledWith(
+      expect(mockNavigate).toHaveBeenCalledWith(
         "Game",
         expect.objectContaining({
-          initialState: expect.objectContaining({ round: 1, rolls_used: 0, game_over: false }),
+          initialState: expect.objectContaining({
+            round: 1,
+            rolls_used: 0,
+            game_over: false,
+          }),
         })
       )
     );


### PR DESCRIPTION
## Summary
- Replace stack-only navigation with hybrid Tab + Stack navigator
- Add custom BottomTabBar component (Lobby, Ranks, Profile, Settings)
- Add stub screens for Leaderboard, Profile, Settings
- Move theme toggle and language switcher to Settings screen
- Game screens render without tab bar

Part of BC Arcade branding overhaul.

## Test plan
- [ ] Tab bar visible on Lobby, Ranks, Profile, Settings
- [ ] Tab bar hidden during gameplay
- [ ] Game navigation still works from Lobby
- [ ] Settings has theme toggle and language switcher
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)