### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -96,8 +96,8 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10006
-        versionName "1.0.6"
+        versionCode 10008
+        versionName "1.0.8"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gaming App",
     "slug": "gaming-app",
-    "version": "1.0.6",
+    "version": "1.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.buffingchi.games",
-      "buildNumber": "10006",
+      "buildNumber": "10008",
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
           {

--- a/frontend/ios/GamingApp.xcodeproj/project.pbxproj
+++ b/frontend/ios/GamingApp.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 10006;
+				CURRENT_PROJECT_VERSION = 10008;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.8;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -378,14 +378,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 10006;
+				CURRENT_PROJECT_VERSION = 10008;
 				INFOPLIST_FILE = GamingApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.8;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary
- Bump app version 1.0.6 → 1.0.8 across `package.json`, `app.json`, iOS `project.pbxproj` (MARKETING_VERSION + CURRENT_PROJECT_VERSION), and Android `build.gradle` (versionName + versionCode)
- iOS/Android build numbers updated 10006 → 10008
- Supersedes #459 (1.0.7 bump, closed)

## Test plan
- [ ] CI: android-bundle-check / android-build-check pass
- [ ] iOS Xcode Cloud build picks up new MARKETING_VERSION

🤖 Generated with [Claude Code](https://claude.com/claude-code)