### PR TITLE
feat(cascade): persist in-progress game across reload (#216)

### DIFF
--- a/e2e/tests/cascade-reload-persistence.spec.ts
+++ b/e2e/tests/cascade-reload-persistence.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * #216 — Cascade reload persistence.
+ *
+ * Plays a short Cascade session (a few drops, a merge or two via a
+ * pinned RNG seed), then calls `page.reload()` and asserts:
+ *
+ *   - Score is preserved (non-zero after the reload).
+ *   - Fruit count matches what was on the board before the reload
+ *     (within a small tolerance for any fruit mid-merge at the moment
+ *     of the save snapshot).
+ *
+ * Both assertions use the `__cascade_getState` test hook exposed by
+ * CascadeScreen (gated on EXPO_PUBLIC_TEST_HOOKS=1).
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  gotoCascade,
+  getState,
+  setSeed,
+  dropAt,
+  spawnTierAt,
+  fastForward,
+  mockLeaderboard,
+} from "./helpers/cascade";
+
+test.describe("#216 — Cascade reload persistence", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboard(page);
+    // Clear any stale storage from prior test runs sharing this
+    // browser context.
+    await page.goto("/");
+    await page.evaluate(() => {
+      try {
+        window.localStorage.removeItem("cascade_game_v1");
+      } catch {
+        /* ignore */
+      }
+    });
+  });
+
+  test("reload mid-game preserves score and the board of fruits", async ({
+    page,
+  }) => {
+    await gotoCascade(page);
+    await setSeed(page, 42);
+
+    // Drop a handful of fruits in varied positions so the physics world
+    // has meaningful state to snapshot.
+    await dropAt(page, 120);
+    await fastForward(page, 300);
+    await dropAt(page, 200);
+    await fastForward(page, 300);
+    await dropAt(page, 160);
+    await fastForward(page, 300);
+
+    // Spawn two fruits of the same tier stacked near the same x to
+    // trigger a merge, which is the #1 reload-persistence trigger in
+    // CascadeScreen.handleMerge.
+    await spawnTierAt(page, 2, 180);
+    await fastForward(page, 100);
+    await spawnTierAt(page, 2, 180);
+    await fastForward(page, 600);
+
+    // Give the throttled save a chance to land.
+    await page.waitForTimeout(100);
+
+    const before = await getState(page);
+    expect(before.score).toBeGreaterThan(0);
+    expect(before.fruits.length).toBeGreaterThan(0);
+    const scoreBefore = before.score;
+    const fruitCountBefore = before.fruits.length;
+
+    // "Crash" — Playwright preserves localStorage (AsyncStorage
+    // under the hood on web) across page.reload().
+    await page.reload();
+    await gotoCascade(page);
+
+    // Give onReady + restoreFruits a frame to apply.
+    await page.waitForTimeout(200);
+    const after = await getState(page);
+
+    expect(after.score).toBe(scoreBefore);
+    // Fruit count tolerance: ±1 because of any fruit mid-merge at the
+    // snapshot moment. The important assertion is "board is NOT empty".
+    expect(after.fruits.length).toBeGreaterThanOrEqual(
+      Math.max(1, fruitCountBefore - 1),
+    );
+  });
+
+  test("starting a New Game after a reload restore yields a fresh board", async ({
+    page,
+  }) => {
+    await gotoCascade(page);
+    await setSeed(page, 7);
+    // Force a couple of merges so score > 0 (the confirm modal only
+    // appears when `scoreRef > 0 && !gameOver`).
+    await spawnTierAt(page, 1, 150);
+    await fastForward(page, 100);
+    await spawnTierAt(page, 1, 150);
+    await fastForward(page, 600);
+    await spawnTierAt(page, 2, 200);
+    await fastForward(page, 100);
+    await spawnTierAt(page, 2, 200);
+    await fastForward(page, 600);
+    await page.waitForTimeout(100);
+
+    await page.reload();
+    await gotoCascade(page);
+    await page.waitForTimeout(200);
+
+    let state = await getState(page);
+    expect(state.score).toBeGreaterThan(0);
+    expect(state.fruits.length).toBeGreaterThan(0);
+
+    // Press the New Game pill — since score > 0 and game isn't over,
+    // the confirm modal appears. Accept it.
+    await page.getByRole("button", { name: "New Game" }).click();
+    await page.getByRole("button", { name: /start new game/i }).click();
+
+    await page.waitForTimeout(300);
+    state = await getState(page);
+    expect(state.score).toBe(0);
+    expect(state.fruits.length).toBe(0);
+  });
+});

--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -49,12 +49,27 @@ export interface CascadeEngineState {
   fruits: Array<{ id: number; tier: number; x: number; y: number }>;
 }
 
+export interface SavedFruitInput {
+  tier: number;
+  x: number;
+  y: number;
+}
+
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
   reset: () => void;
   announceEvent: (message: string) => void;
-  /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
-  getEngineState?: () => CascadeEngineState;
+  /**
+   * Current engine state snapshot. Returns empty on native — native
+   * Skia canvas doesn't mirror bodies outside of React state yet, so
+   * #216 reload persistence falls back to saving score only on mobile.
+   */
+  getEngineState: () => CascadeEngineState;
+  /**
+   * Restore fruits from a saved snapshot. No-op on native until the
+   * native canvas exposes its body ref; see #216 PR description.
+   */
+  restoreFruits: (fruits: readonly SavedFruitInput[], fruitSet: FruitSet) => void;
   fastForward?: (ms: number) => void;
   /** True once the physics engine has finished async init (Rapier WASM loaded). */
   isReady?: () => boolean;
@@ -66,6 +81,8 @@ interface Props {
   onMerge: (event: MergeEvent) => void;
   onGameOver: () => void;
   onTap: (x: number) => void;
+  /** Fires once after createEngine() resolves. */
+  onReady?: () => void;
   width: number; // world width (px) — physics coordinate space
   height: number; // world height (px) — physics coordinate space
   scale: number; // display scale: canvas CSS size = world * scale
@@ -114,7 +131,7 @@ function FruitBodySkia({
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height, scale }, ref) => {
+  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, onReady, width, height, scale }, ref) => {
     const { colors } = useTheme();
     const { t } = useTranslation("cascade");
 
@@ -130,6 +147,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const lastFrameTimeRef = useRef<number>(0); // tracks last RAF timestamp for elapsed-time physics
     const onMergeRef = useRef(onMerge);
     const onGameOverRef = useRef(onGameOver);
+    const onReadyRef = useRef(onReady);
     const fruitSetRef = useRef(fruitSet);
 
     useEffect(() => {
@@ -138,6 +156,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onGameOverRef.current = onGameOver;
     }, [onGameOver]);
+    useEffect(() => {
+      onReadyRef.current = onReady;
+    }, [onReady]);
     useEffect(() => {
       fruitSetRef.current = fruitSet;
     }, [fruitSet]);
@@ -169,7 +190,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         );
       } catch (err) {
         setEngineError(err instanceof Error ? err.message : String(err));
+        return;
       }
+      onReadyRef.current?.();
     }, [width, height, fruitSet]);
 
     useEffect(() => {
@@ -214,6 +237,15 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         announceEvent(message) {
           AccessibilityInfo.announceForAccessibility(message);
+        },
+        // Native fallbacks — the native Skia canvas doesn't expose its
+        // body ref, so #216 reload persistence saves score only on
+        // mobile. Full parity is tracked as a native-canvas follow-up.
+        getEngineState() {
+          return { fruitCount: 0, dangerRatio: 0, fruits: [] };
+        },
+        restoreFruits() {
+          // no-op
         },
       }),
       [initEngine, width]

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -36,12 +36,30 @@ export interface CascadeEngineState {
   fruits: Array<{ id: number; tier: number; x: number; y: number }>;
 }
 
+export interface SavedFruitInput {
+  tier: number;
+  x: number;
+  y: number;
+}
+
 export interface GameCanvasHandle {
   drop: (def: FruitDefinition, x: number) => void;
   reset: () => void;
   announceEvent: (message: string) => void;
-  /** Only populated when EXPO_PUBLIC_TEST_HOOKS=1 */
-  getEngineState?: () => CascadeEngineState;
+  /**
+   * Returns the current engine state snapshot. Used by #216 reload
+   * persistence to serialize in-flight fruits, and by test hooks to
+   * inspect the physics state. Always available (was test-only in
+   * earlier versions).
+   */
+  getEngineState: () => CascadeEngineState;
+  /**
+   * Restore a set of fruits to specific (x, y) positions. Used by
+   * #216 reload persistence after loading a saved game. Fruits are
+   * spawned at rest; physics will settle them over the next frame or
+   * two.
+   */
+  restoreFruits: (fruits: readonly SavedFruitInput[], fruitSet: FruitSet) => void;
   fastForward?: (ms: number) => void;
   /** True once the physics engine has finished async init (Rapier WASM loaded). */
   isReady?: () => boolean;
@@ -53,6 +71,8 @@ interface Props {
   onMerge: (event: MergeEvent) => void;
   onGameOver: () => void;
   onTap: (x: number) => void;
+  /** Called once, after createEngine() resolves and the engine is ready to drop. */
+  onReady?: () => void;
   width: number; // world width (px) — physics coordinate space
   height: number; // world height (px) — physics coordinate space
   scale: number; // display scale: canvas CSS size = world * scale
@@ -133,7 +153,7 @@ function drawCollisionOverlay(
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, width, height, scale }, ref) => {
+  ({ fruitSet, nextDef, onMerge, onGameOver, onTap, onReady, width, height, scale }, ref) => {
     const { colors } = useTheme();
     const { t } = useTranslation("cascade");
 
@@ -141,6 +161,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const engineRef = useRef<EngineHandle | null>(null);
     const onMergeRef = useRef(onMerge);
     const onGameOverRef = useRef(onGameOver);
+    const onReadyRef = useRef(onReady);
     const fruitSetRef = useRef(fruitSet);
     const colorsRef = useRef(colors);
     const nextDefRef = useRef(nextDef);
@@ -156,6 +177,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onGameOverRef.current = onGameOver;
     }, [onGameOver]);
+    useEffect(() => {
+      onReadyRef.current = onReady;
+    }, [onReady]);
     useEffect(() => {
       fruitSetRef.current = fruitSet;
     }, [fruitSet]);
@@ -341,6 +365,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           });
         }
       );
+      // Notify listeners — CascadeScreen uses this to know when it's
+      // safe to restore saved fruits via restoreFruits().
+      onReadyRef.current?.();
     }, [width, height, fruitSet]);
 
     useEffect(() => {
@@ -393,6 +420,28 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     }, []); // intentionally empty — loop lives for component lifetime
 
     useImperativeHandle(ref, () => {
+      const getEngineState = (): CascadeEngineState => {
+        const bodies = bodiesRef.current;
+        const dangerY = height * DANGER_LINE_RATIO;
+        let dangerRatio = 0;
+        if (bodies.length > 0) {
+          const minTopY = Math.min(
+            ...bodies.map((b) => b.y - (fruitSetRef.current.fruits[b.tier]?.radius ?? 0))
+          );
+          dangerRatio = Math.max(0, Math.min(1, 1 - minTopY / dangerY));
+        }
+        return {
+          fruitCount: bodies.length,
+          dangerRatio,
+          fruits: bodies.map((b) => ({
+            id: b.id,
+            tier: b.tier,
+            x: Math.round(b.x),
+            y: Math.round(b.y),
+          })),
+        };
+      };
+
       const base: GameCanvasHandle = {
         drop(def, x) {
           if (!engineRef.current) return;
@@ -412,33 +461,28 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         isReady() {
           return engineRef.current !== null;
         },
+        getEngineState,
+        restoreFruits(fruits, restoringSet) {
+          if (!engineRef.current) return;
+          for (const f of fruits) {
+            const def = restoringSet.fruits[f.tier];
+            if (!def) continue;
+            // Drop at the saved (x, y) with zero velocity. The fruit
+            // starts at rest and physics settles it over the next frame.
+            const clampedX = clamp(
+              f.x,
+              WALL_THICKNESS + def.radius,
+              width - WALL_THICKNESS - def.radius
+            );
+            engineRef.current.drop(def, restoringSet.id, clampedX, f.y);
+          }
+        },
       };
 
       if (process.env.EXPO_PUBLIC_TEST_HOOKS !== "1") return base;
 
       return {
         ...base,
-        getEngineState(): CascadeEngineState {
-          const bodies = bodiesRef.current;
-          const dangerY = height * DANGER_LINE_RATIO;
-          let dangerRatio = 0;
-          if (bodies.length > 0) {
-            const minTopY = Math.min(
-              ...bodies.map((b) => b.y - (fruitSetRef.current.fruits[b.tier]?.radius ?? 0))
-            );
-            dangerRatio = Math.max(0, Math.min(1, 1 - minTopY / dangerY));
-          }
-          return {
-            fruitCount: bodies.length,
-            dangerRatio,
-            fruits: bodies.map((b) => ({
-              id: b.id,
-              tier: b.tier,
-              x: Math.round(b.x),
-              y: Math.round(b.y),
-            })),
-          };
-        },
         fastForward(ms: number) {
           if (!engineRef.current) return;
           const STEP_S = 1 / 60; // ~16.67 ms per step

--- a/frontend/src/game/cascade/__tests__/storage.test.ts
+++ b/frontend/src/game/cascade/__tests__/storage.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #216 — Cascade reload persistence storage tests.
+ *
+ * Covers the save/load/clear round-trip and schema validation. The
+ * integration points (CascadeScreen wiring, canvas restore) are
+ * exercised by the e2e spec separately.
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { saveGame, loadGame, clearGame, CascadeGameSnapshot, SavedFruit } from "../storage";
+
+const KEY = "cascade_game_v1";
+
+function makeSnapshot(overrides: Partial<CascadeGameSnapshot> = {}): CascadeGameSnapshot {
+  return {
+    version: 1,
+    score: 42,
+    gameOver: false,
+    fruitSetId: "fruits",
+    queueTiers: [0, 1],
+    fruits: [
+      { tier: 0, x: 100, y: 200 },
+      { tier: 2, x: 150, y: 400 },
+    ],
+    savedAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("cascade/storage", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  describe("round-trip", () => {
+    it("saveGame + loadGame returns the same snapshot", async () => {
+      const snap = makeSnapshot();
+      await saveGame(snap);
+      const loaded = await loadGame();
+      expect(loaded).toEqual(snap);
+    });
+
+    it("empty fruits array round-trips cleanly (native fallback case)", async () => {
+      const snap = makeSnapshot({ fruits: [] });
+      await saveGame(snap);
+      const loaded = await loadGame();
+      expect(loaded?.fruits).toEqual([]);
+      expect(loaded?.score).toBe(42);
+    });
+
+    it("game_over=true round-trips for resume-to-game-over scenarios", async () => {
+      const snap = makeSnapshot({ gameOver: true, score: 9999 });
+      await saveGame(snap);
+      const loaded = await loadGame();
+      expect(loaded?.gameOver).toBe(true);
+      expect(loaded?.score).toBe(9999);
+    });
+  });
+
+  describe("clear", () => {
+    it("clearGame removes any saved snapshot", async () => {
+      await saveGame(makeSnapshot());
+      await clearGame();
+      const loaded = await loadGame();
+      expect(loaded).toBeNull();
+    });
+
+    it("loadGame returns null when nothing is saved", async () => {
+      const loaded = await loadGame();
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe("schema validation", () => {
+    async function writeRaw(raw: unknown): Promise<void> {
+      await AsyncStorage.setItem(KEY, JSON.stringify(raw));
+    }
+
+    it("returns null for a wrong version", async () => {
+      await writeRaw({ ...makeSnapshot(), version: 99 });
+      expect(await loadGame()).toBeNull();
+    });
+
+    it("returns null when score is missing", async () => {
+      const snap = makeSnapshot() as Partial<CascadeGameSnapshot>;
+      delete snap.score;
+      await writeRaw(snap);
+      expect(await loadGame()).toBeNull();
+    });
+
+    it("returns null when queueTiers is missing or wrong length", async () => {
+      await writeRaw({ ...makeSnapshot(), queueTiers: [0] });
+      expect(await loadGame()).toBeNull();
+      await writeRaw({ ...makeSnapshot(), queueTiers: undefined });
+      expect(await loadGame()).toBeNull();
+    });
+
+    it("returns null when fruits is not an array", async () => {
+      await writeRaw({ ...makeSnapshot(), fruits: "not an array" });
+      expect(await loadGame()).toBeNull();
+    });
+
+    it("drops malformed fruit entries but keeps the snapshot", async () => {
+      const snap = makeSnapshot({
+        fruits: [
+          { tier: 0, x: 100, y: 200 },
+          { tier: 1, x: NaN, y: 200 } as SavedFruit, // bad
+          null as unknown as SavedFruit, // bad
+          { tier: 3, x: 50, y: 50 },
+        ],
+      });
+      await writeRaw(snap);
+      const loaded = await loadGame();
+      expect(loaded?.fruits).toHaveLength(2);
+      expect(loaded?.fruits[0].tier).toBe(0);
+      expect(loaded?.fruits[1].tier).toBe(3);
+    });
+
+    it("returns null and deletes the entry when the stored JSON is corrupt", async () => {
+      await AsyncStorage.setItem(KEY, "{not json");
+      expect(await loadGame()).toBeNull();
+      // Subsequent load sees nothing (the corrupt entry was removed).
+      expect(await loadGame()).toBeNull();
+    });
+  });
+});

--- a/frontend/src/game/cascade/fruitQueue.ts
+++ b/frontend/src/game/cascade/fruitQueue.ts
@@ -5,10 +5,18 @@ export class FruitQueue {
   private queue: FruitTier[];
   private readonly selector: ControlledSpawnSelector;
 
-  constructor(selector: ControlledSpawnSelector = new ControlledSpawnSelector()) {
+  constructor(
+    selector: ControlledSpawnSelector = new ControlledSpawnSelector(),
+    initialQueue?: readonly [FruitTier, FruitTier]
+  ) {
     this.selector = selector;
-    // Pre-fill two: current + next preview
-    this.queue = [this.selector.next(), this.selector.next()];
+    // Pre-fill two: current + next preview. If a caller passes an
+    // `initialQueue` (used by #216's reload persistence to restore the
+    // [current, next] pair that was showing at save time), use those
+    // instead of pulling fresh values from the selector.
+    this.queue = initialQueue
+      ? [initialQueue[0], initialQueue[1]]
+      : [this.selector.next(), this.selector.next()];
   }
 
   peek(): FruitTier {

--- a/frontend/src/game/cascade/storage.ts
+++ b/frontend/src/game/cascade/storage.ts
@@ -1,0 +1,102 @@
+/**
+ * AsyncStorage persistence for Cascade in-progress games (#216).
+ *
+ * Cascade is a physics-simulation game, so "saving" the board means
+ * serializing each fruit's tier + resting position. On reload, fruits
+ * are re-spawned at their saved coordinates with zero velocity and
+ * allowed to settle for a frame or two — the visual difference is
+ * minimal compared to a crash-and-lose-everything outcome.
+ *
+ * Save trigger: after each merge + on a throttled interval while the
+ * player is dropping. Clear trigger: game-over, fruit-set switch,
+ * explicit New Game.
+ *
+ * Native (iOS/Android) caveat: the native Skia canvas doesn't yet
+ * expose its fruit snapshot, so `fruits` may be empty when saving
+ * from native. The loader tolerates this — score + game-over flag
+ * still resume correctly, just with an empty board. Full native
+ * parity is a follow-up.
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+
+const GAME_KEY = "cascade_game_v1";
+
+export interface SavedFruit {
+  tier: number;
+  x: number;
+  y: number;
+}
+
+export interface CascadeGameSnapshot {
+  version: 1;
+  score: number;
+  gameOver: boolean;
+  fruitSetId: string;
+  /** [currentTier, nextPreviewTier] from FruitQueue at save time. */
+  queueTiers: [number, number];
+  /** Array of in-flight fruits at save time. May be empty on native. */
+  fruits: SavedFruit[];
+  savedAt: number;
+}
+
+export async function saveGame(snapshot: CascadeGameSnapshot): Promise<void> {
+  try {
+    await AsyncStorage.setItem(GAME_KEY, JSON.stringify(snapshot));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "cascade.storage", op: "save" } });
+  }
+}
+
+export async function loadGame(): Promise<CascadeGameSnapshot | null> {
+  try {
+    const raw = await AsyncStorage.getItem(GAME_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CascadeGameSnapshot>;
+    // Schema validation — discard anything that doesn't match the v1 shape.
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.score !== "number" ||
+      typeof parsed.gameOver !== "boolean" ||
+      typeof parsed.fruitSetId !== "string" ||
+      !Array.isArray(parsed.queueTiers) ||
+      parsed.queueTiers.length !== 2 ||
+      !Array.isArray(parsed.fruits)
+    ) {
+      return null;
+    }
+    // Defensive clamp: drop any fruit with malformed fields.
+    const fruits: SavedFruit[] = parsed.fruits.filter(
+      (f): f is SavedFruit =>
+        !!f &&
+        typeof f.tier === "number" &&
+        typeof f.x === "number" &&
+        typeof f.y === "number" &&
+        Number.isFinite(f.x) &&
+        Number.isFinite(f.y)
+    );
+    return {
+      version: 1,
+      score: parsed.score,
+      gameOver: parsed.gameOver,
+      fruitSetId: parsed.fruitSetId,
+      queueTiers: [parsed.queueTiers[0] as number, parsed.queueTiers[1] as number],
+      fruits,
+      savedAt: typeof parsed.savedAt === "number" ? parsed.savedAt : Date.now(),
+    };
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "cascade.storage", op: "load" } });
+    // Remove corrupted entry so it doesn't fail on every subsequent load.
+    await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
+    return null;
+  }
+}
+
+export async function clearGame(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(GAME_KEY);
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "cascade.storage", op: "clear" } });
+  }
+}

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -11,6 +11,7 @@ import { FruitSetProvider, useFruitSet } from "../theme/FruitSetContext";
 import { FruitQueue } from "../game/cascade/fruitQueue";
 import { ControlledSpawnSelector, createSeededRng } from "../game/cascade/spawnSelector";
 import { MergeEvent, WORLD_W, WORLD_H } from "../game/cascade/engine";
+import type { FruitTier } from "../theme/fruitSets";
 import { scoreForMerge } from "../game/cascade/scoring";
 import GameCanvas, { GameCanvasHandle } from "../components/cascade/GameCanvas";
 import NextFruitPreview from "../components/cascade/NextFruitPreview";
@@ -19,6 +20,15 @@ import ThemeSelector from "../components/cascade/ThemeSelector";
 import GameOverOverlay from "../components/cascade/GameOverOverlay";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { gameEventClient } from "../game/_shared/gameEventClient";
+import {
+  saveGame as saveCascadeGame,
+  loadGame as loadCascadeGame,
+  clearGame as clearCascadeGame,
+  CascadeGameSnapshot,
+} from "../game/cascade/storage";
+
+/** Throttle for save-during-play — saves at most this often. */
+const SAVE_THROTTLE_MS = 2000;
 
 function CascadeGame() {
   const { t } = useTranslation(["cascade", "common"]);
@@ -52,6 +62,15 @@ function CascadeGame() {
   const completedRef = useRef(false);
   const gameStartTimeRef = useRef<number>(Date.now());
   const mergeCountRef = useRef(0);
+
+  // Reload persistence state (#216).
+  const lastSaveTimeRef = useRef<number>(0);
+  // Holds a loaded snapshot until the canvas signals ready via onReady,
+  // at which point we restore fruits onto the physics world.
+  const pendingLoadRef = useRef<CascadeGameSnapshot | null>(null);
+  // One-shot guard — load runs exactly once per screen mount, even if
+  // onReady fires multiple times because of canvas re-init.
+  const hasLoadedRef = useRef(false);
 
   const startInstrumentedSession = useCallback((themeId: string) => {
     gameStartTimeRef.current = Date.now();
@@ -99,6 +118,79 @@ function CascadeGame() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // #216 — Load any saved game on mount. The snapshot is held in
+  // `pendingLoadRef` until the canvas signals ready, at which point
+  // `handleCanvasReady` restores the fruits. Score + game-over state
+  // restore synchronously here so the HUD updates immediately.
+  useEffect(() => {
+    let active = true;
+    loadCascadeGame().then((snapshot) => {
+      if (!active || !snapshot) return;
+      // Don't restore a snapshot from a different theme — switching
+      // fruit sets should show a fresh board, not the previous skin's
+      // physics state.
+      if (snapshot.fruitSetId !== activeFruitSetRef.current.id) {
+        clearCascadeGame().catch(() => {});
+        return;
+      }
+      scoreRef.current = snapshot.score;
+      setScore(snapshot.score);
+      if (snapshot.gameOver) {
+        gameOverRef.current = true;
+        setGameOver(true);
+      }
+      pendingLoadRef.current = snapshot;
+    });
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fired by GameCanvas once the physics engine has finished init.
+  // At this point it's safe to call canvasRef.current.restoreFruits().
+  const handleCanvasReady = useCallback(() => {
+    if (hasLoadedRef.current) return;
+    const snapshot = pendingLoadRef.current;
+    if (!snapshot) return;
+    hasLoadedRef.current = true;
+    pendingLoadRef.current = null;
+    // Rebuild the queue so [current, next] match what the player saw.
+    // queueTiers is stored as plain numbers in the snapshot; cast back
+    // to the narrower FruitTier union (0..10) — the storage loader
+    // already validated these are finite numbers from a trusted save.
+    const [cur, nxt] = snapshot.queueTiers as [FruitTier, FruitTier];
+    queueRef.current = new FruitQueue(new ControlledSpawnSelector(), [cur, nxt]);
+    setQueueVersion((v) => v + 1);
+    // Restore fruits to the physics world. Web supports this; native
+    // no-ops and the board stays empty (score is still preserved).
+    canvasRef.current?.restoreFruits?.(snapshot.fruits, activeFruitSetRef.current);
+  }, []);
+
+  /** Build a snapshot from the current refs + canvas engine state. */
+  const buildSnapshot = useCallback((): CascadeGameSnapshot => {
+    const engineState = canvasRef.current?.getEngineState?.();
+    const fruits = engineState?.fruits ?? [];
+    return {
+      version: 1,
+      score: scoreRef.current,
+      gameOver: gameOverRef.current,
+      fruitSetId: activeFruitSetRef.current.id,
+      queueTiers: [queueRef.current.peek(), queueRef.current.peekNext()],
+      fruits: fruits.map((f) => ({ tier: f.tier, x: f.x, y: f.y })),
+      savedAt: Date.now(),
+    };
+  }, []);
+
+  /** Throttled save — called from gameplay triggers (merge, drop, etc). */
+  const saveGameThrottled = useCallback(() => {
+    const now = Date.now();
+    if (now - lastSaveTimeRef.current < SAVE_THROTTLE_MS) return;
+    lastSaveTimeRef.current = now;
+    if (gameOverRef.current) return;
+    saveCascadeGame(buildSnapshot()).catch(() => {});
+  }, [buildSnapshot]);
+
   // Refs are updated synchronously at mutation sites (handleMerge,
   // handleGameOver, handleRestart, and test hooks) so that Playwright reads
   // see the latest value without waiting for a React commit to flush.
@@ -121,6 +213,9 @@ function CascadeGame() {
       setGameOver(false);
       setQueueVersion((v) => v + 1);
       canvasRef.current?.reset();
+      // Drop any saved snapshot from the old theme — switching skins
+      // starts fresh, per the "different theme" guard in the load effect.
+      clearCascadeGame().catch(() => {});
       startInstrumentedSession(activeFruitSet.id);
     }
   }, [activeFruitSet.id, endInstrumentedSession, startInstrumentedSession]);
@@ -158,8 +253,12 @@ function CascadeGame() {
       if (merged) {
         canvasRef.current?.announceEvent(t("cascade:event.merged", { fruit: merged.name }));
       }
+      // #216 — merges are the highest-value save trigger. A player who
+      // just merged up a tier definitely wants that progress preserved
+      // across an accidental reload.
+      saveGameThrottled();
     },
-    [activeFruitSet, t]
+    [activeFruitSet, t, saveGameThrottled]
   );
 
   const handleGameOver = useCallback(() => {
@@ -167,6 +266,9 @@ function CascadeGame() {
     gameOverRef.current = true;
     setGameOver(true);
     endInstrumentedSession("completed");
+    // #216 — game over: clear the saved snapshot so the next mount
+    // starts with a fresh board instead of resuming a lost game.
+    clearCascadeGame().catch(() => {});
   }, [t, endInstrumentedSession]);
 
   const handleTap = useCallback(
@@ -211,11 +313,16 @@ function CascadeGame() {
       const def = activeFruitSet.fruits[tier];
       canvasRef.current?.drop(def, x);
 
+      // #216 — throttled save on drop. Merges already save on their own,
+      // but a player who drops a run of fruit without a merge should also
+      // have their board captured every couple of seconds.
+      saveGameThrottled();
+
       setTimeout(() => {
         droppingRef.current = false;
       }, 200);
     },
-    [gameOver, activeFruitSet]
+    [gameOver, activeFruitSet, saveGameThrottled]
   );
 
   // -------------------------------------------------------------------------
@@ -279,6 +386,12 @@ function CascadeGame() {
     setGameOver(false);
     setQueueVersion((v) => v + 1);
     canvasRef.current?.reset();
+    // #216 — user-initiated restart clears the saved snapshot and
+    // resets the throttle so the next drop saves immediately.
+    clearCascadeGame().catch(() => {});
+    lastSaveTimeRef.current = 0;
+    hasLoadedRef.current = true; // prevent onReady from re-applying any stale pending load
+    pendingLoadRef.current = null;
     startInstrumentedSession(activeFruitSetRef.current.id);
   }
 
@@ -362,6 +475,7 @@ function CascadeGame() {
             onMerge={handleMerge}
             onGameOver={handleGameOver}
             onTap={handleTap}
+            onReady={handleCanvasReady}
             width={WORLD_W}
             height={WORLD_H}
             scale={scale}


### PR DESCRIPTION
Cascade was the only offline-engine game without local save/load — an accidental browser reload or tab close wiped a long session. This mirrors the Yacht/2048/Blackjack pattern: save on merge + on a throttled interval during play, clear on game-over / theme switch / New Game, load on mount after the canvas is ready.

### Storage

`frontend/src/game/cascade/storage.ts` — AsyncStorage under key `cascade_game_v1`. Snapshot shape:

  { version: 1, score, gameOver, fruitSetId, queueTiers: [cur, next],
    fruits: [{ tier, x, y }], savedAt }

Schema-validated on load; corrupt entries are discarded and removed. Malformed individual fruits are filtered out but the rest of the snapshot still loads.

### Canvas handle changes

- `getEngineState()` is now always available on the web handle (was gated behind EXPO_PUBLIC_TEST_HOOKS). This is the serialization surface CascadeScreen uses to read fruit positions at save time.
- New `restoreFruits(fruits, fruitSet)` method re-spawns fruits at their saved (x, y) with zero velocity. Physics settles them over the next frame.
- New `onReady` prop fires once after `createEngine()` resolves — CascadeScreen uses this as the signal that it's safe to call restoreFruits with pending-load data.

### Native parity

The native Skia canvas doesn't mirror its body state outside React state, so `getEngineState()` returns empty on native and `restoreFruits()` is a no-op. Score + game-over flag still resume correctly on mobile — just with an empty board. Full native parity is a follow-up (would need a bodiesRef in GameCanvas.tsx).

### CascadeScreen wiring

- Mount effect: `loadCascadeGame()` → if snapshot matches the current theme, restore score + game-over immediately and stash the snapshot in `pendingLoadRef` until the canvas signals ready.
- `handleCanvasReady` (new): pops pendingLoadRef, rebuilds the FruitQueue with the saved [current, next] pair, calls `canvasRef.current.restoreFruits(...)`.
- `handleMerge`: throttled `saveGameThrottled()` after the merge settles. Merges are the highest-value save trigger.
- `handleTap`: throttled save after each drop — catches runs of drops without merges.
- `handleGameOver`: `clearCascadeGame()` so the next mount starts fresh.
- `handleRestart`: clears the snapshot and disarms `pendingLoadRef` so any in-flight load doesn't re-apply.
- Theme switch: clears the snapshot (snapshots are theme-specific; switching skins starts fresh).

### Tests

- 11 new jest unit tests in `cascade/__tests__/storage.test.ts` (round-trip, clear, schema validation, corruption recovery, malformed-fruit filtering).
- 2 new e2e tests in `cascade-reload-persistence.spec.ts`:
  - reload mid-game preserves score + fruit count
  - New Game after reload-restore yields a clean board
- Full frontend jest: 1069/1069 pass
- Full `cascade` Playwright project: 23 pass + 5 pre-existing failures on the leaderboard save-score path (verified present on clean dev via `git stash`; unrelated to this PR)

### FruitQueue

Added an optional `initialQueue?: [FruitTier, FruitTier]` constructor param so reload restore can pin the [current, next] pair that was showing at save time. Default behavior unchanged.

Closes #216.

## Summary

## <!-- What does this PR do? Focus on the why, not the how. -->

## Type of change

- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done

<!-- What did you run? Any coverage delta? -->

- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist

- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist _(web / frontend PRs only)_

- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom

## Mobile checklist _(iOS / Android PRs only)_

- [ ] Tested on iOS Simulator or physical device
- [ ] `ios-build-check` / `android-build-check` CI job passes
- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)
