### PR TITLE
feat(2048): restyle board container with ambient glow decoration

### DIFF
--- a/frontend/src/components/twenty48/Grid.tsx
+++ b/frontend/src/components/twenty48/Grid.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, StyleSheet, useWindowDimensions } from "react-native";
+import { View, StyleSheet, Platform, useWindowDimensions } from "react-native";
 import { useTheme } from "../../theme/ThemeContext";
 import { TileData } from "../../game/twenty48/types";
 import AnimatedTile from "./AnimatedTile";
@@ -11,6 +11,18 @@ const MAX_BOARD = 360;
 interface GridProps {
   tiles: TileData[];
 }
+
+// Large drop shadow: native properties + web boxShadow via inline style.
+const BOARD_SHADOW =
+  Platform.OS === "web"
+    ? ({ boxShadow: "0 8px 40px rgba(0,0,0,0.6)" } as object)
+    : ({
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 8 },
+        shadowOpacity: 0.5,
+        shadowRadius: 24,
+        elevation: 24,
+      } as object);
 
 export default function Grid({ tiles }: GridProps) {
   const { width } = useWindowDimensions();
@@ -29,10 +41,7 @@ export default function Grid({ tiles }: GridProps) {
       slots.push(
         <View
           key={`slot-${r}-${c}`}
-          style={[
-            styles.slot,
-            { width: tileSize, height: tileSize, top, left, backgroundColor: colors.border },
-          ]}
+          style={[styles.slot, { width: tileSize, height: tileSize, top, left }]}
           accessibilityRole={isEmpty ? "image" : undefined}
           accessibilityLabel={isEmpty ? "empty" : undefined}
         />
@@ -44,7 +53,8 @@ export default function Grid({ tiles }: GridProps) {
     <View
       style={[
         styles.grid,
-        { width: boardWidth, height: boardWidth, backgroundColor: colors.border },
+        { width: boardWidth, height: boardWidth, backgroundColor: colors.surface },
+        BOARD_SHADOW,
       ]}
       accessible={true}
       accessibilityLabel="Game board"
@@ -59,11 +69,14 @@ export default function Grid({ tiles }: GridProps) {
 
 const styles = StyleSheet.create({
   grid: {
-    borderRadius: 10,
+    borderRadius: 32,
     position: "relative",
   },
   slot: {
     position: "absolute",
     borderRadius: 6,
+    backgroundColor: "#000000",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.05)",
   },
 });

--- a/frontend/src/components/twenty48/__tests__/Grid.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/Grid.test.tsx
@@ -50,4 +50,16 @@ describe("Grid", () => {
     expect(getAllByLabelText("4")).toHaveLength(1);
     expect(getAllByLabelText("8")).toHaveLength(1);
   });
+
+  it("marks all 16 empty slots with label 'empty' when no tiles are present", () => {
+    const { getAllByLabelText } = renderGrid([]);
+    expect(getAllByLabelText("empty")).toHaveLength(16);
+  });
+
+  it("only marks unoccupied cells as empty when tiles are present", () => {
+    // 2 tiles placed → 14 empty slots.
+    const tiles = [makeTile(1, 2, 0, 0), makeTile(2, 4, 3, 3)];
+    const { getAllByLabelText } = renderGrid(tiles);
+    expect(getAllByLabelText("empty")).toHaveLength(14);
+  });
 });

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -160,6 +160,9 @@ export default function Twenty48Screen({ navigation }: Props) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [handleMove]);
 
+  // Blur filter for ambient glow blobs — web only (native uses opacity alone).
+  const glowBlur = Platform.OS === "web" ? ({ filter: "blur(80px)" } as object) : undefined;
+
   const swipeGesture = Gesture.Pan()
     .minDistance(SWIPE_THRESHOLD)
     .onEnd((e) => {
@@ -255,7 +258,22 @@ export default function Twenty48Screen({ navigation }: Props) {
 
       {/* Board */}
       <GestureDetector gesture={swipeGesture}>
-        <View style={styles.boardContainer}>{state && <Grid tiles={state.tiles} />}</View>
+        <View style={styles.boardContainer}>
+          {/* Ambient glow blobs — decorative, placed behind the grid */}
+          <View
+            style={[styles.glowTopLeft, { backgroundColor: colors.accent }, glowBlur]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+          />
+          <View
+            style={[styles.glowBottomRight, { backgroundColor: colors.secondary }, glowBlur]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            pointerEvents="none"
+          />
+          {state && <Grid tiles={state.tiles} />}
+        </View>
       </GestureDetector>
 
       {/* Overlays */}
@@ -334,6 +352,25 @@ const styles = StyleSheet.create({
   boardContainer: {
     alignItems: "center",
     justifyContent: "center",
+    position: "relative",
+  },
+  glowTopLeft: {
+    position: "absolute",
+    width: 192,
+    height: 192,
+    top: -24,
+    left: -24,
+    borderRadius: 96,
+    opacity: 0.1,
+  },
+  glowBottomRight: {
+    position: "absolute",
+    width: 192,
+    height: 192,
+    bottom: -24,
+    right: -24,
+    borderRadius: 96,
+    opacity: 0.1,
   },
   error: {
     fontSize: 13,


### PR DESCRIPTION
Closes #349. Part of epic #346.

## Summary
- **Board container**: background switches to `colors.surface` (#19191f dark), `borderRadius` 32, large drop shadow (`boxShadow` on web, native shadow + `elevation` on iOS/Android)
- **Empty cells**: `#000000` background with a 5% opacity white border outline (replaces the old `colors.border` fill)
- **Ambient glow blobs**: two absolutely-positioned decorative Views in the board wrapper — cyan (`colors.accent`) top-left, magenta (`colors.secondary`) bottom-right — 192×192, 10% opacity, `blur(80px)` on web via `filter`, radius-only on native
- **Grid.test**: added two tests covering empty-slot accessibility labels (all 16 empty on a blank board; 14 empty with 2 tiles placed)

## Test plan
- [ ] `npx jest src/components/twenty48 src/screens/__tests__/Twenty48Screen.test.tsx` — all 25 tests green
- [ ] Visual spot-check: board corners are noticeably rounded; empty cells are black with faint border; subtle cyan/magenta halos visible behind board corners on web
- [ ] Animations (slide/merge/spawn) unchanged
- [ ] Accessibility: "Game board" label + per-tile labels intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)