### PR TITLE
feat(ci): Android release smoke test + Sentry auth + dep gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,8 +293,100 @@ jobs:
       working-directory: frontend
     secrets: inherit
 
-  # --- Phase 8: Gradle wrapper validation -----------------------------------
+  # --- Phase 8: Android release smoke test (Linux, path-filtered) ------------
+  # The debug build check cannot catch release-only failures (Sentry upload,
+  # release CMake config, ProGuard). This runs assembleRelease for a single ABI
+  # only when Android-relevant files change.
+
+  android-release-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Android-relevant changes
+        id: changes
+        run: |
+          CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD)
+          if echo "$CHANGED" | grep -qE 'frontend/android/|frontend/package\.json|frontend/package-lock\.json'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Android-relevant file changes — skipping release smoke test"
+          fi
+
+      - uses: actions/setup-java@v4
+        if: steps.changes.outputs.should_run == 'true'
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - uses: actions/setup-node@v6
+        if: steps.changes.outputs.should_run == 'true'
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install JS dependencies
+        if: steps.changes.outputs.should_run == 'true'
+        run: npm ci
+
+      - name: Release build smoke test (arm64-v8a only)
+        if: steps.changes.outputs.should_run == 'true'
+        run: |
+          cd android
+          ./gradlew assembleRelease \
+            -PreactNativeArchitectures=arm64-v8a \
+            --no-daemon
+        env:
+          # Sentry upload is conditional on this token; omit to skip upload
+          # while still validating the rest of the release build chain
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  # --- Phase 9: Sentry CLI auth validation (Linux, fast) --------------------
+  # Catches expired or misconfigured Sentry auth tokens before they break
+  # release builds. Runs only when Sentry config or the token may be affected.
+
+  sentry-cli-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Sentry CLI auth
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "::warning::SENTRY_AUTH_TOKEN secret is not set — release builds will skip source map upload"
+            exit 0
+          fi
+          npx sentry-cli info
+          echo "Sentry CLI authenticated successfully"
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: buffing-chi
+          SENTRY_PROJECT: react-native
+
+  # --- Phase 10: Gradle wrapper + dependency version gate -------------------
   # Validates the Gradle wrapper JAR checksum to prevent supply-chain attacks.
+  # Also flags dependency version changes that warrant a full release build test.
 
   gradle-wrapper-check:
     if: github.event_name == 'pull_request'
@@ -310,5 +402,11 @@ jobs:
           CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}"...HEAD)
           if echo "$CHANGED_FILES" | grep -qE 'frontend/android/(app/)?build\.gradle|frontend/android/settings\.gradle'; then
             echo "::notice::Android Gradle build files changed — ensure gradle.properties settings (SDK versions, Hermes, architectures) are still correct."
+          fi
+          if echo "$CHANGED_FILES" | grep -qE 'frontend/android/gradle\.properties|frontend/android/gradle/wrapper/gradle-wrapper\.properties'; then
+            echo "::warning::Gradle or wrapper version changed — verify android-release-smoke passes before merging."
+          fi
+          if echo "$CHANGED_FILES" | grep -qE 'frontend/package\.json'; then
+            echo "::notice::package.json changed — native module versions may have shifted. Check android-release-smoke and android-build-check results."
           fi
           echo "Gradle wrapper validation passed"

--- a/docs/ANDROID-CI.md
+++ b/docs/ANDROID-CI.md
@@ -53,19 +53,42 @@ The `android-build-check` CI job compiles Debug mode via `./gradlew assembleDebu
 Debug builds skip JS bundling (Metro dev server is expected), so it only validates
 native compilation. The bundle check covers JS.
 
+## Release build smoke test (GitHub Actions)
+
+The `android-release-smoke` CI job runs `./gradlew assembleRelease` for a single
+ABI (arm64-v8a) on PRs that change Android-relevant files (`frontend/android/`,
+`frontend/package.json`, `frontend/package-lock.json`). This catches release-only
+failures that the debug build cannot detect:
+
+- Sentry source map upload issues (only runs on release builds)
+- Release CMake configuration errors (e.g. JDK compatibility)
+- ProGuard/R8 shrinking issues
+
+The job uses JDK 17 (Zulu) to avoid JDK 22+ restricted-method warnings that AGP
+misinterprets as build errors.
+
+## Sentry CLI auth validation (GitHub Actions)
+
+The `sentry-cli-check` CI job validates the `SENTRY_AUTH_TOKEN` secret by running
+`npx sentry-cli info`. This catches expired or misconfigured tokens before they
+break release builds. If the token is not set, the job warns but does not fail.
+
 ## Gradle wrapper security
 
 The `gradle-wrapper-check` CI job validates the Gradle wrapper JAR checksum to
 prevent supply-chain attacks. Never replace `gradlew` or `gradle-wrapper.jar`
 manually — use `gradle wrapper --gradle-version=X.Y.Z` to upgrade.
 
+The job also flags changes to `gradle.properties`, `gradle-wrapper.properties`,
+and `package.json` with warnings to verify release build compatibility.
+
 ## Sentry integration
 
-`@sentry/react-native` applies `sentry.gradle` in `app/build.gradle`. The plugin
-uploads source maps during release builds. It reads `sentry.properties` for the
-CLI path and falls back to `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN`
-env vars. CI builds should set `SENTRY_ALLOW_FAILURE=true` to prevent upload
-failures from blocking the build.
+`@sentry/react-native` applies `sentry.gradle` in `app/build.gradle` conditionally
+— only when `SENTRY_AUTH_TOKEN` is set. This means local builds and CI builds
+without the token skip source map upload instead of failing. The plugin reads
+`sentry.properties` for the CLI path and falls back to `SENTRY_ORG`,
+`SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` env vars.
 
 ## Key differences from iOS CI
 


### PR DESCRIPTION
## Summary

Closes #435 — CI did not catch the CMake and Sentry upload failures that broke Build 45. Adds three new guardrails:

### 1. `android-release-smoke` (path-filtered)
- Runs `./gradlew assembleRelease -PreactNativeArchitectures=arm64-v8a` on PRs touching `frontend/android/`, `package.json`, or `package-lock.json`
- Uses JDK 17 (Zulu) to avoid the AGP + JDK 22+ restricted-method incompatibility
- Catches release-only failures: Sentry upload, release CMake config, ProGuard/R8
- Single ABI keeps build time reasonable (~5 min vs ~15 min for all 4)

### 2. `sentry-cli-check`
- Validates `SENTRY_AUTH_TOKEN` by running `npx sentry-cli info`
- Warns (does not fail) if the token is unset — catches expired tokens early

### 3. Enhanced `gradle-wrapper-check`
- Now flags changes to `gradle.properties` and `gradle-wrapper.properties` with warnings
- Flags `package.json` changes that may shift native module versions
- Existing wrapper JAR validation unchanged

### Docs
- Updated `docs/ANDROID-CI.md` to document all three new CI jobs and the conditional Sentry upload behavior from PR #437

## Test plan

- [ ] CI runs successfully on this PR (the new jobs should execute since we changed `ci.yml`)
- [ ] `android-release-smoke` skips when no Android files changed (verify via `::notice::` in logs)
- [ ] `sentry-cli-check` warns or passes depending on token availability
- [ ] `gradle-wrapper-check` emits notices for relevant file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)