### PR TITLE
fix(observability): stop reporting HTTP 4xx/5xx as Sentry exceptions (#513)

### DIFF
--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -66,13 +66,21 @@ describe("httpClient — BASE_URL configuration", () => {
 describe("httpClient — error handling", () => {
   let request: (path: string, options?: RequestInit) => Promise<unknown>;
   const mockFetch = jest.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Sentry: any;
 
   beforeEach(() => {
     jest.resetModules();
     global.fetch = mockFetch;
     mockFetch.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    Sentry = require("@sentry/react-native");
+    Sentry.captureException.mockClear();
+    Sentry.captureMessage.mockClear();
+    Sentry.addBreadcrumb.mockClear();
     const { createGameClient } = require("../httpClient") as typeof import("../httpClient");
-    request = createGameClient({ apiTag: "test" });
+    // Default: never sample 5xx, so most tests can ignore the sampling path.
+    request = createGameClient({ apiTag: "test", serverErrorSampleRate: 0 });
   });
 
   it("throws Error with detail when response is not ok", async () => {
@@ -138,5 +146,136 @@ describe("httpClient — error handling", () => {
     const headers = callArgs.headers as Record<string, string>;
     expect(headers["Content-Type"]).toBe("application/json");
     expect(headers["X-Session-ID"]).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe("httpClient — Sentry reporting (#513)", () => {
+  const mockFetch = jest.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let Sentry: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    global.fetch = mockFetch;
+    mockFetch.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    Sentry = require("@sentry/react-native");
+    Sentry.captureException.mockClear();
+    Sentry.captureMessage.mockClear();
+    Sentry.addBreadcrumb.mockClear();
+  });
+
+  function makeRequest(opts: { sampleRate?: number; random?: () => number } = {}) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createGameClient } = require("../httpClient") as typeof import("../httpClient");
+    return createGameClient({
+      apiTag: "test",
+      serverErrorSampleRate: opts.sampleRate ?? 0,
+      random: opts.random,
+    });
+  }
+
+  it("4xx (429) emits a warning breadcrumb and never calls captureMessage or captureException", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      json: () => Promise.resolve({ detail: "rate limited" }),
+    } as Response);
+    const request = makeRequest();
+    await expect(request("/cascade/score", { method: "POST" })).rejects.toThrow("rate limited");
+    const apiErrorCrumb = Sentry.addBreadcrumb.mock.calls.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any[]) => c[0]?.category === "api.error"
+    );
+    expect(apiErrorCrumb).toBeDefined();
+    expect(apiErrorCrumb[0]).toMatchObject({
+      category: "api.error",
+      level: "warning",
+      data: expect.objectContaining({ status: 429, api: "test" }),
+    });
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it.each([400, 401, 403, 404, 409, 422])(
+    "%i 4xx never calls captureMessage or captureException",
+    async (status) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status,
+        statusText: "Bad",
+        json: () => Promise.resolve({ detail: "nope" }),
+      } as Response);
+      const request = makeRequest();
+      await expect(request("/x")).rejects.toThrow();
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    }
+  );
+
+  it("5xx always emits a breadcrumb but only escalates to captureMessage when sample fires", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ detail: "boom" }),
+    } as Response);
+    // Sample miss: random() = 0.99 ≥ 0.1 → no captureMessage.
+    const requestMiss = makeRequest({ sampleRate: 0.1, random: () => 0.99 });
+    await expect(requestMiss("/x")).rejects.toThrow();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(
+      Sentry.addBreadcrumb.mock.calls.some(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (c: any[]) => c[0]?.category === "api.error"
+      )
+    ).toBe(true);
+
+    Sentry.addBreadcrumb.mockClear();
+    // Sample hit: random() = 0 < 0.1 → captureMessage fires once.
+    const requestHit = makeRequest({ sampleRate: 0.1, random: () => 0 });
+    await expect(requestHit("/x")).rejects.toThrow();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("5xx"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ errorType: "http5xx", status: "500" }),
+      })
+    );
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("network failure (TypeError) emits captureMessage warning, not captureException", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const request = makeRequest();
+    await expect(request("/x")).rejects.toThrow("Failed to fetch");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("network failure"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ errorType: "network" }),
+      })
+    );
+  });
+
+  it("genuine unexpected JS error (non-Api, non-Type) is captured as an exception with stack", async () => {
+    // A RangeError from inside fetch is the kind of thing we want loud
+    // visibility on — it indicates a bug we wrote, not a network issue.
+    mockFetch.mockRejectedValueOnce(new RangeError("oops"));
+    const request = makeRequest();
+    await expect(request("/x")).rejects.toThrow("oops");
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(RangeError),
+      expect.objectContaining({
+        tags: expect.objectContaining({ errorType: "unexpected" }),
+      })
+    );
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -45,10 +45,19 @@ function resolveBaseUrl(): string {
 export interface HttpClientOptions {
   /** Sentry tag value, e.g. "cascade", "yacht". Used for per-game observability. */
   apiTag: string;
+  /**
+   * Probability (0..1) of escalating a 5xx response to a Sentry warning
+   * `captureMessage`. 4xx is never escalated. Defaults to 0.1 so persistent
+   * backend outages stay visible without flooding the dashboard. Tests
+   * override this to make sampling deterministic.
+   */
+  serverErrorSampleRate?: number;
+  /** Injection seam for deterministic sampling in tests. */
+  random?: () => number;
 }
 
 export function createGameClient(options: HttpClientOptions) {
-  const { apiTag } = options;
+  const { apiTag, serverErrorSampleRate = 0.1, random = Math.random } = options;
   const BASE_URL = resolveBaseUrl();
 
   Sentry.addBreadcrumb({
@@ -74,20 +83,60 @@ export function createGameClient(options: HttpClientOptions) {
       if (!res.ok) {
         const err = await res.json().catch(() => ({ detail: res.statusText }));
         const msg = err.detail ?? "Request failed";
-        Sentry.captureMessage(`API error: ${method} ${path} → ${res.status}`, {
+        // 4xx and 5xx are HTTP-layer outcomes, not JS exceptions. Emit a
+        // breadcrumb only — never `captureMessage` (which attaches a
+        // synthetic stack and creates a grouped Sentry issue per status
+        // code) and never `captureException`. See #513: a single 429
+        // status used to spawn a 476-event Sentry issue grouped on the
+        // ApiError constructor frame.
+        Sentry.addBreadcrumb({
+          category: "api.error",
           level: "warning",
-          extra: { url, status: res.status, detail: msg, platform: Platform.OS },
+          message: `${method} ${path} → ${res.status}`,
+          data: { url, status: res.status, detail: msg, platform: Platform.OS, api: apiTag },
         });
+        // 5xx only: optionally surface as a low-sample warning so a
+        // sustained backend outage still leaves a trail in the dashboard
+        // without flooding it. 4xx never escalates — those are client-
+        // side / expected-recoverable.
+        if (res.status >= 500 && random() < serverErrorSampleRate) {
+          Sentry.captureMessage(`API ${apiTag} 5xx: ${method} ${path} → ${res.status}`, {
+            level: "warning",
+            tags: { api: apiTag, errorType: "http5xx", status: String(res.status) },
+            extra: { url, detail: msg, platform: Platform.OS },
+          });
+        }
         throw new ApiError(msg, res.status);
       }
       return res.json();
     } catch (e) {
-      if (e instanceof TypeError) {
-        Sentry.captureException(e, {
-          extra: { url, platform: Platform.OS, method },
-          tags: { api: apiTag, errorType: "network" },
-        });
+      if (e instanceof ApiError) {
+        // Already breadcrumbed in the !res.ok branch above. Re-throw so
+        // callers can inspect `.status` and decide how to react.
+        throw e;
       }
+      if (e instanceof TypeError) {
+        // `fetch` throws TypeError for network-layer failures (offline,
+        // DNS, CORS, "Failed to fetch"). These are recoverable and
+        // distinct from a programming error — surface as a warning
+        // message, not a captured exception with a stack. The synthetic
+        // stack here would otherwise group every offline user under a
+        // single misleading issue.
+        Sentry.captureMessage(`API ${apiTag} network failure: ${method} ${path}`, {
+          level: "warning",
+          tags: { api: apiTag, errorType: "network" },
+          extra: { url, platform: Platform.OS, originalMessage: e.message },
+        });
+        throw e;
+      }
+      // Anything else is a genuine JS error from the request-building
+      // code (e.g. session-id read failure, unexpected throw inside a
+      // mocked fetch). Capture with stack — this is exactly the case
+      // where a stacktrace in Sentry is useful.
+      Sentry.captureException(e, {
+        extra: { url, platform: Platform.OS, method },
+        tags: { api: apiTag, errorType: "unexpected" },
+      });
       throw e;
     }
   };


### PR DESCRIPTION
## Summary

Fixes #513. `httpClient.createGameClient` used to call `Sentry.captureMessage(...)` for every non-2xx response. `captureMessage` attaches a synthetic stacktrace and creates a grouped issue per status code, so 429s and 500s on `/cascade/score` looked like crashes in the dashboard (~950 events grouped on the `ApiError` constructor frame for what were really rate-limits and backend hiccups).

This PR rewrites the Sentry-reporting branches in `frontend/src/game/_shared/httpClient.ts`:

| Outcome | Before | After |
|---|---|---|
| **4xx** | `captureMessage` warning (synthetic stack) + throw | `addBreadcrumb` (`category: api.error`, `level: warning`) + throw. Never captures a Sentry event. |
| **5xx** | same as 4xx | `addBreadcrumb` always, plus `captureMessage` at a **1/10 default sample rate** so sustained outages still surface without flooding. Sample rate and RNG are injectable via `createGameClient({ serverErrorSampleRate, random })` for deterministic tests. |
| **Network (`TypeError`)** | `captureException` with stack | `captureMessage` warning, no stack. Offline / DNS / CORS are recoverable, not programmer errors. |
| **Unknown JS error** | *(nothing)* | `captureException` with stack — the **only** path that produces a stacktrace event in Sentry now. |

## Contract preserved

`ApiError` is still an `Error` subclass with `.status`, so the existing consumers keep working unchanged:
- `frontend/src/screens/PachisiScreen.tsx:64` — `e instanceof ApiError && e.status === 404`
- `frontend/src/components/cascade/GameOverOverlay.tsx:57` — `e instanceof ApiError && e.status === 429`

## Test plan

New `httpClient — Sentry reporting (#513)` describe block with 10 tests:

- [x] 429 → warning breadcrumb only, no `captureMessage`, no `captureException`
- [x] Parametrized: 400 / 401 / 403 / 404 / 409 / 422 all behave identically
- [x] 5xx sampling: `random() = 0.99` → breadcrumb only; `random() = 0` → `captureMessage` fires with `errorType: http5xx`
- [x] `TypeError` → `captureMessage` warning with `errorType: network`, no `captureException`
- [x] `RangeError` (genuine JS bug) → `captureException` with stack
- [x] 18/18 `httpClient.test.ts` pass
- [x] 345/345 downstream tests pass across 25 suites (cascade, pachisi, syncWorker, gameEventClient, GameOverOverlay, PachisiScreen)

## Related

- #510 — blackjack `loadGame` has the same wrong-log-level pattern (fixed in a separate PR alongside #501)
- #511 — the localhost-fallback bug that was driving volume on the cascade `/score` path (separate PR)