### PR TITLE
ops(render): rename services to -dev and pin branch (closes #500)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Cloudflare Bot Fight Mode blocks GHA runner IPs (Azure cloud ranges) before
       # the WAF skip rule fires — health checks must bypass the proxy.
       # See wcmchenry3-stack/.github#45.
-      backend-url: "https://yahtzee-api.onrender.com"
+      backend-url: "https://gaming-app-api-dev.onrender.com"
       health-path: "/health"
       probe-path: "/yacht/state"
       probe-expected-status: "400"

--- a/render.yaml
+++ b/render.yaml
@@ -1,22 +1,33 @@
 services:
-  # --- Python FastAPI backend ---
+  # --- Python FastAPI backend (dev environment) ---
+  # The -dev suffix is explicit: this service tracks the `dev` branch.
+  # A future prod environment should be a separate service (e.g.
+  # `gaming-app-api`) pinned to `main`, with its own Postgres.
   - type: web
-    name: gaming-app-api
+    name: gaming-app-api-dev
     runtime: python
+    branch: dev
     rootDir: backend
     buildCommand: pip install -r requirements.txt
-    startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT --timeout-keep-alive 5 --limit-max-requests 10000
+    # alembic runs before uvicorn on every boot so schema stays in sync with
+    # models shipped on dev. It is idempotent — noop when already current.
+    startCommand: alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port $PORT --timeout-keep-alive 5 --limit-max-requests 10000
     healthCheckPath: /health
     envVars:
       - key: PYTHON_VERSION
         value: 3.11.0
       - key: ALLOWED_ORIGINS
         value: "https://dev-games.buffingchi.com,https://dev-games-api.buffingchi.com"
+      - key: DATABASE_URL
+        sync: false
+      - key: SENTRY_DSN
+        sync: false
 
-  # --- Expo Web static frontend ---
+  # --- Expo Web static frontend (dev environment) ---
   - type: web
-    name: gaming-app-frontend
+    name: gaming-app-frontend-dev
     runtime: static
+    branch: dev
     rootDir: frontend
     # fetch-render-env.js merges EXPO_PUBLIC_API_URL (and SENTRY_DSN if set)
     # into .env before Expo bakes them into the static bundle.


### PR DESCRIPTION
## Summary

- Updates \`render.yaml\` to match the live Render infrastructure after the #500 migration
- Renames services: \`gaming-app-api\` → \`gaming-app-api-dev\`, \`gaming-app-frontend\` → \`gaming-app-frontend-dev\`
- Adds explicit \`branch: dev\` (previously implicit, led to live services tracking \`main\` while serving the dev hostname)
- Wraps backend \`startCommand\` with \`alembic upgrade head && ...\` so schema migrations run on every boot (idempotent)
- Declares \`DATABASE_URL\` and \`SENTRY_DSN\` as \`sync: false\` secrets (values stay in Render UI / API)

## Why

#500 root cause: the "dev-games-api.buffingchi.com" hostname was attached to a Render service pinned to \`main\`. v1.0.8 shipped with frontend calls to \`/games\`, \`/games/me\`, \`/stats/me\` — routes that only exist on the dev-branch backend. Those calls 404'd.

Fix: suspend the old main-tracking services, create explicit \`-dev\` services pinned to \`dev\`, move the custom domains, update Cloudflare DNS, re-point everything.

Verified after migration:
\`\`\`
GET  https://dev-games-api.buffingchi.com/health        → 200 {"status":"ok"}
GET  https://dev-games-api.buffingchi.com/games/me?...  → 200 {"items":[],"next_cursor":null}
GET  https://dev-games-api.buffingchi.com/stats/me      → 200 {"total_games":0,"by_game":{},"favorite_game":null}
POST https://dev-games-api.buffingchi.com/games         → 200 {"id":"...","started_at":"..."}
\`\`\`

## Follow-up (not in this PR)

Future prod environment = separate \`gaming-app-api\` / \`gaming-app-frontend\` services pinned to \`main\`, with their own Postgres. The two original suspended services can be unsuspended and repurposed when that lands. I'll file that as a separate tracking issue.

## Test plan

- [ ] Render reads \`render.yaml\` without errors on next blueprint sync (services already exist; names now match)
- [ ] Next deploy on \`dev\` runs \`alembic upgrade head\` cleanly (currently migration state is at head; rerun is a noop)
- [ ] \`/health\`, \`/games/me\`, \`/stats/me\`, \`POST /games\` still green after this PR merges and a fresh deploy runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)