### PR TITLE
feat(2048): restyle win + game-over modals with BC Arcade treatment

### DIFF
--- a/frontend/src/components/twenty48/GameOverlay.tsx
+++ b/frontend/src/components/twenty48/GameOverlay.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { View, Text, Pressable, StyleSheet } from "react-native";
+import { View, Text, Pressable, StyleSheet, Platform, ViewStyle, TextStyle } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
 
 interface GameOverlayProps {
   type: "game_over" | "win";
@@ -25,16 +26,68 @@ export default function GameOverlay({
   const title = isWin ? t("twenty48:win.title") : t("twenty48:gameOver.title");
   const body = isWin ? t("twenty48:win.body") : t("twenty48:gameOver.body", { score });
 
+  const accentColor = isWin ? colors.accent : colors.secondary;
+
+  // Backdrop blur on web for depth.
+  const backdropExtra: ViewStyle =
+    Platform.OS === "web" ? ({ backdropFilter: "blur(8px)" } as ViewStyle) : {};
+
+  // Gradient CTA — web uses CSS linear-gradient, native falls back to solid.
+  const ctaStyle: ViewStyle =
+    Platform.OS === "web"
+      ? ({
+          backgroundImage: `linear-gradient(135deg, ${colors.accent}, ${colors.accentBright})`,
+          boxShadow: `0 0 24px ${colors.accent}55`,
+        } as ViewStyle)
+      : { backgroundColor: colors.accentBright };
+
+  // Score glow on web.
+  const scoreGlow: TextStyle =
+    Platform.OS === "web"
+      ? ({
+          textShadow: `0 0 18px ${accentColor}66, 0 0 6px ${accentColor}`,
+        } as TextStyle)
+      : {};
+
   return (
-    <View style={styles.backdrop}>
-      <View style={[styles.modal, { backgroundColor: colors.surface }]}>
-        <Text style={[styles.title, { color: colors.text }]}>{title}</Text>
+    <View style={[styles.backdrop, { backgroundColor: "rgba(0,0,0,0.75)" }, backdropExtra]}>
+      <View
+        style={[
+          styles.card,
+          {
+            backgroundColor: colors.surfaceHigh,
+            borderColor: colors.border,
+            borderTopColor: accentColor,
+          },
+        ]}
+      >
+        <Text
+          style={[styles.title, { color: colors.text, fontFamily: typography.heading }]}
+          accessibilityRole="header"
+        >
+          {title}
+        </Text>
+
+        <Text style={[styles.scoreLabel, { color: colors.textMuted }]}>
+          {t("twenty48:score.label")}
+        </Text>
+        <Text
+          style={[styles.scoreValue, { color: accentColor }, scoreGlow]}
+          accessibilityLabel={t("twenty48:score.accessibilityLabel", { score })}
+        >
+          {score}
+        </Text>
+
         <Text style={[styles.body, { color: colors.textMuted }]}>{body}</Text>
 
         <View style={styles.buttons}>
           {isWin && onKeepPlaying && (
             <Pressable
-              style={[styles.btn, { backgroundColor: colors.accent }]}
+              style={({ pressed }) => [
+                styles.btn,
+                ctaStyle,
+                pressed && { transform: [{ scale: 0.96 }] },
+              ]}
               onPress={onKeepPlaying}
               accessibilityRole="button"
               accessibilityLabel={t("twenty48:actions.keepPlayingLabel")}
@@ -46,12 +99,17 @@ export default function GameOverlay({
           )}
 
           <Pressable
-            style={[styles.btn, { backgroundColor: colors.accent }]}
+            style={({ pressed }) => [
+              styles.btn,
+              isWin ? styles.outlineBtn : ctaStyle,
+              isWin ? { borderColor: colors.border } : null,
+              !isWin && pressed && { transform: [{ scale: 0.96 }] },
+            ]}
             onPress={onNewGame}
             accessibilityRole="button"
             accessibilityLabel={t("twenty48:actions.newGameLabel")}
           >
-            <Text style={[styles.btnText, { color: colors.textOnAccent }]}>
+            <Text style={[styles.btnText, { color: isWin ? colors.text : colors.textOnAccent }]}>
               {t("twenty48:actions.newGame")}
             </Text>
           </Pressable>
@@ -62,7 +120,7 @@ export default function GameOverlay({
             accessibilityRole="button"
             accessibilityLabel={t("twenty48:actions.quitLabel")}
           >
-            <Text style={[styles.btnText, { color: colors.text }]}>
+            <Text style={[styles.btnText, { color: colors.textMuted }]}>
               {t("twenty48:gameOver.home")}
             </Text>
           </Pressable>
@@ -75,32 +133,48 @@ export default function GameOverlay({
 const styles = StyleSheet.create({
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.5)",
     alignItems: "center",
     justifyContent: "center",
     zIndex: 10,
   },
-  modal: {
-    borderRadius: 16,
+  card: {
+    borderRadius: 20,
+    borderWidth: 1,
+    borderTopWidth: 3,
     padding: 28,
     width: "85%",
     maxWidth: 340,
     alignItems: "center",
-    gap: 12,
+    gap: 8,
   },
   title: {
-    fontSize: 28,
+    fontSize: 26,
+    fontWeight: "900",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    marginBottom: 4,
+  },
+  scoreLabel: {
+    fontSize: 11,
     fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+  },
+  scoreValue: {
+    fontSize: 64,
+    fontWeight: "900",
+    lineHeight: 70,
+    marginBottom: 4,
   },
   body: {
-    fontSize: 15,
+    fontSize: 14,
     textAlign: "center",
-    lineHeight: 22,
+    lineHeight: 20,
+    marginBottom: 8,
   },
   buttons: {
     width: "100%",
     gap: 10,
-    marginTop: 8,
   },
   btn: {
     width: "100%",
@@ -117,5 +191,6 @@ const styles = StyleSheet.create({
   btnText: {
     fontSize: 16,
     fontWeight: "700",
+    letterSpacing: 0.5,
   },
 });

--- a/frontend/src/components/twenty48/__tests__/GameOverlay.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/GameOverlay.test.tsx
@@ -45,6 +45,11 @@ describe("GameOverlay — game over state", () => {
     fireEvent.press(getByLabelText("Quit and return to home screen"));
     expect(onHome).toHaveBeenCalledTimes(1);
   });
+
+  it("renders the score callout with correct accessibility label", () => {
+    const { getByLabelText } = renderOverlay("game_over", { score: 512 });
+    expect(getByLabelText("Current score: 512")).toBeTruthy();
+  });
 });
 
 describe("GameOverlay — win state", () => {
@@ -75,5 +80,10 @@ describe("GameOverlay — win state", () => {
   it("does not show keep playing button when onKeepPlaying is not provided", () => {
     const { queryByLabelText } = renderOverlay("win");
     expect(queryByLabelText("Continue playing after reaching 2048")).toBeNull();
+  });
+
+  it("renders the score callout with correct accessibility label", () => {
+    const { getByLabelText } = renderOverlay("win", { score: 2048 });
+    expect(getByLabelText("Current score: 2048")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #350. Part of epic #346.

## Summary
- **Backdrop**: `rgba(0,0,0,0.75)` + `backdropFilter: blur(8px)` on web for depth
- **Card**: `surfaceHigh` background, 1px `border`, 3px accent-colored top border — cyan (`colors.accent`) for win, magenta (`colors.secondary`) for game over
- **Score callout**: large (64px) extrabold number in accent/secondary color; web glow via `textShadow`
- **Primary CTA**: `linear-gradient(135deg, accent → accentBright)` on web, solid `accentBright` on native; scale-down press feedback
- **Secondary CTAs** (New Game on win, Home): outline style with `colors.border`
- **Typography**: titles use `typography.heading` (Space Grotesk), uppercase with letter spacing
- All accessibility labels unchanged — e2e specs unaffected

## Test plan
- [ ] `npx jest src/components/twenty48/__tests__/GameOverlay.test.tsx` — 12 tests green
- [ ] Visual spot-check: game-over modal has magenta top border + magenta score; win modal has cyan top border + cyan score + gradient Keep Playing button
- [ ] Button interactions: Keep Playing dismisses overlay, New Game resets, Home navigates back
- [ ] `twenty48-win-flow.spec.ts` and `twenty48-game-over.spec.ts` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)