### PR TITLE
feat(yacht): BC Arcade treatment for Game Over modal (#344)

### DIFF
--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import {
+  Modal,
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Platform,
+  ViewStyle,
+  TextStyle,
+} from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+
+interface GameOverModalProps {
+  visible: boolean;
+  totalScore: number;
+  upperBonus: number;
+  yachtBonusCount: number;
+  yachtBonusTotal: number;
+  onPlayAgain: () => void;
+  onDismiss: () => void;
+}
+
+export default function GameOverModal({
+  visible,
+  totalScore,
+  upperBonus,
+  yachtBonusCount,
+  yachtBonusTotal,
+  onPlayAgain,
+  onDismiss,
+}: GameOverModalProps) {
+  const { t } = useTranslation("yacht");
+  const { colors } = useTheme();
+
+  const scoreGlow: TextStyle | null =
+    Platform.OS === "web"
+      ? ({ textShadow: `0 0 18px ${colors.accent}66, 0 0 6px ${colors.accent}` } as TextStyle)
+      : null;
+
+  const playAgainBg: ViewStyle =
+    Platform.OS === "web"
+      ? ({
+          backgroundImage: `linear-gradient(135deg, ${colors.accent}, ${colors.accentBright})`,
+          boxShadow: `0 0 24px ${colors.accent}55`,
+        } as ViewStyle)
+      : { backgroundColor: colors.accentBright };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" accessibilityViewIsModal>
+      <View style={[styles.overlay, { backgroundColor: "rgba(0,0,0,0.75)" }]}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.surfaceHigh,
+              borderColor: colors.border,
+              borderTopColor: colors.accent,
+            },
+          ]}
+        >
+          <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+            {t("gameOver.title")}
+          </Text>
+          <Text style={[styles.scoreLabel, { color: colors.textMuted }]}>
+            {t("gameOver.finalScore")}
+          </Text>
+          <Text
+            style={[styles.scoreValue, { color: colors.accent }, scoreGlow]}
+            accessibilityLabel={t("gameOver.scoreLabel", { score: totalScore })}
+          >
+            {totalScore}
+          </Text>
+          {(upperBonus > 0 || yachtBonusTotal > 0) && (
+            <View style={styles.bonusStack}>
+              {upperBonus > 0 && (
+                <View
+                  style={[
+                    styles.bonusPill,
+                    { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
+                  ]}
+                >
+                  <Text style={[styles.bonusText, { color: colors.bonus }]}>
+                    {t("gameOver.upperBonus")}
+                  </Text>
+                </View>
+              )}
+              {yachtBonusTotal > 0 && (
+                <View
+                  style={[
+                    styles.bonusPill,
+                    { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
+                  ]}
+                >
+                  <Text style={[styles.bonusText, { color: colors.bonus }]}>
+                    {t("gameOver.yachtBonus", {
+                      count: yachtBonusCount,
+                      total: yachtBonusTotal,
+                    })}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
+          <Pressable
+            style={({ pressed }) => [
+              styles.playAgainButton,
+              playAgainBg,
+              pressed ? { transform: [{ scale: 0.96 }] } : null,
+            ]}
+            onPress={onPlayAgain}
+            accessibilityRole="button"
+            accessibilityLabel={t("gameOver.playAgainLabel")}
+          >
+            <Text style={[styles.playAgainText, { color: colors.textOnAccent }]}>
+              {t("gameOver.playAgain")}
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.dismissButton, { borderColor: colors.border }]}
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel={t("gameOver.dismissLabel")}
+          >
+            <Text style={[styles.dismissText, { color: colors.textMuted }]}>
+              {t("gameOver.dismiss")}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderTopWidth: 3,
+    padding: 28,
+    alignItems: "center",
+    width: "86%",
+    maxWidth: 340,
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: "900",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginBottom: 10,
+  },
+  scoreLabel: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+    marginBottom: 4,
+  },
+  scoreValue: {
+    fontSize: 64,
+    fontWeight: "900",
+    lineHeight: 70,
+    marginBottom: 12,
+  },
+  bonusStack: {
+    gap: 6,
+    marginBottom: 18,
+    alignItems: "center",
+  },
+  bonusPill: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  bonusText: {
+    fontSize: 12,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+  },
+  playAgainButton: {
+    paddingHorizontal: 36,
+    paddingVertical: 14,
+    borderRadius: 999,
+    marginTop: 4,
+  },
+  playAgainText: {
+    fontSize: 15,
+    fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+  },
+  dismissButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 999,
+    marginTop: 12,
+    borderWidth: 1,
+  },
+  dismissText: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+});

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { View, Text, StyleSheet, Modal, Pressable, useWindowDimensions } from "react-native";
+import { View, Text, StyleSheet, Pressable, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -17,6 +17,7 @@ import { saveGame, clearGame } from "../game/yacht/storage";
 import * as Sentry from "@sentry/react-native";
 import DiceRow from "../components/DiceRow";
 import Scorecard from "../components/Scorecard";
+import GameOverModal from "../components/yacht/GameOverModal";
 import { useTheme } from "../theme/ThemeContext";
 
 type Props = {
@@ -205,61 +206,15 @@ export default function GameScreen({ navigation, route }: Props) {
         />
       </View>
 
-      {/* Game Over Modal */}
-      <Modal
+      <GameOverModal
         visible={gameState.game_over}
-        transparent
-        animationType="fade"
-        accessibilityViewIsModal
-      >
-        <View style={styles.modalOverlay}>
-          <View style={[styles.modalBox, { backgroundColor: colors.modalBg }]}>
-            <Text style={[styles.modalTitle, { color: colors.text }]} accessibilityRole="header">
-              {t("gameOver.title")}
-            </Text>
-            <Text style={[styles.modalScore, { color: colors.textMuted }]}>
-              {t("gameOver.finalScore")}
-            </Text>
-            <Text
-              style={[styles.modalScoreValue, { color: colors.accent }]}
-              accessibilityLabel={t("gameOver.scoreLabel", { score: gameState.total_score })}
-            >
-              {gameState.total_score}
-            </Text>
-            {gameState.upper_bonus > 0 && (
-              <Text style={[styles.modalBonus, { color: colors.bonus }]}>
-                {t("gameOver.upperBonus")}
-              </Text>
-            )}
-            {gameState.yacht_bonus_total > 0 && (
-              <Text style={[styles.modalBonus, { color: colors.bonus }]}>
-                {t("gameOver.yachtBonus", {
-                  count: gameState.yacht_bonus_count,
-                  total: gameState.yacht_bonus_total,
-                })}
-              </Text>
-            )}
-            <Pressable
-              style={[styles.modalButton, { backgroundColor: colors.accent }]}
-              onPress={startNewGame}
-              accessibilityRole="button"
-              accessibilityLabel={t("gameOver.playAgainLabel")}
-            >
-              <Text style={styles.modalButtonText}>{t("gameOver.playAgain")}</Text>
-            </Pressable>
-            <Pressable
-              style={[styles.modalDismissButton]}
-              onPress={() => navigation.goBack()}
-              accessibilityRole="button"
-              accessibilityLabel={t("gameOver.dismissLabel")}
-            >
-              <Text style={[styles.modalDismissText, { color: colors.textMuted }]}>
-                {t("gameOver.dismiss")}
-              </Text>
-            </Pressable>
-          </View>
-        </View>
-      </Modal>
+        totalScore={gameState.total_score}
+        upperBonus={gameState.upper_bonus}
+        yachtBonusCount={gameState.yacht_bonus_count}
+        yachtBonusTotal={gameState.yacht_bonus_total}
+        onPlayAgain={startNewGame}
+        onDismiss={() => navigation.goBack()}
+      />
     </View>
   );
 }
@@ -327,56 +282,5 @@ const styles = StyleSheet.create({
     flex: 1,
     marginHorizontal: 12,
     marginBottom: 12,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.7)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  modalBox: {
-    borderRadius: 16,
-    padding: 24,
-    alignItems: "center",
-    width: "85%",
-    maxWidth: 320,
-  },
-  modalTitle: {
-    fontSize: 28,
-    fontWeight: "800",
-    marginBottom: 8,
-  },
-  modalScore: {
-    fontSize: 16,
-    marginBottom: 4,
-  },
-  modalScoreValue: {
-    fontSize: 52,
-    fontWeight: "800",
-    marginBottom: 4,
-  },
-  modalBonus: {
-    fontSize: 13,
-    marginBottom: 16,
-  },
-  modalButton: {
-    paddingHorizontal: 32,
-    paddingVertical: 12,
-    borderRadius: 8,
-    marginTop: 8,
-  },
-  modalButtonText: {
-    color: "#fff",
-    fontSize: 16,
-    fontWeight: "700",
-  },
-  modalDismissButton: {
-    paddingHorizontal: 32,
-    paddingVertical: 12,
-    marginTop: 8,
-  },
-  modalDismissText: {
-    fontSize: 14,
-    fontWeight: "600",
   },
 });


### PR DESCRIPTION
## Summary

Part of epic #340. Rebuilds the Yacht Game Over modal to match the BC Arcade aesthetic.

- Extracts the inline modal into a dedicated \`components/yacht/GameOverModal.tsx\`.
- Card treatment: accent top border, \`surfaceHigh\` bg, rounded corners.
- Large glowing total-score number (web \`text-shadow\`).
- Bonus achievements render as bordered surfaceAlt pills.
- **Play Again** is now a gradient pill button (same treatment as the Roll button).
- **No Thanks** is an outlined ghost button using theme border / muted text.
- Removes the last hardcoded \`#fff\` from \`GameScreen.tsx\`.

Behavior, i18n copy, and accessibility labels are unchanged.

## Test plan

- [x] \`frontend\` jest — GameScreen suite (16/16) pass
- [x] \`e2e\` Playwright — yacht-full-game and yacht-accessibility specs pass
- [x] Screenshot at 420w — modal renders with glow, gradient CTA, and ghost dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)