### PR TITLE
ci: wire called-feedback-token-lint as tier 1 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,11 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
     secrets: inherit
 
+  feedback-token-lint:
+    needs: [lint-python, lint-frontend, secret-scan]
+    uses: wcmchenry3-stack/.github/.github/workflows/called-feedback-token-lint.yml@main
+    secrets: inherit
+
   # --- Android JS bundle validation (Linux, fast) ---------------------------
   # Catches silent bundling failures BEFORE they reach EAS Build.
   # The Android build check below only compiles in Debug mode (skips bundling),


### PR DESCRIPTION
## Summary
Adds \`called-feedback-token-lint\` as a tier 1 job in \`.github/workflows/ci.yml\`. The reusable workflow validates that \`frontend/feedback-theme.css\` defines every required \`--feedback-*\` token from the org schema (\`schemas/feedback-widget-tokens.schema.json\` in dot-github).

The workflow skips gracefully when the theme file doesn't exist yet, so this is safe to land before the gaming_app feedback widget (#110) ships its theme file. Enforcement mode is \`advisory\` per org default in \`policy-enforcement.yml\`.

Closes wcmchenry3-stack/.github#118

## Test plan
- [ ] CI passes — \`feedback-token-lint\` runs in tier 1 and skips with a notice (theme file absent)
- [ ] Tier ordering preserved (job runs after tier 0, in parallel with other tier 1 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)