### PR TITLE
fix(rn): avoid processTransform(null) crash in Pressable styles

### DIFF
--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -90,7 +90,11 @@ export default function DiceRow({ dice, rollsUsed, gameOver, onRoll, resetHeld }
           styles.rollButton,
           isCompact && styles.rollButtonCompact,
           rollButtonBg,
-          pressed && canRoll && !rolling ? { transform: [{ scale: 0.95 }] } : null,
+          // Always emit a transform (identity when not pressed) so it never
+          // goes undefined → null between renders. RN's ReactNativeAttributePayload
+          // coerces undefined props to null, and processTransform(null) crashes
+          // in _validateTransforms (__DEV__ only) with "forEach of null".
+          { transform: [{ scale: pressed && canRoll && !rolling ? 0.95 : 1 }] },
         ]}
         onPress={handleRoll}
         disabled={!canRoll || rolling}

--- a/frontend/src/components/shared/NewGameConfirmModal.tsx
+++ b/frontend/src/components/shared/NewGameConfirmModal.tsx
@@ -54,7 +54,7 @@ export default function NewGameConfirmModal({ visible, onConfirm, onCancel, titl
             style={({ pressed }) => [
               styles.confirmButton,
               confirmBg,
-              pressed ? { transform: [{ scale: 0.96 }] } : null,
+              { transform: [{ scale: pressed ? 0.96 : 1 }] },
             ]}
             onPress={onConfirm}
             accessibilityRole="button"

--- a/frontend/src/components/twenty48/GameOverlay.tsx
+++ b/frontend/src/components/twenty48/GameOverlay.tsx
@@ -86,7 +86,7 @@ export default function GameOverlay({
               style={({ pressed }) => [
                 styles.btn,
                 ctaStyle,
-                pressed && { transform: [{ scale: 0.96 }] },
+                { transform: [{ scale: pressed ? 0.96 : 1 }] },
               ]}
               onPress={onKeepPlaying}
               accessibilityRole="button"
@@ -103,7 +103,7 @@ export default function GameOverlay({
               styles.btn,
               isWin ? styles.outlineBtn : ctaStyle,
               isWin ? { borderColor: colors.border } : null,
-              !isWin && pressed && { transform: [{ scale: 0.96 }] },
+              { transform: [{ scale: !isWin && pressed ? 0.96 : 1 }] },
             ]}
             onPress={onNewGame}
             accessibilityRole="button"

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -107,7 +107,7 @@ export default function GameOverModal({
             style={({ pressed }) => [
               styles.playAgainButton,
               playAgainBg,
-              pressed ? { transform: [{ scale: 0.96 }] } : null,
+              { transform: [{ scale: pressed ? 0.96 : 1 }] },
             ]}
             onPress={onPlayAgain}
             accessibilityRole="button"


### PR DESCRIPTION
## Summary

- Fixes #496 — React ErrorBoundary `TypeError: Cannot read property 'forEach' of null` on Android dev builds
- Always emit a `transform` slot (identity `scale: 1` when not pressed) so RN's attribute diffing never coerces `transform` to `null` between renders

## Root cause

RN 0.83's `ReactNativeAttributePayload.js:82-85` coerces any `undefined` prop to `null` before invoking processors. `transform` is wired to `processTransform`, whose `__DEV__` validator (`processTransform.js:142`) calls `transform.forEach(...)` with no null guard and throws.

Trigger: `style={({pressed}) => [..., pressed ? {transform: [...]} : null]}`. When the Pressable releases, `transform` disappears from the flattened style, becomes `undefined`, gets coerced to `null`, and `_validateTransforms(null)` crashes on the next commit. `__DEV__`-only, matching the Sentry environment (`development`).

## Files touched

- `frontend/src/components/DiceRow.tsx`
- `frontend/src/components/yacht/GameOverModal.tsx`
- `frontend/src/components/shared/NewGameConfirmModal.tsx`
- `frontend/src/components/twenty48/GameOverlay.tsx` (2 call sites)

Policy-compliance (design-tokens): PASS — no color/spacing/typography touched, scale values preserved verbatim. Policy gate bypassed with explicit user authorization after the review.

## Test plan

- [x] Component test suites for DiceRow / yacht / shared / twenty48 — 68/68 pass
- [x] tsc --noEmit — no new type errors in edited files
- [ ] Android dev build: Lobby → Yacht → Game, press/release the ROLL button and dice repeatedly; confirm no ErrorBoundary fallback
- [ ] Android dev build: 2048 GameOverlay buttons, Yacht GameOverModal "Play Again", NewGameConfirmModal "Confirm" — press/release without crash
- [ ] iOS dev build: smoke-test same flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)