### PR TITLE
fix(cascade/e2e): eliminate races behind flaky Playwright tests (closes #375)

### DIFF
--- a/e2e/tests/helpers/cascade.ts
+++ b/e2e/tests/helpers/cascade.ts
@@ -43,6 +43,17 @@ export async function gotoCascade(page: Page): Promise<void> {
   await page
     .getByRole("img", { name: /Cascade game/i })
     .waitFor({ timeout: 15_000 });
+  // The canvas DOM mounts before Rapier WASM finishes async init; without
+  // this wait the first spawnTierAt() calls can silently no-op because
+  // engineRef is still null, causing flaky first-run failures (#375).
+  await page.waitForFunction(
+    () =>
+      (
+        window as { __cascade_isReady?: () => boolean }
+      ).__cascade_isReady?.() === true,
+    undefined,
+    { timeout: 15_000 },
+  );
 }
 
 /** Read the current engine state exposed by the test hook. */

--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -56,6 +56,8 @@ export interface GameCanvasHandle {
   /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
   getEngineState?: () => CascadeEngineState;
   fastForward?: (ms: number) => void;
+  /** True once the physics engine has finished async init (Rapier WASM loaded). */
+  isReady?: () => boolean;
 }
 
 interface Props {

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -43,6 +43,8 @@ export interface GameCanvasHandle {
   /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
   getEngineState?: () => CascadeEngineState;
   fastForward?: (ms: number) => void;
+  /** True once the physics engine has finished async init (Rapier WASM loaded). */
+  isReady?: () => boolean;
 }
 
 interface Props {
@@ -406,6 +408,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         announceEvent(message) {
           AccessibilityInfo.announceForAccessibility(message);
+        },
+        isReady() {
+          return engineRef.current !== null;
         },
       };
 

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -44,13 +44,10 @@ function CascadeGame({ navigation }: Props) {
   const gameOverRef = useRef(false);
   const activeFruitSetRef = useRef(activeFruitSet);
 
-  // Keep refs in sync with state for test hooks
-  useEffect(() => {
-    scoreRef.current = score;
-  }, [score]);
-  useEffect(() => {
-    gameOverRef.current = gameOver;
-  }, [gameOver]);
+  // Refs are updated synchronously at mutation sites (handleMerge,
+  // handleGameOver, handleRestart, and test hooks) so that Playwright reads
+  // see the latest value without waiting for a React commit to flush.
+  // Only activeFruitSetRef tracks a prop and is safe to sync via effect.
   useEffect(() => {
     activeFruitSetRef.current = activeFruitSet;
   }, [activeFruitSet]);
@@ -60,6 +57,8 @@ function CascadeGame({ navigation }: Props) {
     if (prevFruitSetId.current !== activeFruitSet.id) {
       prevFruitSetId.current = activeFruitSet.id;
       queueRef.current = new FruitQueue();
+      scoreRef.current = 0;
+      gameOverRef.current = false;
       setScore(0);
       setGameOver(false);
       setQueueVersion((v) => v + 1);
@@ -75,7 +74,9 @@ function CascadeGame({ navigation }: Props) {
 
   const handleMerge = useCallback(
     (event: MergeEvent) => {
-      setScore((s) => s + scoreForMerge(event.tier));
+      const delta = scoreForMerge(event.tier);
+      scoreRef.current += delta;
+      setScore((s) => s + delta);
       const merged = activeFruitSet.fruits[event.tier];
       if (merged) {
         canvasRef.current?.announceEvent(t("cascade:event.merged", { fruit: merged.name }));
@@ -86,6 +87,7 @@ function CascadeGame({ navigation }: Props) {
 
   const handleGameOver = useCallback(() => {
     canvasRef.current?.announceEvent(t("cascade:event.gameOver"));
+    gameOverRef.current = true;
     setGameOver(true);
   }, [t]);
 
@@ -148,8 +150,10 @@ function CascadeGame({ navigation }: Props) {
       canvasRef.current?.fastForward?.(ms);
     };
     g.__cascade_triggerGameOver = () => {
+      gameOverRef.current = true;
       setGameOver(true);
     };
+    g.__cascade_isReady = () => canvasRef.current?.isReady?.() === true;
     g.__cascade_spawnTierAt = (tier: number, x: number) => {
       if (gameOverRef.current) return;
       const def = activeFruitSetRef.current.fruits[tier];
@@ -163,11 +167,14 @@ function CascadeGame({ navigation }: Props) {
       delete g.__cascade_fastForward;
       delete g.__cascade_triggerGameOver;
       delete g.__cascade_spawnTierAt;
+      delete g.__cascade_isReady;
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleRestart() {
     queueRef.current = new FruitQueue();
+    scoreRef.current = 0;
+    gameOverRef.current = false;
     setScore(0);
     setGameOver(false);
     setQueueVersion((v) => v + 1);


### PR DESCRIPTION
## Summary

Two independent races caused the 6 flaky Cascade Playwright tests from #375:

1. **React commit lag on test-hook refs.** `scoreRef` / `gameOverRef` were synced to state via `useEffect`, so Playwright reading `getState()` right after `triggerGameOver()` or after a merge inside `fastForward()` could observe the pre-update ref. Fix: update refs synchronously at every mutation site (`handleMerge`, `handleGameOver`, `handleRestart`, fruit-set reset effect, `triggerGameOver` hook).

2. **Engine-not-ready race.** `initEngine()` awaits Rapier WASM. `gotoCascade()` only waited for the canvas DOM, so early `spawnTierAt()` calls could hit `engineRef.current === null` and silently no-op — producing `score=0` on first attempt, then passing on retry once WASM was cached. Fix: new `isReady()` on the `GameCanvas` handle, new `window.__cascade_isReady` test hook, and `gotoCascade()` now `waitForFunction`s on it.

This matches issue hypothesis #2 (`triggerGameOver` state flush) exactly, and refines hypothesis #1: the problem wasn't "physics warmup" but "engine never initialized in the first place on cold runs."

## Test plan

- [ ] CI Playwright job passes without retries
- [ ] Cascade unit tests still pass (`frontend/src/screens/__tests__/CascadeScreen.test.tsx` — verified locally, 6/6 pass)
- [ ] Watch a few dev PRs to confirm the 6 cascade tests no longer flake on first attempt

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)