### PR TITLE
fix(logs): age-based eviction policy with P1 protection (#486)

### DIFF
--- a/e2e/tests/helpers/logstore.ts
+++ b/e2e/tests/helpers/logstore.ts
@@ -214,23 +214,52 @@ export async function seedBugLogs(
 
 /**
  * Seed a mix of rows across all four priority tiers in a single batch.
- * Used by eviction scenarios (#480) that need to compose a 10k fixture.
+ * Used by eviction scenarios (#480, #486) that need to compose large
+ * fixtures.
+ *
+ * Timestamps are explicitly staggered across tiers so ordering is
+ * deterministic under the #486 age-based eviction policy: P3 rows are
+ * the oldest, then P2, then P1, then P0 (newest). Each tier reserves a
+ * 10,000,000 ms slot, which is wider than any plausible fixture size,
+ * so within-tier FIFO offsets can't leak into the next tier's slot.
+ * Base time is anchored far enough in the past that TTL sweeps don't
+ * accidentally expire the rows.
  */
 export async function seedEvictionFixture(
   page: Page,
   counts: { p0?: number; p1?: number; p2?: number; p3?: number },
 ): Promise<void> {
   const { p0 = 0, p1 = 0, p2 = 0, p3 = 0 } = counts;
-  if (p3) await seedEvents(page, { count: p3, priority: 3, eventType: "move" });
+  // Anchor all seeded rows ~11 h in the past so every staggered slot
+  // still lands before Date.now() and comfortably inside TTL_MS (7 d).
+  const TIER_SLOT = 10_000_000;
+  const base = Date.now() - 4 * TIER_SLOT;
+  if (p3)
+    await seedEvents(page, {
+      count: p3,
+      priority: 3,
+      eventType: "move",
+      createdAt: base,
+    });
   if (p2)
-    await seedEvents(page, { count: p2, priority: 2, eventType: "score" });
+    await seedEvents(page, {
+      count: p2,
+      priority: 2,
+      eventType: "score",
+      createdAt: base + TIER_SLOT,
+    });
   if (p1)
     await seedEvents(page, {
       count: p1,
       priority: 1,
       eventType: "game_started",
+      createdAt: base + 2 * TIER_SLOT,
     });
-  if (p0) await seedBugLogs(page, { count: p0 });
+  if (p0)
+    await seedBugLogs(page, {
+      count: p0,
+      createdAt: base + 3 * TIER_SLOT,
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/tests/logs-bug-spam.spec.ts
+++ b/e2e/tests/logs-bug-spam.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * #373 scenario 13 — runaway bug-log pressure doesn't starve lifecycle or
+ * fresh granular events.
+ *
+ * This scenario was deferred from #480 and motivated the eviction-policy
+ * rewrite in #486. See the file header on `frontend/src/game/_shared/
+ * eventStore.ts` for the policy in force.
+ *
+ * Two phases:
+ *
+ *   Part 1 — bug spam crowds the queue to the cap.
+ *     Seed 1 `game_ended` (P1 lifecycle) + 4,999 bug logs (P0), exactly
+ *     hitting MAX_ROWS = 5,000. Seed 100 more bug logs. Eviction must
+ *     drop the 100 OLDEST bug logs while the lifecycle row survives —
+ *     P1 is protected and the 100 new bugs are the newest pool rows.
+ *
+ *   Part 2 — fresh granular burst arrives after the bug backlog.
+ *     From Part 1's 1 P1 + 4,999 P0, enqueue 5,000 P3 `move` events.
+ *     Queue swells to 10,000 → evict 5,000. Under age-based pool
+ *     eviction, the 5,000 oldest pool rows are all 4,999 bug logs plus
+ *     1 granular — but the assertion from the epic is that the final
+ *     queue is "1 P1 + 0 P0 + 4,999 P3". In other words, every bug log
+ *     must be gone and the newest granular burst must dominate.
+ */
+
+import { test } from "@playwright/test";
+import {
+  clearLogstore,
+  expect,
+  inspectQueue,
+  resetLogConfig,
+  seedBugLogs,
+  seedEvents,
+  waitForLogstoreReady,
+} from "./helpers/logstore";
+
+test.describe("#373 scenario 13 — runaway bug-log pressure (#486)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await waitForLogstoreReady(page);
+    await resetLogConfig(page);
+    await clearLogstore(page);
+  });
+
+  test("age-based pool eviction protects lifecycle and favors fresh events", async ({
+    page,
+  }) => {
+    // Stagger timestamps so the seed order equals the age order.
+    // TTL is 7 days; every slot stays comfortably within the past.
+    const now = Date.now();
+    const SLOT = 10_000_000;
+    const tP1 = now - 4 * SLOT;
+    const tBugsOld = now - 3 * SLOT;
+    const tBugsNew = now - 2 * SLOT;
+    const tMoves = now - 1 * SLOT;
+
+    // ---- Part 1 ----------------------------------------------------------
+    // 1 P1 game_ended + 4,999 bug logs = 5,000 (exactly at cap).
+    await seedEvents(page, {
+      count: 1,
+      priority: 1,
+      eventType: "game_ended",
+      createdAt: tP1,
+    });
+    await seedBugLogs(page, { count: 4999, createdAt: tBugsOld });
+
+    let stats = await inspectQueue(page);
+    expect(stats.totalRows).toBe(5000);
+    expect(stats.byPriority[1]).toBe(1);
+    expect(stats.byPriority[0]).toBe(4999);
+
+    // +100 bug logs — queue is 5,100 → evict 100 oldest pool rows.
+    // Expectation: 100 oldest bugs gone, the 100 new bugs survive, the
+    // lone lifecycle event is untouched.
+    await seedBugLogs(page, { count: 100, createdAt: tBugsNew });
+
+    stats = await inspectQueue(page);
+    expect(stats.totalRows).toBe(5000);
+    expect(stats.byPriority[1]).toBe(1); // game_ended preserved
+    expect(stats.byPriority[0]).toBe(4999); // 4899 old + 100 new bugs
+    expect(stats.byPriority[3]).toBe(0);
+    expect(stats.byPriority[2]).toBe(0);
+
+    // ---- Part 2 ----------------------------------------------------------
+    // +5,000 P3 move events — queue is 10,000 → evict 5,000 oldest pool
+    // rows. Those are every bug log + 1 of the newly-added moves.
+    // Final queue: 1 P1 + 0 P0 + 4,999 P3.
+    await seedEvents(page, {
+      count: 5000,
+      priority: 3,
+      eventType: "move",
+      createdAt: tMoves,
+    });
+
+    stats = await inspectQueue(page);
+    expect(stats.totalRows).toBe(5000);
+    expect(stats.byPriority[1]).toBe(1); // game_ended still present
+    expect(stats.byPriority[0]).toBe(0); // all bug logs evicted
+    expect(stats.byPriority[2]).toBe(0);
+    expect(stats.byPriority[3]).toBe(4999); // fresh move burst dominates
+    expect(stats.byLogType.bug_log).toBe(0);
+    expect(stats.byLogType.game_event).toBe(5000);
+  });
+});

--- a/frontend/src/game/_shared/__tests__/eventStore.test.ts
+++ b/frontend/src/game/_shared/__tests__/eventStore.test.ts
@@ -182,9 +182,10 @@ describe("EventStore", () => {
       expect(s.byPriority[Priority.BUG_LOG]).toBe(1);
     });
 
-    it("runaway bug_log scenario: bug logs FIFO-evicted before starving lifecycle", async () => {
+    it("runaway bug_log scenario: fresh granular events survive, old bugs yield (#486)", async () => {
       logConfig.MAX_ROWS = 100;
-      // Fill 99 bug logs + 1 lifecycle event.
+      // Fill 1 lifecycle (P1, protected) + 99 bug logs (P0, oldest non-P1
+      // rows in the queue).
       await store.enqueueEvent({
         game_id: "g",
         event_index: 0,
@@ -204,28 +205,11 @@ describe("EventStore", () => {
       expect(s.byPriority[Priority.BUG_LOG]).toBe(99);
       expect(s.byPriority[Priority.LIFECYCLE]).toBe(1);
 
-      // Now enqueue 5 more granular events. No higher-priority tier to evict,
-      // so oldest bug logs go (P0 is still lowest priority when it's the
-      // only populated tier above the granular ones).
-      //
-      // Actually: we evict P3 first. There's no P3 yet. Adding 5 granulars
-      // puts us at 105 rows. Eviction walks P3→P0, but since we just added
-      // P3 rows, those get evicted first… which is the *wrong* behavior for
-      // this scenario. The epic spec wants the bugs to eventually yield.
-      //
-      // The subtlety: the P3 granular events we JUST added are the newest
-      // of the P3 tier. Since FIFO evicts oldest-first, if granular is the
-      // only populated higher tier then those very rows stay. Here we walk
-      // P3 first and drop the oldest P3 — but only AS MANY AS WE JUST ADDED.
-      // After those are gone we drop from P0.
-      //
-      // Since we added exactly 5 P3 rows and need to drop 5, all 5 P3 rows
-      // are dropped and the bugs are untouched. That matches the strict
-      // priority interpretation: "P3 first" wins over "be fair to bugs".
-      //
-      // For the true runaway-bug scenario the epic describes (evict old
-      // bugs to make room for new moves), we need to exceed the cap *more*
-      // than the P3 rows we add in one shot. That's tested below.
+      // Enqueue 5 granular move events. Queue is 105 rows → evict 5.
+      // Under the #486 age-based pool policy, P1 is protected and the rest
+      // of the queue is one FIFO pool. The 5 oldest pool rows are the 5
+      // oldest bug logs (enqueued before the moves), so they get dropped
+      // and all 5 fresh granular rows survive.
       for (let i = 0; i < 5; i += 1) {
         await store.enqueueEvent({
           game_id: "g",
@@ -236,12 +220,8 @@ describe("EventStore", () => {
       }
       s = await store.stats();
       expect(s.totalRows).toBe(100);
-      // All 5 granular survived because they're the freshest; the 5 oldest
-      // bugs got evicted since there was nothing else to drop first.
-      // Actually no — under "P3 first" policy, the 5 granulars we just
-      // added get evicted before the bugs. So we should have 0 granular.
-      expect(s.byPriority[Priority.GRANULAR]).toBe(0);
-      expect(s.byPriority[Priority.BUG_LOG]).toBe(99);
+      expect(s.byPriority[Priority.GRANULAR]).toBe(5);
+      expect(s.byPriority[Priority.BUG_LOG]).toBe(94);
       expect(s.byPriority[Priority.LIFECYCLE]).toBe(1);
     });
 

--- a/frontend/src/game/_shared/eventStore.ts
+++ b/frontend/src/game/_shared/eventStore.ts
@@ -11,10 +11,32 @@
  *   event_queue_v1/tier/3   → granular events (P3, evicted first)
  *   event_queue_v1/meta     → { warningLastShownAt }
  *
- * Eviction policy at cap: walk tiers from high to low (P3→P2→P1→P0),
- * drop oldest rows in each tier until the queue fits MAX_ROWS /
- * MAX_SIZE_BYTES. This preserves bug logs longest but doesn't starve the
- * queue if one source goes runaway.
+ * Eviction policy at cap (#486 redesign):
+ *
+ *   1. P1 (lifecycle) is protected — never evicted unless the entire
+ *      non-P1 pool has already been drained. Lifecycle events are the
+ *      load-bearing story of a game (started / ended / resumed); losing
+ *      them silently corrupts analytics in a way no granular event can.
+ *      The epic's "FIFO-evictable at the hard cap" language still holds —
+ *      P1 is last-to-evict, not never-evict — so a pathological caller
+ *      filling the queue with only lifecycle events still drains via FIFO.
+ *
+ *   2. The rest of the queue (P0 bug logs, P2 mid, P3 granular) is one
+ *      age-based FIFO pool. Eviction drops the oldest rows across that
+ *      combined pool until the overage is covered, ignoring tier. Newer
+ *      rows survive regardless of tier — a fresh spam of P3 moves that
+ *      arrives after 5,000 ancient bug logs should evict the ancient bugs,
+ *      not the moves that just arrived.
+ *
+ *   3. logConfig.priorityForEvent still decides peek order (SyncWorker
+ *      drains P1 → P2 → P3 → P0) and still feeds the capacity-warning
+ *      signal. Only the eviction ordering changes.
+ *
+ * Why this replaces the old "tier-walk high → low" policy: see #486. The
+ * original P3-first walk couldn't satisfy scenario 13 of the #373
+ * acceptance gate — specifically the case where a burst of 5,000 fresh P3
+ * rows needs to survive at the expense of 5,000 older P0 rows. No pure
+ * tier ordering resolves that without an age dimension.
  *
  * All operations are single-writer — the store itself is not concurrency-
  * safe within one JS runtime, but the FE is single-threaded so that's fine.
@@ -400,35 +422,104 @@ export class EventStore {
   }
 
   private async evictToCapacityUnlocked(): Promise<number> {
-    // Batched eviction: compute the overage once, then walk tiers from
-    // highest priority (P3 granular, evicted first) down to P0 (bug logs,
-    // preserved longest), dropping as many oldest rows per tier as the
-    // remaining overage requires. This is a single read+write per tier
-    // instead of one per evicted row — the per-row loop was O(overage × n)
-    // on AsyncStorage, which blew up test fixtures that seeded 10k rows.
+    // #486 policy: age-based FIFO across the combined non-P1 pool, with
+    // P1 (lifecycle) as a last-resort drain once the pool is exhausted.
+    // See the file header for the full rationale. All reads and writes
+    // are batched one-per-tier so seeding 10k rows stays O(tiers) on
+    // AsyncStorage rather than O(overage).
     const stats = await this.statsUnlocked();
     let overageRows = stats.totalRows - logConfig.MAX_ROWS;
     let overageBytes = stats.sizeBytes - logConfig.MAX_SIZE_BYTES;
     if (overageRows <= 0 && overageBytes <= 0) return 0;
 
-    let totalEvicted = 0;
-    for (let pri = 3; pri >= 0; pri -= 1) {
-      if (overageRows <= 0 && overageBytes <= 0) break;
-      const tierRows = await this.readTier(pri as Priority);
-      if (tierRows.length === 0) continue;
-      tierRows.sort((a, b) => a.created_at - b.created_at);
+    const poolTiers: Priority[] = [
+      Priority.BUG_LOG,
+      Priority.MID,
+      Priority.GRANULAR,
+    ];
 
-      let drop = 0;
-      while (drop < tierRows.length && (overageRows > 0 || overageBytes > 0)) {
-        overageBytes -= rowBytes(tierRows[drop]);
-        overageRows -= 1;
-        drop += 1;
-      }
-      if (drop > 0) {
-        await this.writeTier(pri as Priority, tierRows.slice(drop));
-        totalEvicted += drop;
+    type TierEntry = { tier: Priority; rows: Row[]; dirty: boolean };
+    const entries: Record<Priority, TierEntry | undefined> = {
+      0: undefined,
+      1: undefined,
+      2: undefined,
+      3: undefined,
+    };
+
+    type Candidate = { tier: Priority; idx: number; row: Row };
+    const pool: Candidate[] = [];
+    for (const tier of poolTiers) {
+      const rows = await this.readTier(tier);
+      if (rows.length === 0) continue;
+      entries[tier] = { tier, rows, dirty: false };
+      for (let i = 0; i < rows.length; i += 1) {
+        pool.push({ tier, idx: i, row: rows[i] });
       }
     }
+    // Primary key: older first. Tiebreaker: when two rows share a
+    // created_at (serial enqueues inside the same millisecond, common in
+    // tests and during bursts), prefer evicting the row with the higher
+    // priority *number* — i.e. drop P3 before P2 before P0, so bug logs
+    // still win ties against granular events. Without this tiebreaker
+    // the stable-sort insertion order would arbitrarily decide which
+    // tier loses.
+    pool.sort(
+      (a, b) => a.row.created_at - b.row.created_at || b.tier - a.tier,
+    );
+
+    let totalEvicted = 0;
+    const dropped: Record<Priority, Set<number>> = {
+      0: new Set(),
+      1: new Set(),
+      2: new Set(),
+      3: new Set(),
+    };
+
+    for (const cand of pool) {
+      if (overageRows <= 0 && overageBytes <= 0) break;
+      dropped[cand.tier].add(cand.idx);
+      overageBytes -= rowBytes(cand.row);
+      overageRows -= 1;
+      totalEvicted += 1;
+    }
+
+    for (const tier of poolTiers) {
+      const entry = entries[tier];
+      if (!entry) continue;
+      const drop = dropped[tier];
+      if (drop.size === 0) continue;
+      entry.rows = entry.rows.filter((_, i) => !drop.has(i));
+      entry.dirty = true;
+    }
+
+    // Last-resort: the whole non-P1 pool couldn't cover the overage.
+    // Drop oldest P1 rows until the cap is met. This only fires when the
+    // queue is pathologically full of lifecycle events; normal workloads
+    // never touch this branch.
+    if (overageRows > 0 || overageBytes > 0) {
+      const p1Rows = (await this.readTier(Priority.LIFECYCLE)).slice();
+      if (p1Rows.length > 0) {
+        p1Rows.sort((a, b) => a.created_at - b.created_at);
+        let drop = 0;
+        while (drop < p1Rows.length && (overageRows > 0 || overageBytes > 0)) {
+          overageBytes -= rowBytes(p1Rows[drop]);
+          overageRows -= 1;
+          drop += 1;
+          totalEvicted += 1;
+        }
+        if (drop > 0) {
+          await this.writeTier(Priority.LIFECYCLE, p1Rows.slice(drop));
+        }
+      }
+    }
+
+    for (const tier of poolTiers) {
+      const entry = entries[tier];
+      if (entry && entry.dirty) {
+        await this.writeTier(tier, entry.rows);
+      }
+    }
+
     return totalEvicted;
   }
 

--- a/frontend/src/game/_shared/eventStore.ts
+++ b/frontend/src/game/_shared/eventStore.ts
@@ -432,11 +432,7 @@ export class EventStore {
     let overageBytes = stats.sizeBytes - logConfig.MAX_SIZE_BYTES;
     if (overageRows <= 0 && overageBytes <= 0) return 0;
 
-    const poolTiers: Priority[] = [
-      Priority.BUG_LOG,
-      Priority.MID,
-      Priority.GRANULAR,
-    ];
+    const poolTiers: Priority[] = [Priority.BUG_LOG, Priority.MID, Priority.GRANULAR];
 
     type TierEntry = { tier: Priority; rows: Row[]; dirty: boolean };
     const entries: Record<Priority, TierEntry | undefined> = {
@@ -463,9 +459,7 @@ export class EventStore {
     // still win ties against granular events. Without this tiebreaker
     // the stable-sort insertion order would arbitrarily decide which
     // tier loses.
-    pool.sort(
-      (a, b) => a.row.created_at - b.row.created_at || b.tier - a.tier,
-    );
+    pool.sort((a, b) => a.row.created_at - b.row.created_at || b.tier - a.tier);
 
     let totalEvicted = 0;
     const dropped: Record<Priority, Set<number>> = {

--- a/frontend/src/game/_shared/testHooks.ts
+++ b/frontend/src/game/_shared/testHooks.ts
@@ -100,6 +100,18 @@ function generateSeedId(): string {
   });
 }
 
+// When no explicit createdAt is provided, anchor the seeded batch so the
+// newest row equals Date.now() and older rows recede into the past by
+// their per-row offset. Seeded rows must never be "in the future"
+// relative to wall-clock time, otherwise real enqueues that happen right
+// after the seed will look older than the fixture and get evicted first
+// by the #486 age-based pool policy. Explicit createdAt (from fixtures
+// like seedEvictionFixture) is honored as-is.
+function seedBaseTime(createdAt: number | undefined, count: number): number {
+  if (createdAt !== undefined) return createdAt;
+  return Date.now() - Math.max(0, count - 1);
+}
+
 function buildSeedGameEvents(spec: SeedEventSpec): GameEventRow[] {
   const {
     count,
@@ -109,7 +121,7 @@ function buildSeedGameEvents(spec: SeedEventSpec): GameEventRow[] {
     createdAt,
     startIndex = 0,
   } = spec;
-  const baseTime = createdAt ?? Date.now();
+  const baseTime = seedBaseTime(createdAt, count);
   const pri =
     priority !== undefined ? priority : logConfig.priorityForEvent("game_event", eventType);
   const rows: GameEventRow[] = [];
@@ -121,8 +133,7 @@ function buildSeedGameEvents(spec: SeedEventSpec): GameEventRow[] {
       event_index: startIndex + i,
       event_type: eventType,
       payload: { _seed: true, i },
-      // Use a small offset per row so ordering is stable and distinct even
-      // when the caller pins a fixed createdAt.
+      // Per-row offset keeps within-batch ordering stable and distinct.
       created_at: baseTime + i,
       priority: pri,
       retry_count: 0,
@@ -134,7 +145,7 @@ function buildSeedGameEvents(spec: SeedEventSpec): GameEventRow[] {
 
 function buildSeedBugLogs(spec: SeedBugLogSpec): BugLogRow[] {
   const { count, level = "warn", source = "__seed", createdAt, message = "seeded bug log" } = spec;
-  const baseTime = createdAt ?? Date.now();
+  const baseTime = seedBaseTime(createdAt, count);
   const rows: BugLogRow[] = [];
   for (let i = 0; i < count; i += 1) {
     rows.push({


### PR DESCRIPTION
## Summary
- Replaces the P3→P0 tier-walking eviction with age-based FIFO across the combined non-P1 pool; P1 (lifecycle) is protected and only drained as a last resort.
- Age ties fall back to tier-number-descending so bug logs still beat granular events when timestamps collide (common in rapid test enqueues).
- Default seed-row timestamps now recede into the past so test-hook batches never look newer than subsequent real enqueues under the new policy.
- Adds `e2e/tests/logs-bug-spam.spec.ts` for #373 scenario 13 (both parts) and marks the scenario satisfied on umbrella #373.

Closes #486.
Part of #373 / #362.

## Why
The strict P3→P0 walk couldn't express scenario 13: a fresh P3 burst must survive at the expense of older P0 rows, and `game_ended` must never be evicted while bug-log spam is available to drain. No pure tier ordering resolves that without an age dimension. Decision record lives in the file header of `frontend/src/game/_shared/eventStore.ts`.

## Test plan
- [x] `frontend` unit tests: `npx jest src/game/_shared/__tests__/` — 99 / 99 pass.
- [x] Eviction-related e2e: `logs-eviction`, `logs-bug-spam`, `logs-config-overrides`, `logs-capacity-warning`, `logs-smoke`, `logs-ttl`, `logs-manual-clear` — 19 / 19 pass under `logs-budget`.
- [x] Scenario 13 new spec asserts both Part 1 (100 new bugs replace 100 oldest, `game_ended` survives) and Part 2 (5,000 P3 burst wipes every bug log, lifecycle survives).
- [ ] CI logs-budget job.

Note: `logs-crash-recovery`, `logs-rate-limit`, `logs-server-unreachable`, `logs-memory`, `logs-offline-marathon` fail on the `dev` baseline as well (verified by running against an unmodified dev build). They are unrelated drain/flush failures and are not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)