### PR TITLE
fix(storage): downgrade corrupt-payload recovery to warning-level Sentry (#501, #510)

### DIFF
--- a/frontend/src/game/blackjack/__tests__/storage.test.ts
+++ b/frontend/src/game/blackjack/__tests__/storage.test.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame } from "../storage";
 import { newGame, EngineState } from "../engine";
 
@@ -7,6 +8,8 @@ const STORAGE_KEY = "blackjack_game_v2";
 describe("blackjack storage", () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
   it("saves and loads a game", async () => {
@@ -21,13 +24,35 @@ describe("blackjack storage", () => {
   });
 
   it("returns null when saved data is corrupted", async () => {
-    await AsyncStorage.setItem("blackjack_game_v1", "not json");
+    // NB: previous revision of this test wrote to "blackjack_game_v1",
+    // which no longer exists as a key — so the test was passing because
+    // loadGame saw an empty slot, not because it survived a parse error.
+    // #510 exposed that: the actual key is v2.
+    await AsyncStorage.setItem(STORAGE_KEY, "not-valid-json{{{");
     expect(await loadGame()).toBeNull();
   });
 
   it("returns null when saved data has different shape", async () => {
-    await AsyncStorage.setItem("blackjack_game_v1", JSON.stringify({ foo: "bar" }));
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: "bar" }));
     expect(await loadGame()).toBeNull();
+  });
+
+  // #510: corrupt payload should be reported at WARNING level and the
+  // corrupt entry should be cleared so it doesn't re-fire every launch.
+  it("reports corrupt payload as warning (not exception) and clears the entry", async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, "not-valid-json{{{");
+    expect(await loadGame()).toBeNull();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("corrupt game payload"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ subsystem: "blackjack.storage", op: "load" }),
+      })
+    );
+    // Subsequent load sees a clean slot — the corrupt entry was removed.
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it("clearGame removes the saved state", async () => {

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -48,7 +48,15 @@ export async function loadGame(): Promise<EngineState | null> {
     }
     return parsed;
   } catch (e) {
-    Sentry.captureException(e, { tags: { subsystem: "blackjack.storage", op: "load" } });
+    // Corrupt payload: recovery is complete (we remove the bad entry and
+    // return null, so the caller starts a fresh game). This is not an
+    // error — downgrade from captureException to a warning captureMessage
+    // so it doesn't page as a crash in Sentry. See #510.
+    Sentry.captureMessage("blackjack.storage: corrupt game payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "blackjack.storage", op: "load" },
+      extra: { error: String(e), key: STORAGE_KEY },
+    });
     await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
     return null;
   }

--- a/frontend/src/game/cascade/__tests__/storage.test.ts
+++ b/frontend/src/game/cascade/__tests__/storage.test.ts
@@ -7,6 +7,7 @@
  */
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame, CascadeGameSnapshot, SavedFruit } from "../storage";
 
 const KEY = "cascade_game_v1";
@@ -30,6 +31,8 @@ function makeSnapshot(overrides: Partial<CascadeGameSnapshot> = {}): CascadeGame
 describe("cascade/storage", () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
   describe("round-trip", () => {
@@ -121,6 +124,21 @@ describe("cascade/storage", () => {
       expect(await loadGame()).toBeNull();
       // Subsequent load sees nothing (the corrupt entry was removed).
       expect(await loadGame()).toBeNull();
+    });
+
+    // Same #501/#510 pattern: corrupt payload reports as warning.
+    it("reports corrupt payload as warning (not exception)", async () => {
+      await AsyncStorage.setItem(KEY, "{not json");
+      expect(await loadGame()).toBeNull();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining("corrupt game payload"),
+        expect.objectContaining({
+          level: "warning",
+          tags: expect.objectContaining({ subsystem: "cascade.storage", op: "load" }),
+        })
+      );
     });
   });
 });

--- a/frontend/src/game/cascade/storage.ts
+++ b/frontend/src/game/cascade/storage.ts
@@ -86,7 +86,14 @@ export async function loadGame(): Promise<CascadeGameSnapshot | null> {
       savedAt: typeof parsed.savedAt === "number" ? parsed.savedAt : Date.now(),
     };
   } catch (e) {
-    Sentry.captureException(e, { tags: { subsystem: "cascade.storage", op: "load" } });
+    // Corrupt payload: recovery is complete. See #501/#510 for the
+    // rationale behind downgrading this from captureException to a
+    // warning-level captureMessage.
+    Sentry.captureMessage("cascade.storage: corrupt game payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "cascade.storage", op: "load" },
+      extra: { error: String(e), key: GAME_KEY },
+    });
     // Remove corrupted entry so it doesn't fail on every subsequent load.
     await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
     return null;

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -1,6 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame, saveBestScore, loadBestScore } from "../storage";
 import { Twenty48State } from "../types";
+
+const GAME_KEY = "twenty48_game_v2";
 
 const sample: Twenty48State = {
   board: [
@@ -26,6 +29,8 @@ const sample: Twenty48State = {
 describe("twenty48 storage", () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
   it("saves and loads a game", async () => {
@@ -40,9 +45,26 @@ describe("twenty48 storage", () => {
   });
 
   it("returns null when saved data is corrupted", async () => {
-    await AsyncStorage.setItem("twenty48_game_v2", "not json");
+    await AsyncStorage.setItem(GAME_KEY, "not json");
     const loaded = await loadGame();
     expect(loaded).toBeNull();
+  });
+
+  // #501: corrupt payload is fully recovered — should be a warning, not
+  // an exception, and the corrupt entry must be cleared.
+  it("reports corrupt payload as warning (not exception) and clears the entry", async () => {
+    await AsyncStorage.setItem(GAME_KEY, "garbage{not json}");
+    expect(await loadGame()).toBeNull();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("corrupt game payload"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ subsystem: "twenty48.storage", op: "load" }),
+      })
+    );
+    expect(await AsyncStorage.getItem(GAME_KEY)).toBeNull();
   });
 
   it("returns null when saved data has a different shape", async () => {

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -41,7 +41,15 @@ export async function loadGame(): Promise<Twenty48State | null> {
     parsed.accumulatedMs = parsed.accumulatedMs ?? 0;
     return parsed;
   } catch (e) {
-    Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "load" } });
+    // Corrupt payload: recovery is complete (we remove the bad entry and
+    // return null, so the caller starts a fresh game). This is not an
+    // error — downgrade from captureException to a warning captureMessage
+    // so it doesn't page as a crash in Sentry. See #501.
+    Sentry.captureMessage("twenty48.storage: corrupt game payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "twenty48.storage", op: "load" },
+      extra: { error: String(e), key: GAME_KEY },
+    });
     // Remove corrupted entry so it doesn't fail on every subsequent load.
     await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
     return null;

--- a/frontend/src/game/yacht/__tests__/storage.test.ts
+++ b/frontend/src/game/yacht/__tests__/storage.test.ts
@@ -1,10 +1,15 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame } from "../storage";
 import { newGame } from "../engine";
+
+const STORAGE_KEY = "yacht_game_v1";
 
 describe("yacht storage", () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
   });
 
   it("saves and loads a game", async () => {
@@ -19,13 +24,30 @@ describe("yacht storage", () => {
   });
 
   it("returns null when saved data is corrupted", async () => {
-    await AsyncStorage.setItem("yacht_game_v1", "not json");
+    await AsyncStorage.setItem(STORAGE_KEY, "not json");
     expect(await loadGame()).toBeNull();
   });
 
   it("returns null when saved data has different shape", async () => {
-    await AsyncStorage.setItem("yacht_game_v1", JSON.stringify({ foo: "bar" }));
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: "bar" }));
     expect(await loadGame()).toBeNull();
+  });
+
+  // Same #501/#510 pattern: corrupt payload reports as warning, not
+  // exception, and the entry is cleared.
+  it("reports corrupt payload as warning (not exception) and clears the entry", async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, "not-valid-json{{{");
+    expect(await loadGame()).toBeNull();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("corrupt game payload"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ subsystem: "yacht.storage", op: "load" }),
+      })
+    );
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
   it("clearGame removes the saved state", async () => {

--- a/frontend/src/game/yacht/storage.ts
+++ b/frontend/src/game/yacht/storage.ts
@@ -36,7 +36,14 @@ export async function loadGame(): Promise<GameState | null> {
     }
     return parsed;
   } catch (e) {
-    Sentry.captureException(e, { tags: { subsystem: "yacht.storage", op: "load" } });
+    // Corrupt payload: recovery is complete. See #501/#510 for the
+    // rationale behind downgrading this from captureException to a
+    // warning-level captureMessage.
+    Sentry.captureMessage("yacht.storage: corrupt game payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "yacht.storage", op: "load" },
+      extra: { error: String(e), key: STORAGE_KEY },
+    });
     await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #501 and #510. When reading the code, both issues turned out to be the same bug in four places:

- **#501 (twenty48):** Recovery already works (corrupt key removed, `null` returned, fresh game starts). Only problem is `captureException` reports it as crash-grade.
- **#510 (blackjack):** Described as broken recovery, but `blackjack/storage.ts:50-54` already had the try/catch + `removeItem` + `return null`. Same bug as #501: wrong log level.
- **yacht and cascade:** Cross-check per #510's checklist showed they have the **identical** pattern and the **identical** latent bug. Not observed in Sentry yet but guaranteed to fire on first corruption.

Scope collapsed to: change `captureException` → warning-level `captureMessage` in four `loadGame` catch blocks, and the error stops paging as a crash.

Each `loadGame` catch now calls:

```ts
Sentry.captureMessage("<game>.storage: corrupt game payload, discarding", {
  level: "warning",
  tags: { subsystem: "<game>.storage", op: "load" },
  extra: { error: String(e), key: <KEY> },
});
```

Frequency tracking is preserved (a spike in corruption is still visible in the dashboard) but severity matches actual user impact: zero. `save` / `clear` / `saveBest` / `loadBest` keep `captureException` — those are genuine AsyncStorage I/O failures, not routine parse recovery.

## Pre-existing latent bug also fixed

`frontend/src/game/blackjack/__tests__/storage.test.ts:24` and `:29` wrote to `"blackjack_game_v1"`, but the real storage key is `"blackjack_game_v2"`. The "corrupted data" and "different shape" tests were passing only because `loadGame` found an empty slot at v2 and returned `null` early — **they never exercised the parse-recovery path at all**. That's why #510's bug went uncaught. Fixed to use the `STORAGE_KEY` constant.

## Test plan

- [x] 4 new `reports corrupt payload as warning (not exception)` tests — one per game — asserting:
  - `Sentry.captureException` is **not** called
  - `Sentry.captureMessage` is called once with `level: "warning"` and the right subsystem tag
  - Corrupt entry is removed (blackjack / twenty48 / yacht)
- [x] 35/35 storage tests pass across all 4 suites
- [x] 710/710 tests pass across 36 downstream suites (blackjack/twenty48/yacht/cascade engines + contexts + screens)

## Related

- #513 — same "wrong severity" pattern on the HTTP client (separate PR)