### PR TITLE
feat(chrome): apply shared AppHeader on Settings / Profile / Ranks (#359)

### DIFF
--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
+import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
 export default function LeaderboardScreen() {
   const { colors } = useTheme();
@@ -11,12 +12,13 @@ export default function LeaderboardScreen() {
 
   return (
     <View
-      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingTop: APP_HEADER_HEIGHT + insets.top },
+      ]}
     >
+      <AppHeader title={t("nav.ranks")} />
       <Text style={[styles.icon]}>🏆</Text>
-      <Text style={[styles.title, { color: colors.text }]}>
-        {t("screens.leaderboard", "Leaderboard")}
-      </Text>
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
     </View>
   );
@@ -25,6 +27,5 @@ export default function LeaderboardScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   icon: { fontSize: 48, marginBottom: 16 },
-  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
   subtitle: { fontSize: 16 },
 });

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
+import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
 export default function ProfileScreen() {
   const { colors } = useTheme();
@@ -11,10 +12,13 @@ export default function ProfileScreen() {
 
   return (
     <View
-      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingTop: APP_HEADER_HEIGHT + insets.top },
+      ]}
     >
+      <AppHeader title={t("nav.profile")} />
       <Text style={[styles.icon]}>👤</Text>
-      <Text style={[styles.title, { color: colors.text }]}>{t("screens.profile", "Profile")}</Text>
       <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
     </View>
   );
@@ -23,6 +27,5 @@ export default function ProfileScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
   icon: { fontSize: 48, marginBottom: 16 },
-  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
   subtitle: { fontSize: 16 },
 });

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
 import LanguageSwitcher from "../components/LanguageSwitcher";
+import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
 export default function SettingsScreen() {
   const { colors, theme, toggle } = useTheme();
@@ -12,11 +13,12 @@ export default function SettingsScreen() {
 
   return (
     <View
-      style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top }]}
+      style={[
+        styles.container,
+        { backgroundColor: colors.background, paddingTop: APP_HEADER_HEIGHT + insets.top },
+      ]}
     >
-      <Text style={[styles.title, { color: colors.text }]}>
-        {t("screens.settings", "Settings")}
-      </Text>
+      <AppHeader title={t("nav.settings")} />
 
       <View style={[styles.row, { borderColor: colors.border }]}>
         <Text style={[styles.label, { color: colors.text }]}>{t("theme.label", "Theme")}</Text>
@@ -47,7 +49,6 @@ export default function SettingsScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 24 },
-  title: { fontSize: 24, fontWeight: "700", marginBottom: 24, marginTop: 16 },
   row: {
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import LeaderboardScreen from "../LeaderboardScreen";
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <LeaderboardScreen />
+    </ThemeProvider>
+  );
+}
+
+describe("LeaderboardScreen", () => {
+  it("renders the AppHeader", () => {
+    renderScreen();
+    expect(screen.getByRole("header")).toBeTruthy();
+  });
+
+  it("renders the coming soon placeholder", () => {
+    renderScreen();
+    expect(screen.getByText("Coming Soon")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/frontend/src/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import ProfileScreen from "../ProfileScreen";
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <ProfileScreen />
+    </ThemeProvider>
+  );
+}
+
+describe("ProfileScreen", () => {
+  it("renders the AppHeader", () => {
+    renderScreen();
+    expect(screen.getByRole("header")).toBeTruthy();
+  });
+
+  it("renders the coming soon placeholder", () => {
+    renderScreen();
+    expect(screen.getByText("Coming Soon")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/__tests__/SettingsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SettingsScreen.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import SettingsScreen from "../SettingsScreen";
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../../components/LanguageSwitcher", () => ({
+  __esModule: true,
+  default: "MockLanguageSwitcher",
+}));
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <SettingsScreen />
+    </ThemeProvider>
+  );
+}
+
+describe("SettingsScreen", () => {
+  it("renders the AppHeader", () => {
+    renderScreen();
+    expect(screen.getByRole("header")).toBeTruthy();
+  });
+
+  it("renders the theme toggle button", () => {
+    renderScreen();
+    expect(screen.getByTestId("theme-toggle-button")).toBeTruthy();
+  });
+
+  it("theme toggle button responds to press", () => {
+    renderScreen();
+    const toggle = screen.getByTestId("theme-toggle-button");
+    const labelBefore = toggle.props.accessibilityLabel;
+    fireEvent.press(toggle);
+    const labelAfter = screen.getByTestId("theme-toggle-button").props.accessibilityLabel;
+    expect(labelAfter).not.toBe(labelBefore);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `<AppHeader />` to `SettingsScreen`, `ProfileScreen`, and `LeaderboardScreen`
- Removes local title `Text` from each screen (AppHeader handles screen identity)
- Adjusts container `paddingTop` from `insets.top` → `APP_HEADER_HEIGHT + insets.top` so content clears the absolute-positioned header
- Creates unit test files for all three screens with AppHeader presence + core content assertions

Part of epic #353 (issue F). Closes #359.

## Test plan

- [ ] All 7 new unit tests pass locally (verified)
- [ ] ESLint + Prettier clean on all 6 changed files (verified)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)