### PR TITLE
fix(e2e): restore ui-preferences Playwright tests after lobby redesign (closes #378)

### DIFF
--- a/e2e/tests/ui-preferences.spec.ts
+++ b/e2e/tests/ui-preferences.spec.ts
@@ -1,97 +1,100 @@
 /**
  * ui-preferences.spec.ts
  *
- * E2E tests for theme toggle and language switcher.
+ * E2E tests for the theme toggle and language switcher, both of which live
+ * on the Settings tab (the lobby redesign in #309/#326 moved them off Home).
  *
  * Theme: toggles between dark/light mode — verifies the toggle button label changes.
- * Language: switching to a non-English locale changes visible UI copy.
+ * Language: switching to a non-English locale changes visible UI copy in the lobby.
+ *
+ * On web, LanguageSwitcher.web.tsx renders a native <select>, so tests use
+ * .selectOption() directly. The testID is used instead of the aria-label
+ * because the label localizes, which broke the round-trip test historically.
  */
 
-import { test, expect } from "@playwright/test";
-import { installYachtGameMock } from "./helpers/api-mock";
+import { test, expect, type Page } from "@playwright/test";
+
+async function gotoSettings(page: Page) {
+  await page.goto("/");
+  // BottomTabBar exposes each tab with role=tab + hardcoded English accessibilityLabel
+  // from TAB_ITEMS, so this navigation is stable across locale changes.
+  await page.getByRole("tab", { name: "Settings" }).click();
+  await expect(page.getByTestId("theme-toggle-button")).toBeVisible();
+}
 
 test.describe("Theme toggle", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await gotoSettings(page);
   });
 
-  test("theme toggle button is visible on Home", async ({ page }) => {
-    // The button shows either "Light mode" or "Dark mode" text
-    const toggle = page.getByRole("button", { name: /mode/i });
-    await expect(toggle).toBeVisible();
+  test("theme toggle button is visible in Settings", async ({ page }) => {
+    await expect(page.getByTestId("theme-toggle-button")).toBeVisible();
   });
 
   test("clicking theme toggle changes the button label", async ({ page }) => {
-    const toggle = page.getByRole("button", { name: /mode/i });
+    const toggle = page.getByTestId("theme-toggle-button");
     const initialLabel = await toggle.textContent();
 
     await toggle.click();
 
-    // Label should have changed (light ↔ dark)
     const newLabel = await toggle.textContent();
     expect(newLabel).not.toBe(initialLabel);
   });
 
-  test("theme toggle persists into Yacht game screen", async ({ page }) => {
-    await installYachtGameMock(page);
-
-    // Switch theme first
-    const toggle = page.getByRole("button", { name: /mode/i });
+  test("theme toggle persists across tab navigation", async ({ page }) => {
+    const toggle = page.getByTestId("theme-toggle-button");
     await toggle.click();
-    const themeAfterToggle = await toggle.textContent();
+    const labelAfterToggle = await toggle.textContent();
 
-    // Navigate to game
-    await page.getByRole("button", { name: "Play Yacht" }).click();
-    await expect(page.getByText("Round 1 / 13")).toBeVisible();
+    await page.getByRole("tab", { name: "Lobby" }).click();
+    await page.getByRole("tab", { name: "Settings" }).click();
 
-    // The game screen also has a theme toggle; its label should match
-    const gameToggle = page.getByRole("button", { name: /mode/i });
-    await expect(gameToggle).toBeVisible();
-    const gameToggleLabel = await gameToggle.textContent();
-    expect(gameToggleLabel).toBe(themeAfterToggle);
+    const labelAfterNav = await page.getByTestId("theme-toggle-button").textContent();
+    expect(labelAfterNav).toBe(labelAfterToggle);
   });
 });
 
 test.describe("Language switcher", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await gotoSettings(page);
   });
 
-  test("language switcher is visible on Home", async ({ page }) => {
-    // Language switcher has accessibilityLabel "Select language"
-    await expect(page.getByRole("combobox", { name: /language/i })).toBeVisible();
+  test("language switcher is visible in Settings", async ({ page }) => {
+    await expect(page.getByTestId("lang-switcher-select")).toBeVisible();
   });
 
   test("switching to Spanish shows Spanish UI copy", async ({ page }) => {
-    const switcher = page.getByRole("combobox", { name: /language/i });
-    await switcher.selectOption("es");
+    await page.getByTestId("lang-switcher-select").selectOption("es");
 
-    // Spanish locale: "game.playLabel" = "Jugar Yacht"
+    await page.getByRole("tab", { name: "Lobby" }).click();
     await expect(page.getByRole("button", { name: "Jugar Yacht" })).toBeVisible({
       timeout: 3000,
     });
   });
 
   test("switching to German shows German UI copy", async ({ page }) => {
-    const switcher = page.getByRole("combobox", { name: /language/i });
-    await switcher.selectOption("de");
+    await page.getByTestId("lang-switcher-select").selectOption("de");
 
-    // German: "game.playLabel" for yacht
+    await page.getByRole("tab", { name: "Lobby" }).click();
     await expect(page.getByRole("button", { name: "Yacht spielen" })).toBeVisible({
       timeout: 3000,
     });
   });
 
   test("switching language and back to English restores English copy", async ({ page }) => {
-    // Use the <select> element directly — its accessible name changes locale after selection
-    const switcher = page.locator("select").first();
+    await page.getByTestId("lang-switcher-select").selectOption("es");
 
-    await switcher.selectOption("es");
+    await page.getByRole("tab", { name: "Lobby" }).click();
     await expect(page.getByRole("button", { name: "Jugar Yacht" })).toBeVisible({
       timeout: 3000,
     });
 
-    await switcher.selectOption("en");
+    // Back to Settings — the <select>'s aria-label is now "Seleccionar idioma",
+    // but data-testid is stable so we don't need name-based selectors.
+    await page.getByRole("tab", { name: "Settings" }).click();
+    await page.getByTestId("lang-switcher-select").selectOption("en");
+
+    await page.getByRole("tab", { name: "Lobby" }).click();
     await expect(page.getByRole("button", { name: "Play Yacht" })).toBeVisible({
       timeout: 3000,
     });

--- a/frontend/src/components/LanguageSwitcher.web.tsx
+++ b/frontend/src/components/LanguageSwitcher.web.tsx
@@ -12,6 +12,7 @@ export default function LanguageSwitcher() {
       value={i18n.language}
       onChange={(e) => i18n.changeLanguage(e.target.value)}
       aria-label={t("lang.switcherLabel")}
+      data-testid="lang-switcher-select"
       style={{
         backgroundColor: colors.surface,
         color: colors.textMuted,

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -23,6 +23,7 @@ export default function SettingsScreen() {
         <Pressable
           onPress={toggle}
           style={[styles.toggle, { backgroundColor: colors.surfaceAlt }]}
+          testID="theme-toggle-button"
           accessibilityRole="button"
           accessibilityLabel={t("theme.switchTo", {
             mode: theme === "dark" ? t("theme.light") : t("theme.dark"),


### PR DESCRIPTION
## Summary

- Adds `data-testid=\"lang-switcher-select\"` to `LanguageSwitcher.web.tsx` and `testID=\"theme-toggle-button\"` to the Settings theme `Pressable`, giving the two ui-preferences controls locale-stable selectors.
- Rewrites `ui-preferences.spec.ts` to navigate Home → Settings tab (the lobby redesign in #309/#326 moved these controls off Home) and drive the native web `<select>` with `.selectOption()`.

### Root cause

#374's earlier attempt couldn't make `testID` resolve on the language switcher. The reason: there's a platform-specific `LanguageSwitcher.web.tsx` that renders a real HTML `<select>`, and Metro resolves `.web.tsx` over `.tsx` for web builds. #374 added `testID` to the wrong file (`LanguageSwitcher.tsx`, the native `Pressable`+`Modal` version) — so the attribute never reached the DOM on web. There's no react-native-web testID propagation bug. See https://github.com/wcmchenry3-stack/gaming_app/issues/378#issuecomment-4227847864 for the full investigation.

## Test plan

- [x] All 7 `ui-preferences.spec.ts` tests pass locally (`cross` project)
- [x] All 4 `accessibility.spec.ts` tests still pass (no regression in `cross`)
- [x] Round-trip \"switch to Spanish and back to English\" test works across locale change
- [ ] CI `e2e / cross` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)