### PR TITLE
feat(2048): add Highest Tile + Time Played stats bento

### DIFF
--- a/frontend/src/components/twenty48/StatsBento.tsx
+++ b/frontend/src/components/twenty48/StatsBento.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
+import { Twenty48State } from "../../game/twenty48/types";
+
+interface Props {
+  state: Twenty48State;
+}
+
+export function formatTime(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function highestTile(board: number[][]): number {
+  return Math.max(0, ...board.flat());
+}
+
+export default function StatsBento({ state }: Props) {
+  const { t } = useTranslation("twenty48");
+  const { colors } = useTheme();
+
+  // Tick every second while game is active to keep elapsed time current.
+  const [now, setNow] = useState(Date.now);
+  useEffect(() => {
+    if (state.game_over || state.startedAt === null) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [state.game_over, state.startedAt]);
+
+  const elapsedMs = state.accumulatedMs + (state.startedAt !== null ? now - state.startedAt : 0);
+
+  const maxTile = highestTile(state.board);
+
+  return (
+    <View style={styles.row}>
+      <View style={[styles.card, { backgroundColor: colors.surfaceAlt }]}>
+        <Text style={[styles.label, { color: colors.tertiary }]}>{t("stats.highestTile")}</Text>
+        <Text
+          style={[styles.value, { color: colors.tertiary, fontFamily: typography.heading }]}
+          accessibilityLabel={`Highest tile: ${maxTile > 0 ? maxTile : 0}`}
+        >
+          {maxTile > 0 ? maxTile : "—"}
+        </Text>
+      </View>
+
+      <View style={[styles.card, { backgroundColor: colors.surfaceAlt }]}>
+        <Text style={[styles.label, { color: colors.secondary }]}>{t("stats.timePlayed")}</Text>
+        <Text
+          style={[styles.value, { color: colors.secondary, fontFamily: typography.heading }]}
+          accessibilityLabel={`Time played: ${formatTime(elapsedMs)}`}
+        >
+          {formatTime(elapsedMs)}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    gap: 12,
+    width: "100%",
+    maxWidth: 360,
+    marginTop: 12,
+  },
+  card: {
+    flex: 1,
+    borderRadius: 16,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    alignItems: "center",
+    gap: 4,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+  },
+  value: {
+    fontSize: 28,
+    fontWeight: "900",
+    letterSpacing: -0.5,
+  },
+});

--- a/frontend/src/components/twenty48/__tests__/StatsBento.test.tsx
+++ b/frontend/src/components/twenty48/__tests__/StatsBento.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import StatsBento, { formatTime, highestTile } from "../StatsBento";
+import { ThemeProvider } from "../../../theme/ThemeContext";
+import { Twenty48State } from "../../../game/twenty48/types";
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("formatTime", () => {
+  it("formats zero as 00:00", () => {
+    expect(formatTime(0)).toBe("00:00");
+  });
+
+  it("formats 61 000 ms as 01:01", () => {
+    expect(formatTime(61_000)).toBe("01:01");
+  });
+
+  it("formats 3599 000 ms as 59:59", () => {
+    expect(formatTime(3_599_000)).toBe("59:59");
+  });
+
+  it("pads single-digit minutes and seconds", () => {
+    expect(formatTime(9_000)).toBe("00:09");
+    expect(formatTime(60_000)).toBe("01:00");
+  });
+});
+
+describe("highestTile", () => {
+  it("returns 0 for an empty board", () => {
+    expect(
+      highestTile([
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ])
+    ).toBe(0);
+  });
+
+  it("returns the max value on the board", () => {
+    expect(
+      highestTile([
+        [2, 4, 8, 16],
+        [32, 64, 128, 256],
+        [512, 1024, 0, 0],
+        [0, 0, 0, 0],
+      ])
+    ).toBe(1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component rendering
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Partial<Twenty48State> = {}): Twenty48State {
+  return {
+    board: [
+      [2, 4, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 0],
+    ],
+    tiles: [],
+    score: 0,
+    scoreDelta: 0,
+    game_over: false,
+    has_won: false,
+    startedAt: null,
+    accumulatedMs: 0,
+    ...overrides,
+  };
+}
+
+function renderBento(state: Twenty48State) {
+  return render(
+    <ThemeProvider>
+      <StatsBento state={state} />
+    </ThemeProvider>
+  );
+}
+
+describe("StatsBento — rendering", () => {
+  it("renders Highest Tile label", () => {
+    const { getByText } = renderBento(makeState());
+    expect(getByText("Highest Tile")).toBeTruthy();
+  });
+
+  it("renders Time Played label", () => {
+    const { getByText } = renderBento(makeState());
+    expect(getByText("Time Played")).toBeTruthy();
+  });
+
+  it("displays the correct highest tile value", () => {
+    const { getByLabelText } = renderBento(makeState());
+    // Board has max value 4.
+    expect(getByLabelText("Highest tile: 4")).toBeTruthy();
+  });
+
+  it("shows — when board is all zeros", () => {
+    const state = makeState({
+      board: [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+    });
+    const { getByText } = renderBento(state);
+    expect(getByText("—")).toBeTruthy();
+  });
+
+  it("displays elapsed time from accumulatedMs when startedAt is null", () => {
+    const state = makeState({ accumulatedMs: 125_000, startedAt: null });
+    // 125 000 ms = 2 min 5 s → "02:05"
+    const { getByText } = renderBento(state);
+    expect(getByText("02:05")).toBeTruthy();
+  });
+
+  it("time accessibility label includes formatted time", () => {
+    const state = makeState({ accumulatedMs: 61_000, startedAt: null });
+    const { getByLabelText } = renderBento(state);
+    expect(getByLabelText("Time played: 01:01")).toBeTruthy();
+  });
+});

--- a/frontend/src/game/twenty48/__tests__/engine.test.ts
+++ b/frontend/src/game/twenty48/__tests__/engine.test.ts
@@ -49,6 +49,8 @@ function stateWith(board: number[][], overrides: Partial<Twenty48State> = {}): T
     scoreDelta: 0,
     game_over: false,
     has_won: false,
+    startedAt: null,
+    accumulatedMs: 0,
     ...overrides,
   };
 }
@@ -460,5 +462,114 @@ describe("seedable RNG (setRng + createSeededRng)", () => {
     const flatB = b.board.flat();
     const anyDiff = flatA.some((v, i) => v !== flatB[i]);
     expect(anyDiff).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timer tracking
+// ---------------------------------------------------------------------------
+
+describe("timer — newGame", () => {
+  it("initialises startedAt to null", () => {
+    expect(newGame().startedAt).toBeNull();
+  });
+
+  it("initialises accumulatedMs to 0", () => {
+    expect(newGame().accumulatedMs).toBe(0);
+  });
+});
+
+describe("timer — first move starts the clock", () => {
+  beforeEach(() => setRng(createSeededRng(1)));
+  afterEach(() => setRng(Math.random));
+
+  it("sets startedAt to a recent timestamp on the first move", () => {
+    const before = Date.now();
+    const s = move(
+      stateWith([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]),
+      "left"
+    );
+    const after = Date.now();
+    expect(s.startedAt).not.toBeNull();
+    expect(s.startedAt).toBeGreaterThanOrEqual(before);
+    expect(s.startedAt).toBeLessThanOrEqual(after);
+  });
+
+  it("preserves accumulatedMs on non-terminal moves", () => {
+    const s = move(
+      stateWith(
+        [
+          [2, 2, 0, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+        ],
+        {
+          accumulatedMs: 5000,
+        }
+      ),
+      "left"
+    );
+    expect(s.accumulatedMs).toBe(5000);
+  });
+
+  it("resumes from existing startedAt on subsequent moves", () => {
+    const t0 = Date.now() - 3000;
+    const s1 = move(
+      stateWith(
+        [
+          [2, 2, 0, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+          [0, 0, 0, 0],
+        ],
+        {
+          startedAt: t0,
+        }
+      ),
+      "left"
+    );
+    // startedAt should remain the same value (clock ticking from t0).
+    expect(s1.startedAt).toBe(t0);
+  });
+});
+
+describe("timer — game over freezes the clock", () => {
+  afterEach(() => setRng(Math.random));
+
+  it("sets startedAt to null and adds elapsed time to accumulatedMs when game ends", () => {
+    // Board: fully filled, one merge available (row 3 cols 2-3: 8+8).
+    // Moving right merges them → 16, leaving empty cell at [3,0].
+    // setRng(() => 0) spawns value 2 (rng < 0.9) at first empty in row-major
+    // order → [3,0]. Result board has no adjacent equal pairs → game_over.
+    //
+    // Verify result board is locked:
+    //   [4, 2, 4, 2]
+    //   [2, 4, 2, 4]
+    //   [4, 2, 4, 2]
+    //   [2, 4, 2, 16]   ← spawned 2 at [3,0]; no col/row adjacent equals.
+    const almostDoneBoard = [
+      [4, 2, 4, 2],
+      [2, 4, 2, 4],
+      [4, 2, 4, 2],
+      [4, 2, 8, 8], // merge 8+8→16 on right; spawn 2 at [3,0]
+    ];
+    setRng(() => 0);
+
+    const t0 = Date.now() - 2000;
+    const before = Date.now();
+    const result = move(stateWith(almostDoneBoard, { startedAt: t0, accumulatedMs: 500 }), "right");
+    const after = Date.now();
+
+    expect(result.game_over).toBe(true);
+    expect(result.startedAt).toBeNull();
+    // accumulatedMs = prior 500 ms + elapsed since t0 (≥ 2000 ms).
+    expect(result.accumulatedMs).toBeGreaterThanOrEqual(500 + (before - t0));
+    expect(result.accumulatedMs).toBeLessThanOrEqual(500 + (after - t0));
   });
 });

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -19,6 +19,8 @@ const sample: Twenty48State = {
   scoreDelta: 0,
   game_over: false,
   has_won: false,
+  startedAt: null,
+  accumulatedMs: 0,
 };
 
 describe("twenty48 storage", () => {

--- a/frontend/src/game/twenty48/engine.ts
+++ b/frontend/src/game/twenty48/engine.ts
@@ -322,7 +322,16 @@ export function newGame(): Twenty48State {
     for (let c = 0; c < SIZE; c++) if (idBoard[r][c] !== 0) spawnedIds.add(idBoard[r][c]);
 
   const tiles = buildTiles(board, idBoard, new Map(), new Set(), spawnedIds);
-  return { board, tiles, score: 0, scoreDelta: 0, game_over: false, has_won: false };
+  return {
+    board,
+    tiles,
+    score: 0,
+    scoreDelta: 0,
+    game_over: false,
+    has_won: false,
+    startedAt: null,
+    accumulatedMs: 0,
+  };
 }
 
 /**
@@ -387,6 +396,18 @@ export function move(state: Twenty48State, direction: Direction): Twenty48State 
   const has_won = state.has_won || boardHas2048(nextBoard);
   const game_over = isGameOver(nextBoard);
 
+  // --- Timer tracking ---
+  const now = Date.now();
+  // Start timer on first move of a session.
+  const activeStartedAt = state.startedAt ?? now;
+  let nextStartedAt: number | null = activeStartedAt;
+  let nextAccumulatedMs = state.accumulatedMs;
+  // Freeze when the game ends.
+  if (game_over) {
+    nextAccumulatedMs = nextAccumulatedMs + (now - activeStartedAt);
+    nextStartedAt = null;
+  }
+
   return {
     board: nextBoard,
     tiles,
@@ -394,5 +415,7 @@ export function move(state: Twenty48State, direction: Direction): Twenty48State 
     scoreDelta: gained,
     game_over,
     has_won,
+    startedAt: nextStartedAt,
+    accumulatedMs: nextAccumulatedMs,
   };
 }

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -36,6 +36,9 @@ export async function loadGame(): Promise<Twenty48State | null> {
     ) {
       return null;
     }
+    // Normalize timer fields — absent in states saved before timer was added.
+    parsed.startedAt = parsed.startedAt ?? null;
+    parsed.accumulatedMs = parsed.accumulatedMs ?? 0;
     return parsed;
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "load" } });

--- a/frontend/src/game/twenty48/types.ts
+++ b/frontend/src/game/twenty48/types.ts
@@ -24,4 +24,8 @@ export interface Twenty48State {
   scoreDelta: number;
   game_over: boolean;
   has_won: boolean;
+  /** Timestamp (Date.now()) when the current play session started; null if not yet started or game is over. */
+  startedAt: number | null;
+  /** Total elapsed milliseconds accumulated across all sessions before the current one. */
+  accumulatedMs: number;
 }

--- a/frontend/src/i18n/locales/ar/twenty48.json
+++ b/frontend/src/i18n/locales/ar/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "الرئيسية",
   "win.title": "فزت!",
   "win.body": "وصلت إلى 2048! يمكنك الاستمرار للحصول على نتيجة أعلى.",
-  "controls.keyboardHint": "أو استخدم مفاتيح الأسهم"
+  "controls.keyboardHint": "أو استخدم مفاتيح الأسهم",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/de/twenty48.json
+++ b/frontend/src/i18n/locales/de/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Startseite",
   "win.title": "Gewonnen!",
   "win.body": "Du hast 2048 erreicht! Du kannst weiterspielen für einen höheren Punktestand.",
-  "controls.keyboardHint": "Oder nutze die Pfeiltasten"
+  "controls.keyboardHint": "Oder nutze die Pfeiltasten",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/en/twenty48.json
+++ b/frontend/src/i18n/locales/en/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.newGame": "New Game",
   "gameOver.home": "Home",
   "win.title": "You Win!",
-  "win.body": "You reached 2048! You can keep playing for a higher score."
+  "win.body": "You reached 2048! You can keep playing for a higher score.",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/es/twenty48.json
+++ b/frontend/src/i18n/locales/es/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Inicio",
   "win.title": "¡Ganaste!",
   "win.body": "¡Llegaste a 2048! Puedes seguir jugando para una puntuación más alta.",
-  "controls.keyboardHint": "O usa las flechas del teclado"
+  "controls.keyboardHint": "O usa las flechas del teclado",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/fr-CA/twenty48.json
+++ b/frontend/src/i18n/locales/fr-CA/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Accueil",
   "win.title": "Vous avez gagné !",
   "win.body": "Vous avez atteint 2048 ! Vous pouvez continuer pour un meilleur score.",
-  "controls.keyboardHint": "Ou utilise les touches fléchées"
+  "controls.keyboardHint": "Ou utilise les touches fléchées",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/he/twenty48.json
+++ b/frontend/src/i18n/locales/he/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "בית",
   "win.title": "ניצחת!",
   "win.body": "הגעת ל-2048! אתה יכול להמשיך לשחק לניקוד גבוה יותר.",
-  "controls.keyboardHint": "או השתמש במקשי החיצים"
+  "controls.keyboardHint": "או השתמש במקשי החיצים",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/hi/twenty48.json
+++ b/frontend/src/i18n/locales/hi/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "होम",
   "win.title": "आप जीते!",
   "win.body": "आप 2048 तक पहुँच गए! उच्च स्कोर के लिए खेलना जारी रख सकते हैं।",
-  "controls.keyboardHint": "या तीर कुंजियों का उपयोग करें"
+  "controls.keyboardHint": "या तीर कुंजियों का उपयोग करें",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/ja/twenty48.json
+++ b/frontend/src/i18n/locales/ja/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "ホーム",
   "win.title": "勝利！",
   "win.body": "2048に到達しました！さらに高いスコアを目指して続けられます。",
-  "controls.keyboardHint": "または矢印キーを使用"
+  "controls.keyboardHint": "または矢印キーを使用",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/ko/twenty48.json
+++ b/frontend/src/i18n/locales/ko/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "홈",
   "win.title": "승리!",
   "win.body": "2048에 도달했습니다! 더 높은 점수를 위해 계속 플레이할 수 있습니다.",
-  "controls.keyboardHint": "또는 방향키 사용"
+  "controls.keyboardHint": "또는 방향키 사용",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/nl/twenty48.json
+++ b/frontend/src/i18n/locales/nl/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Start",
   "win.title": "Gewonnen!",
   "win.body": "Je hebt 2048 bereikt! Je kunt doorspelen voor een hogere score.",
-  "controls.keyboardHint": "Of gebruik de pijltoetsen"
+  "controls.keyboardHint": "Of gebruik de pijltoetsen",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/pt/twenty48.json
+++ b/frontend/src/i18n/locales/pt/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Início",
   "win.title": "Você venceu!",
   "win.body": "Você alcançou 2048! Você pode continuar jogando para uma pontuação maior.",
-  "controls.keyboardHint": "Ou use as setas do teclado"
+  "controls.keyboardHint": "Ou use as setas do teclado",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/ru/twenty48.json
+++ b/frontend/src/i18n/locales/ru/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "Главная",
   "win.title": "Вы выиграли!",
   "win.body": "Вы достигли 2048! Можете продолжить игру для более высокого счёта.",
-  "controls.keyboardHint": "Или используйте клавиши со стрелками"
+  "controls.keyboardHint": "Или используйте клавиши со стрелками",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/i18n/locales/zh/twenty48.json
+++ b/frontend/src/i18n/locales/zh/twenty48.json
@@ -19,5 +19,7 @@
   "gameOver.home": "主页",
   "win.title": "你赢了！",
   "win.body": "你达到了2048！你可以继续游戏以获得更高分数。",
-  "controls.keyboardHint": "或使用方向键"
+  "controls.keyboardHint": "或使用方向键",
+  "stats.highestTile": "Highest Tile",
+  "stats.timePlayed": "Time Played"
 }

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -18,6 +18,7 @@ import {
 import Grid from "../components/twenty48/Grid";
 import ScoreBoard from "../components/twenty48/ScoreBoard";
 import GameOverlay from "../components/twenty48/GameOverlay";
+import StatsBento from "../components/twenty48/StatsBento";
 
 const SWIPE_THRESHOLD = 30;
 /** How long (ms) to hold the move lock — matches slide animation duration. */
@@ -52,7 +53,11 @@ export default function Twenty48Screen({ navigation }: Props) {
     let active = true;
     Promise.all([loadGame(), loadBestScore()]).then(([saved, best]) => {
       if (!active) return;
-      const next = saved ?? newGame();
+      let next = saved ?? newGame();
+      // Resume timer when reloading a mid-game state.
+      if (!next.game_over && next.startedAt !== null) {
+        next = { ...next, startedAt: Date.now() };
+      }
       setState(next);
       if (!saved) saveGame(next);
       setBestScore(best);
@@ -275,6 +280,9 @@ export default function Twenty48Screen({ navigation }: Props) {
           {state && <Grid tiles={state.tiles} />}
         </View>
       </GestureDetector>
+
+      {/* Stats bento — Highest Tile + Time Played */}
+      {state && <StatsBento state={state} />}
 
       {/* Overlays */}
       {showWinOverlay && (


### PR DESCRIPTION
Closes #351. Part of epic #346.

## Summary
- **`Twenty48State`**: new `startedAt: number | null` + `accumulatedMs: number` fields
- **`engine.ts`**: timer starts on first `move()` call; freezes into `accumulatedMs` on game over
- **`storage.ts`**: `loadGame` normalises missing timer fields (backward compat with old saves)
- **`StatsBento.tsx`**: new 2-column bento below the board — Highest Tile (tertiary/lime) + Time Played (secondary/magenta, ticks every second via `setInterval`)
- **`Twenty48Screen.tsx`**: resumes timer on mid-game reload (`startedAt = Date.now()`); renders `StatsBento` below the board
- **i18n**: `stats.highestTile` + `stats.timePlayed` keys added to all 14 locales (English copy; other locales use English fallback pending translation)

## Test plan
- [ ] `npx jest src/game/twenty48/__tests__/engine.test.ts src/components/twenty48/__tests__/StatsBento.test.tsx` — 74 tests green
- [ ] Visual: two bento cards visible below board; Highest Tile updates on merges; Time Played ticks up every second during play, freezes on game over
- [ ] Kill and reopen app mid-game: timer resumes from where it left off
- [ ] New Game resets both stats to 0 / —

🤖 Generated with [Claude Code](https://claude.com/claude-code)