### PR TITLE
feat(games): shared New Game button + confirm modal on all games (#455)

### DIFF
--- a/e2e/tests/twenty48-full-game.spec.ts
+++ b/e2e/tests/twenty48-full-game.spec.ts
@@ -131,6 +131,9 @@ test.describe("2048 — full happy-path game journey", () => {
     await page.getByLabel("Game board").waitFor();
 
     await page.getByRole("button", { name: "Start a new 2048 game" }).click();
+    // Mid-game now shows a confirmation modal — click through.
+    await expect(page.getByText("Start new game?")).toBeVisible();
+    await page.getByRole("button", { name: "Start new game" }).click();
 
     await expect(page.locator('[aria-label="Current score: 0"]')).toBeVisible({
       timeout: 3000,

--- a/frontend/src/components/shared/NewGameConfirmModal.tsx
+++ b/frontend/src/components/shared/NewGameConfirmModal.tsx
@@ -7,10 +7,14 @@ interface Props {
   visible: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  /** Override the default "Start new game?" title. */
+  title?: string;
+  /** Override the default body copy about losing progress. */
+  body?: string;
 }
 
-export default function NewGameConfirmModal({ visible, onConfirm, onCancel }: Props) {
-  const { t } = useTranslation("yacht");
+export default function NewGameConfirmModal({ visible, onConfirm, onCancel, title, body }: Props) {
+  const { t } = useTranslation("common");
   const { colors } = useTheme();
 
   const confirmBg: ViewStyle =
@@ -29,7 +33,7 @@ export default function NewGameConfirmModal({ visible, onConfirm, onCancel }: Pr
       accessibilityViewIsModal
       onRequestClose={onCancel}
     >
-      <View style={[styles.overlay, { backgroundColor: "rgba(0,0,0,0.75)" }]}>
+      <View style={[styles.overlay, styles.overlayBg]}>
         <View
           style={[
             styles.card,
@@ -41,10 +45,10 @@ export default function NewGameConfirmModal({ visible, onConfirm, onCancel }: Pr
           ]}
         >
           <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
-            {t("newGame.confirm.title")}
+            {title ?? t("newGame.confirm.title")}
           </Text>
           <Text style={[styles.body, { color: colors.textMuted }]}>
-            {t("newGame.confirm.body")}
+            {body ?? t("newGame.confirm.body")}
           </Text>
           <Pressable
             style={({ pressed }) => [
@@ -81,6 +85,9 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+  },
+  overlayBg: {
+    backgroundColor: "#000000bf",
   },
   card: {
     borderRadius: 20,

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "الردهة",
   "nav.ranks": "الترتيب",
   "nav.profile": "الملف",
-  "nav.settings": "الإعدادات"
+  "nav.settings": "الإعدادات",
+  "newGame.button": "لعبة جديدة",
+  "newGame.confirm.title": "بدء لعبة جديدة؟",
+  "newGame.confirm.body": "ستفقد لعبتك الحالية. ستتم إعادة تعيين النتيجة والجولة.",
+  "newGame.confirm.confirm": "بدء لعبة جديدة",
+  "newGame.confirm.cancel": "إلغاء"
 }

--- a/frontend/src/i18n/locales/ar/yacht.json
+++ b/frontend/src/i18n/locales/ar/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "العب مجددًا",
   "gameOver.playAgainLabel": "ابدأ لعبة جديدة",
   "gameOver.dismiss": "لا شكرًا",
-  "gameOver.dismissLabel": "إغلاق وإبقاء النتيجة الحالية ظاهرة",
-  "newGame.button": "لعبة جديدة",
-  "newGame.confirm.title": "بدء لعبة جديدة؟",
-  "newGame.confirm.body": "ستفقد لعبتك الحالية. ستتم إعادة تعيين النتيجة والجولة.",
-  "newGame.confirm.confirm": "بدء لعبة جديدة",
-  "newGame.confirm.cancel": "إلغاء"
+  "gameOver.dismissLabel": "إغلاق وإبقاء النتيجة الحالية ظاهرة"
 }

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Lobby",
   "nav.ranks": "Rangliste",
   "nav.profile": "Profil",
-  "nav.settings": "Einstellungen"
+  "nav.settings": "Einstellungen",
+  "newGame.button": "Neues Spiel",
+  "newGame.confirm.title": "Neues Spiel starten?",
+  "newGame.confirm.body": "Das aktuelle Spiel geht verloren. Punkte und Runde werden zurückgesetzt.",
+  "newGame.confirm.confirm": "Neues Spiel starten",
+  "newGame.confirm.cancel": "Abbrechen"
 }

--- a/frontend/src/i18n/locales/de/yacht.json
+++ b/frontend/src/i18n/locales/de/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Nochmal",
   "gameOver.playAgainLabel": "Ein neues Spiel starten",
   "gameOver.dismiss": "Nein danke",
-  "gameOver.dismissLabel": "Schließen und aktuelle Punktzahl sichtbar lassen",
-  "newGame.button": "Neues Spiel",
-  "newGame.confirm.title": "Neues Spiel starten?",
-  "newGame.confirm.body": "Das aktuelle Spiel geht verloren. Punkte und Runde werden zurückgesetzt.",
-  "newGame.confirm.confirm": "Neues Spiel starten",
-  "newGame.confirm.cancel": "Abbrechen"
+  "gameOver.dismissLabel": "Schließen und aktuelle Punktzahl sichtbar lassen"
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Lobby",
   "nav.ranks": "Ranks",
   "nav.profile": "Profile",
-  "nav.settings": "Settings"
+  "nav.settings": "Settings",
+  "newGame.button": "New Game",
+  "newGame.confirm.title": "Start new game?",
+  "newGame.confirm.body": "Your current game will be lost. Score and round will reset.",
+  "newGame.confirm.confirm": "Start new game",
+  "newGame.confirm.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/en/yacht.json
+++ b/frontend/src/i18n/locales/en/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Play Again",
   "gameOver.playAgainLabel": "Start a new game",
   "gameOver.dismiss": "No Thanks",
-  "gameOver.dismissLabel": "Dismiss and keep current score visible",
-  "newGame.button": "New Game",
-  "newGame.confirm.title": "Start new game?",
-  "newGame.confirm.body": "Your current game will be lost. Score and round will reset.",
-  "newGame.confirm.confirm": "Start new game",
-  "newGame.confirm.cancel": "Cancel"
+  "gameOver.dismissLabel": "Dismiss and keep current score visible"
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Lobby",
   "nav.ranks": "Rangos",
   "nav.profile": "Perfil",
-  "nav.settings": "Ajustes"
+  "nav.settings": "Ajustes",
+  "newGame.button": "Nueva partida",
+  "newGame.confirm.title": "¿Empezar nueva partida?",
+  "newGame.confirm.body": "Perderás la partida actual. La puntuación y la ronda se reiniciarán.",
+  "newGame.confirm.confirm": "Empezar nueva partida",
+  "newGame.confirm.cancel": "Cancelar"
 }

--- a/frontend/src/i18n/locales/es/yacht.json
+++ b/frontend/src/i18n/locales/es/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Jugar de nuevo",
   "gameOver.playAgainLabel": "Iniciar un juego nuevo",
   "gameOver.dismiss": "No, gracias",
-  "gameOver.dismissLabel": "Cerrar y mantener la puntuación actual visible",
-  "newGame.button": "Nueva partida",
-  "newGame.confirm.title": "¿Empezar nueva partida?",
-  "newGame.confirm.body": "Perderás la partida actual. La puntuación y la ronda se reiniciarán.",
-  "newGame.confirm.confirm": "Empezar nueva partida",
-  "newGame.confirm.cancel": "Cancelar"
+  "gameOver.dismissLabel": "Cerrar y mantener la puntuación actual visible"
 }

--- a/frontend/src/i18n/locales/fr-CA/common.json
+++ b/frontend/src/i18n/locales/fr-CA/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Accueil",
   "nav.ranks": "Classement",
   "nav.profile": "Profil",
-  "nav.settings": "Paramètres"
+  "nav.settings": "Paramètres",
+  "newGame.button": "Nouvelle partie",
+  "newGame.confirm.title": "Commencer une nouvelle partie?",
+  "newGame.confirm.body": "Votre partie en cours sera perdue. Le score et la manche seront réinitialisés.",
+  "newGame.confirm.confirm": "Commencer une nouvelle partie",
+  "newGame.confirm.cancel": "Annuler"
 }

--- a/frontend/src/i18n/locales/fr-CA/yacht.json
+++ b/frontend/src/i18n/locales/fr-CA/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Rejouer",
   "gameOver.playAgainLabel": "Commencer une nouvelle partie",
   "gameOver.dismiss": "Non merci",
-  "gameOver.dismissLabel": "Fermer et garder le score actuel visible",
-  "newGame.button": "Nouvelle partie",
-  "newGame.confirm.title": "Commencer une nouvelle partie?",
-  "newGame.confirm.body": "Votre partie en cours sera perdue. Le score et la manche seront réinitialisés.",
-  "newGame.confirm.confirm": "Commencer une nouvelle partie",
-  "newGame.confirm.cancel": "Annuler"
+  "gameOver.dismissLabel": "Fermer et garder le score actuel visible"
 }

--- a/frontend/src/i18n/locales/he/common.json
+++ b/frontend/src/i18n/locales/he/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "לובי",
   "nav.ranks": "דירוג",
   "nav.profile": "פרופיל",
-  "nav.settings": "הגדרות"
+  "nav.settings": "הגדרות",
+  "newGame.button": "משחק חדש",
+  "newGame.confirm.title": "להתחיל משחק חדש?",
+  "newGame.confirm.body": "המשחק הנוכחי יאבד. הניקוד והסיבוב יאופסו.",
+  "newGame.confirm.confirm": "התחל משחק חדש",
+  "newGame.confirm.cancel": "ביטול"
 }

--- a/frontend/src/i18n/locales/he/yacht.json
+++ b/frontend/src/i18n/locales/he/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "שחק שוב",
   "gameOver.playAgainLabel": "התחל משחק חדש",
   "gameOver.dismiss": "לא תודה",
-  "gameOver.dismissLabel": "סגור והשאר את הניקוד הנוכחי גלוי",
-  "newGame.button": "משחק חדש",
-  "newGame.confirm.title": "להתחיל משחק חדש?",
-  "newGame.confirm.body": "המשחק הנוכחי יאבד. הניקוד והסיבוב יאופסו.",
-  "newGame.confirm.confirm": "התחל משחק חדש",
-  "newGame.confirm.cancel": "ביטול"
+  "gameOver.dismissLabel": "סגור והשאר את הניקוד הנוכחי גלוי"
 }

--- a/frontend/src/i18n/locales/hi/common.json
+++ b/frontend/src/i18n/locales/hi/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "लॉबी",
   "nav.ranks": "रैंक",
   "nav.profile": "प्रोफ़ाइल",
-  "nav.settings": "सेटिंग्स"
+  "nav.settings": "सेटिंग्स",
+  "newGame.button": "नया गेम",
+  "newGame.confirm.title": "नया गेम शुरू करें?",
+  "newGame.confirm.body": "आपका वर्तमान गेम खो जाएगा। स्कोर और राउंड रीसेट हो जाएंगे।",
+  "newGame.confirm.confirm": "नया गेम शुरू करें",
+  "newGame.confirm.cancel": "रद्द करें"
 }

--- a/frontend/src/i18n/locales/hi/yacht.json
+++ b/frontend/src/i18n/locales/hi/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "फिर से खेलें",
   "gameOver.playAgainLabel": "नया खेल शुरू करें",
   "gameOver.dismiss": "नहीं धन्यवाद",
-  "gameOver.dismissLabel": "बंद करें और वर्तमान स्कोर दिखाए रखें",
-  "newGame.button": "नया गेम",
-  "newGame.confirm.title": "नया गेम शुरू करें?",
-  "newGame.confirm.body": "आपका वर्तमान गेम खो जाएगा। स्कोर और राउंड रीसेट हो जाएंगे।",
-  "newGame.confirm.confirm": "नया गेम शुरू करें",
-  "newGame.confirm.cancel": "रद्द करें"
+  "gameOver.dismissLabel": "बंद करें और वर्तमान स्कोर दिखाए रखें"
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "ロビー",
   "nav.ranks": "ランキング",
   "nav.profile": "プロフィール",
-  "nav.settings": "設定"
+  "nav.settings": "設定",
+  "newGame.button": "新しいゲーム",
+  "newGame.confirm.title": "新しいゲームを開始しますか?",
+  "newGame.confirm.body": "現在のゲームは失われます。スコアとラウンドがリセットされます。",
+  "newGame.confirm.confirm": "新しいゲームを開始",
+  "newGame.confirm.cancel": "キャンセル"
 }

--- a/frontend/src/i18n/locales/ja/yacht.json
+++ b/frontend/src/i18n/locales/ja/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "もう一度",
   "gameOver.playAgainLabel": "新しいゲームを始める",
   "gameOver.dismiss": "いいえ",
-  "gameOver.dismissLabel": "閉じて現在のスコアを表示したままにする",
-  "newGame.button": "新しいゲーム",
-  "newGame.confirm.title": "新しいゲームを開始しますか?",
-  "newGame.confirm.body": "現在のゲームは失われます。スコアとラウンドがリセットされます。",
-  "newGame.confirm.confirm": "新しいゲームを開始",
-  "newGame.confirm.cancel": "キャンセル"
+  "gameOver.dismissLabel": "閉じて現在のスコアを表示したままにする"
 }

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "로비",
   "nav.ranks": "순위",
   "nav.profile": "프로필",
-  "nav.settings": "설정"
+  "nav.settings": "설정",
+  "newGame.button": "새 게임",
+  "newGame.confirm.title": "새 게임을 시작할까요?",
+  "newGame.confirm.body": "현재 게임이 사라집니다. 점수와 라운드가 초기화됩니다.",
+  "newGame.confirm.confirm": "새 게임 시작",
+  "newGame.confirm.cancel": "취소"
 }

--- a/frontend/src/i18n/locales/ko/yacht.json
+++ b/frontend/src/i18n/locales/ko/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "다시 하기",
   "gameOver.playAgainLabel": "새 게임 시작",
   "gameOver.dismiss": "괜찮습니다",
-  "gameOver.dismissLabel": "닫고 현재 점수를 계속 표시",
-  "newGame.button": "새 게임",
-  "newGame.confirm.title": "새 게임을 시작할까요?",
-  "newGame.confirm.body": "현재 게임이 사라집니다. 점수와 라운드가 초기화됩니다.",
-  "newGame.confirm.confirm": "새 게임 시작",
-  "newGame.confirm.cancel": "취소"
+  "gameOver.dismissLabel": "닫고 현재 점수를 계속 표시"
 }

--- a/frontend/src/i18n/locales/nl/common.json
+++ b/frontend/src/i18n/locales/nl/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Lobby",
   "nav.ranks": "Ranglijst",
   "nav.profile": "Profiel",
-  "nav.settings": "Instellingen"
+  "nav.settings": "Instellingen",
+  "newGame.button": "Nieuw spel",
+  "newGame.confirm.title": "Nieuw spel starten?",
+  "newGame.confirm.body": "Je huidige spel gaat verloren. Score en ronde worden gereset.",
+  "newGame.confirm.confirm": "Nieuw spel starten",
+  "newGame.confirm.cancel": "Annuleren"
 }

--- a/frontend/src/i18n/locales/nl/yacht.json
+++ b/frontend/src/i18n/locales/nl/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Opnieuw",
   "gameOver.playAgainLabel": "Een nieuw spel starten",
   "gameOver.dismiss": "Nee bedankt",
-  "gameOver.dismissLabel": "Sluiten en huidige score zichtbaar houden",
-  "newGame.button": "Nieuw spel",
-  "newGame.confirm.title": "Nieuw spel starten?",
-  "newGame.confirm.body": "Je huidige spel gaat verloren. Score en ronde worden gereset.",
-  "newGame.confirm.confirm": "Nieuw spel starten",
-  "newGame.confirm.cancel": "Annuleren"
+  "gameOver.dismissLabel": "Sluiten en huidige score zichtbaar houden"
 }

--- a/frontend/src/i18n/locales/pt/common.json
+++ b/frontend/src/i18n/locales/pt/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Saguão",
   "nav.ranks": "Classificação",
   "nav.profile": "Perfil",
-  "nav.settings": "Configurações"
+  "nav.settings": "Configurações",
+  "newGame.button": "Novo jogo",
+  "newGame.confirm.title": "Iniciar novo jogo?",
+  "newGame.confirm.body": "O jogo atual será perdido. A pontuação e a rodada serão redefinidas.",
+  "newGame.confirm.confirm": "Iniciar novo jogo",
+  "newGame.confirm.cancel": "Cancelar"
 }

--- a/frontend/src/i18n/locales/pt/yacht.json
+++ b/frontend/src/i18n/locales/pt/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Jogar de Novo",
   "gameOver.playAgainLabel": "Iniciar um novo jogo",
   "gameOver.dismiss": "Não, obrigado",
-  "gameOver.dismissLabel": "Fechar e manter a pontuação atual visível",
-  "newGame.button": "Novo jogo",
-  "newGame.confirm.title": "Iniciar novo jogo?",
-  "newGame.confirm.body": "O jogo atual será perdido. A pontuação e a rodada serão redefinidas.",
-  "newGame.confirm.confirm": "Iniciar novo jogo",
-  "newGame.confirm.cancel": "Cancelar"
+  "gameOver.dismissLabel": "Fechar e manter a pontuação atual visível"
 }

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "Лобби",
   "nav.ranks": "Рейтинг",
   "nav.profile": "Профиль",
-  "nav.settings": "Настройки"
+  "nav.settings": "Настройки",
+  "newGame.button": "Новая игра",
+  "newGame.confirm.title": "Начать новую игру?",
+  "newGame.confirm.body": "Текущая игра будет потеряна. Счёт и раунд сбросятся.",
+  "newGame.confirm.confirm": "Начать новую игру",
+  "newGame.confirm.cancel": "Отмена"
 }

--- a/frontend/src/i18n/locales/ru/yacht.json
+++ b/frontend/src/i18n/locales/ru/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "Играть снова",
   "gameOver.playAgainLabel": "Начать новую игру",
   "gameOver.dismiss": "Нет, спасибо",
-  "gameOver.dismissLabel": "Закрыть и оставить текущий счёт видимым",
-  "newGame.button": "Новая игра",
-  "newGame.confirm.title": "Начать новую игру?",
-  "newGame.confirm.body": "Текущая игра будет потеряна. Счёт и раунд сбросятся.",
-  "newGame.confirm.confirm": "Начать новую игру",
-  "newGame.confirm.cancel": "Отмена"
+  "gameOver.dismissLabel": "Закрыть и оставить текущий счёт видимым"
 }

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -14,5 +14,10 @@
   "nav.lobby": "大厅",
   "nav.ranks": "排名",
   "nav.profile": "个人",
-  "nav.settings": "设置"
+  "nav.settings": "设置",
+  "newGame.button": "新游戏",
+  "newGame.confirm.title": "开始新游戏？",
+  "newGame.confirm.body": "当前游戏将丢失。得分和回合将重置。",
+  "newGame.confirm.confirm": "开始新游戏",
+  "newGame.confirm.cancel": "取消"
 }

--- a/frontend/src/i18n/locales/zh/yacht.json
+++ b/frontend/src/i18n/locales/zh/yacht.json
@@ -49,10 +49,5 @@
   "gameOver.playAgain": "再玩一次",
   "gameOver.playAgainLabel": "开始新游戏",
   "gameOver.dismiss": "不用了",
-  "gameOver.dismissLabel": "关闭并保持当前分数可见",
-  "newGame.button": "新游戏",
-  "newGame.confirm.title": "开始新游戏？",
-  "newGame.confirm.body": "当前游戏将丢失。得分和回合将重置。",
-  "newGame.confirm.confirm": "开始新游戏",
-  "newGame.confirm.cancel": "取消"
+  "gameOver.dismissLabel": "关闭并保持当前分数可见"
 }

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
@@ -19,6 +19,7 @@ import ActionButtons from "../components/blackjack/ActionButtons";
 import ResultBanner from "../components/blackjack/ResultBanner";
 import GameOverModal from "../components/blackjack/GameOverModal";
 import HudSidebar from "../components/blackjack/HudSidebar";
+import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
 type Props = {
@@ -30,6 +31,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const { engine, loading, error, apply, handlePlayAgain } = useBlackjackGame();
+  const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
 
   // Redirect to BettingScreen when Next Hand transitions phase back to betting.
   useEffect(() => {
@@ -37,6 +39,20 @@ export default function BlackjackTableScreen({ navigation }: Props) {
       navigation.replace("BlackjackBetting");
     }
   }, [loading, engine, navigation]);
+
+  const currentPhase = engine?.phase;
+  const handleNewGamePress = useCallback(() => {
+    if (currentPhase && currentPhase !== "betting") {
+      setConfirmNewGameVisible(true);
+    } else {
+      handlePlayAgain();
+    }
+  }, [currentPhase, handlePlayAgain]);
+
+  const handleConfirmNewGame = useCallback(() => {
+    setConfirmNewGameVisible(false);
+    handlePlayAgain();
+  }, [handlePlayAgain]);
 
   if (!engine && loading) {
     return (
@@ -94,6 +110,20 @@ export default function BlackjackTableScreen({ navigation }: Props) {
           {t(`blackjack:phase.${state.phase}` as Parameters<typeof t>[0])}
         </Text>
       )}
+
+      {/* New Game */}
+      <View style={styles.actionRow}>
+        <Pressable
+          onPress={handleNewGamePress}
+          style={[styles.newGameBtn, { borderColor: colors.accent }]}
+          accessibilityRole="button"
+          accessibilityLabel={t("common:newGame.button")}
+        >
+          <Text style={[styles.newGameText, { color: colors.accent }]}>
+            {t("common:newGame.button")}
+          </Text>
+        </Pressable>
+      </View>
 
       {/* Table + HUD sidebar */}
       {state && (
@@ -176,6 +206,12 @@ export default function BlackjackTableScreen({ navigation }: Props) {
           onHome={() => navigation.goBack()}
         />
       )}
+
+      <NewGameConfirmModal
+        visible={confirmNewGameVisible}
+        onConfirm={handleConfirmNewGame}
+        onCancel={() => setConfirmNewGameVisible(false)}
+      />
     </View>
   );
 }
@@ -197,6 +233,26 @@ const styles = StyleSheet.create({
     letterSpacing: 0.8,
     marginTop: 4,
     marginBottom: 4,
+  },
+  actionRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  newGameBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  newGameText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
   },
   tableRow: {
     flex: 1,

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { View, StyleSheet, LayoutChangeEvent } from "react-native";
+import { View, Text, Pressable, StyleSheet, LayoutChangeEvent } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -17,6 +17,7 @@ import NextFruitPreview from "../components/cascade/NextFruitPreview";
 import ScoreDisplay from "../components/cascade/ScoreDisplay";
 import ThemeSelector from "../components/cascade/ThemeSelector";
 import GameOverOverlay from "../components/cascade/GameOverOverlay";
+import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 
 function CascadeGame() {
   const { t } = useTranslation(["cascade", "common"]);
@@ -27,6 +28,7 @@ function CascadeGame() {
 
   const [score, setScore] = useState(0);
   const [gameOver, setGameOver] = useState(false);
+  const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
   const [, setQueueVersion] = useState(0);
@@ -180,6 +182,22 @@ function CascadeGame() {
     canvasRef.current?.reset();
   }
 
+  const handleNewGamePress = useCallback(() => {
+    if (scoreRef.current > 0 && !gameOverRef.current) {
+      setConfirmNewGameVisible(true);
+    } else {
+      handleRestart();
+    }
+    // handleRestart reads refs only, safe to exclude from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleConfirmNewGame = useCallback(() => {
+    setConfirmNewGameVisible(false);
+    handleRestart();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const queue = queueRef.current;
   const currentDef = activeFruitSet.fruits[queue.peek()];
   const nextDef = activeFruitSet.fruits[queue.peekNext()];
@@ -204,7 +222,22 @@ function CascadeGame() {
         },
       ]}
     >
-      <AppHeader title={t("game.title")} onBack={() => navigation.popToTop()} />
+      <AppHeader
+        title={t("game.title")}
+        onBack={() => navigation.popToTop()}
+        rightSlot={
+          <Pressable
+            onPress={handleNewGamePress}
+            style={[styles.newGameBtn, { borderColor: colors.accent }]}
+            accessibilityRole="button"
+            accessibilityLabel={t("common:newGame.button")}
+          >
+            <Text style={[styles.newGameText, { color: colors.accent }]}>
+              {t("common:newGame.button")}
+            </Text>
+          </Pressable>
+        }
+      />
 
       {/* Combined HUD: score + drop/next previews + high, all one row */}
       <ScoreDisplay score={score}>
@@ -237,6 +270,12 @@ function CascadeGame() {
       </View>
 
       {gameOver && <GameOverOverlay score={score} onRestart={handleRestart} />}
+
+      <NewGameConfirmModal
+        visible={confirmNewGameVisible}
+        onConfirm={handleConfirmNewGame}
+        onCancel={() => setConfirmNewGameVisible(false)}
+      />
     </View>
   );
 }
@@ -252,6 +291,20 @@ export default function CascadeScreen() {
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
+  },
+  newGameBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  newGameText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
   },
   canvasOuter: {
     flex: 1,

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -19,7 +19,7 @@ import * as Sentry from "@sentry/react-native";
 import DiceRow from "../components/DiceRow";
 import Scorecard from "../components/Scorecard";
 import GameOverModal from "../components/yacht/GameOverModal";
-import NewGameConfirmModal from "../components/yacht/NewGameConfirmModal";
+import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { useTheme } from "../theme/ThemeContext";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
@@ -148,9 +148,11 @@ export default function GameScreen({ navigation, route }: Props) {
           onPress={handleNewGamePress}
           style={[styles.newGameBtn, { borderColor: colors.accent }]}
           accessibilityRole="button"
-          accessibilityLabel={t("newGame.button")}
+          accessibilityLabel={t("common:newGame.button")}
         >
-          <Text style={[styles.newGameText, { color: colors.accent }]}>{t("newGame.button")}</Text>
+          <Text style={[styles.newGameText, { color: colors.accent }]}>
+            {t("common:newGame.button")}
+          </Text>
         </Pressable>
       </View>
 

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -20,6 +20,7 @@ import Grid from "../components/twenty48/Grid";
 import ScoreBoard from "../components/twenty48/ScoreBoard";
 import GameOverlay from "../components/twenty48/GameOverlay";
 import StatsBento from "../components/twenty48/StatsBento";
+import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 
 const SWIPE_THRESHOLD = 30;
 /** How long (ms) to hold the move lock — matches slide animation duration. */
@@ -38,6 +39,7 @@ export default function Twenty48Screen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [winDismissed, setWinDismissed] = useState(false);
   const [bestScore, setBestScore] = useState(0);
+  const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
 
   /** Blocks new moves while the slide animation plays. */
   const movingRef = useRef(false);
@@ -118,7 +120,7 @@ export default function Twenty48Screen({ navigation }: Props) {
     [state, executeMove]
   );
 
-  const handleNewGame = useCallback(() => {
+  const resetGame = useCallback(() => {
     movingRef.current = false;
     pendingMove.current = null;
     setWinDismissed(false);
@@ -126,6 +128,19 @@ export default function Twenty48Screen({ navigation }: Props) {
     setState(next);
     saveGame(next);
   }, []);
+
+  const handleNewGamePress = useCallback(() => {
+    if (state && state.score > 0 && !state.game_over) {
+      setConfirmNewGameVisible(true);
+    } else {
+      resetGame();
+    }
+  }, [state, resetGame]);
+
+  const handleConfirmNewGame = useCallback(() => {
+    setConfirmNewGameVisible(false);
+    resetGame();
+  }, [resetGame]);
 
   // When game ends, remove the saved state so a fresh game starts next launch.
   useEffect(() => {
@@ -219,7 +234,7 @@ export default function Twenty48Screen({ navigation }: Props) {
         )}
         <Pressable
           style={[styles.newGameBtn, { backgroundColor: colors.accent }]}
-          onPress={handleNewGame}
+          onPress={handleNewGamePress}
           accessibilityRole="button"
           accessibilityLabel={t("twenty48:actions.newGameLabel")}
         >
@@ -265,7 +280,7 @@ export default function Twenty48Screen({ navigation }: Props) {
         <GameOverlay
           type="win"
           score={state!.score}
-          onNewGame={handleNewGame}
+          onNewGame={resetGame}
           onKeepPlaying={() => setWinDismissed(true)}
           onHome={() => navigation.goBack()}
         />
@@ -274,10 +289,16 @@ export default function Twenty48Screen({ navigation }: Props) {
         <GameOverlay
           type="game_over"
           score={state!.score}
-          onNewGame={handleNewGame}
+          onNewGame={resetGame}
           onHome={() => navigation.goBack()}
         />
       )}
+
+      <NewGameConfirmModal
+        visible={confirmNewGameVisible}
+        onConfirm={handleConfirmNewGame}
+        onCancel={() => setConfirmNewGameVisible(false)}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary

Generalizes Yacht's existing New Game + confirm modal pattern to Blackjack, Cascade, and 2048, and consolidates the shared piece.

## What changed

- **Shared modal**: `components/yacht/NewGameConfirmModal` → `components/shared/NewGameConfirmModal`. Default namespace switched from `yacht` to `common`. Added optional `title`/`body` string overrides for per-game copy.
- **i18n migration**: the 5 `newGame.*` keys (`button`, `confirm.title`, `confirm.body`, `confirm.confirm`, `confirm.cancel`) move from each locale's `yacht.json` into `common.json`. Done across all 13 locales using each locale's existing Yacht translations verbatim — no new strings invented. `check-i18n-strings.js` is clean.
- **Yacht** (`GameScreen.tsx`): import path + `common:newGame.button`.
- **2048** (`Twenty48Screen.tsx`): `handleNewGamePress` gates on `score > 0 && !game_over`; renders the shared modal; game-over overlay still resets directly.
- **Cascade** (`CascadeScreen.tsx`): adds a New Game pill in `AppHeader.rightSlot`, gates on `scoreRef.current > 0 && !gameOverRef.current`, reuses `handleRestart` on confirm.
- **Blackjack** (`BlackjackTableScreen.tsx`): adds a New Game action row under the phase label, gates on `engine.phase !== "betting"`, reuses the context's `handlePlayAgain`. Hooks refactored above the loading early return so they satisfy rules of hooks.

Closes #455.

## Test plan

- [x] `npx jest src/screens/__tests__ src/components` — **305 / 305 passing**.
- [x] `node scripts/check-i18n-strings.js` — all locales in sync.
- [x] Prettier clean.
- [ ] iOS Simulator: press New Game with a game in progress on each screen — confirm modal, Cancel is no-op, Confirm resets.
- [ ] iOS Simulator: press New Game with a fresh state — resets immediately, no modal.
- [ ] Yacht regression: existing confirm flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)