### PR TITLE
feat(cascade): migrate leaderboard from in-memory to Postgres (#366)

### DIFF
--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -1,39 +1,114 @@
-from fastapi import APIRouter, Request
+"""Cascade leaderboard — now backed by the games table (#366).
 
+POST /cascade/score creates and immediately completes a Game row tagged
+with `cascade` and the player name in `game_metadata`. GET /cascade/scores
+queries the top 10 by final_score, joined against the cached `game_types`
+row so we only pay one lookup per query.
+
+The response shape (`ScoreEntry`, `LeaderboardResponse`) is unchanged so the
+frontend scoreSync client needs no updates.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
 from limiter import limiter
-from .models import ScoreSubmitRequest, ScoreEntry, LeaderboardResponse
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
 
 router = APIRouter()
 
-_leaderboard: list[ScoreEntry] = []
 LEADERBOARD_LIMIT = 10
+_CASCADE_GAME_TYPE = "cascade"
+_CASCADE_SESSION = "cascade-anon"  # placeholder until SSO; rows still rank
+
+
+async def _cascade_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == _CASCADE_GAME_TYPE))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="cascade game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _cascade_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
 
 
 @router.post("/score", response_model=ScoreEntry, status_code=201)
 @limiter.limit("5/minute")
-def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
-    entry = ScoreEntry(player_name=body.player_name, score=body.score, rank=0)
-    _leaderboard.append(entry)
-    # Stable sort: ties preserve insertion order, so a new tied entry ranks
-    # *below* an older tied entry. This is the existing behavior.
-    _leaderboard.sort(key=lambda e: e.score, reverse=True)
-    # Identity check — can't use .index() because two tied entries compare
-    # equal by Pydantic field equality.
-    rank = next(i for i, e in enumerate(_leaderboard) if e is entry) + 1
-    entry.rank = rank
-    # Renumber remaining entries since a mid-list insert shifts ranks below.
-    for i, e in enumerate(_leaderboard):
-        e.rank = i + 1
-    del _leaderboard[LEADERBOARD_LIMIT:]
-    return entry
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _cascade_game_type_id(db)
+        # Create + complete in a single commit. We still store the row even if
+        # it won't make the top 10 — matches the previous in-memory behavior
+        # where .rank > LEADERBOARD_LIMIT meant "dropped".
+        from datetime import datetime, timezone
+
+        game = Game(
+            session_id=_CASCADE_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    # Not in top 10 — report the truncated-off rank.
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
 
 
 @router.get("/scores", response_model=LeaderboardResponse)
 @limiter.limit("60/minute")
-def get_scores(request: Request) -> LeaderboardResponse:
-    return LeaderboardResponse(scores=list(_leaderboard))
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
 
 
 def reset_leaderboard() -> None:
-    """Test helper — clears in-memory leaderboard."""
-    _leaderboard.clear()
+    """Test helper — no-op now that the leaderboard lives in the DB.
+
+    Kept for backward compatibility with the existing
+    `test_cascade_api.py` autouse fixture, which calls it on setup/teardown.
+    The conftest clean_db_tables fixture handles the actual cleanup.
+    """
+    return None

--- a/backend/db/base.py
+++ b/backend/db/base.py
@@ -53,7 +53,12 @@ def get_engine() -> AsyncEngine:
     if _engine is None:
         if not DATABASE_URL:
             raise RuntimeError("DATABASE_URL is not configured")
-        _engine = create_async_engine(DATABASE_URL, pool_pre_ping=True, pool_size=5, max_overflow=5)
+        # SQLite uses NullPool under the async driver and rejects pool_size /
+        # max_overflow. Only pass connection-pool tuning to Postgres.
+        kwargs: dict = {"pool_pre_ping": True}
+        if not DATABASE_URL.startswith("sqlite"):
+            kwargs.update({"pool_size": 5, "max_overflow": 5})
+        _engine = create_async_engine(DATABASE_URL, **kwargs)
     return _engine
 
 

--- a/backend/db/base.py
+++ b/backend/db/base.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import os
 from typing import AsyncIterator
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -59,6 +60,17 @@ def get_engine() -> AsyncEngine:
         if not DATABASE_URL.startswith("sqlite"):
             kwargs.update({"pool_size": 5, "max_overflow": 5})
         _engine = create_async_engine(DATABASE_URL, **kwargs)
+
+        # SQLite doesn't enforce foreign keys unless explicitly enabled per
+        # connection. Only affects the test DB; Postgres always enforces.
+        if DATABASE_URL.startswith("sqlite"):
+
+            @event.listens_for(_engine.sync_engine, "connect")
+            def _enable_sqlite_fk(dbapi_conn, _record):  # type: ignore[no-untyped-def]
+                cur = dbapi_conn.cursor()
+                cur.execute("PRAGMA foreign_keys = ON")
+                cur.close()
+
     return _engine
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,6 +4,7 @@ markers = [
 ]
 testpaths = ["tests"]
 addopts = "--cov=. --cov-report=term-missing --cov-fail-under=80"
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 omit = ["tests/*"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ limits==3.14.0
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.30.0
 psycopg2-binary==2.9.10
+aiosqlite==0.20.0
 alembic==1.14.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,68 @@
-"""Shared pytest fixtures."""
+"""Shared pytest fixtures.
+
+Sets up a session-scoped SQLite database for tests that hit the DB layer
+(cascade leaderboard, games/logs/stats APIs). The hook fires in
+pytest_configure — before any test module is imported — so pytestmark
+skipifs that gate on DATABASE_URL evaluate to False and the tests run.
+
+Tests that were skipped before #366 (games/logs/stats API tests guarded on
+DATABASE_URL) now run on CI too, because this fixture guarantees one.
+
+Real Postgres is still used when DATABASE_URL is provided externally
+(e.g. running against the live Render DB locally for a smoke check).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
 
 import pytest
+
+_TEST_DB_FILE: Path | None = None
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Provision a SQLite test DB before any test module is imported.
+
+    We must set DATABASE_URL before collection so module-level
+    `pytestmark = pytest.mark.skipif(not os.environ.get("DATABASE_URL"), ...)`
+    resolves correctly.
+    """
+    global _TEST_DB_FILE
+    if os.environ.get("DATABASE_URL"):
+        # Caller provided a DB (e.g. Render Postgres for smoke tests).
+        return
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="gaming_app_test_"))
+    db_path = tmp_dir / "test.db"
+    _TEST_DB_FILE = db_path
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{db_path}"
+
+    # Run alembic upgrade head using the sync sqlite URL (env.py strips the
+    # +aiosqlite driver). We invoke the CLI so the stock alembic.ini loads.
+    backend = Path(__file__).resolve().parent.parent
+    env = os.environ.copy()
+    env["DATABASE_URL"] = f"sqlite:///{db_path}"
+    subprocess.run(
+        ["alembic", "upgrade", "head"],
+        cwd=backend,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    global _TEST_DB_FILE
+    if _TEST_DB_FILE and _TEST_DB_FILE.exists():
+        try:
+            _TEST_DB_FILE.unlink()
+        except OSError:
+            pass
+    _TEST_DB_FILE = None
 
 
 @pytest.fixture(autouse=True)
@@ -15,3 +77,26 @@ def reset_rate_limiter():
     limiter.reset()
     yield
     limiter.reset()
+
+
+@pytest.fixture(autouse=True)
+async def _clean_db_tables():
+    """Truncate DB state between tests so ordering doesn't matter.
+
+    Lightweight — only touches tables the new API suite writes to. Existing
+    in-memory game state (blackjack, yacht, cascade in-memory) is reset by
+    their own router-level reset helpers.
+    """
+    from db.base import get_engine, is_configured
+
+    if not is_configured():
+        yield
+        return
+
+    from sqlalchemy import text
+
+    engine = get_engine()
+    async with engine.begin() as conn:
+        for table in ("game_events", "games", "bug_logs"):
+            await conn.execute(text(f"DELETE FROM {table}"))
+    yield

--- a/backend/tests/test_cascade_leaderboard_persistence.py
+++ b/backend/tests/test_cascade_leaderboard_persistence.py
@@ -1,0 +1,55 @@
+"""#366: cascade leaderboard survives across engine dispose + reload.
+
+The in-memory leaderboard that preceded #366 lost every score on restart.
+This test exercises the DB-backed replacement by:
+  1. POSTing a score via one TestClient
+  2. Disposing the engine pool (proxy for a process restart — drops all
+     open connections)
+  3. Re-opening a fresh TestClient and asserting the score is still visible
+
+Uses a dedicated SQLite file so autouse clean_db_tables fixture in
+conftest.py does NOT wipe the row (we disable that fixture for this module).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from db.base import get_engine
+
+
+# Disable the autouse table-clearing fixture for this file: the whole point
+# is that data survives across in-process "restarts".
+@pytest.fixture(autouse=True)
+async def _clean_db_tables():
+    yield
+
+
+async def test_cascade_score_survives_engine_dispose() -> None:
+    from main import app
+
+    with TestClient(app) as c1:
+        r = c1.post(
+            "/cascade/score",
+            json={"player_name": "PersistenceTester", "score": 4242},
+        )
+        assert r.status_code == 201, r.text
+
+    # Proxy for "backend restart" — drop connection pool.
+    engine = get_engine()
+    await engine.dispose()
+
+    with TestClient(app) as c2:
+        r = c2.get("/cascade/scores")
+        assert r.status_code == 200
+        scores = r.json()["scores"]
+        assert any(
+            s["player_name"] == "PersistenceTester" and s["score"] == 4242 for s in scores
+        ), f"Expected persisted score in {scores!r}"
+
+    # Manual cleanup since clean_db_tables is disabled.
+    from sqlalchemy import text
+
+    async with engine.begin() as conn:
+        await conn.execute(text("DELETE FROM games"))

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -37,4 +37,5 @@ async def test_alembic_head_applied() -> None:
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
-        assert version == "0001_baseline"
+        # Latest head — bump when a new migration lands.
+        assert version == "0002_games_events_lookups"

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -110,9 +110,7 @@ async def test_game_events_and_buglog_roundtrip() -> None:
 
         fetched = (
             await s.execute(
-                select(Game)
-                .options(selectinload(Game.events))
-                .where(Game.session_id == sid)
+                select(Game).options(selectinload(Game.events)).where(Game.session_id == sid)
             )
         ).scalar_one()
         assert fetched.final_score == 123
@@ -140,11 +138,7 @@ async def test_unknown_event_type_id_fails_fk() -> None:
         s.add(game)
         await s.flush()
 
-        s.add(
-            GameEvent(
-                game_id=game.id, event_index=0, event_type_id=999_999, data={}
-            )
-        )
+        s.add(GameEvent(game_id=game.id, event_index=0, event_type_id=999_999, data={}))
         with pytest.raises((IntegrityError, DBAPIError)):
             await s.commit()
         await s.rollback()

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.orm import selectinload
 
 from db.base import get_session_factory
 from db.models import BugLog, EventType, Game, GameEvent, GameType
@@ -76,11 +77,24 @@ async def test_game_events_and_buglog_roundtrip() -> None:
         s.add(game)
         await s.flush()
 
-        game.events.append(
-            GameEvent(event_index=0, event_type_id=roll_type.id, data={"dice": [1, 2, 3, 4, 5]})
+        # Add events via session.add() rather than game.events.append() —
+        # the latter triggers an implicit lazy load of the collection, which
+        # fails under the async driver without a greenlet context.
+        s.add(
+            GameEvent(
+                game_id=game.id,
+                event_index=0,
+                event_type_id=roll_type.id,
+                data={"dice": [1, 2, 3, 4, 5]},
+            )
         )
-        game.events.append(
-            GameEvent(event_index=1, event_type_id=roll_type.id, data={"dice": [6, 6, 6, 6, 6]})
+        s.add(
+            GameEvent(
+                game_id=game.id,
+                event_index=1,
+                event_type_id=roll_type.id,
+                data={"dice": [6, 6, 6, 6, 6]},
+            )
         )
 
         bug = BugLog(
@@ -94,7 +108,13 @@ async def test_game_events_and_buglog_roundtrip() -> None:
         s.add(bug)
         await s.commit()
 
-        fetched = (await s.execute(select(Game).where(Game.session_id == sid))).scalar_one()
+        fetched = (
+            await s.execute(
+                select(Game)
+                .options(selectinload(Game.events))
+                .where(Game.session_id == sid)
+            )
+        ).scalar_one()
         assert fetched.final_score == 123
         assert fetched.outcome == "win"
         assert fetched.game_metadata == {"note": "smoke test"}
@@ -120,7 +140,11 @@ async def test_unknown_event_type_id_fails_fk() -> None:
         s.add(game)
         await s.flush()
 
-        game.events.append(GameEvent(event_index=0, event_type_id=999_999, data={}))
+        s.add(
+            GameEvent(
+                game_id=game.id, event_index=0, event_type_id=999_999, data={}
+            )
+        )
         with pytest.raises((IntegrityError, DBAPIError)):
             await s.commit()
         await s.rollback()


### PR DESCRIPTION
Part of epic #362. Closes #366.

## Scope

Replaces Cascade's in-memory \`_leaderboard\` list with DB-backed reads and writes so scores survive backend restarts. Zero frontend changes.

## Behavior

- \`POST /cascade/score\` writes a Game row tagged \`cascade\` with \`game_metadata.player_name\` + \`final_score\`. Rank is computed by querying the top 10 with the same stable-sort ordering as before (score DESC, completed_at ASC as tie-breaker). Off-leaderboard submissions still return \`rank=11\`.
- \`GET /cascade/scores\` queries the top 10 from \`games\` where \`game_type='cascade'\`.
- Response shapes (\`ScoreEntry\`, \`LeaderboardResponse\`) are unchanged.

## Test infrastructure upgrade

The bigger story in this PR is that **\`tests/conftest.py\` now provisions a file-backed SQLite DB** before any test module is imported (via \`pytest_configure\`), runs \`alembic upgrade head\`, and sets \`DATABASE_URL\`. This has two wins:

1. **API tests now run on CI.** The games/logs/stats tests from #364 and #365 were guarded by \`pytest.mark.skipif(not DATABASE_URL)\` and silently skipped in CI. With this conftest, \`DATABASE_URL\` is always set, so those tests run against a SQLite instance on every PR.
2. **Cascade persistence tests are cheap.** A new \`test_cascade_leaderboard_persistence.py\` submits a score, disposes the engine pool (proxy for a process restart), then reopens a fresh TestClient and verifies the row is still there.

An autouse async fixture also truncates \`games\`/\`game_events\`/\`bug_logs\` between tests so ordering is deterministic.

Requires:
- \`aiosqlite==0.20.0\` — async SQLite driver for the test DB
- \`pytest-asyncio\` auto mode (set in \`pyproject.toml\`) so async fixtures run without per-function \`@pytest.mark.asyncio\` decorators

## Files

- \`backend/cascade/router.py\` — async handlers, DB reads/writes
- \`backend/requirements.txt\` — \`aiosqlite==0.20.0\`
- \`backend/pyproject.toml\` — \`asyncio_mode = \"auto\"\`
- \`backend/tests/conftest.py\` — \`pytest_configure\` + autouse cleanup fixture
- \`backend/tests/test_cascade_leaderboard_persistence.py\` — new

Unchanged: \`backend/tests/test_cascade_api.py\`, \`backend/cascade/models.py\`, \`frontend/\` (scoreSync.ts keeps working).

## Verification

- \`alembic upgrade head\` on SQLite (CI path) ✅
- \`alembic check\` ✅
- Black + ruff clean on all touched files
- Existing cascade-api test cases preserved verbatim

## Test plan

- [ ] CI: \`test-python\` should now run the API test suites from #364 and #365 too — those will actually exercise the code rather than skip
- [ ] CI: cascade tests still green
- [ ] After merge: phase 2 complete. Phase 3 starts with #367 (bounded SQLite LogStore + SyncWorker — the load-bearing client-side pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)