### PR TITLE
chore(android): bump version to 1.0.6

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 5
-        versionName "1.0.5"
+        versionCode 6
+        versionName "1.0.6"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gaming App",
     "slug": "gaming-app",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",


### PR DESCRIPTION
## Summary
- Bump versionCode 5 → 6 and versionName 1.0.5 → 1.0.6 in build.gradle
- Align app.json version to 1.0.6

Bumping for new release that includes the BC Arcade branding overhaul:
- Neon Arcade theme tokens (#306)
- Space Grotesk + Manrope typography (#307)
- Bottom tab navigation (#308)
- Lobby 2-column card grid (#309)
- Cascade glass-jar / score bar / theme selector / game over restyle (#310-313)
- Settings screen with theme + language toggles (#315)

AAB built locally and ready to upload to Play Console internal testing.

## Test plan
- [ ] Local AAB build succeeded (verified)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)