### PR TITLE
fix(games): accept lifecycle outcome vocabulary on PATCH /complete (#514)

### DIFF
--- a/backend/alembic/versions/0003_relax_games_outcome_constraint.py
+++ b/backend/alembic/versions/0003_relax_games_outcome_constraint.py
@@ -37,7 +37,6 @@ from typing import Sequence, Union
 
 from alembic import op
 
-
 revision: str = "0003_relax_games_outcome_constraint"
 down_revision: Union[str, None] = "0002_games_events_lookups"
 branch_labels: Union[str, Sequence[str], None] = None

--- a/backend/alembic/versions/0003_relax_games_outcome_constraint.py
+++ b/backend/alembic/versions/0003_relax_games_outcome_constraint.py
@@ -1,0 +1,63 @@
+"""relax games.outcome check constraint to accept lifecycle vocabulary (#514)
+
+Revision ID: 0003_relax_games_outcome_constraint
+Revises: 0002_games_events_lookups
+Create Date: 2026-04-15
+
+Background
+----------
+The original `ck_games_outcome` constraint (added in 0002) only accepted the
+blackjack result vocabulary `{win, loss, push, blackjack}` plus `abandoned`.
+Score-based games (yacht, cascade, twenty48) that send a lifecycle outcome
+like `completed` or `kept_playing` were rejected at the DB layer — even
+though every one of their frontend screens emits that vocabulary.
+
+#514 documented the symptom (PATCH /games/:id/complete → 400). Prior to
+this migration the 400 was raised by the Pydantic/application validator
+in `games/service.py:_VALID_OUTCOMES`; under the same migration the DB
+constraint would also have rejected the write. This migration and the
+companion `_VALID_OUTCOMES` expansion bring both layers in line with the
+vocabulary the frontends actually use.
+
+Forward migration
+-----------------
+Drops the old `ck_games_outcome` and recreates it with the union of both
+vocabularies. Uses `batch_alter_table` so SQLite (the CI test DB) can
+rewrite the table — SQLite has no ALTER TABLE DROP CONSTRAINT.
+
+Downgrade
+---------
+Restores the original constraint. Any rows with the new vocabulary
+(`completed`, `kept_playing`) would fail the tighter constraint on
+downgrade, so the downgrade is only safe on a DB that has not yet
+accepted any lifecycle-vocabulary rows.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0003_relax_games_outcome_constraint"
+down_revision: Union[str, None] = "0002_games_events_lookups"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_NEW_CHECK = (
+    "outcome IS NULL OR outcome IN "
+    "('win','loss','push','blackjack','completed','abandoned','kept_playing')"
+)
+_OLD_CHECK = "outcome IS NULL OR outcome IN ('win','loss','push','blackjack','abandoned')"
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("games") as batch_op:
+        batch_op.drop_constraint("ck_games_outcome", type_="check")
+        batch_op.create_check_constraint("ck_games_outcome", _NEW_CHECK)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("games") as batch_op:
+        batch_op.drop_constraint("ck_games_outcome", type_="check")
+        batch_op.create_check_constraint("ck_games_outcome", _OLD_CHECK)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -88,7 +88,12 @@ class Game(Base):
     __tablename__ = "games"
     __table_args__ = (
         CheckConstraint(
-            "outcome IS NULL OR outcome IN ('win','loss','push','blackjack','abandoned')",
+            # Two vocabularies coexist here — see _VALID_OUTCOMES in
+            # games/service.py for the rationale. Result vocabulary:
+            # win/loss/push/blackjack. Lifecycle vocabulary (#514):
+            # completed/abandoned/kept_playing.
+            "outcome IS NULL OR outcome IN "
+            "('win','loss','push','blackjack','completed','abandoned','kept_playing')",
             name="ck_games_outcome",
         ),
         Index("games_session_id_started_at_idx", "session_id", "started_at"),

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -21,7 +21,33 @@ from sqlalchemy.orm import selectinload
 
 from db.models import EventType, Game, GameEvent, GameType
 
-_VALID_OUTCOMES = {"win", "loss", "push", "blackjack", "abandoned"}
+# Valid values for Game.outcome. Two vocabularies live here intentionally:
+#
+#   1. Result vocabulary — `win` / `loss` / `push` / `blackjack`. Came from
+#      blackjack where each round has a defined winner. Still used when a
+#      game surfaces a concrete player vs. dealer / player vs. house result.
+#
+#   2. Lifecycle vocabulary — `completed` / `abandoned` / `kept_playing`.
+#      Used by score-based games that have no win/loss semantics — Yacht,
+#      Cascade, Twenty48, etc. These ship whatever final score the player
+#      reached and just need to distinguish "game ended naturally" from
+#      "player quit mid-game" from "player chose to keep playing past the
+#      win condition" (2048 specifically).
+#
+# Both vocabularies are stored as-is in `game.outcome`; the backend does
+# not branch on the value, it just validates the string and records it for
+# analytics. Prior to #514 only the result vocabulary plus `abandoned`
+# were accepted, so every natural game-end PATCH from the score-based
+# games came back 400 on `outcome="completed"`.
+_VALID_OUTCOMES = {
+    "win",
+    "loss",
+    "push",
+    "blackjack",
+    "completed",
+    "abandoned",
+    "kept_playing",
+}
 
 
 class GameServiceError(Exception):

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0002_games_events_lookups"
+        assert version == "0003_relax_games_outcome_constraint"

--- a/backend/tests/test_games_api.py
+++ b/backend/tests/test_games_api.py
@@ -237,6 +237,37 @@ def test_complete_game_rejects_invalid_outcome(client: TestClient, session_id: s
     assert r.status_code == 400
 
 
+# #514: prior to this fix the set of valid outcomes only covered the blackjack
+# result vocabulary (`win` / `loss` / `push` / `blackjack`) plus `abandoned`,
+# so every natural game-end from a score-based game (yacht, cascade, twenty48)
+# came back 400 on `outcome="completed"`. Cover both vocabularies explicitly.
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        # Result vocabulary
+        "win",
+        "loss",
+        "push",
+        "blackjack",
+        # Lifecycle vocabulary (#514)
+        "completed",
+        "abandoned",
+        "kept_playing",
+    ],
+)
+def test_complete_game_accepts_valid_outcomes(
+    client: TestClient, session_id: str, outcome: str
+) -> None:
+    gid = _new_game(client, session_id)
+    r = client.patch(
+        f"/games/{gid}/complete",
+        headers=_headers(session_id),
+        json={"final_score": 100, "outcome": outcome, "duration_ms": 5_000},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["outcome"] == outcome
+
+
 def test_complete_game_cross_session_forbidden(client: TestClient, session_id: str) -> None:
     gid = _new_game(client, session_id)
     other = str(uuid.uuid4())

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -335,6 +335,74 @@ describe("SyncWorker", () => {
     expect(patches.length).toBe(0);
   });
 
+  // #514: the in-memory CompleteSummary is camelCase for idiomatic TS, but
+  // the backend Pydantic schema is snake_case. Pydantic default is
+  // extra="ignore", so before this fix the camelCase fields were silently
+  // dropped and every completed game landed with final_score=NULL and
+  // duration_ms=NULL. Pin the wire format here so a future refactor can't
+  // quietly re-introduce the bug.
+  it("PATCH /complete body uses snake_case field names", async () => {
+    api.defaultResponse = ok();
+    const gid = client.startGame("yacht");
+    client.completeGame(gid, {
+      finalScore: 312,
+      outcome: "completed",
+      durationMs: 45_000,
+    });
+    await flushMicro();
+    await worker.flush();
+
+    const patch = api.calls.find(
+      (c) => c.method === "PATCH" && c.path === `/games/${gid}/complete`
+    );
+    expect(patch).toBeDefined();
+    expect(patch!.body).toEqual({
+      final_score: 312,
+      outcome: "completed",
+      duration_ms: 45_000,
+    });
+    // And the old camelCase keys must NOT be present — otherwise Pydantic
+    // would still ignore them, but it would leave us with a confusing
+    // double-keyed payload.
+    expect(patch!.body).not.toHaveProperty("finalScore");
+    expect(patch!.body).not.toHaveProperty("durationMs");
+  });
+
+  // #514: include the 400 response body in the Sentry warning so the next
+  // occurrence self-explains. The original Sentry event only said
+  // "400 on PATCH /complete" with no hint that the root cause was an
+  // invalid `outcome` value.
+  it("400 on PATCH /complete surfaces the response body via captureMessage", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/react-native");
+    Sentry.captureMessage.mockClear();
+
+    api.defaultResponse = ok();
+    api.onNext((p) => p.endsWith("/complete"), {
+      status: 400,
+      ok: false,
+      retryAfterMs: null,
+      body: { detail: "Invalid outcome: 'completed'" },
+    });
+    const gid = client.startGame("yacht");
+    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
+    await flushMicro();
+    await worker.flush();
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("400 on PATCH /complete"),
+      expect.objectContaining({
+        level: "warning",
+        extra: expect.objectContaining({
+          status: 400,
+          body: { detail: "Invalid outcome: 'completed'" },
+          gameId: gid,
+          sentOutcome: "completed",
+        }),
+      })
+    );
+  });
+
   // -------------------------------------------------------------------------
   // Bug logs
   // -------------------------------------------------------------------------

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -315,12 +315,7 @@ export class SyncWorker {
         outcome: summary.outcome ?? null,
         duration_ms: summary.durationMs ?? null,
       };
-      const res = await this.api.request(
-        "PATCH",
-        `/games/${gameId}/complete`,
-        body,
-        now
-      );
+      const res = await this.api.request("PATCH", `/games/${gameId}/complete`, body, now);
       result.attempted += 1;
       if (res.ok) {
         await this.games.markCompleteSynced(gameId);

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -302,10 +302,23 @@ export class SyncWorker {
       const outstanding = await this.hasOutstandingEvents(gameId, now);
       if (outstanding) continue;
 
+      // Serialize summary with snake_case field names to match the
+      // backend Pydantic schema (`final_score`, `duration_ms`). The
+      // in-memory `CompleteSummary` is camelCase, and Pydantic's
+      // default `extra="ignore"` silently dropped the camelCase keys —
+      // every game prior to #514 landed with final_score = NULL and
+      // duration_ms = NULL even when the PATCH succeeded. Transform
+      // at the wire boundary so the in-memory type stays idiomatic TS.
+      const summary = game.completeSummary ?? {};
+      const body = {
+        final_score: summary.finalScore ?? null,
+        outcome: summary.outcome ?? null,
+        duration_ms: summary.durationMs ?? null,
+      };
       const res = await this.api.request(
         "PATCH",
         `/games/${gameId}/complete`,
-        game.completeSummary ?? {},
+        body,
         now
       );
       result.attempted += 1;
@@ -330,8 +343,19 @@ export class SyncWorker {
         if (g) g.startedSynced = false;
         continue;
       }
+      // 4xx (400/403/etc.) is a permanent, non-retryable rejection from
+      // the server. Include the response body so future occurrences
+      // self-explain in Sentry — the original #514 event only surfaced
+      // "400 on PATCH /complete" with no indication the root cause was
+      // an invalid `outcome` value.
       Sentry.captureMessage(`syncWorker: ${res.status} on PATCH /complete ${gameId}`, {
         level: res.status === 403 ? "error" : "warning",
+        extra: {
+          status: res.status,
+          body: res.body,
+          gameId,
+          sentOutcome: body.outcome,
+        },
       });
       await this.games.forget(gameId);
       result.deadLettered += 1;


### PR DESCRIPTION
## Summary

Fixes #514. When reading the code, this turned out to be **three bugs hiding in one Sentry event**.

### Bug 1 — the actual 400 (what #514 reported)

Pure vocabulary mismatch between client and server. All four frontend callers pass lifecycle outcomes — `completed`, `abandoned`, `kept_playing` — but the backend only accepted the blackjack result vocabulary (`win`, `loss`, `push`, `blackjack`) plus `abandoned`:

| Frontend caller | Outcomes sent | Valid per backend? |
|---|---|---|
| `Twenty48Screen.tsx:95` | `completed`, `abandoned`, `kept_playing` | only `abandoned` |
| `BlackjackGameContext.tsx:51` | `completed`, `abandoned` | only `abandoned` |
| `GameScreen.tsx:139` (Yacht) | `completed`, `abandoned` | only `abandoned` |
| `CascadeScreen.tsx:86` | `completed`, `abandoned` | only `abandoned` |

So **every natural game-end** returned 400. The "1 user / 1 event" Sentry signal understated reality by a huge margin — it looked isolated because client-side logging is limited and the bug is easy to miss in dev.

The mismatch lived in **two** places:
1. `backend/games/service.py:_VALID_OUTCOMES` — application-layer validator
2. `ck_games_outcome` CHECK constraint — DB-layer enforcement

Both are now expanded to the union of the two vocabularies. A new alembic migration `0003_relax_games_outcome_constraint` drops and recreates the CHECK in `batch_alter_table` mode so it rewrites cleanly on both SQLite (CI test DB) and Postgres (prod).

### Bug 2 — silent data loss (discovered during investigation)

The in-memory `CompleteSummary` type uses **camelCase** (`finalScore`, `durationMs`) but the backend Pydantic schema is **snake_case** (`final_score`, `duration_ms`). Pydantic's default `extra="ignore"` silently dropped the camelCase keys, so **every successfully-completed game prior to #514 landed in the DB with `final_score = NULL` and `duration_ms = NULL`**. `syncWorker.flushCompletions` now serializes the summary as snake_case at the wire boundary, keeping the in-memory type idiomatic TS while matching the backend contract.

Pinned with a regression test (`PATCH /complete body uses snake_case field names`) so a future refactor can't quietly re-introduce it.

### Bug 3 — observability (the issue's suggested fix direction)

The 4xx/5xx `Sentry.captureMessage` in `flushCompletions` only said `"400 on PATCH /complete"` — no response body, no outcome, no way to diagnose. Now it includes `{ status, body, gameId, sentOutcome }` in `extra`, so the next occurrence self-explains.

### About the red-herring stacktrace attribution

The issue noted Sentry grouped the event by `generateSeedId` in `testHooks.ts:93` (a UUID generator that obviously can't cause a PATCH 400). That's Hermes/Sentry's in-app-frame fallback picking the wrong frame. #516 (the #513 observability fix already merged) made `captureMessage` paths less stack-grouped, so this should improve automatically. Not tracking separately unless it recurs.

## Test plan

- [x] **Backend:** 520 passed, 26 skipped
  - New parametrized `test_complete_game_accepts_valid_outcomes` covering all 7 valid outcomes (4 result + 3 lifecycle)
  - Existing `rejects_invalid_outcome` still asserts `"bogus"` → 400 (untouched)
  - Updated hardcoded alembic head in `test_db_connection.py`
  - All other existing games/blackjack/yacht/cascade/db tests continue to pass
- [x] **Frontend:** 1082 passed across 73 suites
  - New `PATCH /complete body uses snake_case field names` asserts the serialized body shape
  - New `400 on PATCH /complete surfaces the response body via captureMessage` verifies the observability improvement
  - All existing syncWorker / gameEventClient / game-screen tests continue to pass
- [ ] Manual smoke: play a full yacht/cascade/twenty48 game in dev, confirm PATCH /complete returns 200 and the DB row has non-NULL `final_score` and `duration_ms`