### PR TITLE
fix(cascade): initialize lastDropTimeRef to Date.now() to prevent epo…

### DIFF
--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -34,7 +34,7 @@ function CascadeGame() {
   const canvasRef = useRef<GameCanvasHandle>(null);
   const queueRef = useRef(new FruitQueue());
   const droppingRef = useRef(false);
-  const lastDropTimeRef = useRef<number>(0);
+  const lastDropTimeRef = useRef<number>(Date.now());
   const dropCountRef = useRef<number>(0);
   const prevFruitSetId = useRef(activeFruitSet.id);
 


### PR DESCRIPTION
…ch-sized intervalMs on first drop

Fixes #442 — lastDropTimeRef was initialized to 0, causing the first drop's interval calculation (Date.now() - 0) to equal the full Unix epoch (~1.776T ms), which placed the fruit far outside play area bounds and triggered the "fruit escaped boundary" crash.

## Summary

## <!-- What does this PR do? Focus on the why, not the how. -->

## Type of change

- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done

<!-- What did you run? Any coverage delta? -->

- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist

- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist _(web / frontend PRs only)_

- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom

## Mobile checklist _(iOS / Android PRs only)_

- [ ] Tested on iOS Simulator or physical device
- [ ] `ios-build-check` / `android-build-check` CI job passes
- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)
