### PR TITLE
fix(yacht): prevent Fabric forEach-null crash in Die transform (#444)

### DIFF
--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -70,7 +70,7 @@ export default function Die({ value, held, onPress, disabled, index }: DieProps)
           backgroundColor: held ? colors.heldBg : colors.dieBg,
           borderColor: held ? colors.heldBorder : colors.dieBorder,
           borderWidth: held ? 2 : 1,
-          transform: pressed && !disabled ? [{ scale: 0.95 }] : undefined,
+          transform: [{ scale: pressed && !disabled ? 0.95 : 1 }],
         },
         glowStyle,
         disabled && styles.disabled,


### PR DESCRIPTION
## Summary

- Always emit a `transform` array in `Die.tsx` instead of toggling between `[{scale: 0.95}]` and `undefined`.
- Fixes #444 — React Fabric crash `TypeError: Cannot read property 'forEach' of null` in `_validateTransforms`.

The previous code fed `undefined` to Fabric on press release; the renderer's diff path coerced it to `null` and then called `processTransform(null)`. Keeping `transform` as an always-present array sidesteps the diff foot-gun.

## Test plan

- [ ] iOS Simulator dev build: open Yacht, tap and release dice — no crash, scale animation still works.
- [ ] Android dev build: same flow.
- [ ] Web: verify Pressable press state still visually scales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)