### PR TITLE
feat(yacht): mid-game New Game button with confirmation (#352)

### DIFF
--- a/frontend/src/components/yacht/NewGameConfirmModal.tsx
+++ b/frontend/src/components/yacht/NewGameConfirmModal.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import { Modal, View, Text, Pressable, StyleSheet, Platform, ViewStyle } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+
+interface Props {
+  visible: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function NewGameConfirmModal({ visible, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation("yacht");
+  const { colors } = useTheme();
+
+  const confirmBg: ViewStyle =
+    Platform.OS === "web"
+      ? ({
+          backgroundImage: `linear-gradient(135deg, ${colors.accent}, ${colors.accentBright})`,
+          boxShadow: `0 0 20px ${colors.accent}55`,
+        } as ViewStyle)
+      : { backgroundColor: colors.accentBright };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      accessibilityViewIsModal
+      onRequestClose={onCancel}
+    >
+      <View style={[styles.overlay, { backgroundColor: "rgba(0,0,0,0.75)" }]}>
+        <View
+          style={[
+            styles.card,
+            {
+              backgroundColor: colors.surfaceHigh,
+              borderColor: colors.border,
+              borderTopColor: colors.accent,
+            },
+          ]}
+        >
+          <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+            {t("newGame.confirm.title")}
+          </Text>
+          <Text style={[styles.body, { color: colors.textMuted }]}>
+            {t("newGame.confirm.body")}
+          </Text>
+          <Pressable
+            style={({ pressed }) => [
+              styles.confirmButton,
+              confirmBg,
+              pressed ? { transform: [{ scale: 0.96 }] } : null,
+            ]}
+            onPress={onConfirm}
+            accessibilityRole="button"
+            accessibilityLabel={t("newGame.confirm.confirm")}
+          >
+            <Text style={[styles.confirmText, { color: colors.textOnAccent }]}>
+              {t("newGame.confirm.confirm")}
+            </Text>
+          </Pressable>
+          <Pressable
+            style={[styles.cancelButton, { borderColor: colors.border }]}
+            onPress={onCancel}
+            accessibilityRole="button"
+            accessibilityLabel={t("newGame.confirm.cancel")}
+          >
+            <Text style={[styles.cancelText, { color: colors.textMuted }]}>
+              {t("newGame.confirm.cancel")}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderTopWidth: 3,
+    padding: 24,
+    alignItems: "center",
+    width: "86%",
+    maxWidth: 360,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "900",
+    letterSpacing: 0.5,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 20,
+    textAlign: "center",
+  },
+  confirmButton: {
+    paddingHorizontal: 32,
+    paddingVertical: 12,
+    borderRadius: 999,
+    marginBottom: 10,
+  },
+  confirmText: {
+    fontSize: 14,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+  },
+  cancelButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  cancelText: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+});

--- a/frontend/src/game/yacht/__tests__/engine.test.ts
+++ b/frontend/src/game/yacht/__tests__/engine.test.ts
@@ -11,6 +11,7 @@ import {
   possibleScores,
   calculateScore,
   computeDerived,
+  isInProgress,
   setRng,
   createSeededRng,
   Category,
@@ -627,5 +628,31 @@ describe("seedable RNG (setRng + createSeededRng)", () => {
     const a = roll(newGame(), [false, false, false, false, false]);
     const b = roll(newGame(), [false, false, false, false, false]);
     expect(a.dice).not.toEqual(b.dice);
+  });
+});
+
+describe("isInProgress", () => {
+  it("returns false for a fresh new game", () => {
+    expect(isInProgress(newGame())).toBe(false);
+  });
+
+  it("returns true when rolls_used > 0", () => {
+    const g = newGame();
+    expect(isInProgress({ ...g, rolls_used: 1 })).toBe(true);
+  });
+
+  it("returns true when round > 1", () => {
+    const g = newGame();
+    expect(isInProgress({ ...g, round: 2 })).toBe(true);
+  });
+
+  it("returns true when any category has been scored", () => {
+    const g = newGame();
+    expect(isInProgress({ ...g, scores: { ...g.scores, chance: 12 } })).toBe(true);
+  });
+
+  it("returns true when a category is scored to 0 (still a decision made)", () => {
+    const g = newGame();
+    expect(isInProgress({ ...g, scores: { ...g.scores, yacht: 0 } })).toBe(true);
   });
 });

--- a/frontend/src/game/yacht/engine.ts
+++ b/frontend/src/game/yacht/engine.ts
@@ -281,6 +281,15 @@ function jokerActive(state: GameState): boolean {
 // Public API
 // ---------------------------------------------------------------------------
 
+export function isInProgress(state: GameState): boolean {
+  if (state.round > 1) return true;
+  if (state.rolls_used > 0) return true;
+  for (const cat of CATEGORIES) {
+    if (state.scores[cat] != null) return true;
+  }
+  return false;
+}
+
 export function newGame(): GameState {
   const scores: GameState["scores"] = {};
   for (const cat of CATEGORIES) scores[cat] = null;

--- a/frontend/src/i18n/locales/ar/yacht.json
+++ b/frontend/src/i18n/locales/ar/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "العب مجددًا",
   "gameOver.playAgainLabel": "ابدأ لعبة جديدة",
   "gameOver.dismiss": "لا شكرًا",
-  "gameOver.dismissLabel": "إغلاق وإبقاء النتيجة الحالية ظاهرة"
+  "gameOver.dismissLabel": "إغلاق وإبقاء النتيجة الحالية ظاهرة",
+  "newGame.button": "لعبة جديدة",
+  "newGame.confirm.title": "بدء لعبة جديدة؟",
+  "newGame.confirm.body": "ستفقد لعبتك الحالية. ستتم إعادة تعيين النتيجة والجولة.",
+  "newGame.confirm.confirm": "بدء لعبة جديدة",
+  "newGame.confirm.cancel": "إلغاء"
 }

--- a/frontend/src/i18n/locales/de/yacht.json
+++ b/frontend/src/i18n/locales/de/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Nochmal",
   "gameOver.playAgainLabel": "Ein neues Spiel starten",
   "gameOver.dismiss": "Nein danke",
-  "gameOver.dismissLabel": "Schließen und aktuelle Punktzahl sichtbar lassen"
+  "gameOver.dismissLabel": "Schließen und aktuelle Punktzahl sichtbar lassen",
+  "newGame.button": "Neues Spiel",
+  "newGame.confirm.title": "Neues Spiel starten?",
+  "newGame.confirm.body": "Das aktuelle Spiel geht verloren. Punkte und Runde werden zurückgesetzt.",
+  "newGame.confirm.confirm": "Neues Spiel starten",
+  "newGame.confirm.cancel": "Abbrechen"
 }

--- a/frontend/src/i18n/locales/en/yacht.json
+++ b/frontend/src/i18n/locales/en/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Play Again",
   "gameOver.playAgainLabel": "Start a new game",
   "gameOver.dismiss": "No Thanks",
-  "gameOver.dismissLabel": "Dismiss and keep current score visible"
+  "gameOver.dismissLabel": "Dismiss and keep current score visible",
+  "newGame.button": "New Game",
+  "newGame.confirm.title": "Start new game?",
+  "newGame.confirm.body": "Your current game will be lost. Score and round will reset.",
+  "newGame.confirm.confirm": "Start new game",
+  "newGame.confirm.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/es/yacht.json
+++ b/frontend/src/i18n/locales/es/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Jugar de nuevo",
   "gameOver.playAgainLabel": "Iniciar un juego nuevo",
   "gameOver.dismiss": "No, gracias",
-  "gameOver.dismissLabel": "Cerrar y mantener la puntuación actual visible"
+  "gameOver.dismissLabel": "Cerrar y mantener la puntuación actual visible",
+  "newGame.button": "Nueva partida",
+  "newGame.confirm.title": "¿Empezar nueva partida?",
+  "newGame.confirm.body": "Perderás la partida actual. La puntuación y la ronda se reiniciarán.",
+  "newGame.confirm.confirm": "Empezar nueva partida",
+  "newGame.confirm.cancel": "Cancelar"
 }

--- a/frontend/src/i18n/locales/fr-CA/yacht.json
+++ b/frontend/src/i18n/locales/fr-CA/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Rejouer",
   "gameOver.playAgainLabel": "Commencer une nouvelle partie",
   "gameOver.dismiss": "Non merci",
-  "gameOver.dismissLabel": "Fermer et garder le score actuel visible"
+  "gameOver.dismissLabel": "Fermer et garder le score actuel visible",
+  "newGame.button": "Nouvelle partie",
+  "newGame.confirm.title": "Commencer une nouvelle partie?",
+  "newGame.confirm.body": "Votre partie en cours sera perdue. Le score et la manche seront réinitialisés.",
+  "newGame.confirm.confirm": "Commencer une nouvelle partie",
+  "newGame.confirm.cancel": "Annuler"
 }

--- a/frontend/src/i18n/locales/he/yacht.json
+++ b/frontend/src/i18n/locales/he/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "שחק שוב",
   "gameOver.playAgainLabel": "התחל משחק חדש",
   "gameOver.dismiss": "לא תודה",
-  "gameOver.dismissLabel": "סגור והשאר את הניקוד הנוכחי גלוי"
+  "gameOver.dismissLabel": "סגור והשאר את הניקוד הנוכחי גלוי",
+  "newGame.button": "משחק חדש",
+  "newGame.confirm.title": "להתחיל משחק חדש?",
+  "newGame.confirm.body": "המשחק הנוכחי יאבד. הניקוד והסיבוב יאופסו.",
+  "newGame.confirm.confirm": "התחל משחק חדש",
+  "newGame.confirm.cancel": "ביטול"
 }

--- a/frontend/src/i18n/locales/hi/yacht.json
+++ b/frontend/src/i18n/locales/hi/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "फिर से खेलें",
   "gameOver.playAgainLabel": "नया खेल शुरू करें",
   "gameOver.dismiss": "नहीं धन्यवाद",
-  "gameOver.dismissLabel": "बंद करें और वर्तमान स्कोर दिखाए रखें"
+  "gameOver.dismissLabel": "बंद करें और वर्तमान स्कोर दिखाए रखें",
+  "newGame.button": "नया गेम",
+  "newGame.confirm.title": "नया गेम शुरू करें?",
+  "newGame.confirm.body": "आपका वर्तमान गेम खो जाएगा। स्कोर और राउंड रीसेट हो जाएंगे।",
+  "newGame.confirm.confirm": "नया गेम शुरू करें",
+  "newGame.confirm.cancel": "रद्द करें"
 }

--- a/frontend/src/i18n/locales/ja/yacht.json
+++ b/frontend/src/i18n/locales/ja/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "もう一度",
   "gameOver.playAgainLabel": "新しいゲームを始める",
   "gameOver.dismiss": "いいえ",
-  "gameOver.dismissLabel": "閉じて現在のスコアを表示したままにする"
+  "gameOver.dismissLabel": "閉じて現在のスコアを表示したままにする",
+  "newGame.button": "新しいゲーム",
+  "newGame.confirm.title": "新しいゲームを開始しますか?",
+  "newGame.confirm.body": "現在のゲームは失われます。スコアとラウンドがリセットされます。",
+  "newGame.confirm.confirm": "新しいゲームを開始",
+  "newGame.confirm.cancel": "キャンセル"
 }

--- a/frontend/src/i18n/locales/ko/yacht.json
+++ b/frontend/src/i18n/locales/ko/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "다시 하기",
   "gameOver.playAgainLabel": "새 게임 시작",
   "gameOver.dismiss": "괜찮습니다",
-  "gameOver.dismissLabel": "닫고 현재 점수를 계속 표시"
+  "gameOver.dismissLabel": "닫고 현재 점수를 계속 표시",
+  "newGame.button": "새 게임",
+  "newGame.confirm.title": "새 게임을 시작할까요?",
+  "newGame.confirm.body": "현재 게임이 사라집니다. 점수와 라운드가 초기화됩니다.",
+  "newGame.confirm.confirm": "새 게임 시작",
+  "newGame.confirm.cancel": "취소"
 }

--- a/frontend/src/i18n/locales/nl/yacht.json
+++ b/frontend/src/i18n/locales/nl/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Opnieuw",
   "gameOver.playAgainLabel": "Een nieuw spel starten",
   "gameOver.dismiss": "Nee bedankt",
-  "gameOver.dismissLabel": "Sluiten en huidige score zichtbaar houden"
+  "gameOver.dismissLabel": "Sluiten en huidige score zichtbaar houden",
+  "newGame.button": "Nieuw spel",
+  "newGame.confirm.title": "Nieuw spel starten?",
+  "newGame.confirm.body": "Je huidige spel gaat verloren. Score en ronde worden gereset.",
+  "newGame.confirm.confirm": "Nieuw spel starten",
+  "newGame.confirm.cancel": "Annuleren"
 }

--- a/frontend/src/i18n/locales/pt/yacht.json
+++ b/frontend/src/i18n/locales/pt/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Jogar de Novo",
   "gameOver.playAgainLabel": "Iniciar um novo jogo",
   "gameOver.dismiss": "Não, obrigado",
-  "gameOver.dismissLabel": "Fechar e manter a pontuação atual visível"
+  "gameOver.dismissLabel": "Fechar e manter a pontuação atual visível",
+  "newGame.button": "Novo jogo",
+  "newGame.confirm.title": "Iniciar novo jogo?",
+  "newGame.confirm.body": "O jogo atual será perdido. A pontuação e a rodada serão redefinidas.",
+  "newGame.confirm.confirm": "Iniciar novo jogo",
+  "newGame.confirm.cancel": "Cancelar"
 }

--- a/frontend/src/i18n/locales/ru/yacht.json
+++ b/frontend/src/i18n/locales/ru/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "Играть снова",
   "gameOver.playAgainLabel": "Начать новую игру",
   "gameOver.dismiss": "Нет, спасибо",
-  "gameOver.dismissLabel": "Закрыть и оставить текущий счёт видимым"
+  "gameOver.dismissLabel": "Закрыть и оставить текущий счёт видимым",
+  "newGame.button": "Новая игра",
+  "newGame.confirm.title": "Начать новую игру?",
+  "newGame.confirm.body": "Текущая игра будет потеряна. Счёт и раунд сбросятся.",
+  "newGame.confirm.confirm": "Начать новую игру",
+  "newGame.confirm.cancel": "Отмена"
 }

--- a/frontend/src/i18n/locales/zh/yacht.json
+++ b/frontend/src/i18n/locales/zh/yacht.json
@@ -49,5 +49,10 @@
   "gameOver.playAgain": "再玩一次",
   "gameOver.playAgainLabel": "开始新游戏",
   "gameOver.dismiss": "不用了",
-  "gameOver.dismissLabel": "关闭并保持当前分数可见"
+  "gameOver.dismissLabel": "关闭并保持当前分数可见",
+  "newGame.button": "新游戏",
+  "newGame.confirm.title": "开始新游戏？",
+  "newGame.confirm.body": "当前游戏将丢失。得分和回合将重置。",
+  "newGame.confirm.confirm": "开始新游戏",
+  "newGame.confirm.cancel": "取消"
 }

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -11,6 +11,7 @@ import {
   roll as engineRoll,
   score as engineScore,
   possibleScores as enginePossibleScores,
+  isInProgress,
   Category,
 } from "../game/yacht/engine";
 import { saveGame, clearGame } from "../game/yacht/storage";
@@ -18,6 +19,7 @@ import * as Sentry from "@sentry/react-native";
 import DiceRow from "../components/DiceRow";
 import Scorecard from "../components/Scorecard";
 import GameOverModal from "../components/yacht/GameOverModal";
+import NewGameConfirmModal from "../components/yacht/NewGameConfirmModal";
 import { useTheme } from "../theme/ThemeContext";
 
 type Props = {
@@ -36,6 +38,7 @@ export default function GameScreen({ navigation, route }: Props) {
   const [resetHeld, setResetHeld] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [gameKey, setGameKey] = useState(0);
+  const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
 
   // Keep a ref in sync so startNewGame can log the pre-reset state without
   // closing over a stale copy of gameState (useCallback has [] deps).
@@ -98,6 +101,19 @@ export default function GameScreen({ navigation, route }: Props) {
     });
   }, []);
 
+  const handleNewGamePress = useCallback(() => {
+    if (isInProgress(gameStateRef.current)) {
+      setConfirmNewGameVisible(true);
+    } else {
+      void startNewGame();
+    }
+  }, [startNewGame]);
+
+  const handleConfirmNewGame = useCallback(() => {
+    setConfirmNewGameVisible(false);
+    void startNewGame();
+  }, [startNewGame]);
+
   return (
     <View
       style={[
@@ -155,6 +171,16 @@ export default function GameScreen({ navigation, route }: Props) {
               </Text>
             </View>
           )}
+          <Pressable
+            onPress={handleNewGamePress}
+            style={[styles.newGameBtn, { borderColor: colors.accent }]}
+            accessibilityRole="button"
+            accessibilityLabel={t("newGame.button")}
+          >
+            <Text style={[styles.newGameText, { color: colors.accent }]}>
+              {t("newGame.button")}
+            </Text>
+          </Pressable>
           <Pressable
             onPress={toggle}
             style={styles.navBtn}
@@ -215,6 +241,12 @@ export default function GameScreen({ navigation, route }: Props) {
         onPlayAgain={startNewGame}
         onDismiss={() => navigation.goBack()}
       />
+
+      <NewGameConfirmModal
+        visible={confirmNewGameVisible}
+        onConfirm={handleConfirmNewGame}
+        onCancel={() => setConfirmNewGameVisible(false)}
+      />
     </View>
   );
 }
@@ -254,6 +286,20 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     minHeight: 44,
     justifyContent: "center",
+  },
+  newGameBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  newGameText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
   },
   navText: {
     fontSize: 13,


### PR DESCRIPTION
## Summary

Final child of epic #340. Adds an always-available **New Game** button to the Yacht GameScreen header, with a confirmation dialog when a game is already in progress.

- Header gains an outlined cyan pill (to the right of the round indicator) labeled "New Game".
- Fresh game → tapping starts a new game immediately, no dialog.
- Any progress (round > 1, any roll used, or any category scored) → tapping shows a BC Arcade confirmation modal:
  - **Start new game** (gradient pill)
  - **Cancel** (outlined ghost)
- New engine helper \`isInProgress(state)\` covers all three branches; unit-tested.
- New \`components/yacht/NewGameConfirmModal.tsx\` reuses the BC Arcade treatment established in #344.
- \`newGame.*\` i18n keys added to all 13 yacht locales.

## Test plan

- [x] \`frontend\` jest — engine (add isInProgress coverage) + GameScreen suite all pass
- [x] Engine tests cover: fresh game (false), rolls_used > 0 (true), round > 1 (true), scored category (true), 0-scored category (true)
- [x] Lint + prettier clean
- [ ] Reviewer: smoke-test the confirm flow and confirm the button placement reads well in the header at 1024w and 380w

🤖 Generated with [Claude Code](https://claude.com/claude-code)