### PR TITLE
test(yacht): cover New Game button branches (#393)

### DIFF
--- a/e2e/tests/yacht-new-game.spec.ts
+++ b/e2e/tests/yacht-new-game.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * yacht-new-game.spec.ts — GH #393
+ *
+ * Covers the New Game button and confirmation modal flows:
+ *   - Fresh game: tap New Game → immediately back in round 1, no dialog
+ *   - In-progress: roll + score → tap New Game → Cancel → state preserved
+ *   - In-progress: roll + score → tap New Game → Start new game → fresh round 1
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Yacht — New Game button", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("yacht_game_v1"));
+    await page.goto("/");
+  });
+
+  test("fresh game: New Game resets immediately with no confirm dialog", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Play Yacht" }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible();
+
+    await page.getByRole("button", { name: /new game/i }).click();
+
+    // Confirm dialog must NOT appear
+    await expect(page.getByText("Start new game?")).not.toBeVisible();
+    // Still in round 1 — game reset in place
+    await expect(page.getByText("Round 1 / 13")).toBeVisible();
+  });
+
+  test("in-progress: Cancel preserves game state", async ({ page }) => {
+    await page.getByRole("button", { name: "Play Yacht" }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible();
+
+    // Advance to round 2 by rolling and scoring Ones
+    await page.getByRole("button", { name: /roll/i }).click();
+    await page.getByText("Ones").first().click();
+    await expect(page.getByText("Round 2 / 13")).toBeVisible();
+
+    // Tap New Game — confirm dialog should appear
+    await page.getByRole("button", { name: /new game/i }).click();
+    await expect(page.getByText("Start new game?")).toBeVisible();
+
+    // Cancel — dialog closes, still in round 2
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(page.getByText("Start new game?")).not.toBeVisible();
+    await expect(page.getByText("Round 2 / 13")).toBeVisible();
+  });
+
+  test("in-progress: Start new game resets to round 1 with no scored categories", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Play Yacht" }).click();
+    await expect(page.getByText("Round 1 / 13")).toBeVisible();
+
+    // Advance to round 2
+    await page.getByRole("button", { name: /roll/i }).click();
+    await page.getByText("Ones").first().click();
+    await expect(page.getByText("Round 2 / 13")).toBeVisible();
+
+    // Tap New Game → confirm
+    await page.getByRole("button", { name: /new game/i }).click();
+    await expect(page.getByText("Start new game?")).toBeVisible();
+    await page.getByRole("button", { name: "Start new game" }).click();
+
+    // Back to round 1 with fresh state
+    await expect(page.getByText("Round 1 / 13")).toBeVisible({ timeout: 5000 });
+    // No scored categories — all rows show "not available"
+    await expect(
+      page.getByRole("button", { name: "Ones: not available" }),
+    ).toBeVisible();
+    // Rolls should be fresh (Roll button available)
+    await expect(page.getByRole("button", { name: /roll/i })).toBeVisible();
+  });
+});

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -250,6 +250,67 @@ describe("GameScreen — Play Again reset (GH #225)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// GH #393 — New Game button branches
+// ---------------------------------------------------------------------------
+
+describe("GameScreen — New Game button (GH #393)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fresh game: tapping New Game resets immediately without showing confirm modal", async () => {
+    // round=1, rolls_used=0, all scores null → isInProgress() = false
+    const { getByRole, queryByText } = renderScreen();
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /new game/i }));
+    });
+    // Confirm modal must NOT appear
+    expect(queryByText("Start new game?")).toBeNull();
+    // clearGame is called (startNewGame ran)
+    expect(clearGame).toHaveBeenCalled();
+  });
+
+  it("in-progress game: tapping New Game shows confirm modal", async () => {
+    // round=2 → isInProgress() = true
+    const { getByRole, getByText } = renderScreen({ round: 2 });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /new game/i }));
+    });
+    expect(getByText("Start new game?")).toBeTruthy();
+  });
+
+  it("confirm modal 'Start new game' calls startNewGame and closes modal", async () => {
+    const { getByRole, queryByText } = renderScreen({ round: 2 });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /new game/i }));
+    });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /start new game/i }));
+    });
+    // Modal closes
+    expect(queryByText("Start new game?")).toBeNull();
+    // startNewGame ran → clearGame called, round reset to 1
+    expect(clearGame).toHaveBeenCalled();
+    expect(getByRole("button", { name: /roll dice/i })).toBeTruthy();
+  });
+
+  it("confirm modal 'Cancel' does not call startNewGame and closes modal", async () => {
+    const { getByRole, queryByText, getByText } = renderScreen({ round: 2 });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /new game/i }));
+    });
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /^cancel$/i }));
+    });
+    // Modal closes
+    expect(queryByText("Start new game?")).toBeNull();
+    // startNewGame did NOT run — clearGame not called, round still 2
+    expect(clearGame).not.toHaveBeenCalled();
+    expect(getByText(/round.*2/i)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // GH #263 — scorecard visual reset (upper & lower sections)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds 4 `GameScreen` unit tests covering the New Game button branches: fresh game skips confirm modal, in-progress shows modal, Confirm resets, Cancel preserves state
- Adds `e2e/tests/yacht-new-game.spec.ts` with 3 Playwright flows: fresh / cancel / confirm

## Test plan
- [ ] `npx jest --testPathPattern="GameScreen.test"` — all 20 tests pass
- [ ] Playwright `yacht-new-game.spec.ts` — 3 tests pass in CI
- [ ] No regressions in existing jest/playwright suites

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)