### PR TITLE
feat(release): sync Android/iOS native versions and add version-sync workflow

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,99 @@
+name: Version Sync
+
+# Triggered when release-please publishes a GitHub release.
+# Patches Android build.gradle, iOS project.pbxproj, app.json, and
+# package.json so all platform version fields stay in sync, then
+# opens a PR targeting dev.
+#
+# versionCode / CURRENT_PROJECT_VERSION formula:
+#   major * 10000 + minor * 100 + patch
+#   e.g. 1.0.6 → 10006, 1.1.0 → 10100, 2.0.0 → 20000
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  version-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Parse version from tag
+        id: ver
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+          IFS='.' read -r major minor patch <<< "$VERSION"
+          VERSION_CODE=$(( major * 10000 + minor * 100 + patch ))
+          echo "version=$VERSION"       >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Patch frontend/package.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('frontend/package.json', 'utf8'));
+            pkg.version = '${{ steps.ver.outputs.version }}';
+            fs.writeFileSync('frontend/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Patch frontend/app.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const app = JSON.parse(fs.readFileSync('frontend/app.json', 'utf8'));
+            app.expo.version = '${{ steps.ver.outputs.version }}';
+            app.expo.ios.buildNumber = '${{ steps.ver.outputs.version_code }}';
+            fs.writeFileSync('frontend/app.json', JSON.stringify(app, null, 2) + '\n');
+          "
+
+      - name: Patch Android versionName and versionCode
+        run: |
+          sed -i \
+            "s/versionCode [0-9]*/versionCode ${{ steps.ver.outputs.version_code }}/" \
+            frontend/android/app/build.gradle
+          sed -i \
+            "s/versionName \"[^\"]*\"/versionName \"${{ steps.ver.outputs.version }}\"/" \
+            frontend/android/app/build.gradle
+
+      - name: Patch iOS MARKETING_VERSION and CURRENT_PROJECT_VERSION
+        run: |
+          sed -i \
+            "s/MARKETING_VERSION = [^;]*/MARKETING_VERSION = ${{ steps.ver.outputs.version }}/" \
+            frontend/ios/GamingApp.xcodeproj/project.pbxproj
+          sed -i \
+            "s/CURRENT_PROJECT_VERSION = [0-9]*/CURRENT_PROJECT_VERSION = ${{ steps.ver.outputs.version_code }}/" \
+            frontend/ios/GamingApp.xcodeproj/project.pbxproj
+
+      - name: Open PR to dev
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/sync-native-version-${{ steps.ver.outputs.version }}
+          base: dev
+          commit-message: "chore(release): sync native version to ${{ steps.ver.outputs.version }} [skip ci]"
+          title: "chore(release): sync native version to v${{ steps.ver.outputs.version }}"
+          body: |
+            Automated version sync after release `v${{ steps.ver.outputs.version }}`.
+
+            | File | Field | New value |
+            |------|-------|-----------|
+            | `frontend/package.json` | `version` | `${{ steps.ver.outputs.version }}` |
+            | `frontend/app.json` | `expo.version` | `${{ steps.ver.outputs.version }}` |
+            | `frontend/app.json` | `expo.ios.buildNumber` | `${{ steps.ver.outputs.version_code }}` |
+            | `frontend/android/app/build.gradle` | `versionName` | `${{ steps.ver.outputs.version }}` |
+            | `frontend/android/app/build.gradle` | `versionCode` | `${{ steps.ver.outputs.version_code }}` |
+            | `frontend/ios/.../project.pbxproj` | `MARKETING_VERSION` | `${{ steps.ver.outputs.version }}` |
+            | `frontend/ios/.../project.pbxproj` | `CURRENT_PROJECT_VERSION` | `${{ steps.ver.outputs.version_code }}` |
+
+            **versionCode formula:** `major × 10000 + minor × 100 + patch`
+
+            Closes #424

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -94,7 +94,7 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 6
+        versionCode 10006
         versionName "1.0.6"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -14,7 +14,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.buffingchi.games",
-      "buildNumber": "1",
+      "buildNumber": "10006",
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
           {

--- a/frontend/ios/GamingApp.xcodeproj/project.pbxproj
+++ b/frontend/ios/GamingApp.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 10006;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -378,14 +378,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 10006;
 				INFOPLIST_FILE = GamingApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

- **Fixes version drift** across all four platform version files — they were all pointing at different values for the same release (1.0.6)
- **Establishes a `versionCode` formula** (`major × 10000 + minor × 100 + patch`) so the integer build number is always deterministically derivable from the semver string
- **Adds `.github/workflows/version-sync.yml`** — fires on `release: published` (i.e. whenever release-please cuts a release), patches all files, and opens a PR to `dev`

### Version drift fixed

| File | Field | Before | After |
|------|-------|--------|-------|
| `frontend/package.json` | `version` | `1.0.0` | `1.0.6` |
| `frontend/app.json` | `expo.ios.buildNumber` | `"1"` | `"10006"` |
| `frontend/android/app/build.gradle` | `versionCode` | `6` | `10006` |
| `frontend/ios/.../project.pbxproj` | `MARKETING_VERSION` | `1.0` | `1.0.6` |
| `frontend/ios/.../project.pbxproj` | `CURRENT_PROJECT_VERSION` | `1` | `10006` |

### Workflow behaviour

1. release-please merges its PR to `main` and publishes a GitHub release (e.g. `v1.0.7`)
2. `version-sync.yml` triggers, derives `version=1.0.7` and `version_code=10007`
3. Patches all four files in a checkout of `main`
4. Opens a PR (`chore/sync-native-version-1.0.7`) targeting `dev` via `peter-evans/create-pull-request`

## Test plan

- [ ] Verify `frontend/package.json` reads `"version": "1.0.6"`
- [ ] Verify `frontend/app.json` `expo.version` = `"1.0.6"` and `expo.ios.buildNumber` = `"10006"`
- [ ] Verify `frontend/android/app/build.gradle` `versionCode 10006` / `versionName "1.0.6"`
- [ ] Verify `frontend/ios/GamingApp.xcodeproj/project.pbxproj` has `MARKETING_VERSION = 1.0.6` and `CURRENT_PROJECT_VERSION = 10006` in both Debug and Release configs
- [ ] CI (`android-bundle-check`, `android-build-check`) passes
- [ ] After the next real release, confirm the `version-sync` workflow fires and opens a PR with correct values

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)