### PR TITLE
feat(db): games, game_events, bug_logs, and lookup tables (#363)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -15,7 +15,10 @@ import os
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import MetaData, engine_from_config, pool
+from sqlalchemy import engine_from_config, pool
+
+from db.base import Base
+import db.models  # noqa: F401 — ensure models are registered on Base.metadata
 
 config = context.config
 
@@ -36,7 +39,7 @@ _raw = os.environ.get("DATABASE_URL", "").strip()
 if _raw:
     config.set_main_option("sqlalchemy.url", _sync_url(_raw))
 
-target_metadata = MetaData()
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:

--- a/backend/alembic/versions/0002_games_events_lookups.py
+++ b/backend/alembic/versions/0002_games_events_lookups.py
@@ -1,0 +1,269 @@
+"""games, events, bug_logs, and lookup tables (#363)
+
+Revision ID: 0002_games_events_lookups
+Revises: 0001_baseline
+Create Date: 2026-04-12
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0002_games_events_lookups"
+down_revision: Union[str, None] = "0001_baseline"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_JSONB = sa.JSON().with_variant(JSONB(), "postgresql")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "game_types",
+        sa.Column("id", sa.SmallInteger(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.Text(), nullable=False, unique=True),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column("icon_emoji", sa.Text(), nullable=True),
+        sa.Column("sort_order", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
+        "event_types",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "game_type_id",
+            sa.SmallInteger(),
+            sa.ForeignKey("game_types.id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deprecated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("game_type_id", "name", name="uq_event_types_game_name"),
+    )
+
+    op.create_table(
+        "games",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("session_id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column(
+            "game_type_id",
+            sa.SmallInteger(),
+            sa.ForeignKey("game_types.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("final_score", sa.Integer(), nullable=True),
+        sa.Column("outcome", sa.Text(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("metadata", _JSONB, nullable=False, server_default="{}"),
+        sa.CheckConstraint(
+            "outcome IS NULL OR outcome IN ('win','loss','push','blackjack','abandoned')",
+            name="ck_games_outcome",
+        ),
+    )
+    op.create_index(
+        "games_session_id_started_at_idx",
+        "games",
+        ["session_id", "started_at"],
+    )
+    op.create_index(
+        "games_user_id_started_at_idx",
+        "games",
+        ["user_id", "started_at"],
+        postgresql_where=sa.text("user_id IS NOT NULL"),
+        sqlite_where=sa.text("user_id IS NOT NULL"),
+    )
+    op.create_index(
+        "games_game_type_score_idx",
+        "games",
+        ["game_type_id", "final_score"],
+        postgresql_where=sa.text("final_score IS NOT NULL"),
+        sqlite_where=sa.text("final_score IS NOT NULL"),
+    )
+
+    op.create_table(
+        "game_events",
+        sa.Column(
+            "game_id",
+            sa.Uuid(),
+            sa.ForeignKey("games.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("event_index", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column(
+            "event_type_id",
+            sa.Integer(),
+            sa.ForeignKey("event_types.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("data", _JSONB, nullable=False),
+    )
+    op.create_index(
+        "game_events_event_type_id_idx",
+        "game_events",
+        ["event_type_id"],
+    )
+
+    op.create_table(
+        "bug_logs",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("session_id", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column("logged_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("level", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("context", _JSONB, nullable=False, server_default="{}"),
+        sa.CheckConstraint("level IN ('warn','error','fatal')", name="ck_bug_logs_level"),
+    )
+    op.create_index("bug_logs_session_logged_idx", "bug_logs", ["session_id", "logged_at"])
+    op.create_index("bug_logs_level_logged_idx", "bug_logs", ["level", "logged_at"])
+    op.create_index("bug_logs_source_idx", "bug_logs", ["source"])
+
+    # ---- seed data ----
+    game_types = sa.table(
+        "game_types",
+        sa.column("id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("icon_emoji", sa.Text),
+        sa.column("sort_order", sa.SmallInteger),
+        sa.column("is_active", sa.Boolean),
+    )
+    op.bulk_insert(
+        game_types,
+        [
+            {
+                "id": 1,
+                "name": "yacht",
+                "display_name": "Yacht",
+                "icon_emoji": "🎲",
+                "sort_order": 10,
+                "is_active": True,
+            },
+            {
+                "id": 2,
+                "name": "twenty48",
+                "display_name": "2048",
+                "icon_emoji": "🔢",
+                "sort_order": 20,
+                "is_active": True,
+            },
+            {
+                "id": 3,
+                "name": "blackjack",
+                "display_name": "Blackjack",
+                "icon_emoji": "🃏",
+                "sort_order": 30,
+                "is_active": True,
+            },
+            {
+                "id": 4,
+                "name": "cascade",
+                "display_name": "Cascade",
+                "icon_emoji": "🍉",
+                "sort_order": 40,
+                "is_active": True,
+            },
+        ],
+    )
+
+    event_types = sa.table(
+        "event_types",
+        sa.column("game_type_id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("description", sa.Text),
+    )
+
+    _baseline = [
+        # yacht
+        (1, "game_started", "Game Started", None),
+        (1, "roll", "Dice Roll", None),
+        (1, "score", "Category Scored", None),
+        (1, "game_ended", "Game Ended", None),
+        # 2048
+        (2, "game_started", "Game Started", None),
+        (2, "move", "Move", None),
+        (2, "game_ended", "Game Ended", None),
+        # blackjack
+        (3, "game_started", "Game Started", None),
+        (3, "bet_placed", "Bet Placed", None),
+        (3, "hand_dealt", "Hand Dealt", None),
+        (3, "player_action", "Player Action", None),
+        (3, "hand_resolved", "Hand Resolved", None),
+        (3, "game_ended", "Game Ended", None),
+        # cascade
+        (4, "game_started", "Game Started", None),
+        (4, "drop", "Fruit Drop", None),
+        (4, "merge", "Fruit Merge", None),
+        (4, "game_ended", "Game Ended", None),
+    ]
+    op.bulk_insert(
+        event_types,
+        [
+            {"game_type_id": gt, "name": n, "display_name": dn, "description": d}
+            for gt, n, dn, d in _baseline
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("bug_logs_source_idx", table_name="bug_logs")
+    op.drop_index("bug_logs_level_logged_idx", table_name="bug_logs")
+    op.drop_index("bug_logs_session_logged_idx", table_name="bug_logs")
+    op.drop_table("bug_logs")
+
+    op.drop_index("game_events_event_type_id_idx", table_name="game_events")
+    op.drop_table("game_events")
+
+    op.drop_index("games_game_type_score_idx", table_name="games")
+    op.drop_index("games_user_id_started_at_idx", table_name="games")
+    op.drop_index("games_session_id_started_at_idx", table_name="games")
+    op.drop_table("games")
+
+    op.drop_table("event_types")
+    op.drop_table("game_types")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,0 +1,175 @@
+"""SQLAlchemy models for epic #362 — games, events, bug logs.
+
+Design notes (issue #363):
+
+* Lookup tables (`game_types`, `event_types`) hold evolvable vocabularies.
+  Renames and deprecations happen via row updates — no schema migrations.
+* Stable vocabularies (outcome, level) are CHECK constraints instead.
+* `user_id` is nullable with no FK today; the `users` table doesn't exist yet
+  and won't until the SSO epic backfills it.
+
+Portability: the runtime DB is always Postgres, but CI's schema-migration
+check runs these models against SQLite. All types below adapt cleanly to
+both — JSONB → JSON on sqlite, UUID → CHAR(32) on sqlite, etc. UUID PK
+defaults are generated in Python so we don't need `gen_random_uuid()` /
+pgcrypto.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    SmallInteger,
+    Text,
+    UniqueConstraint,
+    Uuid,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.base import Base
+
+# JSONB on Postgres, JSON (TEXT) on sqlite — both round-trip Python dicts.
+_JSONB = JSON().with_variant(JSONB(), "postgresql")
+
+
+class GameType(Base):
+    __tablename__ = "game_types"
+
+    id: Mapped[int] = mapped_column(SmallInteger, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    display_name: Mapped[str] = mapped_column(Text, nullable=False)
+    icon_emoji: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    sort_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
+    is_active: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    event_types: Mapped[list["EventType"]] = relationship(
+        back_populates="game_type", cascade="all, delete-orphan"
+    )
+    games: Mapped[list["Game"]] = relationship(back_populates="game_type")
+
+
+class EventType(Base):
+    __tablename__ = "event_types"
+    __table_args__ = (UniqueConstraint("game_type_id", "name", name="uq_event_types_game_name"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    game_type_id: Mapped[int] = mapped_column(
+        SmallInteger, ForeignKey("game_types.id"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    display_name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    deprecated_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    game_type: Mapped[GameType] = relationship(back_populates="event_types")
+    events: Mapped[list["GameEvent"]] = relationship(back_populates="event_type")
+
+
+class Game(Base):
+    __tablename__ = "games"
+    __table_args__ = (
+        CheckConstraint(
+            "outcome IS NULL OR outcome IN ('win','loss','push','blackjack','abandoned')",
+            name="ck_games_outcome",
+        ),
+        Index("games_session_id_started_at_idx", "session_id", "started_at"),
+        Index(
+            "games_user_id_started_at_idx",
+            "user_id",
+            "started_at",
+            postgresql_where="user_id IS NOT NULL",
+            sqlite_where="user_id IS NOT NULL",
+        ),
+        Index(
+            "games_game_type_score_idx",
+            "game_type_id",
+            "final_score",
+            postgresql_where="final_score IS NOT NULL",
+            sqlite_where="final_score IS NOT NULL",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(Uuid, nullable=True)
+    game_type_id: Mapped[int] = mapped_column(
+        SmallInteger, ForeignKey("game_types.id"), nullable=False
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    final_score: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    outcome: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    game_metadata: Mapped[dict] = mapped_column(
+        "metadata", _JSONB, nullable=False, server_default="{}"
+    )
+
+    game_type: Mapped[GameType] = relationship(back_populates="games")
+    events: Mapped[list["GameEvent"]] = relationship(
+        back_populates="game",
+        cascade="all, delete-orphan",
+        order_by="GameEvent.event_index",
+    )
+
+
+class GameEvent(Base):
+    __tablename__ = "game_events"
+    __table_args__ = (Index("game_events_event_type_id_idx", "event_type_id"),)
+
+    game_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("games.id", ondelete="CASCADE"), primary_key=True
+    )
+    event_index: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event_type_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("event_types.id"), nullable=False
+    )
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    data: Mapped[dict] = mapped_column(_JSONB, nullable=False)
+
+    game: Mapped[Game] = relationship(back_populates="events")
+    event_type: Mapped[EventType] = relationship(back_populates="events")
+
+
+class BugLog(Base):
+    __tablename__ = "bug_logs"
+    __table_args__ = (
+        CheckConstraint("level IN ('warn','error','fatal')", name="ck_bug_logs_level"),
+        Index("bug_logs_session_logged_idx", "session_id", "logged_at"),
+        Index("bug_logs_level_logged_idx", "level", "logged_at"),
+        Index("bug_logs_source_idx", "source"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(Uuid, nullable=True)
+    logged_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    level: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    context: Mapped[dict] = mapped_column(_JSONB, nullable=False, server_default="{}")

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -1,0 +1,155 @@
+"""Schema smoke tests for #363.
+
+Skipped unless DATABASE_URL is set. Verifies:
+  1. Seed data present (4 game_types, 17 baseline event_types).
+  2. A game + events + bug_log round-trip via SQLAlchemy ORM.
+  3. Unknown event_type_id fails the FK constraint.
+  4. Invalid games.outcome fails the CHECK constraint.
+  5. Invalid bug_logs.level fails the CHECK constraint.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from db.base import get_session_factory
+from db.models import BugLog, EventType, Game, GameEvent, GameType
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping live DB schema tests",
+)
+
+
+@pytest.mark.asyncio
+async def test_seed_data_present() -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        gt_names = (await s.execute(select(GameType.name).order_by(GameType.id))).scalars().all()
+        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade"]
+
+        total = (await s.execute(select(func.count()).select_from(EventType))).scalar_one()
+        assert total >= 17
+
+        yacht_events = (
+            (
+                await s.execute(
+                    select(EventType.name)
+                    .join(GameType)
+                    .where(GameType.name == "yacht")
+                    .order_by(EventType.name)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert set(yacht_events) >= {"game_started", "roll", "score", "game_ended"}
+
+
+@pytest.mark.asyncio
+async def test_game_events_and_buglog_roundtrip() -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        yacht = (await s.execute(select(GameType).where(GameType.name == "yacht"))).scalar_one()
+        roll_type = (
+            await s.execute(
+                select(EventType).where(
+                    EventType.game_type_id == yacht.id, EventType.name == "roll"
+                )
+            )
+        ).scalar_one()
+
+        sid = f"test-session-{uuid.uuid4().hex[:8]}"
+        game = Game(
+            session_id=sid,
+            game_type_id=yacht.id,
+            final_score=123,
+            outcome="win",
+            game_metadata={"note": "smoke test"},
+        )
+        s.add(game)
+        await s.flush()
+
+        game.events.append(
+            GameEvent(event_index=0, event_type_id=roll_type.id, data={"dice": [1, 2, 3, 4, 5]})
+        )
+        game.events.append(
+            GameEvent(event_index=1, event_type_id=roll_type.id, data={"dice": [6, 6, 6, 6, 6]})
+        )
+
+        bug = BugLog(
+            session_id=sid,
+            logged_at=datetime.now(timezone.utc),
+            level="warn",
+            source="yacht.engine",
+            message="dice reroll invariant violated",
+            context={"turn": 3},
+        )
+        s.add(bug)
+        await s.commit()
+
+        fetched = (await s.execute(select(Game).where(Game.session_id == sid))).scalar_one()
+        assert fetched.final_score == 123
+        assert fetched.outcome == "win"
+        assert fetched.game_metadata == {"note": "smoke test"}
+        assert len(fetched.events) == 2
+        assert fetched.events[0].data == {"dice": [1, 2, 3, 4, 5]}
+
+        fetched_bug = (await s.execute(select(BugLog).where(BugLog.session_id == sid))).scalar_one()
+        assert fetched_bug.level == "warn"
+        assert fetched_bug.context == {"turn": 3}
+
+        # cleanup
+        await s.delete(fetched)
+        await s.delete(fetched_bug)
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_id_fails_fk() -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        yacht = (await s.execute(select(GameType).where(GameType.name == "yacht"))).scalar_one()
+        game = Game(session_id="fk-test", game_type_id=yacht.id)
+        s.add(game)
+        await s.flush()
+
+        game.events.append(GameEvent(event_index=0, event_type_id=999_999, data={}))
+        with pytest.raises((IntegrityError, DBAPIError)):
+            await s.commit()
+        await s.rollback()
+
+
+@pytest.mark.asyncio
+async def test_invalid_outcome_fails_check() -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        yacht = (await s.execute(select(GameType).where(GameType.name == "yacht"))).scalar_one()
+        game = Game(session_id="outcome-test", game_type_id=yacht.id, outcome="bogus")
+        s.add(game)
+        with pytest.raises((IntegrityError, DBAPIError)):
+            await s.commit()
+        await s.rollback()
+
+
+@pytest.mark.asyncio
+async def test_invalid_level_fails_check() -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        bug = BugLog(
+            session_id="level-test",
+            logged_at=datetime.now(timezone.utc),
+            level="info",  # not in ('warn','error','fatal')
+            source="test",
+            message="should fail",
+        )
+        s.add(bug)
+        with pytest.raises((IntegrityError, DBAPIError)):
+            await s.commit()
+        await s.rollback()


### PR DESCRIPTION
Part of epic #362. Closes #363.

## Scope

Adds the full data model for stats + logs as specified in #363: two lookup tables (`game_types`, `event_types`) and three application tables (`games`, `game_events`, `bug_logs`).

No API endpoints yet — that's #364 (write API) and #365 (read API).

## Design notes

- **Lookup tables** (`game_types`, `event_types`) for evolvable vocabularies — renames / new types / deprecations happen via row updates, not ALTER TABLE.
- **CHECK constraints** for stable vocabularies (`outcome` on games, `level` on bug_logs).
- **Partial indexes** on `games` for the two common query shapes: user history (`WHERE user_id IS NOT NULL`) and leaderboards (`WHERE final_score IS NOT NULL`).
- **Portable types.** Runtime DB is always Postgres, but the schema-check CI job runs against sqlite. Used `sa.Uuid` + `JSON().with_variant(JSONB, 'postgresql')` so the same migration applies clean to both. UUID PK defaults are Python-side (`uuid.uuid4`) so we don't need `gen_random_uuid()` / pgcrypto.
- `user_id` stays nullable with no FK (the `users` table doesn't exist yet — future SSO epic backfills it).

## Files

- `backend/db/models.py` — `GameType`, `EventType`, `Game`, `GameEvent`, `BugLog`
- `backend/alembic/versions/0002_games_events_lookups.py` — DDL + seed
- `backend/alembic/env.py` — `target_metadata` now points at `Base.metadata`
- `backend/tests/test_db_schema.py` — constraint + round-trip tests

## Seed data

- 4 `game_types`: yacht, twenty48, blackjack, cascade
- 17 `event_types` covering the baseline vocabulary for all four games:
  - yacht: `game_started`, `roll`, `score`, `game_ended`
  - 2048: `game_started`, `move`, `game_ended`
  - blackjack: `game_started`, `bet_placed`, `hand_dealt`, `player_action`, `hand_resolved`, `game_ended`
  - cascade: `game_started`, `drop`, `merge`, `game_ended`

## Verification

Ran upgrade/check/downgrade round-trip on **both** backends:

**sqlite (CI path)**
- `alembic upgrade head` ✅
- `alembic check` → "No new upgrade operations detected" ✅
- `alembic downgrade base` ✅
- Seed rows present (4 game_types, 17 event_types)

**Render Postgres (prod)**
- `alembic upgrade head` ✅
- `alembic check` ✅
- `alembic downgrade base` + `alembic upgrade head` ✅
- Seed rows present

## Test plan

- [ ] CI: schema-check, lint-python, test-python pass
- [ ] After merge: confirm gaming-app-api deploy still boots cleanly (engine is lazy, no regression risk)
- [ ] #364 (write API) will consume these models next

🤖 Generated with [Claude Code](https://claude.com/claude-code)