### PR TITLE
fix(cascade): sub-step physics updates to prevent boundary tunneling (#499)

### DIFF
--- a/frontend/src/game/cascade/__tests__/engine.native.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.native.test.ts
@@ -380,5 +380,4 @@ describe("physics sub-stepping", () => {
     expect(updateSpy.mock.calls.length).toBeLessThanOrEqual(11);
     handle.cleanup();
   });
-
 });

--- a/frontend/src/game/cascade/__tests__/engine.native.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.native.test.ts
@@ -4,6 +4,7 @@
  * Uses the real matter.js library (pure JS, no mocks needed).
  * Explicitly imports engine.native.ts to bypass Jest's default resolution.
  */
+import Matter from "matter-js";
 import { createEngine } from "../engine.native";
 import type { EngineHandle } from "../engine.shared";
 import { FRUIT_SETS } from "../../../theme/fruitSets";
@@ -349,4 +350,35 @@ describe("boundary escape", () => {
     expect(onGameOver).not.toHaveBeenCalled();
     handle.cleanup();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Physics sub-stepping (#499) — large frame deltas must be broken into
+// ≤16.67ms sub-steps so fast bodies can't tunnel through static walls.
+// ---------------------------------------------------------------------------
+
+describe("physics sub-stepping", () => {
+  it("splits a 33ms frame into two Matter.Engine.update calls", async () => {
+    const handle = await createEngine(W, H, fruitSet, jest.fn(), jest.fn(), jest.fn());
+    const updateSpy = jest.spyOn(Matter.Engine, "update");
+    handle.step(1 / 30); // 33.33ms
+    expect(updateSpy).toHaveBeenCalledTimes(2);
+    // Each sub-step should be at or under the 60Hz fixed step (~16.67ms).
+    for (const call of updateSpy.mock.calls) {
+      expect(call[1]).toBeLessThanOrEqual(1000 / 60 + 0.001);
+    }
+    handle.cleanup();
+  });
+
+  it("clamps a huge frame delta (1s) to ≤ 1/6s of simulated time", async () => {
+    const handle = await createEngine(W, H, fruitSet, jest.fn(), jest.fn(), jest.fn());
+    const updateSpy = jest.spyOn(Matter.Engine, "update");
+    handle.step(1); // 1 second — would be 60 sub-steps uncapped
+    const totalMs = updateSpy.mock.calls.reduce((sum, c) => sum + (c[1] as number), 0);
+    // 1/6s cap = ~166.67ms. Allow a hair of float drift.
+    expect(totalMs).toBeLessThanOrEqual(1000 / 6 + 0.1);
+    expect(updateSpy.mock.calls.length).toBeLessThanOrEqual(11);
+    handle.cleanup();
+  });
+
 });

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -47,6 +47,11 @@ export interface BoundaryEscapeEvent {
 // With default scale 0.001 and y=1.4, that gives us a punchy-but-controllable fall.
 const MATTER_GRAVITY_Y = 1.4;
 
+// Fixed physics sub-step (60Hz). Matter warns at >16.67ms because collision
+// detection starts missing thin walls. step() breaks larger frame deltas
+// into N × FIXED_STEP_MS updates.
+const FIXED_STEP_MS = 1000 / 60;
+
 export async function createEngine(
   W: number,
   H: number,
@@ -183,10 +188,17 @@ export async function createEngine(
 
   return {
     step(dt?: number): BodySnapshot[] {
-      let elapsed = dt ?? 1 / 60;
-      // Clamp: min 1/120s, max 1/30s
-      elapsed = Math.max(1 / 120, Math.min(elapsed, 1 / 30));
-      Matter.Engine.update(engine, elapsed * 1000);
+      // Matter recommends physics steps ≤ 16.67ms; larger steps let
+      // fast bodies tunnel through thin static walls (#499). Break a
+      // large frame into fixed sub-steps. Clamp total elapsed to 1/6s
+      // so a backgrounded tab can't schedule a hundred catch-up steps.
+      const rawElapsed = dt ?? 1 / 60;
+      let remainingMs = Math.min(rawElapsed, 1 / 6) * 1000;
+      while (remainingMs > 0.01) {
+        const stepMs = Math.min(remainingMs, FIXED_STEP_MS);
+        Matter.Engine.update(engine, stepMs);
+        remainingMs -= stepMs;
+      }
 
       processMerges();
 


### PR DESCRIPTION
## Summary

- Fixes #499 — Cascade fruits tunneling through the floor under large physics-step deltas (Sentry 7391771177).
- Rewrites \`step()\` in \`frontend/src/game/cascade/engine.native.ts\` to break each frame into fixed ~16.67ms sub-steps instead of one \`Matter.Engine.update\` call per frame.
- Caps total simulated time per \`step()\` call at 1/6s so a backgrounded tab can't schedule a hundred catch-up sub-steps when it resumes.

## Root cause

Matter.js warns when the delta passed to \`Engine.update\` exceeds 16.67ms (60Hz): beyond that point, continuous collision detection starts missing thin static walls. The previous clamp allowed up to 33.33ms per update — 2× the safe ceiling. Sentry caught a tier-0 fruit at \`y=755\` on an \`H=700\` canvas, 55px below the floor, immediately after a \`matter-js: delta argument is recommended to be less than or equal to 16.667 ms\` warning in the breadcrumb trail.

## Fix

\`\`\`ts
step(dt?: number): BodySnapshot[] {
  const rawElapsed = dt ?? 1 / 60;
  let remainingMs = Math.min(rawElapsed, 1 / 6) * 1000;
  while (remainingMs > 0.01) {
    const stepMs = Math.min(remainingMs, FIXED_STEP_MS); // 1000 / 60
    Matter.Engine.update(engine, stepMs);
    remainingMs -= stepMs;
  }
  ...
}
\`\`\`

## Tests

New \`physics sub-stepping\` describe block in \`engine.native.test.ts\`:

- \`step(1/30)\` invokes \`Matter.Engine.update\` exactly **2** times, each ≤16.67ms.
- \`step(1)\` (1-second frame, e.g. tab resumed after backgrounding) caps total simulated time at ~166ms (≤11 sub-steps) so there's no runaway catch-up.

## Test plan

- [x] \`engine.native.test.ts\` — 21 passing (19 existing + 2 new)
- [x] Full cascade suite — 218 passing across 12 files
- [x] \`tsc --noEmit\` — no new errors introduced (pre-existing errors in \`engine.ts\` and one unrelated test file are identical to \`origin/dev\`)
- [ ] Manual smoke: play Cascade for 30+ seconds on Android dev build, drop a variety of fruits, confirm no \`Cascade: fruit escaped boundary\` event in Sentry and no \`matter-js delta\` warning in console
- [ ] Confirm no visible physics regressions (merge feel, fall speed, wall bounce)

## Related

- Sentry issue 7391771177 (Cascade: fruit escaped boundary)
- Folded the RAF-stall investigation into this PR per the issue thread — didn't dig deeper because sub-stepping makes the underlying stall benign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)