### PR TITLE
feat(blackjack): show both split hands side-by-side (#446)

### DIFF
--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -41,7 +41,7 @@ export default function BlackjackTable({
         concealed={isPlayerPhase}
         variant="dealer"
       />
-      <View style={styles.divider} />
+      <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
       {isSplit ? (
         <View style={styles.handsRow}>
@@ -112,7 +112,7 @@ const styles = StyleSheet.create({
   divider: {
     width: "60%",
     height: 1,
-    backgroundColor: "rgba(128,128,128,0.2)",
+    opacity: 0.4,
   },
   handsRow: {
     flexDirection: "row",

--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -66,7 +66,7 @@ export default function BlackjackTable({
                   },
                 ]}
               >
-                <HandDisplay hand={hand} label={label} variant="player" />
+                <HandDisplay hand={hand} label={label} variant="player" compact />
                 {bet != null && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
                 )}
@@ -116,13 +116,15 @@ const styles = StyleSheet.create({
   },
   handsRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
     justifyContent: "center",
-    gap: 16,
+    alignItems: "flex-start",
+    width: "100%",
+    gap: 8,
   },
   splitHand: {
+    flex: 1,
     alignItems: "center",
-    padding: 8,
+    padding: 6,
     borderRadius: 10,
     borderWidth: 1,
     borderColor: "transparent",

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -12,12 +12,20 @@ interface Props {
   /** "player" renders larger cards with fan rotation and neon score pill;
    *  "dealer" renders compact cards and glass badge score. */
   variant?: "player" | "dealer";
+  /** Shrink player-variant cards for split-hand side-by-side layout. */
+  compact?: boolean;
 }
 
 // First two player cards get a gentle fan tilt
 const PLAYER_ROTATIONS: Record<number, number> = { 0: -3, 1: 2 };
 
-export default function HandDisplay({ hand, label, concealed = false, variant = "dealer" }: Props) {
+export default function HandDisplay({
+  hand,
+  label,
+  concealed = false,
+  variant = "dealer",
+  compact = false,
+}: Props) {
   const { colors } = useTheme();
   const showScore = hand.cards.length > 0;
 
@@ -25,20 +33,21 @@ export default function HandDisplay({ hand, label, concealed = false, variant = 
     <View style={styles.container}>
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
 
-      {showScore && (
-        <ScorePill value={hand.value} soft={hand.soft} concealed={concealed} variant={variant} />
-      )}
-
       <View style={styles.cards}>
         {hand.cards.map((card, i) => (
           <PlayingCard
             key={i}
             card={card}
             variant={variant}
+            compact={compact}
             rotation={variant === "player" ? (PLAYER_ROTATIONS[i] ?? 0) : 0}
           />
         ))}
       </View>
+
+      {showScore && (
+        <ScorePill value={hand.value} soft={hand.soft} concealed={concealed} variant={variant} />
+      )}
     </View>
   );
 }

--- a/frontend/src/components/blackjack/PlayingCard.tsx
+++ b/frontend/src/components/blackjack/PlayingCard.tsx
@@ -10,6 +10,8 @@ interface Props {
   rotation?: number;
   /** "player" renders a larger card; "dealer" renders the compact default. */
   variant?: "player" | "dealer";
+  /** Shrink the player variant so two split hands fit side-by-side. */
+  compact?: boolean;
 }
 
 const RED_SUITS = new Set(["♥", "♦"]);
@@ -24,13 +26,31 @@ function suitKey(suit: string): string {
   return map[suit] ?? suit;
 }
 
-export default function PlayingCard({ card, rotation = 0, variant = "dealer" }: Props) {
+export default function PlayingCard({
+  card,
+  rotation = 0,
+  variant = "dealer",
+  compact = false,
+}: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
 
-  const cardSizeStyle = variant === "player" ? styles.cardPlayer : styles.cardDealer;
-  const rankSizeStyle = variant === "player" ? styles.rankPlayer : styles.rankDealer;
-  const suitSizeStyle = variant === "player" ? styles.suitPlayer : styles.suitDealer;
+  const isCompactPlayer = variant === "player" && compact;
+  const cardSizeStyle = isCompactPlayer
+    ? styles.cardPlayerCompact
+    : variant === "player"
+      ? styles.cardPlayer
+      : styles.cardDealer;
+  const rankSizeStyle = isCompactPlayer
+    ? styles.rankPlayerCompact
+    : variant === "player"
+      ? styles.rankPlayer
+      : styles.rankDealer;
+  const suitSizeStyle = isCompactPlayer
+    ? styles.suitPlayerCompact
+    : variant === "player"
+      ? styles.suitPlayer
+      : styles.suitDealer;
   const rotateStyle = rotation !== 0 ? { transform: [{ rotate: `${rotation}deg` }] } : undefined;
 
   if (card.face_down) {
@@ -91,6 +111,11 @@ const styles = StyleSheet.create({
     width: 68,
     height: 96,
   },
+  cardPlayerCompact: {
+    width: 48,
+    height: 68,
+    margin: 2,
+  },
   cardBackInner: {
     width: "70%",
     height: "70%",
@@ -113,6 +138,11 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     lineHeight: 24,
   },
+  rankPlayerCompact: {
+    fontSize: 15,
+    fontWeight: "700",
+    lineHeight: 18,
+  },
   suitDealer: {
     fontSize: 18,
     lineHeight: 22,
@@ -120,5 +150,9 @@ const styles = StyleSheet.create({
   suitPlayer: {
     fontSize: 22,
     lineHeight: 26,
+  },
+  suitPlayerCompact: {
+    fontSize: 16,
+    lineHeight: 20,
   },
 });

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -47,6 +47,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   }
 
   const state = engine ? toViewState(engine) : null;
+  const isSplit = (state?.player_hands?.length ?? 0) > 1;
 
   const handleHit = () => apply(engineHit);
   const handleStand = () => apply(engineStand);
@@ -114,8 +115,8 @@ export default function BlackjackTableScreen({ navigation }: Props) {
             />
           </View>
 
-          {/* Right spacer to balance the sidebar */}
-          <View style={styles.sidebarRight} />
+          {/* Right spacer to balance the sidebar — collapsed on split so both hands fit */}
+          {!isSplit && <View style={styles.sidebarRight} />}
         </View>
       )}
 


### PR DESCRIPTION
## Summary

- Add compact (48x68) variant to `PlayingCard` for use in split layouts.
- `BlackjackTable.handsRow` is now a non-wrapping row with `flex: 1` children; each split hand passes `compact`.
- `HandDisplay` renders cards before the ScorePill so any residual clipping still shows the cards first.
- `BlackjackTableScreen` collapses the 88px right spacer on split, giving the table the extra width for two hands side-by-side.
- Also migrates the pre-existing `rgba(128,128,128,0.2)` divider color to `colors.border` from `useTheme()` (design-tokens policy cleanup).

Closes #446.

## Test plan

- [x] `npx jest src/components/blackjack src/screens/__tests__/BlackjackTableScreen` — 57/57 passing.
- [ ] iOS Simulator: play to a split (pair of 9s), confirm both hands' cards visible simultaneously.
- [ ] iPhone SE width: still fits.
- [ ] Non-split hand: unchanged visually.
- [ ] Dealer row + action buttons: unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)