### PR TITLE
test(logs): capacity warning UX scenario (#484)

### DIFF
--- a/e2e/tests/logs-capacity-warning.spec.ts
+++ b/e2e/tests/logs-capacity-warning.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * #484 scenario 6 — Capacity warning UX.
+ *
+ * The last e2e scenario from the #373 acceptance gate (scenario 13 is
+ * deferred to #486). Drives the real CapacityWarningToast component
+ * that landed in #483.
+ *
+ * Flow:
+ *   1. Override MAX_ROWS=100 and pin CAPACITY_WARNING_SUPPRESS_MS to a
+ *      value that outlives the test so the 24h suppression actually
+ *      gates on our dismiss event instead of racing wall clock.
+ *   2. Seed 82 rows (82% fill) — crosses the 80% warning ratio.
+ *   3. Wait for the toast's next poll cycle (the test build uses a
+ *      500 ms interval instead of the production 30 s).
+ *   4. Assert the toast becomes visible.
+ *   5. Click Dismiss — markWarningShown() fires and activates the
+ *      suppression window.
+ *   6. Seed 10 more rows (92% fill — well above the threshold).
+ *   7. Wait two poll cycles and assert the toast does NOT reappear.
+ *
+ * The test runs inside a single withLogConfigOverride block so any
+ * failure path restores defaults on exit.
+ */
+
+import { test } from "@playwright/test";
+import {
+  clearLogstore,
+  expect,
+  seedEvents,
+  waitForLogstoreReady,
+  withLogConfigOverride,
+} from "./helpers/logstore";
+
+test.describe("#484 scenario 6 — capacity warning UX", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForLogstoreReady(page);
+    await clearLogstore(page);
+    // NOTE: we intentionally do NOT call resetLogConfig here — the
+    // override block below is the authority for this spec, and calling
+    // reset before entering it would be a no-op anyway.
+  });
+
+  test("toast appears once at 82% and is suppressed after dismiss", async ({
+    page,
+  }) => {
+    await withLogConfigOverride(
+      page,
+      {
+        MAX_ROWS: 100,
+        // Suppression window much larger than the test wall clock, so
+        // the test's "toast doesn't reappear" assertion is gated on
+        // markWarningShown() — not on the clock drifting.
+        CAPACITY_WARNING_SUPPRESS_MS: 60_000,
+      },
+      async () => {
+        // Seed 82 rows — crosses the 80% CAPACITY_WARNING_RATIO.
+        await seedEvents(page, { count: 82, eventType: "move" });
+
+        // Wait for the next poll cycle to render the toast. Test builds
+        // run the toast's internal poll at 500 ms; give ourselves ~1.5 s
+        // of headroom so CI jitter doesn't flake.
+        const toast = page.getByTestId("capacity-warning-toast");
+        await expect(toast).toBeVisible({ timeout: 2_000 });
+
+        // Tap Dismiss — this calls markWarningShown() which writes
+        // warningLastShownAt to AsyncStorage.
+        await page.getByTestId("capacity-warning-dismiss").click();
+
+        // Toast is hidden immediately.
+        await expect(toast).toBeHidden();
+
+        // Push the queue further over the threshold. With MAX_ROWS=100
+        // we're now at 92% fill — the raw shouldShow() check would
+        // return true if it weren't for the suppression window.
+        await seedEvents(page, { count: 10, eventType: "move" });
+
+        // Wait two poll cycles and assert the toast stays hidden.
+        // 500 ms × 2 = 1 s plus a cushion.
+        await page.waitForTimeout(1_300);
+        await expect(toast).toBeHidden();
+      },
+    );
+  });
+});

--- a/frontend/src/components/shared/CapacityWarningToast.tsx
+++ b/frontend/src/components/shared/CapacityWarningToast.tsx
@@ -20,8 +20,15 @@ import * as Sentry from "@sentry/react-native";
 import { useTheme } from "../../theme/ThemeContext";
 import { eventStore } from "../../game/_shared/eventStore";
 
-/** How often to check whether the warning should be shown. */
-const POLL_INTERVAL_MS = 30_000;
+/**
+ * How often to check whether the warning should be shown. In production
+ * builds this is 30 s — generous since the underlying condition only
+ * shifts over many thousands of enqueue calls. In test builds (set via
+ * EXPO_PUBLIC_TEST_HOOKS=1 at build time) we drop it to 500 ms so the
+ * scenario 6 e2e spec can drive foreground/dismiss cycles without
+ * waiting real-time. Production users never see the faster interval.
+ */
+const POLL_INTERVAL_MS = process.env.EXPO_PUBLIC_TEST_HOOKS === "1" ? 500 : 30_000;
 
 interface Props {
   /**


### PR DESCRIPTION
## Summary

Scenario 6 — the final #373 acceptance gate scenario that isn't blocked on the #486 eviction redesign. Drives the real \`CapacityWarningToast\` component that landed in #483 end to end: seed 82 rows (82% of MAX_ROWS=100), wait for the toast to render, dismiss it, push the queue further past the threshold, and assert the toast stays hidden because \`markWarningShown\` activated the suppression window.

### Spec — \`logs-capacity-warning.spec.ts\`

Runs inside a single \`withLogConfigOverride\` block:

- **\`MAX_ROWS=100\`** so 82 seeded rows gives a clean 82% fill
- **\`CAPACITY_WARNING_SUPPRESS_MS=60000\`** (well above the test's wall clock) so the "stays hidden after dismiss" assertion is gated on \`markWarningShown()\` firing, not on the clock drifting

### Supporting change — poll interval under \`EXPO_PUBLIC_TEST_HOOKS\`

\`CapacityWarningToast\` polled every 30 s by default — fine for production (the capacity ratio shifts over thousands of enqueues, not per second) but way too slow for a deterministic e2e test. Drop to **500 ms in test builds only**, gated on \`process.env.EXPO_PUBLIC_TEST_HOOKS === "1"\`. Same gating pattern as the game engine test hooks. Production bundles inline the constant to \`30_000\` at build time — no runtime cost or behavior change.

### Results

- All **26 logs-budget e2e specs green** (20 prior + 4 perf/memory + 1 manual-clear + 1 new capacity-warning) in ~27 s
- CapacityWarningToast unit tests 6/6 green (the poll-interval change is behind an env check so it doesn't affect Jest)

## Epic state after this PR

This is the last piece of **#373** except **#486** (the eviction policy redesign + scenario 13). After this merges, every non-deferred scenario from the acceptance gate is green on CI:

| # | Scenario | Status |
|---|---|---|
| 1 | Offline marathon | ✅ #481 |
| 2 | Latency budget | ✅ #482 |
| 3 | Memory budget | ✅ #482 |
| 4 | Eviction correctness | ✅ #480 |
| 5 | TTL sweep | ✅ #480 |
| **6** | **Capacity warning UX** | **✅ this PR** |
| 7 | Manual clear | ✅ #482 |
| 8 | Non-blocking proof | ✅ #482 |
| 9 | Crash recovery | ✅ #481 |
| 10 | Server unreachable | ✅ #481 |
| 11 | Rate-limit backoff | ✅ #481 |
| 12 | Config overrides | ✅ #480 |
| 13 | Bug-log spam | ⏸️ deferred to #486 |

Part of #373 / #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)