### PR TITLE
feat(chrome): add shared AppHeader component (#355)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@sentry/react-native": "~7.11.0",
         "@shopify/react-native-skia": "2.4.18",
         "expo": "~55.0.14",
+        "expo-blur": "~55.0.14",
         "expo-localization": "^55.0.13",
         "expo-modules-core": "^55.0.22",
         "expo-status-bar": "^55.0.5",
@@ -7776,6 +7777,17 @@
         "@expo/image-utils": "^0.8.13",
         "expo-constants": "~55.0.13"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-blur": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-55.0.14.tgz",
+      "integrity": "sha512-NKyCKFWTNpX4CZSsiE1sgkqk/yvR1K0UTukuIbxVKoobB+yALLg1CFav0NqfdQqjhtoj5oEzP0Brlq92Z08Zfg==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "@sentry/react-native": "~7.11.0",
     "@shopify/react-native-skia": "2.4.18",
     "expo": "~55.0.14",
+    "expo-blur": "~55.0.14",
     "expo-localization": "^55.0.13",
     "expo-modules-core": "^55.0.22",
     "expo-status-bar": "^55.0.5",

--- a/frontend/src/components/shared/AppHeader.tsx
+++ b/frontend/src/components/shared/AppHeader.tsx
@@ -29,10 +29,7 @@ export function AppHeader({ title, rightSlot }: AppHeaderProps) {
   const bgColor = hexToRgba(colors.background, 0.7);
 
   return (
-    <View
-      accessibilityRole="header"
-      style={[styles.wrapper, { height: totalHeight }]}
-    >
+    <View accessibilityRole="header" style={[styles.wrapper, { height: totalHeight }]}>
       {Platform.OS === "web" ? (
         <View
           style={[

--- a/frontend/src/components/shared/AppHeader.tsx
+++ b/frontend/src/components/shared/AppHeader.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { View, Text, StyleSheet, Platform } from "react-native";
+import { BlurView } from "expo-blur";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
+
+export const APP_HEADER_HEIGHT = 64;
+
+export interface AppHeaderProps {
+  title: string;
+  rightSlot?: React.ReactNode;
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function AppHeader({ title, rightSlot }: AppHeaderProps) {
+  const { colors, theme } = useTheme();
+  const { t } = useTranslation("common");
+  const insets = useSafeAreaInsets();
+
+  const totalHeight = APP_HEADER_HEIGHT + insets.top;
+  const bgColor = hexToRgba(colors.background, 0.7);
+
+  return (
+    <View
+      accessibilityRole="header"
+      style={[styles.wrapper, { height: totalHeight }]}
+    >
+      {Platform.OS === "web" ? (
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            {
+              backgroundColor: bgColor,
+              // React Native Web passes unknown style props through to CSS
+              ...Platform.select({
+                web: {
+                  backdropFilter: "blur(20px)",
+                  WebkitBackdropFilter: "blur(20px)",
+                } as object,
+              }),
+            },
+          ]}
+        />
+      ) : (
+        <BlurView
+          intensity={80}
+          tint={theme === "dark" ? "dark" : "light"}
+          style={StyleSheet.absoluteFill}
+        />
+      )}
+
+      <View style={[styles.content, { paddingTop: insets.top }]}>
+        <Text
+          style={[styles.wordmark, { color: colors.accent }]}
+          numberOfLines={1}
+          accessibilityRole="text"
+        >
+          {t("brand.wordmark")}
+        </Text>
+
+        <Text
+          style={[styles.title, { color: colors.text }]}
+          numberOfLines={1}
+          accessibilityRole="header"
+        >
+          {title}
+        </Text>
+
+        <View style={styles.rightSlot}>{rightSlot ?? null}</View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 50,
+    shadowColor: "#8ff5ff",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 20,
+    elevation: 4,
+  },
+  content: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 24,
+  },
+  wordmark: {
+    fontFamily: typography.heading,
+    fontSize: 13,
+    letterSpacing: -0.3,
+    minWidth: 80,
+  },
+  title: {
+    fontFamily: typography.heading,
+    fontSize: 16,
+    flex: 1,
+    textAlign: "center",
+    marginHorizontal: 8,
+  },
+  rightSlot: {
+    minWidth: 80,
+    alignItems: "flex-end",
+  },
+});

--- a/frontend/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/frontend/src/components/shared/__tests__/AppHeader.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+import { AppHeader, APP_HEADER_HEIGHT } from "../AppHeader";
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("../../../theme/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#0e0e13",
+      accent: "#8ff5ff",
+      text: "#e8e8f0",
+    },
+    theme: "dark",
+  }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === "brand.wordmark" ? "BC Arcade" : key),
+  }),
+}));
+
+describe("AppHeader", () => {
+  it("renders the page title", () => {
+    render(<AppHeader title="Settings" />);
+    expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("renders the BC Arcade wordmark", () => {
+    render(<AppHeader title="Profile" />);
+    expect(screen.getByText("BC Arcade")).toBeTruthy();
+  });
+
+  it("projects the rightSlot when provided", () => {
+    render(
+      <AppHeader title="Game" rightSlot={<Text>Round 3 / 13</Text>} />
+    );
+    expect(screen.getByText("Round 3 / 13")).toBeTruthy();
+  });
+
+  it("renders nothing in the right slot when omitted", () => {
+    render(<AppHeader title="Ranks" />);
+    expect(screen.queryByText("Round")).toBeNull();
+  });
+
+  it("has an accessible header role on the wrapper", () => {
+    const { getByRole } = render(<AppHeader title="Lobby" />);
+    expect(getByRole("header", { name: "Lobby" })).toBeTruthy();
+  });
+
+  it("does not render a back button", () => {
+    render(<AppHeader title="2048" />);
+    expect(screen.queryByText(/back/i)).toBeNull();
+    expect(screen.queryByText(/←/)).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("exports APP_HEADER_HEIGHT as a positive number", () => {
+    expect(typeof APP_HEADER_HEIGHT).toBe("number");
+    expect(APP_HEADER_HEIGHT).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/frontend/src/components/shared/__tests__/AppHeader.test.tsx
@@ -40,9 +40,7 @@ describe("AppHeader", () => {
   });
 
   it("projects the rightSlot when provided", () => {
-    render(
-      <AppHeader title="Game" rightSlot={<Text>Round 3 / 13</Text>} />
-    );
+    render(<AppHeader title="Game" rightSlot={<Text>Round 3 / 13</Text>} />);
     expect(screen.getByText("Round 3 / 13")).toBeTruthy();
   });
 

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "نهار",
   "theme.darkShort": "ليل",
   "lang.switcherLabel": "اختر اللغة",
-  "network.offlineBanner": "غير متصل — ستتم مزامنة النقاط عند إعادة الاتصال"
+  "network.offlineBanner": "غير متصل — ستتم مزامنة النقاط عند إعادة الاتصال",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Hell",
   "theme.darkShort": "Dunkel",
   "lang.switcherLabel": "Sprache wählen",
-  "network.offlineBanner": "Offline — Punkte werden bei erneuter Verbindung synchronisiert"
+  "network.offlineBanner": "Offline — Punkte werden bei erneuter Verbindung synchronisiert",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Light",
   "theme.darkShort": "Dark",
   "lang.switcherLabel": "Select language",
-  "network.offlineBanner": "Offline — scores will sync when you reconnect"
+  "network.offlineBanner": "Offline — scores will sync when you reconnect",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Claro",
   "theme.darkShort": "Oscuro",
   "lang.switcherLabel": "Seleccionar idioma",
-  "network.offlineBanner": "Sin conexión — las puntuaciones se sincronizarán al reconectar"
+  "network.offlineBanner": "Sin conexión — las puntuaciones se sincronizarán al reconectar",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/fr-CA/common.json
+++ b/frontend/src/i18n/locales/fr-CA/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Clair",
   "theme.darkShort": "Sombre",
   "lang.switcherLabel": "Choisir langue",
-  "network.offlineBanner": "Hors ligne — les scores seront synchronisés à la reconnexion"
+  "network.offlineBanner": "Hors ligne — les scores seront synchronisés à la reconnexion",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/he/common.json
+++ b/frontend/src/i18n/locales/he/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "בהיר",
   "theme.darkShort": "כהה",
   "lang.switcherLabel": "בחירת שפה",
-  "network.offlineBanner": "לא מקוון — הניקוד יסונכרן בעת חיבור מחדש"
+  "network.offlineBanner": "לא מקוון — הניקוד יסונכרן בעת חיבור מחדש",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/hi/common.json
+++ b/frontend/src/i18n/locales/hi/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "लाइट",
   "theme.darkShort": "डार्क",
   "lang.switcherLabel": "भाषा चुनें",
-  "network.offlineBanner": "ऑफ़लाइन — पुनः कनेक्ट होने पर स्कोर सिंक होंगे"
+  "network.offlineBanner": "ऑफ़लाइन — पुनः कनेक्ट होने पर स्कोर सिंक होंगे",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "ライト",
   "theme.darkShort": "ダーク",
   "lang.switcherLabel": "言語を選択",
-  "network.offlineBanner": "オフライン — 再接続時にスコアが同期されます"
+  "network.offlineBanner": "オフライン — 再接続時にスコアが同期されます",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "라이트",
   "theme.darkShort": "다크",
   "lang.switcherLabel": "언어 선택",
-  "network.offlineBanner": "오프라인 — 다시 연결되면 점수가 동기화됩니다"
+  "network.offlineBanner": "오프라인 — 다시 연결되면 점수가 동기화됩니다",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/nl/common.json
+++ b/frontend/src/i18n/locales/nl/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Licht",
   "theme.darkShort": "Donker",
   "lang.switcherLabel": "Kies taal",
-  "network.offlineBanner": "Offline — scores worden gesynchroniseerd bij opnieuw verbinden"
+  "network.offlineBanner": "Offline — scores worden gesynchroniseerd bij opnieuw verbinden",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/pt/common.json
+++ b/frontend/src/i18n/locales/pt/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Claro",
   "theme.darkShort": "Escuro",
   "lang.switcherLabel": "Selecionar idioma",
-  "network.offlineBanner": "Offline — as pontuações serão sincronizadas ao reconectar"
+  "network.offlineBanner": "Offline — as pontuações serão sincronizadas ao reconectar",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "Светл.",
   "theme.darkShort": "Тёмн.",
   "lang.switcherLabel": "Выбор языка",
-  "network.offlineBanner": "Нет подключения — результаты синхронизируются при восстановлении"
+  "network.offlineBanner": "Нет подключения — результаты синхронизируются при восстановлении",
+  "brand.wordmark": "BC Arcade"
 }

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -9,5 +9,6 @@
   "theme.lightShort": "浅色",
   "theme.darkShort": "深色",
   "lang.switcherLabel": "选择语言",
-  "network.offlineBanner": "离线 — 重新连接后将同步分数"
+  "network.offlineBanner": "离线 — 重新连接后将同步分数",
+  "brand.wordmark": "BC Arcade"
 }


### PR DESCRIPTION
## Summary

- New `AppHeader` component at `src/components/shared/AppHeader.tsx`
- **Left slot:** BC Arcade wordmark in `colors.accent` (Space Grotesk Bold)
- **Center:** page `title` prop, truncates with ellipsis on narrow screens
- **Right slot:** optional `rightSlot?: ReactNode` for contextual content (e.g. round indicator)
- **Blur:** `expo-blur` `BlurView` on native; CSS `backdrop-filter: blur(20px)` on web
- **Background:** `colors.background` at 70% opacity
- **Shadow:** soft cyan-tinted `0 4px 20px rgba(143, 245, 255, 0.08)`
- **Position:** absolute, `top: 0`, `zIndex: 50`, full width; safe-area top inset respected
- Exports `APP_HEADER_HEIGHT = 64` for scroll-content offset sizing
- Adds `brand.wordmark = "BC Arcade"` to all 13 locale `common.json` files
- Installs `expo-blur ~55.0.14` (compatible with Expo SDK 55)
- No back button, no settings gear

Closes #355
Part of epic #353

## Test plan

- [ ] `AppHeader` renders title and "BC Arcade" wordmark
- [ ] `rightSlot` projects correctly; omitting it renders nothing in that slot
- [ ] No back button or settings gear present
- [ ] `APP_HEADER_HEIGHT` exported as a positive number
- [ ] 7 unit tests pass
- [ ] i18n completeness CI check passes (all 13 locales have `brand.wordmark`)
- [ ] Verify blur renders on Expo Web (backdrop-filter) and iOS/Android (BlurView)

🤖 Generated with [Claude Code](https://claude.com/claude-code)