### PR TITLE
fix(lobby): equalize game tile heights in grid

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -218,6 +218,8 @@ const styles = StyleSheet.create({
   cardTitle: {
     fontFamily: typography.heading,
     fontSize: 14,
+    lineHeight: 18,
+    height: 18,
     letterSpacing: -0.3,
     paddingHorizontal: 8,
     textAlign: "center",
@@ -226,6 +228,7 @@ const styles = StyleSheet.create({
     fontFamily: typography.body,
     fontSize: 10,
     lineHeight: 14,
+    height: 28,
     textAlign: "center",
     paddingHorizontal: 12,
   },


### PR DESCRIPTION
## Summary

Fixes #431 — Game tiles in the lobby 2x2 grid rendered at inconsistent heights when descriptions wrapped differently across games and locales.

- Reserve exactly 1 line (`height: 18`, `lineHeight: 18`) on `cardTitle`
- Reserve exactly 2 lines (`height: 28`, `lineHeight: 14`) on `cardDesc`
- Every content zone is now fixed-height, so all tiles match regardless of text wrapping

## Test plan

- [x] Verified tiles render at equal height at default viewport width
- [x] Lint and type check pass (no new errors)
- [ ] Manual QA: verify at 320, 375, 414, 768, 1024, 1440px viewports
- [ ] Manual QA: verify single-column mode (<360px) still works
- [ ] Manual QA: verify with longest-description locale (`de` or `ru`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)