### PR TITLE
feat(lobby): responsive 2-col lobby + AppHeader on HomeScreen (#356)

### DIFF
--- a/e2e/tests/cascade-flow.spec.ts
+++ b/e2e/tests/cascade-flow.spec.ts
@@ -104,6 +104,5 @@ test.describe("Cascade — navigation and smoke tests", () => {
     await expect(page.getByText("Gaming App").first()).toBeVisible({
       timeout: 5000,
     });
-    await expect(page.getByText("Choose a game")).toBeVisible();
   });
 });

--- a/e2e/tests/lobby-responsive.spec.ts
+++ b/e2e/tests/lobby-responsive.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * lobby-responsive.spec.ts — GH #356
+ *
+ * Verifies that the HomeScreen lobby renders correctly at narrow viewports
+ * (Galaxy Fold outer display ~280 px) and standard widths, and that all
+ * game cards are reachable regardless of viewport width.
+ */
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Lobby — responsive layout", () => {
+  test("all game cards visible at Galaxy Fold width (280 px)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 280, height: 653 },
+    });
+    const page = await context.newPage();
+    await page.goto("/");
+
+    // All four game cards must be visible and tappable
+    await expect(page.getByRole("button", { name: "Play Yacht" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Play Cascade" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Play Blackjack" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Play 2048" })).toBeVisible();
+
+    await context.close();
+  });
+
+  test("all game cards visible at 360 px viewport (2-col breakpoint)", async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 360, height: 740 },
+    });
+    const page = await context.newPage();
+    await page.goto("/");
+
+    await expect(page.getByRole("button", { name: "Play Yacht" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Play Cascade" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Play Blackjack" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Play 2048" })).toBeVisible();
+
+    await context.close();
+  });
+
+  test("all game cards visible at standard mobile width (390 px)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("button", { name: "Play Yacht" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Play Cascade" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Play Blackjack" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Play 2048" })).toBeVisible();
+  });
+
+  test("AppHeader visible on home screen", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "Gaming App", exact: true }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test("game cards are tappable at Galaxy Fold width", async ({ browser }) => {
+    const context = await browser.newContext({
+      viewport: { width: 280, height: 653 },
+    });
+    const page = await context.newPage();
+    await page.goto("/");
+
+    // Tapping Cascade should navigate to Cascade screen
+    await page.getByRole("button", { name: "Play Cascade" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Cascade", exact: true }),
+    ).toBeVisible({ timeout: 10000 });
+
+    await context.close();
+  });
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,14 +1,20 @@
 import React from "react";
-import { View, Text, Pressable, StyleSheet, FlatList } from "react-native";
+import { View, Text, Pressable, StyleSheet, FlatList, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { LinearGradient } from "expo-linear-gradient";
 import { HomeStackParamList } from "../../App";
 import { newGame as newYachtGame } from "../game/yacht/engine";
 import { loadGame as loadYachtGame } from "../game/yacht/storage";
 import { useTheme } from "../theme/ThemeContext";
+import { typography } from "../theme/typography";
+import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import OfflineBanner from "../components/OfflineBanner";
+
+/** Below this viewport width the grid collapses to a single column. */
+const SINGLE_COL_BREAKPOINT = 360;
 
 interface GameCard {
   key: string;
@@ -31,6 +37,9 @@ export default function HomeScreen() {
   ]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+
+  const numColumns = width < SINGLE_COL_BREAKPOINT ? 1 : 2;
 
   async function startYacht() {
     const saved = await loadYachtGame();
@@ -76,128 +85,162 @@ export default function HomeScreen() {
     [t("twenty48:game.title")]: t("twenty48:game.playLabel"),
   };
 
-  function renderCard({ item }: { item: GameCard }) {
+  // Cycle through BC Arcade accent colors for the gradient top border on each card.
+  const cardGradients: [string, string][] = [
+    [colors.tertiary, colors.secondary],
+    [colors.secondary, colors.accent],
+    [colors.accent, colors.accentBright],
+    [colors.accentBright, colors.tertiary],
+  ];
+
+  function renderCard({ item, index }: { item: GameCard; index: number }) {
+    const [gradStart, gradEnd] = cardGradients[index % cardGradients.length];
     return (
-      <View style={styles.cardWrapper}>
+      <View style={[styles.cardWrapper, numColumns === 1 && styles.cardWrapperFull]}>
         <Pressable
-          style={[
-            styles.card,
-            {
-              backgroundColor: colors.surfaceHigh,
-              borderTopColor: colors.accent,
-            },
-          ]}
+          style={[styles.card, { backgroundColor: colors.surfaceHigh }]}
           onPress={item.action}
           accessibilityRole="button"
           accessibilityLabel={playLabels[item.title] ?? item.title}
           accessibilityHint={item.description}
         >
-          <Text style={styles.cardEmoji}>{item.emoji}</Text>
-          <Text style={[styles.cardTitle, { color: colors.text }]}>{item.title}</Text>
+          {/* Gradient top border */}
+          <LinearGradient
+            colors={[gradStart, gradEnd]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.gradientBorder}
+          />
+
+          {/* Emoji icon zone */}
+          <View style={styles.emojiZone}>
+            <Text style={styles.cardEmoji}>{item.emoji}</Text>
+          </View>
+
+          {/* Title */}
+          <Text style={[styles.cardTitle, { color: colors.text }]} numberOfLines={1}>
+            {item.title}
+          </Text>
+
+          {/* Description */}
           <Text style={[styles.cardDesc, { color: colors.textMuted }]} numberOfLines={2}>
             {item.description}
           </Text>
-          <View style={[styles.playBtn, { backgroundColor: colors.accent }]}>
+
+          {/* Play button */}
+          <LinearGradient
+            colors={[gradStart, gradEnd]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.playBtn}
+          >
             <Text style={[styles.playBtnText, { color: colors.textOnAccent }]}>
-              {t("common:play", "Play")}
+              {playLabels[item.title] ?? t("common:play", "Play")}
             </Text>
-          </View>
+          </LinearGradient>
         </Pressable>
       </View>
     );
   }
 
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          backgroundColor: colors.background,
-          paddingTop: insets.top,
-        },
-      ]}
-    >
+    <View style={[styles.screen, { backgroundColor: colors.background }]}>
+      <AppHeader title={t("common:app.title")} />
+
       <View style={styles.offlineBannerWrap}>
         <OfflineBanner />
       </View>
-      <Text style={[styles.title, { color: colors.text }]}>{t("common:app.title")}</Text>
-      <Text style={[styles.subtitle, { color: colors.textMuted }]}>{t("common:app.subtitle")}</Text>
 
       <FlatList
         data={games}
         renderItem={renderCard}
         keyExtractor={(item) => item.key}
-        numColumns={2}
-        contentContainerStyle={styles.grid}
-        columnWrapperStyle={styles.row}
-        scrollEnabled={false}
+        key={numColumns}
+        numColumns={numColumns}
+        contentContainerStyle={[
+          styles.grid,
+          {
+            paddingTop: APP_HEADER_HEIGHT + insets.top + 16,
+            paddingBottom: Math.max(insets.bottom, 16),
+            paddingHorizontal: 16,
+          },
+        ]}
+        columnWrapperStyle={numColumns > 1 ? styles.row : undefined}
+        scrollEnabled={true}
       />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  screen: {
     flex: 1,
-    alignItems: "center",
-    padding: 16,
   },
   offlineBannerWrap: {
     position: "absolute",
     left: 0,
     right: 0,
     top: 0,
-    zIndex: 10,
-  },
-  title: {
-    fontSize: 32,
-    fontWeight: "800",
-    marginTop: 24,
-    marginBottom: 4,
-  },
-  subtitle: {
-    fontSize: 15,
-    marginBottom: 24,
+    zIndex: 100,
   },
   grid: {
-    width: "100%",
-    maxWidth: 480,
+    gap: 16,
   },
   row: {
-    gap: 12,
-    marginBottom: 12,
+    gap: 16,
   },
   cardWrapper: {
     flex: 1,
   },
+  cardWrapperFull: {
+    flex: undefined,
+    width: "100%",
+  },
   card: {
     borderRadius: 24,
-    borderTopWidth: 3,
-    padding: 16,
+    overflow: "hidden",
     alignItems: "center",
+    paddingBottom: 12,
     gap: 8,
   },
+  gradientBorder: {
+    width: "100%",
+    height: 3,
+  },
+  emojiZone: {
+    height: 88,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   cardEmoji: {
-    fontSize: 40,
-    marginTop: 4,
+    fontSize: 48,
   },
   cardTitle: {
-    fontSize: 16,
-    fontWeight: "700",
+    fontFamily: typography.heading,
+    fontSize: 14,
+    letterSpacing: -0.3,
+    paddingHorizontal: 8,
+    textAlign: "center",
   },
   cardDesc: {
-    fontSize: 12,
+    fontFamily: typography.body,
+    fontSize: 10,
+    lineHeight: 14,
     textAlign: "center",
-    lineHeight: 16,
+    paddingHorizontal: 12,
   },
   playBtn: {
     marginTop: 4,
-    paddingHorizontal: 24,
+    marginHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 20,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   playBtnText: {
-    fontSize: 14,
-    fontWeight: "700",
+    fontFamily: typography.label,
+    fontSize: 9,
+    textTransform: "uppercase",
+    letterSpacing: 1,
   },
 });

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import * as ReactNative from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import HomeScreen from "../HomeScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
 
 // ---------------------------------------------------------------------------
 // Mock yacht storage — no saved game by default
@@ -44,7 +53,13 @@ const testInsets = {
   insets: { top: 47, bottom: 34, left: 0, right: 0 },
 };
 
-function renderScreen() {
+function renderScreen(windowWidth = 390) {
+  jest.spyOn(ReactNative, "useWindowDimensions").mockReturnValue({
+    width: windowWidth,
+    height: 844,
+    scale: 2,
+    fontScale: 1,
+  });
   return render(
     <SafeAreaProvider initialMetrics={testInsets}>
       <ThemeProvider>
@@ -99,5 +114,30 @@ describe("HomeScreen — game cards", () => {
         })
       )
     );
+  });
+});
+
+describe("HomeScreen — AppHeader", () => {
+  it("renders AppHeader with app title", () => {
+    const { getByRole } = renderScreen();
+    expect(getByRole("header")).toBeTruthy();
+  });
+});
+
+describe("HomeScreen — responsive layout (Galaxy Fold fix, #356)", () => {
+  it("renders all game cards at 280 px viewport width", () => {
+    const { getByLabelText } = renderScreen(280);
+    expect(getByLabelText("Play Yacht")).toBeTruthy();
+    expect(getByLabelText("Play Cascade")).toBeTruthy();
+    expect(getByLabelText("Play Blackjack")).toBeTruthy();
+    expect(getByLabelText("Play 2048")).toBeTruthy();
+  });
+
+  it("renders all game cards at 360 px viewport width", () => {
+    const { getByLabelText } = renderScreen(360);
+    expect(getByLabelText("Play Yacht")).toBeTruthy();
+    expect(getByLabelText("Play Cascade")).toBeTruthy();
+    expect(getByLabelText("Play Blackjack")).toBeTruthy();
+    expect(getByLabelText("Play 2048")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #356. Part of epic #353.

## Summary

- **AppHeader on HomeScreen**: Replaces hardcoded title/subtitle `Text` elements with `<AppHeader title={t("common:app.title")} />`. Content area uses `paddingTop: APP_HEADER_HEIGHT + insets.top`.
- **2-column card grid**: `FlatList numColumns={2}` with 16 px gap. Below 360 px viewport collapses to 1 column via `useWindowDimensions()`.
- **Galaxy Fold fix**: At 280 px outer display all four game cards are visible and tappable in single-column layout.
- **BC Arcade card design**: 24 px radius, 3 px gradient top border cycling through `tertiary → secondary → accent → accentBright`, emoji icon zone (88 px height), compact `SpaceGrotesk` title + `Manrope` description, full-width gradient play button.
- **New E2E spec**: `e2e/tests/lobby-responsive.spec.ts` — Galaxy Fold (280 px), breakpoint (360 px), and standard (390 px) viewport tests, plus AppHeader heading assertion and tappable card navigation test.
- **Unit tests**: 7 passing, including 280 px and 360 px viewport profile tests.

## Test plan

- [ ] All 7 HomeScreen unit tests pass
- [ ] `lobby-responsive.spec.ts` Playwright tests pass (Galaxy Fold + standard widths)
- [ ] Existing E2E specs still pass (cascade-flow subtitle assertion removed; "Gaming App" text still found via AppHeader)
- [ ] Visual check: 2-col grid on standard width, 1-col on narrow
- [ ] AppHeader shows "Gaming App" title on home screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)