### PR TITLE
fix(blackjack): bet_placed chips_remaining reads prev.chips (#503)

### DIFF
--- a/frontend/src/game/blackjack/BlackjackGameContext.tsx
+++ b/frontend/src/game/blackjack/BlackjackGameContext.tsx
@@ -113,13 +113,17 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
       const gid = gameIdRef.current;
       if (!gid) return;
       try {
-        // bet_placed + hand_dealt: betting → player/result with a fresh deal
+        // bet_placed + hand_dealt: betting → player/result with a fresh deal.
+        // Read chips_remaining from prev.chips, not next.chips — placeBet can
+        // settle immediately on a natural blackjack, and next.chips would then
+        // reflect the post-settlement balance, not the chips the player has
+        // after merely locking in the bet. (closes #503)
         if (prev.phase === "betting" && next.phase !== "betting") {
           gameEventClient.enqueueEvent(gid, {
             type: "bet_placed",
             data: {
               amount: next.bet,
-              chips_remaining: Math.max(0, next.chips - next.bet),
+              chips_remaining: Math.max(0, prev.chips - next.bet),
             },
           });
           gameEventClient.enqueueEvent(gid, {


### PR DESCRIPTION
## Summary

Closes #503 — intermittent failure of `BlackjackGameContext — gameEventClient instrumentation (#370) › emits bet_placed and hand_dealt after placeBet() with correct shape`.

## Root cause

Not test isolation. A semantic bug in instrumentation.

`BlackjackGameContext.tsx:120` computed `chips_remaining: next.chips - next.bet`. But `placeBet()` settles immediately on a natural blackjack — when the seeded deal happens to hand the player a natural, `settleWith("blackjack")` fires from inside `placeBet`, bumping `next.chips` by `ceil(bet * 1.5)` before `emitTransitionEvents` ever runs.

For a 50-chip bet starting from 1000 chips:
- Non-natural deal → `next.chips = 1000`, `chips_remaining = 1000 − 50 = 950` ✅
- Natural-blackjack deal → `next.chips = 1000 + 75 = 1075`, `chips_remaining = 1075 − 50 = 1025` ❌

The latter matches the flake symptom exactly.

## Fix

Read `chips_remaining` from `prev.chips` — the chip count at the instant the bet was locked in, before any settlement — so the event reflects the same value regardless of whether the round resolves immediately.

```diff
-    chips_remaining: Math.max(0, next.chips - next.bet),
+    chips_remaining: Math.max(0, prev.chips - next.bet),
```

## Verification

- [x] Reproduced flake locally: 8/10 runs of the target test failed on `dev` before the fix
- [x] 20 consecutive runs of the target test after the fix — all pass
- [x] Full blackjack suite (BlackjackTableScreen + BlackjackBettingScreen + game/blackjack) — 177/177 pass
- [x] prettier + eslint clean

## Not in scope

The `hand_resolved` / `game_ended` events may have adjacent pre/post-settlement confusion; I left them alone to keep this PR scoped to the flake #503 calls out. Open a follow-up if the same class of bug shows up in those events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)