### PR TITLE
fix(ci): policy-gate rgba false-positive on hexToRgba (#121)

### DIFF
--- a/.claude/policies/design-tokens.md
+++ b/.claude/policies/design-tokens.md
@@ -10,7 +10,7 @@ Policy references:
 
 Files matching ANY of these patterns trigger this policy:
 
-- `:\s*#[0-9a-fA-F]{3,8}|rgba?\s*\(|hsla?\s*\(|font-size:\s*[0-9]+px|font-family:\s*["']|tabindex=["'][1-9]`
+- `:\s*#[0-9a-fA-F]{3,8}|\brgba?\s*\(|\bhsla?\s*\(|font-size:\s*[0-9]+px|font-family:\s*["']|tabindex=["'][1-9]`
 
 Skip the following (checked against full path and basename):
 

--- a/.claude/policies/policy-patterns.json
+++ b/.claude/policies/policy-patterns.json
@@ -16,7 +16,7 @@
     "skip": "^\\.env"
   },
   "design-tokens": {
-    "detect": ":\\s*#[0-9a-fA-F]{3,8}|rgba?\\s*\\(|hsla?\\s*\\(|font-size:\\s*[0-9]+px|font-family:\\s*[\"']|tabindex=[\"'][1-9]",
+    "detect": ":\\s*#[0-9a-fA-F]{3,8}|\\brgba?\\s*\\(|\\bhsla?\\s*\\(|font-size:\\s*[0-9]+px|font-family:\\s*[\"']|tabindex=[\"'][1-9]",
     "skip": "node_modules/|(^|/)dist/|(^|/)build/|(^|/)\\.cache/|(^|/)coverage/|(^|/)public/|(^|/)tokens/|\\.min\\.(css|js)|\\.stories\\.[jt]sx?|\\.test\\.[jt]sx?|\\.spec\\.[jt]sx?|__snapshots__|\\.svg$|\\.mdx?$|\\.tokens\\.json$|tailwind\\.config\\.|theme\\.[^./]+\\.[jt]sx?$"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `\b` word boundary before `rgba?` and `hsla?` in the design-tokens detect regex
- Prevents `hexToRgba()` utility functions from false-triggering the policy gate
- Standalone color literals like `rgba(0,0,0,0.5)` still match correctly

Closes wcmchenry3-stack/.github#121

## Test plan
- [x] `hexToRgba(hex, alpha)` no longer matches the detect pattern
- [x] `"rgba(0,0,0,0.5)"` still matches
- [x] `rgb(255,0,0)` still matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)