### PR TITLE
feat(lobby): redesign HomeScreen as 2-column game card grid (closes #309)

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import { View, Text, Pressable, StyleSheet, FlatList } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -11,11 +11,11 @@ import { useTheme } from "../theme/ThemeContext";
 import OfflineBanner from "../components/OfflineBanner";
 
 interface GameCard {
+  key: string;
   emoji: string;
   title: string;
   description: string;
   action: () => void;
-  badge?: string;
 }
 
 export default function HomeScreen() {
@@ -33,7 +33,6 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets();
 
   async function startYacht() {
-    // Resume an in-progress saved game if one exists, otherwise start fresh.
     const saved = await loadYachtGame();
     const state = saved && !saved.game_over ? saved : newYachtGame();
     navigation.navigate("Game", { initialState: state });
@@ -41,32 +40,28 @@ export default function HomeScreen() {
 
   const games: GameCard[] = [
     {
+      key: "yacht",
       emoji: "🎲",
       title: t("yacht:game.title"),
       description: t("yacht:game.description"),
       action: startYacht,
     },
     {
+      key: "cascade",
       emoji: "🍉",
       title: t("cascade:game.title"),
       description: t("cascade:game.description"),
       action: () => navigation.navigate("Cascade"),
-      badge: undefined,
     },
     {
+      key: "blackjack",
       emoji: "🃏",
       title: t("blackjack:game.title"),
       description: t("blackjack:game.description"),
       action: () => navigation.navigate("Blackjack"),
     },
-    // Pachisi disabled — needs total rewrite before re-enabling
-    // {
-    //   emoji: "🎯",
-    //   title: t("pachisi:game.title"),
-    //   description: t("pachisi:game.description"),
-    //   action: () => navigation.navigate("Pachisi"),
-    // },
     {
+      key: "twenty48",
       emoji: "🔢",
       title: t("twenty48:game.title"),
       description: t("twenty48:game.description"),
@@ -78,47 +73,65 @@ export default function HomeScreen() {
     [t("yacht:game.title")]: t("yacht:game.playLabel"),
     [t("cascade:game.title")]: t("cascade:game.playLabel"),
     [t("blackjack:game.title")]: t("blackjack:game.playLabel"),
-    // [t("pachisi:game.title")]: t("pachisi:game.playLabel"), // Pachisi disabled
     [t("twenty48:game.title")]: t("twenty48:game.playLabel"),
   };
 
+  function renderCard({ item }: { item: GameCard }) {
+    return (
+      <View style={styles.cardWrapper}>
+        <Pressable
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.surfaceHigh,
+              borderTopColor: colors.accent,
+            },
+          ]}
+          onPress={item.action}
+          accessibilityRole="button"
+          accessibilityLabel={playLabels[item.title] ?? item.title}
+          accessibilityHint={item.description}
+        >
+          <Text style={styles.cardEmoji}>{item.emoji}</Text>
+          <Text style={[styles.cardTitle, { color: colors.text }]}>{item.title}</Text>
+          <Text style={[styles.cardDesc, { color: colors.textMuted }]} numberOfLines={2}>
+            {item.description}
+          </Text>
+          <View style={[styles.playBtn, { backgroundColor: colors.accent }]}>
+            <Text style={[styles.playBtnText, { color: colors.textOnAccent }]}>
+              {t("common:play", "Play")}
+            </Text>
+          </View>
+        </Pressable>
+      </View>
+    );
+  }
+
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.offlineBannerWrap, { top: insets.top }]}>
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: insets.top,
+        },
+      ]}
+    >
+      <View style={styles.offlineBannerWrap}>
         <OfflineBanner />
       </View>
       <Text style={[styles.title, { color: colors.text }]}>{t("common:app.title")}</Text>
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>{t("common:app.subtitle")}</Text>
 
-      <View style={styles.cards}>
-        {games.map((game) => (
-          <View key={game.title}>
-            <Pressable
-              style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
-              onPress={game.action}
-              accessibilityRole="button"
-              accessibilityLabel={playLabels[game.title] ?? game.title}
-              accessibilityHint={game.description}
-            >
-              <Text style={styles.cardEmoji}>{game.emoji}</Text>
-              <View style={styles.cardBody}>
-                <View style={styles.cardTitleRow}>
-                  <Text style={[styles.cardTitle, { color: colors.text }]}>{game.title}</Text>
-                  {game.badge && (
-                    <View style={[styles.badge, { backgroundColor: colors.textMuted }]}>
-                      <Text style={styles.badgeText}>{game.badge}</Text>
-                    </View>
-                  )}
-                </View>
-                <Text style={[styles.cardDesc, { color: colors.textMuted }]}>
-                  {game.description}
-                </Text>
-              </View>
-              <Text style={[styles.cardArrow, { color: colors.textMuted }]}>›</Text>
-            </Pressable>
-          </View>
-        ))}
-      </View>
+      <FlatList
+        data={games}
+        renderItem={renderCard}
+        keyExtractor={(item) => item.key}
+        numColumns={2}
+        contentContainerStyle={styles.grid}
+        columnWrapperStyle={styles.row}
+        scrollEnabled={false}
+      />
     </View>
   );
 }
@@ -127,70 +140,64 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: "center",
-    justifyContent: "center",
-    padding: 24,
+    padding: 16,
   },
   offlineBannerWrap: {
     position: "absolute",
     left: 0,
     right: 0,
+    top: 0,
     zIndex: 10,
   },
   title: {
-    fontSize: 42,
+    fontSize: 32,
     fontWeight: "800",
-    marginBottom: 6,
+    marginTop: 24,
+    marginBottom: 4,
   },
   subtitle: {
-    fontSize: 17,
-    marginBottom: 40,
+    fontSize: 15,
+    marginBottom: 24,
   },
-  cards: {
+  grid: {
     width: "100%",
     maxWidth: 480,
-    gap: 16,
   },
-  card: {
-    flexDirection: "row",
-    alignItems: "center",
-    padding: 20,
-    borderRadius: 16,
-    borderWidth: 1,
-    gap: 16,
+  row: {
+    gap: 12,
+    marginBottom: 12,
   },
-  cardEmoji: {
-    fontSize: 36,
-  },
-  cardBody: {
+  cardWrapper: {
     flex: 1,
   },
-  cardTitleRow: {
-    flexDirection: "row",
+  card: {
+    borderRadius: 24,
+    borderTopWidth: 3,
+    padding: 16,
     alignItems: "center",
     gap: 8,
   },
+  cardEmoji: {
+    fontSize: 40,
+    marginTop: 4,
+  },
   cardTitle: {
-    fontSize: 18,
+    fontSize: 16,
     fontWeight: "700",
-    marginBottom: 2,
-  },
-  badge: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 4,
-    marginBottom: 2,
-  },
-  badgeText: {
-    fontSize: 10,
-    fontWeight: "700",
-    color: "#fff",
-    textTransform: "uppercase",
   },
   cardDesc: {
-    fontSize: 13,
+    fontSize: 12,
+    textAlign: "center",
+    lineHeight: 16,
   },
-  cardArrow: {
-    fontSize: 28,
-    lineHeight: 32,
+  playBtn: {
+    marginTop: 4,
+    paddingHorizontal: 24,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  playBtnText: {
+    fontSize: 14,
+    fontWeight: "700",
   },
 });


### PR DESCRIPTION
## Summary
- Replace vertical card list with 2-column FlatList grid
- Cards use surfaceHigh bg, rounded-3xl, cyan top border accent
- Each card: emoji icon, title, description, accent Play button

Depends on #315 (toggle removal). Part of BC Arcade branding overhaul.

## Test plan
- [ ] Lobby shows 4 game cards in 2x2 grid
- [ ] Tapping Play navigates to correct game
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)