### PR TITLE
fix(e2e): upload artifacts on always + retain-on-failure traces (#400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,10 +205,12 @@ jobs:
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
-        if: failure()
+        if: always()
         with:
           name: playwright-report
-          path: e2e/playwright-report/
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
           retention-days: 7
 
   check-i18n:

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,11 +30,15 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI
-    ? [["github"], ["html", { outputFolder: "playwright-report" }]]
+    ? [
+        ["github"],
+        ["html", { outputFolder: "playwright-report" }],
+        ["json", { outputFile: "playwright-report/results.json" }],
+      ]
     : "list",
   use: {
     baseURL: "http://localhost:8081",
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },
   projects: [
@@ -65,10 +69,7 @@ export default defineConfig({
     },
     {
       name: "cross",
-      testMatch: [
-        "accessibility.spec.ts",
-        "ui-preferences.spec.ts",
-      ],
+      testMatch: ["accessibility.spec.ts", "ui-preferences.spec.ts"],
       use: { ...devices["Desktop Chrome"] },
     },
   ],


### PR DESCRIPTION
## Summary

- **`if: failure()` → `if: always()`** on the artifact upload step so flaky-but-passing runs (tests that fail then pass on retry) still produce a report
- **Added `e2e/test-results/`** to the artifact path to capture trace zip files alongside the HTML report
- **`trace: "on-first-retry"` → `trace: "retain-on-failure"`** so a test that passes on retry 2 still records its trace from retry 1
- **Added JSON reporter** in CI (`playwright-report/results.json`) for programmatic flakiness tracking

Part of epic #403 — e2e Playwright flakiness hardening.

## Test plan

- [ ] CI passes green
- [ ] Playwright report artifact is uploaded regardless of pass/fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)