### PR TITLE
fix(http): fail loud when EXPO_PUBLIC_API_URL is unset in non-dev builds (#511)

### DIFF
--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -52,14 +52,37 @@ describe("httpClient — BASE_URL configuration", () => {
     );
   });
 
-  it("falls back to http://localhost:8000 when EXPO_PUBLIC_API_URL is not set", async () => {
+  it("falls back to http://localhost:8000 when EXPO_PUBLIC_API_URL is not set in dev", async () => {
     delete process.env.EXPO_PUBLIC_API_URL;
+    // jest-expo sets __DEV__ = true by default; assert that explicitly
+    // so this test fails loudly if the preset ever changes.
+    expect((globalThis as { __DEV__?: boolean }).__DEV__).toBe(true);
     const request = loadClient();
     await request("/any/path");
     expect(global.fetch as jest.Mock).toHaveBeenCalledWith(
       "http://localhost:8000/any/path",
       expect.any(Object)
     );
+  });
+
+  it("throws at module load when EXPO_PUBLIC_API_URL is not set in a non-dev build (#511)", () => {
+    delete process.env.EXPO_PUBLIC_API_URL;
+    const g = globalThis as { __DEV__?: boolean };
+    const originalDev = g.__DEV__;
+    g.__DEV__ = false;
+    try {
+      // Module-level throw happens inside createGameClient because BASE_URL
+      // is resolved eagerly. Verify both the throw and the Sentry breadcrumb.
+      expect(() => loadClient()).toThrow(/EXPO_PUBLIC_API_URL is not set/);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require("@sentry/react-native");
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining("EXPO_PUBLIC_API_URL is not set"),
+        expect.objectContaining({ level: "fatal" })
+      );
+    } finally {
+      g.__DEV__ = originalDev;
+    }
   });
 });
 

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -25,21 +25,40 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Resolves the base URL for API calls.
+ *
+ * `EXPO_PUBLIC_*` variables are inlined into the bundle by Expo's web/native
+ * exporter at build time, so the value must be present when `npx expo export`
+ * runs — not at runtime. If we ship a non-dev bundle without it, every
+ * request will hit `http://localhost:8000` and fail with a `TypeError:
+ * Failed to fetch`, which is exactly what #511 documented.
+ *
+ * Rather than silently fall back (and then have Sentry record a flood of
+ * confusing per-request fetch errors), we throw at module load. That makes
+ * the misconfiguration impossible to miss: the app fails fast on boot with
+ * a clear message instead of pretending to work and then breaking on every
+ * score submit.
+ */
 function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
-  if (!raw) {
-    if (__DEV__) {
-      return "http://localhost:8000";
-    }
-    Sentry.captureMessage("EXPO_PUBLIC_API_URL is not set in production build", {
-      level: "error",
-      tags: { subsystem: "httpClient", issue: "missing-env" },
-    });
-    // Fall back so the app doesn't hard-crash, but this will fail with a
-    // TypeError: Failed to fetch — which Sentry will capture separately.
+  if (raw) {
+    return raw.startsWith("http") ? raw : `https://${raw}`;
+  }
+  if (__DEV__) {
     return "http://localhost:8000";
   }
-  return raw.startsWith("http") ? raw : `https://${raw}`;
+  const msg =
+    "EXPO_PUBLIC_API_URL is not set in a non-dev build. " +
+    "Expo bakes EXPO_PUBLIC_* vars into the bundle at export time, so this " +
+    "must be present when `expo export` runs — set it on the Render service " +
+    "(see render.yaml) or in the build environment. Refusing to fall back to " +
+    "http://localhost:8000.";
+  Sentry.captureMessage(msg, {
+    level: "fatal",
+    tags: { subsystem: "httpClient", issue: "missing-env" },
+  });
+  throw new Error(msg);
 }
 
 export interface HttpClientOptions {

--- a/frontend/src/game/_shared/syncApi.ts
+++ b/frontend/src/game/_shared/syncApi.ts
@@ -24,10 +24,27 @@ export interface SyncResponse {
   body: unknown;
 }
 
+/**
+ * See httpClient.resolveBaseUrl for the rationale behind throwing rather
+ * than silently falling back to localhost in non-dev builds (#511).
+ */
 function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
-  if (!raw) return "http://localhost:8000";
-  return raw.startsWith("http") ? raw : `https://${raw}`;
+  if (raw) {
+    return raw.startsWith("http") ? raw : `https://${raw}`;
+  }
+  if (__DEV__) {
+    return "http://localhost:8000";
+  }
+  const msg =
+    "EXPO_PUBLIC_API_URL is not set in a non-dev build (syncApi). " +
+    "Expo bakes EXPO_PUBLIC_* vars into the bundle at export time. " +
+    "Refusing to fall back to http://localhost:8000.";
+  Sentry.captureMessage(msg, {
+    level: "fatal",
+    tags: { subsystem: "syncApi", issue: "missing-env" },
+  });
+  throw new Error(msg);
 }
 
 function parseRetryAfter(headerValue: string | null, now: number): number | null {


### PR DESCRIPTION
Both httpClient.createGameClient and syncApi previously fell back to
http://localhost:8000 when the env var was missing. In a non-dev bundle
that fallback is shipped to users' browsers, where every request fails
with TypeError: Failed to fetch and floods Sentry with confusing
network errors (e.g. cascade /score POSTs documented in #511).

Throw at module load (httpClient) / first call (syncApi) instead, with
a fatal Sentry breadcrumb. Per CLAUDE.md, EXPO_PUBLIC_* vars are baked
into the bundle at expo export time, so a missing var is a build-time
misconfig — the only correct behavior is to refuse to start. The dev
fallback is preserved behind __DEV__ so local workflows are unchanged.