### PR TITLE
feat(blackjack): adopt 5/25/100/500 chip denominations (engine + backend)

### DIFF
--- a/backend/blackjack/game.py
+++ b/backend/blackjack/game.py
@@ -139,8 +139,8 @@ class BlackjackGame:
     def place_bet(self, amount: int) -> None:
         if self.phase != "betting":
             raise ValueError("Not in betting phase.")
-        if amount < 10 or amount > 500 or amount % 10 != 0:
-            raise ValueError("Bet must be between 10 and 500 in multiples of 10.")
+        if amount < 5 or amount > 500:
+            raise ValueError("Bet must be between 5 and 500.")
         if amount > self.chips:
             raise ValueError("Insufficient chips.")
 

--- a/backend/blackjack/models.py
+++ b/backend/blackjack/models.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field
 
 
 class PlaceBetRequest(BaseModel):
-    amount: int = Field(..., ge=10, le=500, multiple_of=10)
+    amount: int = Field(..., ge=5, le=500)
 
 
 class RulesRequest(BaseModel):

--- a/backend/tests/test_blackjack_api.py
+++ b/backend/tests/test_blackjack_api.py
@@ -152,15 +152,27 @@ class TestPlaceBet:
 
     def test_amount_below_minimum_returns_422(self):
         new_game()
-        assert bet(5).status_code == 422
+        assert bet(4).status_code == 422
+
+    def test_amount_zero_returns_422(self):
+        new_game()
+        assert bet(0).status_code == 422
 
     def test_amount_above_maximum_returns_422(self):
         new_game()
         assert bet(510).status_code == 422
 
-    def test_amount_not_multiple_of_10_returns_422(self):
+    def test_minimum_bet_of_5_accepted(self):
         new_game()
-        assert bet(15).status_code == 422
+        assert bet(5).status_code == 200
+
+    def test_amount_non_multiple_of_10_accepted(self):
+        new_game()
+        assert bet(15).status_code == 200
+
+    def test_amount_30_accepted(self):
+        new_game()
+        assert bet(30).status_code == 200
 
     def test_bet_wrong_phase_returns_400(self):
         _inject_player_phase()

--- a/backend/tests/test_blackjack_game.py
+++ b/backend/tests/test_blackjack_game.py
@@ -192,15 +192,30 @@ class TestPhaseMachine:
 class TestBetValidation:
     def test_bet_below_minimum_raises(self):
         with pytest.raises(ValueError):
-            BlackjackGame().place_bet(5)
+            BlackjackGame().place_bet(4)
+
+    def test_bet_zero_raises(self):
+        with pytest.raises(ValueError):
+            BlackjackGame().place_bet(0)
 
     def test_bet_above_maximum_raises(self):
         with pytest.raises(ValueError):
             BlackjackGame().place_bet(510)
 
-    def test_bet_not_multiple_of_10_raises(self):
-        with pytest.raises(ValueError):
-            BlackjackGame().place_bet(15)
+    def test_minimum_bet_of_5_accepted(self):
+        g = BlackjackGame()
+        g.place_bet(5)
+        assert g.phase in ("player", "result")
+
+    def test_bet_non_multiple_of_10_accepted(self):
+        g = BlackjackGame()
+        g.place_bet(15)
+        assert g.phase in ("player", "result")
+
+    def test_bet_30_accepted(self):
+        g = BlackjackGame()
+        g.place_bet(30)
+        assert g.phase in ("player", "result")
 
     def test_bet_exceeds_chips_raises(self):
         with pytest.raises(ValueError, match="Insufficient chips"):

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -225,9 +225,21 @@ describe("phase machine", () => {
 // --- Bet validation -------------------------------------------------------
 
 describe("bet validation", () => {
-  it("below minimum throws", () => expect(() => placeBet(newGame(), 5)).toThrow());
+  it("below minimum (4) throws", () => expect(() => placeBet(newGame(), 4)).toThrow());
+  it("zero throws", () => expect(() => placeBet(newGame(), 0)).toThrow());
   it("above maximum throws", () => expect(() => placeBet(newGame(), 510)).toThrow());
-  it("not multiple of 10 throws", () => expect(() => placeBet(newGame(), 15)).toThrow());
+  it("minimum bet of 5 accepted", () => {
+    const g = placeBet(newGame(), 5);
+    expect(["player", "result"]).toContain(g.phase);
+  });
+  it("non-multiple of 10 (15) accepted", () => {
+    const g = placeBet(newGame(), 15);
+    expect(["player", "result"]).toContain(g.phase);
+  });
+  it("non-multiple of 10 (30) accepted", () => {
+    const g = placeBet(newGame(), 30);
+    expect(["player", "result"]).toContain(g.phase);
+  });
   it("exceeds chips throws", () =>
     expect(() => placeBet({ ...newGame(), chips: 50 }, 100)).toThrow(/Insufficient chips/));
   it("exact chips accepted", () => {

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -342,8 +342,8 @@ function settleWith(s: EngineState, outcome: "blackjack" | "win" | "lose" | "pus
 
 export function placeBet(s: EngineState, amount: number): EngineState {
   if (s.phase !== "betting") throw new Error("Not in betting phase.");
-  if (amount < 10 || amount > 500 || amount % 10 !== 0) {
-    throw new Error("Bet must be between 10 and 500 in multiples of 10.");
+  if (amount < 5 || amount > 500) {
+    throw new Error("Bet must be between 5 and 500.");
   }
   if (amount > s.chips) throw new Error("Insufficient chips.");
 


### PR DESCRIPTION
Closes #334. Part of epic #332.

## Summary
- Min bet: 10 → **5**
- Drop multiples-of-10 constraint — bets like 15, 25, 30, 105, 130 are now valid
- No UI change (that's issue C in the epic)

## Changes
- `frontend/src/game/blackjack/engine.ts` — `placeBet` validation: `amount < 5 || amount > 500`
- `backend/blackjack/game.py` — `place_bet` validation: same
- `backend/blackjack/models.py` — `PlaceBetRequest`: `ge=5, le=500` (dropped `multiple_of=10`)
- All affected tests updated: "below min" uses 4, "not multiple of 10" rejection removed, positive tests added for bet=5, bet=15, bet=30

## Test plan
- [ ] Frontend engine: `npm test` — 126 tests pass
- [ ] Backend: `pytest tests/test_blackjack_*.py` — 205 tests pass
- [ ] Parity tests pass (FE + BE engines in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)