### PR TITLE
feat(blackjack): neon score pill, card fan, enhanced split layout (#337)

### DIFF
--- a/backend/blackjack/models.py
+++ b/backend/blackjack/models.py
@@ -26,6 +26,7 @@ class CardResponse(BaseModel):
 class HandResponse(BaseModel):
     cards: list[CardResponse]
     value: int  # 0 when the hand contains a face-down card
+    soft: bool = False  # True when an Ace is counted as 11
 
 
 class BlackjackStateResponse(BaseModel):

--- a/backend/blackjack/router.py
+++ b/backend/blackjack/router.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from limiter import limiter
 from session import get_session_id
-from .game import BlackjackGame, BlackjackRules, hand_value
+from .game import BlackjackGame, BlackjackRules, hand_value, is_soft_hand
 from .models import (
     BlackjackStateResponse,
     CardResponse,
@@ -47,8 +47,14 @@ def _hand_response(cards, conceal_hole: bool = False) -> HandResponse:
             card_responses.append(CardResponse(rank="?", suit="?", face_down=True))
         else:
             card_responses.append(CardResponse(rank=card.rank, suit=card.suit))
-    value = 0 if conceal_hole else hand_value(list(cards))
-    return HandResponse(cards=card_responses, value=value)
+    if conceal_hole:
+        value = 0
+        soft = False
+    else:
+        visible = list(cards)
+        value = hand_value(visible)
+        soft = is_soft_hand(visible)
+    return HandResponse(cards=card_responses, value=value, soft=soft)
 
 
 def _state_response(game: BlackjackGame) -> BlackjackStateResponse:

--- a/backend/tests/test_blackjack_api.py
+++ b/backend/tests/test_blackjack_api.py
@@ -380,3 +380,32 @@ class TestDoubleDownAvailable:
         _current_game().chips = 50
         data = client.get("/blackjack/state", headers=SESSION_HEADERS).json()
         assert data["double_down_available"] is False
+
+
+# ---------------------------------------------------------------------------
+# HandResponse soft field
+# ---------------------------------------------------------------------------
+
+
+class TestHandResponseSoft:
+    def test_soft_false_for_hard_hand(self):
+        _inject_player_phase()  # 7 + 8 = hard 15
+        data = client.get("/blackjack/state", headers=SESSION_HEADERS).json()
+        assert data["player_hand"]["soft"] is False
+
+    def test_soft_true_for_soft_hand(self):
+        new_game()
+        g = _current_game()
+        g.chips = 1000
+        g.bet = 100
+        g._player_hand = [Card("♠", "A"), Card("♥", "6")]  # soft 17
+        g._dealer_hand = [Card("♦", "6"), Card("♣", "9")]
+        g.phase = "player"
+        data = client.get("/blackjack/state", headers=SESSION_HEADERS).json()
+        assert data["player_hand"]["soft"] is True
+
+    def test_dealer_soft_false_when_concealed(self):
+        _inject_player_phase()
+        data = client.get("/blackjack/state", headers=SESSION_HEADERS).json()
+        # Dealer hole card is hidden — soft must be False
+        assert data["dealer_hand"]["soft"] is False

--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -35,7 +35,7 @@ export default function BlackjackTable({
 
   return (
     <View style={styles.container}>
-      <HandDisplay hand={dealerHand} label={t("hand.dealer")} concealed={isPlayerPhase} />
+      <HandDisplay hand={dealerHand} label={t("hand.dealer")} concealed={isPlayerPhase} variant="dealer" />
       <View style={styles.divider} />
 
       {isSplit ? (
@@ -51,10 +51,10 @@ export default function BlackjackTable({
                 key={i}
                 style={[
                   styles.splitHand,
-                  isActive && { borderColor: colors.accent, borderWidth: 2 },
+                  isActive && { borderColor: colors.accent, borderWidth: 2, shadowColor: colors.accent, shadowOpacity: 0.4, shadowRadius: 8, elevation: 4 },
                 ]}
               >
-                <HandDisplay hand={hand} label={label} />
+                <HandDisplay hand={hand} label={label} variant="player" />
                 {bet != null && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
                 )}
@@ -85,7 +85,7 @@ export default function BlackjackTable({
           })}
         </View>
       ) : (
-        <HandDisplay hand={playerHand} label={t("hand.player")} />
+        <HandDisplay hand={playerHand} label={t("hand.player")} variant="player" />
       )}
     </View>
   );

--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -35,7 +35,12 @@ export default function BlackjackTable({
 
   return (
     <View style={styles.container}>
-      <HandDisplay hand={dealerHand} label={t("hand.dealer")} concealed={isPlayerPhase} variant="dealer" />
+      <HandDisplay
+        hand={dealerHand}
+        label={t("hand.dealer")}
+        concealed={isPlayerPhase}
+        variant="dealer"
+      />
       <View style={styles.divider} />
 
       {isSplit ? (
@@ -51,7 +56,14 @@ export default function BlackjackTable({
                 key={i}
                 style={[
                   styles.splitHand,
-                  isActive && { borderColor: colors.accent, borderWidth: 2, shadowColor: colors.accent, shadowOpacity: 0.4, shadowRadius: 8, elevation: 4 },
+                  isActive && {
+                    borderColor: colors.accent,
+                    borderWidth: 2,
+                    shadowColor: colors.accent,
+                    shadowOpacity: 0.4,
+                    shadowRadius: 8,
+                    elevation: 4,
+                  },
                 ]}
               >
                 <HandDisplay hand={hand} label={label} variant="player" />

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -4,34 +4,53 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import { HandResponse } from "../../game/blackjack/types";
 import PlayingCard from "./PlayingCard";
+import ScorePill from "./ScorePill";
 
 interface Props {
   hand: HandResponse;
   label: string;
-  concealed?: boolean; // true when dealer hole card is hidden
+  concealed?: boolean;
+  /** "player" renders larger cards with fan rotation and neon score pill;
+   *  "dealer" renders compact cards and glass badge score. */
+  variant?: "player" | "dealer";
 }
 
-export default function HandDisplay({ hand, label, concealed = false }: Props) {
+// First two player cards get a gentle fan tilt
+const PLAYER_ROTATIONS: Record<number, number> = { 0: -3, 1: 2 };
+
+export default function HandDisplay({
+  hand,
+  label,
+  concealed = false,
+  variant = "dealer",
+}: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
-
-  const valueText = concealed
-    ? t("hand.valueHidden")
-    : hand.soft
-      ? t("hand.softValue" as Parameters<typeof t>[0], { value: hand.value })
-      : t("hand.value", { value: hand.value });
+  const showScore = hand.cards.length > 0;
 
   return (
     <View style={styles.container}>
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
+
+      {showScore && (
+        <ScorePill
+          value={hand.value}
+          soft={hand.soft}
+          concealed={concealed}
+          variant={variant}
+        />
+      )}
+
       <View style={styles.cards}>
         {hand.cards.map((card, i) => (
-          <PlayingCard key={i} card={card} />
+          <PlayingCard
+            key={i}
+            card={card}
+            variant={variant}
+            rotation={variant === "player" ? (PLAYER_ROTATIONS[i] ?? 0) : 0}
+          />
         ))}
       </View>
-      {hand.cards.length > 0 && (
-        <Text style={[styles.value, { color: colors.text }]}>{valueText}</Text>
-      )}
     </View>
   );
 }
@@ -39,7 +58,7 @@ export default function HandDisplay({ hand, label, concealed = false }: Props) {
 const styles = StyleSheet.create({
   container: {
     alignItems: "center",
-    gap: 6,
+    gap: 8,
   },
   label: {
     fontSize: 13,
@@ -51,9 +70,5 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "center",
-  },
-  value: {
-    fontSize: 15,
-    fontWeight: "600",
   },
 });

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
-import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import { HandResponse } from "../../game/blackjack/types";
 import PlayingCard from "./PlayingCard";
@@ -18,13 +17,7 @@ interface Props {
 // First two player cards get a gentle fan tilt
 const PLAYER_ROTATIONS: Record<number, number> = { 0: -3, 1: 2 };
 
-export default function HandDisplay({
-  hand,
-  label,
-  concealed = false,
-  variant = "dealer",
-}: Props) {
-  const { t } = useTranslation("blackjack");
+export default function HandDisplay({ hand, label, concealed = false, variant = "dealer" }: Props) {
   const { colors } = useTheme();
   const showScore = hand.cards.length > 0;
 
@@ -33,12 +26,7 @@ export default function HandDisplay({
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
 
       {showScore && (
-        <ScorePill
-          value={hand.value}
-          soft={hand.soft}
-          concealed={concealed}
-          variant={variant}
-        />
+        <ScorePill value={hand.value} soft={hand.soft} concealed={concealed} variant={variant} />
       )}
 
       <View style={styles.cards}>

--- a/frontend/src/components/blackjack/PlayingCard.tsx
+++ b/frontend/src/components/blackjack/PlayingCard.tsx
@@ -6,6 +6,10 @@ import { CardResponse } from "../../game/blackjack/types";
 
 interface Props {
   card: CardResponse;
+  /** Clockwise rotation in degrees — used for the player-hand card fan. */
+  rotation?: number;
+  /** "player" renders a larger card; "dealer" renders the compact default. */
+  variant?: "player" | "dealer";
 }
 
 const RED_SUITS = new Set(["♥", "♦"]);
@@ -20,22 +24,30 @@ function suitKey(suit: string): string {
   return map[suit] ?? suit;
 }
 
-export default function PlayingCard({ card }: Props) {
+export default function PlayingCard({ card, rotation = 0, variant = "dealer" }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
+
+  const cardSizeStyle = variant === "player" ? styles.cardPlayer : styles.cardDealer;
+  const rankSizeStyle = variant === "player" ? styles.rankPlayer : styles.rankDealer;
+  const suitSizeStyle = variant === "player" ? styles.suitPlayer : styles.suitDealer;
+  const rotateStyle = rotation !== 0 ? { transform: [{ rotate: `${rotation}deg` }] } : undefined;
 
   if (card.face_down) {
     return (
       <View
         style={[
           styles.card,
-          styles.faceDown,
-          { borderColor: colors.border, backgroundColor: colors.surface },
+          cardSizeStyle,
+          { borderColor: colors.secondary, backgroundColor: colors.surface },
+          rotateStyle,
         ]}
         accessibilityLabel={t("card.faceDown")}
         accessibilityRole="image"
       >
-        <Text style={[styles.backPattern, { color: colors.textMuted }]}>?</Text>
+        <View style={[styles.cardBackInner, { borderColor: colors.secondary }]}>
+          <Text style={[styles.backPattern, { color: colors.secondary }]}>?</Text>
+        </View>
       </View>
     );
   }
@@ -47,39 +59,66 @@ export default function PlayingCard({ card }: Props) {
 
   return (
     <View
-      style={[styles.card, { borderColor: colors.border, backgroundColor: colors.surface }]}
+      style={[
+        styles.card,
+        cardSizeStyle,
+        { borderColor: colors.border, backgroundColor: colors.surface },
+        rotateStyle,
+      ]}
       accessibilityLabel={label}
       accessibilityRole="image"
     >
-      <Text style={[styles.rank, { color: rankColor }]}>{card.rank}</Text>
-      <Text style={[styles.suit, { color: rankColor }]}>{card.suit}</Text>
+      <Text style={[rankSizeStyle, { color: rankColor }]}>{card.rank}</Text>
+      <Text style={[suitSizeStyle, { color: rankColor }]}>{card.suit}</Text>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   card: {
-    width: 52,
-    height: 72,
-    borderRadius: 6,
+    borderRadius: 8,
     borderWidth: 1,
     alignItems: "center",
     justifyContent: "center",
     margin: 4,
     gap: 2,
   },
-  faceDown: {},
+  cardDealer: {
+    width: 52,
+    height: 72,
+  },
+  cardPlayer: {
+    width: 68,
+    height: 96,
+  },
+  cardBackInner: {
+    width: "70%",
+    height: "70%",
+    borderRadius: 4,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   backPattern: {
-    fontSize: 24,
+    fontSize: 22,
     fontWeight: "700",
   },
-  rank: {
+  rankDealer: {
     fontSize: 16,
     fontWeight: "700",
     lineHeight: 20,
   },
-  suit: {
+  rankPlayer: {
+    fontSize: 20,
+    fontWeight: "700",
+    lineHeight: 24,
+  },
+  suitDealer: {
     fontSize: 18,
     lineHeight: 22,
+  },
+  suitPlayer: {
+    fontSize: 22,
+    lineHeight: 26,
   },
 });

--- a/frontend/src/components/blackjack/ScorePill.tsx
+++ b/frontend/src/components/blackjack/ScorePill.tsx
@@ -20,7 +20,10 @@ export default function ScorePill({ value, soft = false, concealed = false, vari
   if (variant === "dealer") {
     return (
       <View
-        style={[styles.dealerBadge, { backgroundColor: colors.surfaceHigh, borderColor: colors.border }]}
+        style={[
+          styles.dealerBadge,
+          { backgroundColor: colors.surfaceHigh, borderColor: colors.border },
+        ]}
         accessibilityLabel={concealed ? "Dealer score hidden" : `Dealer score ${label}`}
       >
         <Text style={[styles.dealerText, { color: colors.text }]}>{label}</Text>
@@ -36,7 +39,12 @@ export default function ScorePill({ value, soft = false, concealed = false, vari
     >
       {/* Gradient ring approximated with a cyan-tinted outer view */}
       <View style={[styles.playerRing, { backgroundColor: colors.accent }]}>
-        <View style={[styles.playerInner, { backgroundColor: colors.surface, borderColor: colors.accent }]}>
+        <View
+          style={[
+            styles.playerInner,
+            { backgroundColor: colors.surface, borderColor: colors.accent },
+          ]}
+        >
           <Text style={[styles.playerText, { color: colors.accent }]}>{label}</Text>
         </View>
       </View>

--- a/frontend/src/components/blackjack/ScorePill.tsx
+++ b/frontend/src/components/blackjack/ScorePill.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useTheme } from "../../theme/ThemeContext";
+
+interface Props {
+  /** Numeric hand value. */
+  value: number;
+  /** True when Ace is counted as 11 (soft hand). */
+  soft?: boolean;
+  /** True when dealer hole card is hidden — shows "?" instead of value. */
+  concealed?: boolean;
+  /** "player" renders the large neon-glow pill; "dealer" renders the compact glass badge. */
+  variant: "player" | "dealer";
+}
+
+export default function ScorePill({ value, soft = false, concealed = false, variant }: Props) {
+  const { colors } = useTheme();
+  const label = concealed ? "?" : soft ? `${value}*` : String(value);
+
+  if (variant === "dealer") {
+    return (
+      <View
+        style={[styles.dealerBadge, { backgroundColor: colors.surfaceHigh, borderColor: colors.border }]}
+        accessibilityLabel={concealed ? "Dealer score hidden" : `Dealer score ${label}`}
+      >
+        <Text style={[styles.dealerText, { color: colors.text }]}>{label}</Text>
+      </View>
+    );
+  }
+
+  // Player: neon-glow pill — gradient border ring + inner surface + large bold text
+  return (
+    <View
+      style={[styles.playerGlow, { shadowColor: colors.accent }]}
+      accessibilityLabel={`Player score ${label}`}
+    >
+      {/* Gradient ring approximated with a cyan-tinted outer view */}
+      <View style={[styles.playerRing, { backgroundColor: colors.accent }]}>
+        <View style={[styles.playerInner, { backgroundColor: colors.surface, borderColor: colors.accent }]}>
+          <Text style={[styles.playerText, { color: colors.accent }]}>{label}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dealerBadge: {
+    paddingHorizontal: 20,
+    paddingVertical: 4,
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  dealerText: {
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  // Player pill
+  playerGlow: {
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.35,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+  playerRing: {
+    borderRadius: 24,
+    padding: 2,
+  },
+  playerInner: {
+    paddingHorizontal: 28,
+    paddingVertical: 6,
+    borderRadius: 22,
+    borderWidth: 1,
+    alignItems: "center",
+  },
+  playerText: {
+    fontSize: 32,
+    fontWeight: "900",
+    letterSpacing: -0.5,
+  },
+});

--- a/frontend/src/components/blackjack/__tests__/ScorePill.test.tsx
+++ b/frontend/src/components/blackjack/__tests__/ScorePill.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import ScorePill from "../ScorePill";
+import { ThemeProvider } from "../../../theme/ThemeContext";
+
+function renderPill(props: Parameters<typeof ScorePill>[0]) {
+  return render(
+    <ThemeProvider>
+      <ScorePill {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe("ScorePill", () => {
+  describe("player variant", () => {
+    it("renders the numeric score", () => {
+      const { getByText } = renderPill({ value: 17, variant: "player" });
+      expect(getByText("17")).toBeTruthy();
+    });
+
+    it("appends * for a soft hand", () => {
+      const { getByText } = renderPill({ value: 17, soft: true, variant: "player" });
+      expect(getByText("17*")).toBeTruthy();
+    });
+
+    it("has accessibilityLabel 'Player score 17'", () => {
+      const { getByLabelText } = renderPill({ value: 17, variant: "player" });
+      expect(getByLabelText("Player score 17")).toBeTruthy();
+    });
+
+    it("has accessibilityLabel 'Player score 17*' for soft hand", () => {
+      const { getByLabelText } = renderPill({ value: 17, soft: true, variant: "player" });
+      expect(getByLabelText("Player score 17*")).toBeTruthy();
+    });
+  });
+
+  describe("dealer variant", () => {
+    it("renders the numeric score", () => {
+      const { getByText } = renderPill({ value: 9, variant: "dealer" });
+      expect(getByText("9")).toBeTruthy();
+    });
+
+    it("has accessibilityLabel 'Dealer score 9'", () => {
+      const { getByLabelText } = renderPill({ value: 9, variant: "dealer" });
+      expect(getByLabelText("Dealer score 9")).toBeTruthy();
+    });
+
+    it("renders '?' when concealed", () => {
+      const { getByText } = renderPill({ value: 9, concealed: true, variant: "dealer" });
+      expect(getByText("?")).toBeTruthy();
+    });
+
+    it("has accessibilityLabel 'Dealer score hidden' when concealed", () => {
+      const { getByLabelText } = renderPill({ value: 9, concealed: true, variant: "dealer" });
+      expect(getByLabelText("Dealer score hidden")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **ScorePill component** — two variants: player (large neon-glow pill with cyan ring) and dealer (compact glass badge); handles soft hands (`17*`) and concealed dealer state (`?`)
- **Backend `soft` field** — adds `soft: bool` to `HandResponse` model, computed via `is_soft_hand()` in the router; dealer hand returns `soft=False` while hole card is hidden
- **PlayingCard fan + sizing** — new `variant` prop (player: 68×96 px, dealer: 52×72 px) and `rotation` prop; first two player cards tilt at −3°/+2° for the Stitch-inspired fan effect
- **HandDisplay wiring** — passes `variant` to ScorePill and each PlayingCard; applies fan rotations only when `variant="player"`
- **BlackjackTable** — passes `variant="player"` to all player hands and `variant="dealer"` to dealer; active split-hand ring gains a neon glow shadow
- **Tests** — new `ScorePill.test.tsx` (8 tests); 3 new backend API tests for `soft` field; all 810 frontend tests and 54 backend tests pass

## Test plan

- [ ] Player hand renders large cards with fan tilt and neon score pill
- [ ] Dealer hand renders compact cards with glass badge score
- [ ] Dealer score shows `?` during player phase and reveals after stand
- [ ] Soft hand (e.g. A+6) shows `17*` label in the pill
- [ ] Split hands each render with correct `variant="player"` sizing
- [ ] Active split-hand ring glows cyan

🤖 Generated with [Claude Code](https://claude.com/claude-code)