### PR TITLE
fix: Galaxy Fold responsive layout for Blackjack + Yacht

### DIFF
--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -1,8 +1,23 @@
 import React, { useState, useEffect } from "react";
-import { View, Pressable, Text, StyleSheet, Platform, ViewStyle } from "react-native";
+import {
+  View,
+  Pressable,
+  Text,
+  StyleSheet,
+  Platform,
+  ViewStyle,
+  useWindowDimensions,
+} from "react-native";
 import { useTranslation } from "react-i18next";
 import Die from "./Die";
 import { useTheme } from "../theme/ThemeContext";
+
+// Below this viewport height, the dice row collapses its vertical padding,
+// hides the redundant rolls-left dot indicator (the ROLL button already
+// shows "ROLL (N LEFT)"), and tightens its roll button so the Yacht
+// scorecard gets more usable space. Catches Galaxy Fold landscape (~604dp),
+// Galaxy Fold portrait (~725dp), and smaller phones.
+const COMPACT_HEIGHT_BREAKPOINT = 780;
 
 interface DiceRowProps {
   dice: number[];
@@ -15,6 +30,8 @@ interface DiceRowProps {
 export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }: DiceRowProps) {
   const { t } = useTranslation("yacht");
   const { colors } = useTheme();
+  const { height } = useWindowDimensions();
+  const isCompact = height < COMPACT_HEIGHT_BREAKPOINT;
   const [held, setHeld] = useState<boolean[]>([false, false, false, false, false]);
   const [rolling, setRolling] = useState(false);
 
@@ -49,7 +66,7 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
       : { backgroundColor: canRoll ? colors.accentBright : colors.surfaceHigh };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, isCompact && styles.containerCompact]}>
       <View style={styles.diceRow}>
         {dice.map((val, i) => (
           <Die
@@ -62,12 +79,16 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
           />
         ))}
       </View>
-      <Text style={[styles.hint, { color: colors.textMuted }]} accessibilityLiveRegion="polite">
+      <Text
+        style={[styles.hint, isCompact && styles.hintCompact, { color: colors.textMuted }]}
+        accessibilityLiveRegion="polite"
+      >
         {rollsUsed > 0 ? t("dice.hintAfterRoll") : t("dice.hintBeforeRoll")}
       </Text>
       <Pressable
         style={({ pressed }) => [
           styles.rollButton,
+          isCompact && styles.rollButtonCompact,
           rollButtonBg,
           pressed && canRoll && !rolling ? { transform: [{ scale: 0.95 }] } : null,
         ]}
@@ -90,25 +111,29 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
           {rolling ? t("roll.rolling") : t("roll.button", { count: rollsLeft })}
         </Text>
       </Pressable>
-      <View style={styles.rollCounter} accessibilityElementsHidden importantForAccessibility="no">
-        {[0, 1, 2].map((i) => {
-          const filled = i < rollsLeft;
-          return (
-            <View
-              key={i}
-              style={[
-                styles.rollDot,
-                {
-                  backgroundColor: filled ? colors.accent : colors.surfaceHigh,
-                  ...(filled && Platform.OS === "web"
-                    ? { boxShadow: `0 0 6px ${colors.accent}` }
-                    : null),
-                } as ViewStyle,
-              ]}
-            />
-          );
-        })}
-      </View>
+      {/* Rolls-left dots are redundant with the button label ("ROLL (N LEFT)")
+          — hide them on short viewports to reclaim vertical space. */}
+      {!isCompact && (
+        <View style={styles.rollCounter} accessibilityElementsHidden importantForAccessibility="no">
+          {[0, 1, 2].map((i) => {
+            const filled = i < rollsLeft;
+            return (
+              <View
+                key={i}
+                style={[
+                  styles.rollDot,
+                  {
+                    backgroundColor: filled ? colors.accent : colors.surfaceHigh,
+                    ...(filled && Platform.OS === "web"
+                      ? { boxShadow: `0 0 6px ${colors.accent}` }
+                      : null),
+                  } as ViewStyle,
+                ]}
+              />
+            );
+          })}
+        </View>
+      )}
     </View>
   );
 }
@@ -117,6 +142,9 @@ const styles = StyleSheet.create({
   container: {
     alignItems: "center",
     marginVertical: 16,
+  },
+  containerCompact: {
+    marginVertical: 4,
   },
   diceRow: {
     flexDirection: "row",
@@ -127,10 +155,19 @@ const styles = StyleSheet.create({
     marginTop: 4,
     marginBottom: 8,
   },
+  hintCompact: {
+    fontSize: 12,
+    marginTop: 2,
+    marginBottom: 4,
+  },
   rollButton: {
     paddingHorizontal: 40,
     paddingVertical: 14,
     borderRadius: 999,
+  },
+  rollButtonCompact: {
+    paddingHorizontal: 28,
+    paddingVertical: 9,
   },
   rollButtonText: {
     fontSize: 16,

--- a/frontend/src/components/Scorecard.tsx
+++ b/frontend/src/components/Scorecard.tsx
@@ -31,7 +31,12 @@ const CATEGORY_I18N_KEY: Record<string, string> = {
   chance: "category.chance",
 };
 
-const WIDE_BREAKPOINT = 720;
+// 600dp catches tablets, Galaxy Fold unfolded (both orientations), and other
+// wide-aspect devices where showing the upper and lower sections side-by-side
+// eliminates the need to scroll within the scorecard. Phones in portrait
+// (iPhone ~390dp, typical Android ~410dp) remain below this and keep the
+// single-column stacked layout.
+const WIDE_BREAKPOINT = 600;
 
 interface ScorecardProps {
   scores: Record<string, number | null>;

--- a/frontend/src/components/blackjack/ActionButtons.tsx
+++ b/frontend/src/components/blackjack/ActionButtons.tsx
@@ -13,6 +13,9 @@ interface Props {
   doubleDownAvailable: boolean;
   splitAvailable: boolean;
   loading: boolean;
+  /** Shrink buttons and padding for short-height viewports (Galaxy Fold,
+   *  landscape phones) so the action cluster doesn't overlap the table. */
+  compact?: boolean;
 }
 
 export default function ActionButtons({
@@ -23,9 +26,11 @@ export default function ActionButtons({
   doubleDownAvailable,
   splitAvailable,
   loading,
+  compact = false,
 }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
+  const iconSize = compact ? 22 : 28;
 
   const ddLabel = doubleDownAvailable
     ? t("actions.doubleDownLabel")
@@ -35,24 +40,37 @@ export default function ActionButtons({
 
   return (
     <View
-      style={[styles.cluster, { backgroundColor: colors.surfaceHigh, borderColor: colors.border }]}
+      style={[
+        styles.cluster,
+        compact && styles.clusterCompact,
+        { backgroundColor: colors.surfaceHigh, borderColor: colors.border },
+      ]}
     >
       {/* Hit — primary cyan gradient CTA */}
       <Pressable
-        style={[styles.btn, styles.btnHit, { backgroundColor: colors.accent }]}
+        style={[
+          styles.btn,
+          compact && styles.btnCompact,
+          styles.btnHit,
+          { backgroundColor: colors.accent },
+        ]}
         onPress={onHit}
         disabled={loading}
         accessibilityRole="button"
         accessibilityLabel={t("actions.hitLabel")}
         accessibilityState={{ disabled: loading, busy: loading }}
       >
-        <MaterialIcons name="add" size={28} color={colors.textOnAccent} />
+        <MaterialIcons name="add" size={iconSize} color={colors.textOnAccent} />
         <Text style={[styles.btnLabel, { color: colors.textOnAccent }]}>{t("actions.hit")}</Text>
       </Pressable>
 
       {/* Stand — secondary purple outline */}
       <Pressable
-        style={[styles.btn, { borderColor: colors.secondary, borderWidth: 2 }]}
+        style={[
+          styles.btn,
+          compact && styles.btnCompact,
+          { borderColor: colors.secondary, borderWidth: 2 },
+        ]}
         onPress={onStand}
         disabled={loading}
         accessibilityRole="button"
@@ -60,7 +78,7 @@ export default function ActionButtons({
         accessibilityState={{ disabled: loading, busy: loading }}
       >
         {/* hand-back-right is the closest MCI equivalent to Material Symbols front_hand */}
-        <MaterialCommunityIcons name="hand-back-right" size={28} color={colors.secondary} />
+        <MaterialCommunityIcons name="hand-back-right" size={iconSize} color={colors.secondary} />
         <Text style={[styles.btnLabel, { color: colors.secondary }]}>{t("actions.stand")}</Text>
       </Pressable>
 
@@ -68,6 +86,7 @@ export default function ActionButtons({
       <Pressable
         style={[
           styles.btn,
+          compact && styles.btnCompact,
           {
             borderColor: doubleDownAvailable ? colors.border : colors.border,
             borderWidth: 2,
@@ -83,7 +102,7 @@ export default function ActionButtons({
         {/* numeric-2-circle-outline is the closest MCI equivalent to Material Symbols stat_2 */}
         <MaterialCommunityIcons
           name="numeric-2-circle-outline"
-          size={28}
+          size={iconSize}
           color={colors.textMuted}
         />
         <Text style={[styles.btnLabel, styles.btnLabelSmall, { color: colors.textMuted }]}>
@@ -95,6 +114,7 @@ export default function ActionButtons({
       <Pressable
         style={[
           styles.btn,
+          compact && styles.btnCompact,
           {
             borderColor: colors.border,
             borderWidth: 2,
@@ -107,7 +127,7 @@ export default function ActionButtons({
         accessibilityLabel={splitLabel}
         accessibilityState={{ disabled: !splitAvailable || loading }}
       >
-        <MaterialIcons name="call-split" size={28} color={colors.textMuted} />
+        <MaterialIcons name="call-split" size={iconSize} color={colors.textMuted} />
         <Text style={[styles.btnLabel, { color: colors.textMuted }]}>{t("actions.split")}</Text>
       </Pressable>
     </View>
@@ -123,6 +143,11 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     borderWidth: 1,
   },
+  clusterCompact: {
+    gap: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
   btn: {
     width: 80,
     height: 80,
@@ -130,6 +155,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     gap: 2,
+  },
+  btnCompact: {
+    width: 62,
+    height: 62,
+    borderRadius: 31,
   },
   btnHit: {
     // Shadow for the primary CTA glow effect

--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -17,6 +17,8 @@ interface Props {
   handBets?: number[];
   /** Per-hand outcomes (when split, in result phase). */
   handOutcomes?: (string | null)[];
+  /** Shrink card sizes and table padding on short-height viewports. */
+  compact?: boolean;
 }
 
 export default function BlackjackTable({
@@ -27,6 +29,7 @@ export default function BlackjackTable({
   activeHandIndex = 0,
   handBets,
   handOutcomes,
+  compact = false,
 }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
@@ -34,12 +37,13 @@ export default function BlackjackTable({
   const isSplit = playerHands && playerHands.length > 1;
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, compact && styles.containerCompact]}>
       <HandDisplay
         hand={dealerHand}
         label={t("hand.dealer")}
         concealed={isPlayerPhase}
         variant="dealer"
+        compact={compact}
       />
       <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
@@ -97,7 +101,12 @@ export default function BlackjackTable({
           })}
         </View>
       ) : (
-        <HandDisplay hand={playerHand} label={t("hand.player")} variant="player" />
+        <HandDisplay
+          hand={playerHand}
+          label={t("hand.player")}
+          variant="player"
+          compact={compact}
+        />
       )}
     </View>
   );
@@ -108,6 +117,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 20,
     width: "100%",
+  },
+  containerCompact: {
+    gap: 8,
   },
   divider: {
     width: "60%",

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -33,9 +33,7 @@ export default function HandDisplay({
 
   return (
     <View style={[styles.container, compact && styles.containerCompact]}>
-      <Text
-        style={[styles.label, compact && styles.labelCompact, { color: colors.textMuted }]}
-      >
+      <Text style={[styles.label, compact && styles.labelCompact, { color: colors.textMuted }]}>
         {label}
       </Text>
 

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -12,7 +12,9 @@ interface Props {
   /** "player" renders larger cards with fan rotation and neon score pill;
    *  "dealer" renders compact cards and glass badge score. */
   variant?: "player" | "dealer";
-  /** Shrink player-variant cards for split-hand side-by-side layout. */
+  /** Shrink cards for constrained layouts — used by split-hand side-by-side
+   *  rendering and by the whole table on short-height viewports. Shrinks
+   *  both the "player" and "dealer" variants when set. */
   compact?: boolean;
 }
 
@@ -30,8 +32,12 @@ export default function HandDisplay({
   const showScore = hand.cards.length > 0;
 
   return (
-    <View style={styles.container}>
-      <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
+    <View style={[styles.container, compact && styles.containerCompact]}>
+      <Text
+        style={[styles.label, compact && styles.labelCompact, { color: colors.textMuted }]}
+      >
+        {label}
+      </Text>
 
       <View style={styles.cards}>
         {hand.cards.map((card, i) => (
@@ -57,11 +63,17 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
+  containerCompact: {
+    gap: 2,
+  },
   label: {
     fontSize: 13,
     fontWeight: "600",
     textTransform: "uppercase",
     letterSpacing: 0.5,
+  },
+  labelCompact: {
+    fontSize: 11,
   },
   cards: {
     flexDirection: "row",

--- a/frontend/src/components/blackjack/PlayingCard.tsx
+++ b/frontend/src/components/blackjack/PlayingCard.tsx
@@ -10,7 +10,9 @@ interface Props {
   rotation?: number;
   /** "player" renders a larger card; "dealer" renders the compact default. */
   variant?: "player" | "dealer";
-  /** Shrink the player variant so two split hands fit side-by-side. */
+  /** Shrink the card — either to fit two split hands side-by-side (player
+   *  variant) or to fit the whole table on short-height viewports (both
+   *  variants). */
   compact?: boolean;
 }
 
@@ -36,21 +38,28 @@ export default function PlayingCard({
   const { colors } = useTheme();
 
   const isCompactPlayer = variant === "player" && compact;
+  const isCompactDealer = variant === "dealer" && compact;
   const cardSizeStyle = isCompactPlayer
     ? styles.cardPlayerCompact
-    : variant === "player"
-      ? styles.cardPlayer
-      : styles.cardDealer;
+    : isCompactDealer
+      ? styles.cardDealerCompact
+      : variant === "player"
+        ? styles.cardPlayer
+        : styles.cardDealer;
   const rankSizeStyle = isCompactPlayer
     ? styles.rankPlayerCompact
-    : variant === "player"
-      ? styles.rankPlayer
-      : styles.rankDealer;
+    : isCompactDealer
+      ? styles.rankDealerCompact
+      : variant === "player"
+        ? styles.rankPlayer
+        : styles.rankDealer;
   const suitSizeStyle = isCompactPlayer
     ? styles.suitPlayerCompact
-    : variant === "player"
-      ? styles.suitPlayer
-      : styles.suitDealer;
+    : isCompactDealer
+      ? styles.suitDealerCompact
+      : variant === "player"
+        ? styles.suitPlayer
+        : styles.suitDealer;
   const rotateStyle = rotation !== 0 ? { transform: [{ rotate: `${rotation}deg` }] } : undefined;
 
   if (card.face_down) {
@@ -107,6 +116,11 @@ const styles = StyleSheet.create({
     width: 52,
     height: 72,
   },
+  cardDealerCompact: {
+    width: 40,
+    height: 56,
+    margin: 2,
+  },
   cardPlayer: {
     width: 68,
     height: 96,
@@ -133,6 +147,11 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     lineHeight: 20,
   },
+  rankDealerCompact: {
+    fontSize: 13,
+    fontWeight: "700",
+    lineHeight: 16,
+  },
   rankPlayer: {
     fontSize: 20,
     fontWeight: "700",
@@ -146,6 +165,10 @@ const styles = StyleSheet.create({
   suitDealer: {
     fontSize: 18,
     lineHeight: 22,
+  },
+  suitDealerCompact: {
+    fontSize: 14,
+    lineHeight: 18,
   },
   suitPlayer: {
     fontSize: 22,

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ActivityIndicator,
+  useWindowDimensions,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -22,6 +29,13 @@ import HudSidebar from "../components/blackjack/HudSidebar";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
+// Below this viewport height, card sizes, action-button sizes, and table
+// padding collapse to compact variants so the dealer hand, player hand, and
+// action cluster all fit without overlapping. Catches Galaxy Fold unfolded
+// in landscape (~604dp), Fold unfolded in portrait (~725dp), and smaller
+// phones in landscape.
+const COMPACT_HEIGHT_BREAKPOINT = 780;
+
 type Props = {
   navigation: NativeStackNavigationProp<HomeStackParamList, "BlackjackTable">;
 };
@@ -30,6 +44,8 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   const { t } = useTranslation(["blackjack", "common"]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const { height } = useWindowDimensions();
+  const isCompact = height < COMPACT_HEIGHT_BREAKPOINT;
   const { engine, loading, error, apply, handlePlayAgain } = useBlackjackGame();
   const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
 
@@ -142,6 +158,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
               activeHandIndex={state.active_hand_index}
               handBets={state.hand_bets}
               handOutcomes={state.hand_outcomes}
+              compact={isCompact}
             />
           </View>
 
@@ -151,7 +168,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
       )}
 
       {/* Phase-specific controls */}
-      <View style={styles.controls}>
+      <View style={[styles.controls, isCompact && styles.controlsCompact]}>
         {state?.phase === "result" && (
           <>
             <ResultBanner outcome={state.outcome!} payout={state.payout} />
@@ -191,6 +208,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
             doubleDownAvailable={state.double_down_available}
             splitAvailable={state.split_available}
             loading={false}
+            compact={isCompact}
           />
         )}
 
@@ -258,6 +276,13 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "row",
     alignItems: "stretch",
+    // minHeight: 0 allows this flex child to actually shrink below its
+    // intrinsic content height on constrained viewports (Galaxy Fold
+    // landscape etc.); overflow:hidden guarantees any residual overflow
+    // from the table contents can't visually bleed into the controls row
+    // below.
+    minHeight: 0,
+    overflow: "hidden",
   },
   sidebarLeft: {
     width: 88,
@@ -278,6 +303,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingBottom: 32,
     gap: 16,
+    // flexShrink: 0 keeps the action cluster fully rendered even when the
+    // tableRow above is competing for space — without this, on compact
+    // viewports the controls could be squeezed to zero height.
+    flexShrink: 0,
+  },
+  controlsCompact: {
+    paddingBottom: 12,
+    gap: 8,
   },
   resultActions: {
     width: "100%",


### PR DESCRIPTION
## Summary

Galaxy Fold responsive fixes for the two overlap/space issues reported on the unfolded inner display. Both games (Blackjack, Yacht) assumed a tall-phone aspect ratio and broke down on short-height viewports like the Fold in landscape.

Fixes #460.
Fixes #461.

## Commit 1 — Yacht scorecard space (#461)

On Galaxy Fold the Yacht scorecard was squeezed to ~240dp and only ~2 of 13 rows were visible without scrolling.

- `frontend/src/components/Scorecard.tsx`: `WIDE_BREAKPOINT` 720 → 600 so Fold (and similar wide-aspect devices) flips into the existing side-by-side upper/lower bento layout. Typical phones in portrait stay below the threshold and keep the single-column stacked layout.
- `frontend/src/components/DiceRow.tsx`: new compact mode when `useWindowDimensions().height < 780dp`:
  - `container.marginVertical` 16 → 4
  - `hint` tightened (fontSize 13 → 12, margins 4/8 → 2/4)
  - ROLL button padding 40/14 → 28/9
  - Rolls-left dot indicator hidden (redundant with the button's "ROLL (N LEFT)" label)
- Reclaims ~55dp of vertical space for the scorecard.

## Commit 2 — Blackjack action-button overlap (#460)

On Galaxy Fold (and other short-height viewports) the `BlackjackTable` content exceeded the `tableRow` flex allocation and bled downward into the `controls` area, leaving the STAND / DOUBLE DOWN circles visually colliding with the player's cards.

**Structural flex fix** — `frontend/src/screens/BlackjackTableScreen.tsx`:
- `tableRow`: `minHeight: 0` + `overflow: "hidden"` so the flex child actually shrinks below its intrinsic content height.
- `controls`: `flexShrink: 0` so the action cluster is never squeezed to zero.

**Compact cascade** — when `height < 780dp`:
- `ActionButtons`: 62×62 circles (was 80×80), icon size 28 → 22, tighter cluster padding/gap.
- `BlackjackTable`: outer gap 20 → 8.
- `HandDisplay`: inner gap 8 → 2, label fontSize 13 → 11.
- `PlayingCard`: compact dealer sizing (40×56, was 52×72) with matching rank/suit type sizes. Player card was already compact-aware for split hands; the same treatment now also kicks in whenever the screen is compact.

## Test plan

- [x] `npx jest src/screens/__tests__/BlackjackTableScreen.test.tsx src/components/blackjack/__tests__/` — 57/57 passing
- [x] `npx jest src/components/__tests__/DiceRow.test.tsx src/components/__tests__/Scorecard.test.tsx src/screens/__tests__/GameScreen.test.tsx` — 40/40 passing
- [x] `tsc --noEmit` — no new errors in touched files
- [x] `eslint` — clean on touched files
- [ ] Manual test on a physical Galaxy Fold (unfolded, both orientations): Blackjack player phase, split mode, and result phase all render without overlap.
- [ ] Manual test on a physical Galaxy Fold (unfolded): Yacht scorecard shows the full upper section without intra-card scrolling.
- [ ] Regression check on iPhone SE / standard phone portrait — neither game should visually change for them (layout stays single-column, compact DiceRow applies because SE is also `< 780dp` which is the desired tightening there too).

https://claude.ai/code/session_01TGxYaEYaa8DUvrHCfsnXEw