### PR TITLE
fix(android): resolve CMake/Sentry build failures

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -81,7 +81,9 @@ def enableMinifyInReleaseBuilds = (findProperty('android.enableMinifyInReleaseBu
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
-apply from: new File(["node", "--print", "require('path').dirname(require.resolve('@sentry/react-native/package.json'))"].execute().text.trim(), "sentry.gradle")
+if (System.getenv("SENTRY_AUTH_TOKEN") != null) {
+    apply from: new File(["node", "--print", "require('path').dirname(require.resolve('@sentry/react-native/package.json'))"].execute().text.trim(), "sentry.gradle")
+}
 
 android {
     ndkVersion rootProject.ext.ndkVersion

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -1,5 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+def javaVersion = JavaVersion.current()
+if (javaVersion > JavaVersion.VERSION_21) {
+  def hint = "AGP's CMake integration misinterprets JDK 22+ restricted-method " +
+    "warnings as build errors. Set JAVA_HOME to JDK 17 or 21 before building."
+  if (org.apache.tools.ant.taskdefs.condition.Os.isFamily(org.apache.tools.ant.taskdefs.condition.Os.FAMILY_MAC)) {
+    hint += "\n  Example: export JAVA_HOME=\$(/usr/libexec/java_home -v 17)"
+  }
+  throw new GradleException("JDK ${javaVersion} is not supported. ${hint}")
+}
+
 buildscript {
   repositories {
     google()


### PR DESCRIPTION
## Summary

Fixes #434 — Android release build fails with two errors:

- **CMake restricted-method error**: JDK 22+ emits native-access warnings that AGP's `GeneratePrefabPackages` misinterprets as build errors. Added a JDK version guard in `build.gradle` that fails fast with a clear message and macOS `java_home` hint when JDK > 21 is detected.
- **Sentry CLI upload failure**: `sentry.gradle` unconditionally runs `sentry-cli` source map upload on release builds, failing when `SENTRY_AUTH_TOKEN` isn't set. Wrapped the `apply from: sentry.gradle` in a conditional so it only runs when the token is available.

## Test plan

- [x] `./gradlew assembleDebug` passes with JDK 17
- [x] JDK 25 build fails with clear error message pointing to the fix
- [x] Release builds without `SENTRY_AUTH_TOKEN` skip source map upload instead of failing
- [ ] CI `android-build-check` and `android-bundle-check` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)