### PR TITLE
feat(cascade): redesign game container with glass-jar aesthetic (closes #310)

### DIFF
--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -287,6 +287,15 @@ const styles = StyleSheet.create({
   },
   canvasOuter: {
     flex: 1,
-    alignItems: "center", // centers the canvas horizontally when narrower than container
+    alignItems: "center",
+    marginHorizontal: 8,
+    borderTopLeftRadius: 8,
+    borderTopRightRadius: 8,
+    borderBottomLeftRadius: 48,
+    borderBottomRightRadius: 48,
+    backgroundColor: "rgba(31,31,38,0.4)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.05)",
+    overflow: "hidden",
   },
 });


### PR DESCRIPTION
## Summary
- Add heavy bottom radius (48px) to game container
- Semi-transparent dark gradient background
- Subtle white border at 5% opacity

Part of BC Arcade branding overhaul / Cascade UI redesign.

## Test plan
- [ ] Game container has rounded bottom corners
- [ ] Game still playable (physics unaffected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)