### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -96,8 +96,8 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10006
-        versionName "1.0.6"
+        versionCode 10007
+        versionName "1.0.7"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gaming App",
     "slug": "gaming-app",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.buffingchi.games",
-      "buildNumber": "10006",
+      "buildNumber": "10007",
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
           {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

Bump app version from **1.0.6 → 1.0.7** across all four sources of truth:

- `frontend/package.json` `version`
- `frontend/app.json` `expo.version`
- `frontend/app.json` `expo.ios.buildNumber` (10006 → 10007)
- `frontend/android/app/build.gradle` `versionCode` (10006 → 10007) and `versionName`

## Rolls up

- #445 — fix iOS Die transform crash (Fabric forEach null)
- #447 — Blackjack split hands side-by-side with compact cards
- #449 — Cascade bin enlargement via HUD consolidation
- #453 — 2048 empty-tile theming and New Game button clip
- #456 — AppHeader back label namespace fix
- #457 — Yacht scorecard iOS scroll
- #458 — Shared New Game confirm modal across all games

No code changes; purely version metadata.