### PR TITLE
ci: wire called-provenance-coverage as tier 1 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,11 @@ jobs:
     uses: wcmchenry3-stack/.github/.github/workflows/called-feedback-token-lint.yml@main
     secrets: inherit
 
+  provenance-coverage:
+    needs: [lint-python, lint-frontend, secret-scan]
+    uses: wcmchenry3-stack/.github/.github/workflows/called-provenance-coverage.yml@main
+    secrets: inherit
+
   # --- Android JS bundle validation (Linux, fast) ---------------------------
   # Catches silent bundling failures BEFORE they reach EAS Build.
   # The Android build check below only compiles in Debug mode (skips bundling),


### PR DESCRIPTION
**Draft — depends on wcmchenry3-stack/.github#132 merging first.**

## Summary
Adds \`called-provenance-coverage\` as a tier 1 job in \`.github/workflows/ci.yml\`. The check validates that every i18n key in \`frontend/src/i18n/locales\` has an entry in \`provenance.json\` marking it as \`ai\` or \`human\`.

## Expected behavior on first run
gaming_app's \`provenance.json\` currently has 19 \`feedback.*\` entries while the locale files contain hundreds of keys. The workflow will surface many missing entries as \`::warning\` annotations (advisory mode = doesn't fail check). This is the expected initial state — the long-term plan is to backfill \`provenance.json\` and then flip enforcement to \`required\`.

Closes wcmchenry3-stack/.github#120 (gaming_app half — book_app wiring is a sibling PR)

## Test plan
- [ ] Mark ready for review after #132 merges
- [ ] CI passes — \`provenance-coverage\` job runs in tier 1, annotates missing keys as warnings, check passes
- [ ] Tier ordering preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)