### PR TITLE
feat(2048): restyle ScoreBoard with primary/secondary border accents

### DIFF
--- a/frontend/src/components/twenty48/ScoreBoard.tsx
+++ b/frontend/src/components/twenty48/ScoreBoard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { View, Text, StyleSheet, Animated } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
 
 interface ScoreBoardProps {
   score: number;
@@ -16,12 +17,9 @@ export default function ScoreBoard({ score, bestScore, scoreDelta }: ScoreBoardP
   // Score delta float animation.
   const deltaOpacity = useRef(new Animated.Value(0)).current;
   const deltaTranslateY = useRef(new Animated.Value(0)).current;
-  const lastDelta = useRef(0);
 
   useEffect(() => {
     if (scoreDelta <= 0) return;
-    lastDelta.current = scoreDelta;
-    // Reset to starting position below the score, then float upward.
     deltaOpacity.setValue(1);
     deltaTranslateY.setValue(0);
     Animated.parallel([
@@ -41,12 +39,13 @@ export default function ScoreBoard({ score, bestScore, scoreDelta }: ScoreBoardP
 
   return (
     <View style={styles.row}>
-      {/* Current score */}
-      <View style={[styles.box, { backgroundColor: colors.surface }]}>
+      <View
+        style={[styles.card, { backgroundColor: colors.surfaceAlt, borderTopColor: colors.accent }]}
+      >
         <Text style={[styles.label, { color: colors.textMuted }]}>{t("twenty48:score.label")}</Text>
         <View style={styles.valueWrap}>
           <Text
-            style={[styles.value, { color: colors.text }]}
+            style={[styles.value, { color: colors.accent }]}
             accessibilityLabel={t("twenty48:score.accessibilityLabel", { score })}
           >
             {score}
@@ -62,18 +61,23 @@ export default function ScoreBoard({ score, bestScore, scoreDelta }: ScoreBoardP
                 },
               ]}
               aria-hidden
+              testID="scoreboard-delta"
             >
-              +{lastDelta.current}
+              {`+${scoreDelta}`}
             </Animated.Text>
           )}
         </View>
       </View>
 
-      {/* Best score */}
-      <View style={[styles.box, { backgroundColor: colors.surface }]}>
+      <View
+        style={[
+          styles.card,
+          { backgroundColor: colors.surfaceAlt, borderTopColor: colors.secondary },
+        ]}
+      >
         <Text style={[styles.label, { color: colors.textMuted }]}>{t("twenty48:score.best")}</Text>
         <Text
-          style={[styles.value, { color: colors.text }]}
+          style={[styles.value, { color: colors.secondary }]}
           accessibilityLabel={t("twenty48:score.bestAccessibilityLabel", { score: bestScore })}
         >
           {bestScore}
@@ -86,32 +90,35 @@ export default function ScoreBoard({ score, bestScore, scoreDelta }: ScoreBoardP
 const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
-    gap: 8,
+    gap: 12,
   },
-  box: {
+  card: {
+    flex: 1,
     paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 8,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderTopWidth: 2,
     alignItems: "center",
-    minWidth: 80,
   },
   label: {
+    fontFamily: typography.label,
     fontSize: 11,
-    fontWeight: "600",
     textTransform: "uppercase",
     letterSpacing: 0.8,
   },
   value: {
-    fontSize: 22,
-    fontWeight: "800",
+    fontFamily: typography.heading,
+    fontSize: 24,
+    letterSpacing: -0.5,
+    marginTop: 2,
   },
   valueWrap: {
     alignItems: "center",
   },
   delta: {
     position: "absolute",
+    fontFamily: typography.label,
     fontSize: 13,
-    fontWeight: "700",
     top: -14,
   },
 });

--- a/frontend/src/components/twenty48/__tests__/ScoreBoard.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/ScoreBoard.test.tsx
@@ -3,54 +3,76 @@ import { render } from "@testing-library/react-native";
 import ScoreBoard from "../ScoreBoard";
 import { ThemeProvider } from "../../../theme/ThemeContext";
 
-function renderScoreBoard(score: number) {
+function renderScoreBoard(props: { score: number; bestScore?: number; scoreDelta?: number }) {
+  const { score, bestScore = 0, scoreDelta = 0 } = props;
   return render(
     <ThemeProvider>
-      <ScoreBoard score={score} />
+      <ScoreBoard score={score} bestScore={bestScore} scoreDelta={scoreDelta} />
     </ThemeProvider>
   );
 }
 
 describe("ScoreBoard", () => {
   it("renders the numeric score", () => {
-    const { getByText } = renderScoreBoard(1024);
+    const { getByText } = renderScoreBoard({ score: 1024 });
     expect(getByText("1024")).toBeTruthy();
   });
 
   it("renders score of 0", () => {
-    const { getByText } = renderScoreBoard(0);
-    expect(getByText("0")).toBeTruthy();
+    const { getByLabelText } = renderScoreBoard({ score: 0 });
+    expect(getByLabelText("Current score: 0")).toBeTruthy();
   });
 
   it("renders 'Score' label text", () => {
-    const { getByText } = renderScoreBoard(0);
+    const { getByText } = renderScoreBoard({ score: 0 });
     expect(getByText("Score")).toBeTruthy();
   });
 
+  it("renders the best score", () => {
+    const { getByText } = renderScoreBoard({ score: 100, bestScore: 4096 });
+    expect(getByText("4096")).toBeTruthy();
+  });
+
   it("applies i18n accessibilityLabel with interpolated score", () => {
-    const { getByLabelText } = renderScoreBoard(512);
+    const { getByLabelText } = renderScoreBoard({ score: 512 });
     expect(getByLabelText("Current score: 512")).toBeTruthy();
   });
 
+  it("applies i18n accessibilityLabel for best score", () => {
+    const { getByLabelText } = renderScoreBoard({ score: 0, bestScore: 2048 });
+    expect(getByLabelText("Best score: 2048")).toBeTruthy();
+  });
+
   it("updates accessibilityLabel when score prop changes", () => {
-    const { getByLabelText, rerender } = renderScoreBoard(100);
+    const { getByLabelText, rerender } = renderScoreBoard({ score: 100 });
     expect(getByLabelText("Current score: 100")).toBeTruthy();
     rerender(
       <ThemeProvider>
-        <ScoreBoard score={200} />
+        <ScoreBoard score={200} bestScore={0} scoreDelta={0} />
       </ThemeProvider>
     );
     expect(getByLabelText("Current score: 200")).toBeTruthy();
   });
 
   it("updates displayed value when score prop changes", () => {
-    const { getByText, rerender } = renderScoreBoard(100);
+    const { getByText, rerender } = renderScoreBoard({ score: 100 });
     expect(getByText("100")).toBeTruthy();
     rerender(
       <ThemeProvider>
-        <ScoreBoard score={9999} />
+        <ScoreBoard score={9999} bestScore={0} scoreDelta={0} />
       </ThemeProvider>
     );
     expect(getByText("9999")).toBeTruthy();
+  });
+
+  it("renders floating +delta when scoreDelta > 0", () => {
+    const { getByTestId } = renderScoreBoard({ score: 100, bestScore: 0, scoreDelta: 16 });
+    const delta = getByTestId("scoreboard-delta", { includeHiddenElements: true });
+    expect(delta.props.children).toBe("+16");
+  });
+
+  it("does not render +delta when scoreDelta is 0", () => {
+    const { queryByTestId } = renderScoreBoard({ score: 100, bestScore: 0, scoreDelta: 0 });
+    expect(queryByTestId("scoreboard-delta", { includeHiddenElements: true })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Two-column equal-width card layout — `surfaceAlt` background, 12px radius, 2px top border accent (primary cyan on current, secondary magenta on best).
- Values render in Space Grotesk (`typography.heading`), color-matched to each card's accent. Labels use `typography.label`, uppercase, tight tracking.
- Delta float animation (600ms fade + translateY -24) preserved.
- Drops `lastDelta` ref and renders `scoreDelta` directly. The ref was caching the previous value and causing an initial-render "+0" — pre-existing bug no test caught because the test file hadn't been updated to pass `scoreDelta` at all.
- Updates `ScoreBoard.test.tsx` to pass the full `{score, bestScore, scoreDelta}` props (stale test was the source of the long-running TS error noted in the #347 PR). Adds coverage for best-score render, delta render/hide, best-score a11y label.

Closes #348. Part of #346.

## Test plan
- [x] `npx jest src/components/twenty48 src/screens/__tests__/Twenty48Screen` → 42/42 pass
- [x] `eslint` + `prettier --check` clean on changed files
- [x] `tsc --noEmit` — no new errors from twenty48 files
- [ ] Visually verify layout, border accents, value colors on web
- [ ] Verify +delta animation still fires on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)