### PR TITLE
fix(sync): retry PATCH /complete on 400 up to MAX_COMPLETE_ATTEMPTS b…

### DIFF
--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -428,9 +428,8 @@ describe("SyncWorker", () => {
     // Game must still be tracked — not forgotten yet.
     expect(games.get(gid)).toBeDefined();
     expect(games.get(gid)?.completeAttempts).toBe(1);
-    // Not yet counted as dead-lettered.
-    const result = await worker.flush();
     // This second flush will succeed (api.defaultResponse = ok()).
+    await worker.flush();
     expect(games.get(gid)).toBeUndefined(); // forgotten after 2xx
   });
 

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -372,6 +372,7 @@ describe("SyncWorker", () => {
   // occurrence self-explains. The original Sentry event only said
   // "400 on PATCH /complete" with no hint that the root cause was an
   // invalid `outcome` value.
+  // #519: Sentry extra now also includes attempt/maxAttempts/isFinal.
   it("400 on PATCH /complete surfaces the response body via captureMessage", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Sentry = require("@sentry/react-native");
@@ -398,8 +399,79 @@ describe("SyncWorker", () => {
           body: { detail: "Invalid outcome: 'completed'" },
           gameId: gid,
           sentOutcome: "completed",
+          attempt: 1,
+          isFinal: false,
         }),
       })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // #519 — PATCH /complete retry on 400 (deployment-window resilience)
+  // -------------------------------------------------------------------------
+
+  // 400 on PATCH /complete must NOT immediately dead-letter the game.
+  // The root cause of #519 was a deployment-window mismatch: the server
+  // was running old code that rejected outcome="completed" while the new
+  // code was still being deployed. Retrying gives the deployment time to
+  // roll out.
+  it("400 on PATCH /complete retains the game after the first failure", async () => {
+    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
+    api.defaultResponse = ok();
+    api.onNext((p) => p.endsWith("/complete"), err(400));
+
+    const gid = client.startGame("yacht");
+    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
+    await flushMicro();
+    await worker.flush();
+
+    // Game must still be tracked — not forgotten yet.
+    expect(games.get(gid)).toBeDefined();
+    expect(games.get(gid)?.completeAttempts).toBe(1);
+    // Not yet counted as dead-lettered.
+    const result = await worker.flush();
+    // This second flush will succeed (api.defaultResponse = ok()).
+    expect(games.get(gid)).toBeUndefined(); // forgotten after 2xx
+  });
+
+  it("400 on PATCH /complete dead-letters after MAX_COMPLETE_ATTEMPTS", async () => {
+    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
+    api.defaultResponse = ok();
+    api.onNext((p) => p.endsWith("/complete"), err(400));
+    api.onNext((p) => p.endsWith("/complete"), err(400));
+
+    const gid = client.startGame("yacht");
+    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
+    await flushMicro();
+
+    // First failure — game kept.
+    await worker.flush();
+    expect(games.get(gid)).toBeDefined();
+
+    // Second failure — hits the cap, game forgotten.
+    const result = await worker.flush();
+    expect(games.get(gid)).toBeUndefined();
+    expect(result.deadLettered).toBe(1);
+  });
+
+  it("403 on PATCH /complete is immediately dead-lettered (permanent session mismatch)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/react-native");
+    Sentry.captureMessage.mockClear();
+
+    api.defaultResponse = ok();
+    api.onNext((p) => p.endsWith("/complete"), err(403));
+
+    const gid = client.startGame("yacht");
+    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
+    await flushMicro();
+    const result = await worker.flush();
+
+    expect(games.get(gid)).toBeUndefined();
+    expect(result.deadLettered).toBe(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("403 on PATCH /complete"),
+      expect.objectContaining({ level: "error" })
     );
   });
 

--- a/frontend/src/game/_shared/eventQueueConfig.ts
+++ b/frontend/src/game/_shared/eventQueueConfig.ts
@@ -62,6 +62,11 @@ export interface LogConfig {
   /** Rows exceeding this retry count are dead-lettered. */
   MAX_RETRY_COUNT: number;
 
+  /** How many 4xx failures on PATCH /complete before a game is dead-lettered.
+   * Kept above 1 so a deployment-window mismatch (old server rejecting a
+   * valid outcome) doesn't permanently lose the game on the first try. */
+  MAX_COMPLETE_ATTEMPTS: number;
+
   /** Per-row payload caps — oversized payloads are truncated on enqueue. */
   MAX_EVENT_PAYLOAD_BYTES: number;
   MAX_BUG_CONTEXT_BYTES: number;
@@ -89,6 +94,7 @@ export const logConfig: LogConfig = {
   BACKOFF_BASE_MS: 1000,
   BACKOFF_MAX_MS: 30 * 60 * 1000, // 30 min
   MAX_RETRY_COUNT: 10,
+  MAX_COMPLETE_ATTEMPTS: 3,
   MAX_EVENT_PAYLOAD_BYTES: 8 * 1024, // 8 KB
   MAX_BUG_CONTEXT_BYTES: 16 * 1024, // 16 KB
   REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,
@@ -117,6 +123,7 @@ export function resetLogConfig(): void {
     BACKOFF_BASE_MS: 1000,
     BACKOFF_MAX_MS: 30 * 60 * 1000,
     MAX_RETRY_COUNT: 10,
+    MAX_COMPLETE_ATTEMPTS: 3,
     MAX_EVENT_PAYLOAD_BYTES: 8 * 1024,
     MAX_BUG_CONTEXT_BYTES: 16 * 1024,
     REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,

--- a/frontend/src/game/_shared/pendingGamesStore.ts
+++ b/frontend/src/game/_shared/pendingGamesStore.ts
@@ -5,7 +5,7 @@
  *   - gameType / metadata — needed by SyncWorker to POST /games
  *   - startedSynced — has POST /games returned 2xx?
  *   - nextEventIndex — monotonic counter used when enqueueing events
- *   - completed / completeSummary / completeSynced — for PATCH /complete
+ *   - completed / completeSummary / completeSynced / completeAttempts — for PATCH /complete
  *
  * Storage: in-memory map is authoritative; AsyncStorage persists the same
  * map under `pending_games_v1`. On init() we rehydrate from disk. The
@@ -40,6 +40,11 @@ export interface PendingGame {
   completed: boolean;
   completeSummary: CompleteSummary | null;
   completeSynced: boolean;
+  /** How many times PATCH /complete has returned a non-retryable 4xx. Used
+   * to survive deployment-window mismatches where the server temporarily
+   * rejects a valid outcome value. Missing on pre-#519 persisted records —
+   * always read as `game.completeAttempts ?? 0`. */
+  completeAttempts: number;
 }
 
 export class PendingGamesStore {
@@ -98,6 +103,7 @@ export class PendingGamesStore {
       completed: false,
       completeSummary: null,
       completeSynced: false,
+      completeAttempts: 0,
     });
     return this.persist();
   }
@@ -145,6 +151,16 @@ export class PendingGamesStore {
     if (!game || game.startedSynced) return Promise.resolve();
     game.startedSynced = true;
     return this.persist();
+  }
+
+  /** SyncWorker calls this after a non-403 4xx on PATCH /complete.
+   * Increments the attempt counter, persists, and returns the new count. */
+  incrementCompleteAttempts(gameId: string): Promise<number> {
+    const game = this.games.get(gameId);
+    if (!game) return Promise.resolve(0);
+    const next = (game.completeAttempts ?? 0) + 1;
+    game.completeAttempts = next;
+    return this.persist().then(() => next);
   }
 
   /** SyncWorker marks PATCH /complete confirmed. */

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -338,22 +338,39 @@ export class SyncWorker {
         if (g) g.startedSynced = false;
         continue;
       }
-      // 4xx (400/403/etc.) is a permanent, non-retryable rejection from
-      // the server. Include the response body so future occurrences
-      // self-explain in Sentry — the original #514 event only surfaced
-      // "400 on PATCH /complete" with no indication the root cause was
-      // an invalid `outcome` value.
+      if (res.status === 403) {
+        // Session mismatch — permanent, never retryable.
+        Sentry.captureMessage(`syncWorker: 403 on PATCH /complete ${gameId}`, {
+          level: "error",
+          extra: { body: res.body, gameId, sentOutcome: body.outcome },
+        });
+        await this.games.forget(gameId);
+        result.deadLettered += 1;
+        continue;
+      }
+      // 400 (and other non-403 4xx): retryable up to MAX_COMPLETE_ATTEMPTS.
+      // The original #519 Sentry event was a deployment-window mismatch —
+      // the server was running old code that rejected outcome="completed"
+      // before the #514 fix was deployed. Retrying instead of immediately
+      // dead-lettering gives the deployment time to roll out.
+      const attempts = await this.games.incrementCompleteAttempts(gameId);
+      const isFinal = attempts >= logConfig.MAX_COMPLETE_ATTEMPTS;
       Sentry.captureMessage(`syncWorker: ${res.status} on PATCH /complete ${gameId}`, {
-        level: res.status === 403 ? "error" : "warning",
+        level: "warning",
         extra: {
           status: res.status,
           body: res.body,
           gameId,
           sentOutcome: body.outcome,
+          attempt: attempts,
+          maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
+          isFinal,
         },
       });
-      await this.games.forget(gameId);
-      result.deadLettered += 1;
+      if (isFinal) {
+        await this.games.forget(gameId);
+        result.deadLettered += 1;
+      }
     }
     return true;
   }


### PR DESCRIPTION
…efore dead-lettering (#519)

The original #519 Sentry event (syncWorker: 400 on PATCH /complete) was caused by a deployment-window mismatch: pendingGamesStore persists completed games across app restarts, so a game completed before the #514 fix was deployed hit the old backend (which rejected outcome="completed") and was immediately forgotten — permanent data loss.

- Add `completeAttempts: number` to PendingGame (backward-compat: defaults to 0)
- Add `incrementCompleteAttempts()` to PendingGamesStore — increments + persists
- Add `MAX_COMPLETE_ATTEMPTS: 3` to logConfig (overridable in tests)
- Split 403 (session mismatch, always permanent) from 400 (retryable up to limit)
- Sentry extra now includes attempt/maxAttempts/isFinal for self-explaining events
- 3 new tests + 1 updated; 22/22 passing

## Summary

## <!-- What does this PR do? Focus on the why, not the how. -->

## Type of change

- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done

<!-- What did you run? Any coverage delta? -->

- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist

- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist _(web / frontend PRs only)_

- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom

## Mobile checklist _(iOS / Android PRs only)_

- [ ] Tested on iOS Simulator or physical device
- [ ] `ios-build-check` / `android-build-check` CI job passes
- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)
