### PR TITLE
fix(cascade): boundary escape, cross-tier merge, and dt anomaly (#552)

### DIFF
--- a/frontend/__mocks__/@dimforge/rapier2d-compat.ts
+++ b/frontend/__mocks__/@dimforge/rapier2d-compat.ts
@@ -129,6 +129,7 @@ const RAPIER_MOCK = {
           _y = y;
           return builder;
         },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         setCcdEnabled(_enabled: boolean) {
           return builder;
         },

--- a/frontend/__mocks__/@dimforge/rapier2d-compat.ts
+++ b/frontend/__mocks__/@dimforge/rapier2d-compat.ts
@@ -90,6 +90,15 @@ export class MockWorld {
   _fireCollision(h1: number, h2: number) {
     this._activeEventQueue?._push(h1, h2, true);
   }
+
+  /**
+   * Test helper: force the next createRigidBody call to reuse a specific
+   * handle index.  Used to simulate Rapier's generational-arena handle
+   * recycling so the tier-snapshot guard in processMerges can be exercised.
+   */
+  _forceNextHandle(n: number) {
+    this._bodyHandleCounter = n;
+  }
 }
 
 const mockColliderDescBuilder = () => ({
@@ -105,9 +114,27 @@ const RAPIER_MOCK = {
   World: jest.fn().mockImplementation(() => new MockWorld()),
   EventQueue: jest.fn().mockImplementation(() => new MockEventQueue()),
   RigidBodyDesc: {
-    dynamic: () => ({
-      setTranslation: (x: number, y: number) => ({ x, y }),
-    }),
+    dynamic: () => {
+      let _x = 0,
+        _y = 0;
+      const builder = {
+        get x() {
+          return _x;
+        },
+        get y() {
+          return _y;
+        },
+        setTranslation(x: number, y: number) {
+          _x = x;
+          _y = y;
+          return builder;
+        },
+        setCcdEnabled(_enabled: boolean) {
+          return builder;
+        },
+      };
+      return builder;
+    },
   },
   ColliderDesc: {
     ball: jest.fn().mockImplementation(() => mockColliderDescBuilder()),

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -409,14 +409,41 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         if (lastFrameTimeRef.current === 0) lastFrameTimeRef.current = timestamp;
         const elapsed = (timestamp - lastFrameTimeRef.current) / 1000; // seconds
         lastFrameTimeRef.current = timestamp;
+
+        // Warn when dt hits the engine clamp boundaries (1/120 s – 1/30 s).
+        // Triggers on: slow frames, foldable display-panel switches, tab
+        // backgrounding, or a blocking network call on the main thread.
+        if (__DEV__ && elapsed > 0 && (elapsed > 1 / 30 || elapsed < 1 / 120)) {
+          console.warn(
+            `[GameCanvas] dt=${elapsed.toFixed(4)}s outside [1/120, 1/30] — will be clamped by engine`
+          );
+        }
+
         if (engineRef.current) {
           bodiesRef.current = engineRef.current.step(elapsed);
         }
         drawRef.current();
         id = requestAnimationFrame(loop);
       }
+
+      // When the tab/display becomes visible again after a suspension (e.g.
+      // foldable display-panel switch, app backgrounding), reset the frame
+      // timer so the first post-resume frame doesn't simulate accumulated
+      // idle time.  Without this, a long suspension produces a large elapsed
+      // that — even after the engine clamps it to 1/30 s — can trigger the
+      // upward-velocity anomaly reported in #552.
+      function handleVisibilityChange() {
+        if (!document.hidden) {
+          lastFrameTimeRef.current = 0;
+        }
+      }
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+
       id = requestAnimationFrame(loop);
-      return () => cancelAnimationFrame(id);
+      return () => {
+        cancelAnimationFrame(id);
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+      };
     }, []); // intentionally empty — loop lives for component lifetime
 
     useImperativeHandle(ref, () => {

--- a/frontend/src/game/cascade/__tests__/engine.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.test.ts
@@ -380,6 +380,129 @@ describe("cleanup", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tier-snapshot guard (handle-reuse protection)
+// ---------------------------------------------------------------------------
+
+describe("tier-snapshot guard", () => {
+  /**
+   * Simulate Rapier's generational-arena handle recycling:
+   *
+   *  1. Drop three tier-2 fruits (bodies 0, 1, 2; colliders 1003–1005).
+   *  2. Fire two collisions: [1003,1004] (body 0+1) and [1003,1005] (body 0+2).
+   *     Both pairs are same-tier at drain time, so both are enqueued as
+   *     [0,1,tier=2] and [0,2,tier=2].
+   *  3. Force the next body handle to 0 so the tier-3 fruit spawned from the
+   *     first merge reuses body handle 0.
+   *  4. processMerges processes [0,1,2]: merges correctly → onMerge fires once.
+   *     fruitMap[0] now points to the newly spawned tier-3 body.
+   *  5. processMerges processes [0,2,2]: fruitMap[0].fruitTier(3) !== enqueuedTier(2)
+   *     → guard fires, merge skipped → onMerge is NOT called a second time.
+   */
+  it("skips a merge pair when the body tier no longer matches the enqueued tier", async () => {
+    const onMerge = jest.fn();
+    const handle = await createEngine(W, H, fruitSet, onMerge, jest.fn());
+    const world = getWorld();
+
+    // bodies 0, 1, 2 are tier-2; colliders 1003, 1004, 1005
+    handle.drop(fruitSet.fruits[2], fruitSet.id, 100, 300);
+    handle.drop(fruitSet.fruits[2], fruitSet.id, 110, 300);
+    handle.drop(fruitSet.fruits[2], fruitSet.id, 120, 300);
+    handle.step();
+
+    // Two collision events sharing body 0 — both look same-tier at drain time.
+    world._fireCollision(1003, 1004); // [body0, body1] → enqueued [0,1,tier=2]
+    world._fireCollision(1003, 1005); // [body0, body2] → enqueued [0,2,tier=2]
+
+    // Force the tier-3 fruit spawned by the first merge to reuse handle 0.
+    // This simulates Rapier's arena recycling the freed slot immediately.
+    world._forceNextHandle(0);
+
+    handle.step(); // drain + processMerges
+
+    // First pair [0,1,2] merges cleanly: onMerge fires once for tier 2.
+    // Second pair [0,2,2]: fruitMap[0] is now tier 3 (recycled body) —
+    // the snapshot guard rejects it, so no second merge fires.
+    expect(onMerge).toHaveBeenCalledTimes(1);
+    expect(onMerge).toHaveBeenCalledWith(expect.objectContaining({ tier: 2 }));
+  });
+
+  it("still merges normally when no handle reuse occurs", async () => {
+    const onMerge = jest.fn();
+    const handle = await createEngine(W, H, fruitSet, onMerge, jest.fn());
+    const world = getWorld();
+
+    handle.drop(fruitSet.fruits[3], fruitSet.id, 100, 300);
+    handle.drop(fruitSet.fruits[3], fruitSet.id, 110, 300);
+    handle.step();
+
+    world._fireCollision(1003, 1004);
+    handle.step();
+
+    expect(onMerge).toHaveBeenCalledTimes(1);
+    expect(onMerge).toHaveBeenCalledWith(expect.objectContaining({ tier: 3 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CCD (Continuous Collision Detection)
+// ---------------------------------------------------------------------------
+
+describe("CCD enablement", () => {
+  it("calls setCcdEnabled(true) on every spawned fruit body", async () => {
+    const setCcdSpy = jest.fn().mockImplementation(function (this: unknown) {
+      return this;
+    });
+    const origDynamic = RAPIER_MOCK.RigidBodyDesc.dynamic;
+    RAPIER_MOCK.RigidBodyDesc.dynamic = () => {
+      const builder = origDynamic();
+      builder.setCcdEnabled = setCcdSpy;
+      return builder;
+    };
+
+    try {
+      const handle = await createEngine(W, H, fruitSet, jest.fn(), jest.fn());
+      handle.drop(fruitSet.fruits[1], fruitSet.id, 150, 300);
+      handle.drop(fruitSet.fruits[2], fruitSet.id, 160, 300);
+      handle.step();
+      expect(setCcdSpy).toHaveBeenCalledTimes(2);
+      expect(setCcdSpy).toHaveBeenCalledWith(true);
+    } finally {
+      RAPIER_MOCK.RigidBodyDesc.dynamic = origDynamic;
+    }
+  });
+
+  it("calls setCcdEnabled(true) on the body spawned by a merge", async () => {
+    const setCcdSpy = jest.fn().mockImplementation(function (this: unknown) {
+      return this;
+    });
+    const origDynamic = RAPIER_MOCK.RigidBodyDesc.dynamic;
+    RAPIER_MOCK.RigidBodyDesc.dynamic = () => {
+      const builder = origDynamic();
+      builder.setCcdEnabled = setCcdSpy;
+      return builder;
+    };
+
+    try {
+      const handle = await createEngine(W, H, fruitSet, jest.fn(), jest.fn());
+      const world = getWorld();
+
+      handle.drop(fruitSet.fruits[2], fruitSet.id, 100, 300);
+      handle.drop(fruitSet.fruits[2], fruitSet.id, 110, 300);
+      handle.step(); // 2 drops → 2 CCD calls so far
+      setCcdSpy.mockClear();
+
+      world._fireCollision(1003, 1004);
+      handle.step(); // merge fires → spawns tier-3 body → 1 more CCD call
+
+      expect(setCcdSpy).toHaveBeenCalledTimes(1);
+      expect(setCcdSpy).toHaveBeenCalledWith(true);
+    } finally {
+      RAPIER_MOCK.RigidBodyDesc.dynamic = origDynamic;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Exported types / constants
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -116,7 +116,11 @@ export async function createEngine(
   let gameOverFired = false;
 
   // Merges are queued during collision events and processed synchronously after draining.
-  const mergeQueue: Array<[number, number]> = [];
+  // The third element is the tier snapshotted at enqueue time; processMerges re-verifies
+  // both body tiers against this snapshot to guard against Rapier arena handle reuse
+  // (a body removed during a merge can have its handle recycled for the newly spawned
+  // body, making fruitMap.get(handle) return the wrong tier in subsequent queue entries).
+  const mergeQueue: Array<[number, number, number]> = []; // [handleA, handleB, tier]
 
   function spawnAt(
     def: FruitDefinition,
@@ -128,7 +132,9 @@ export async function createEngine(
     console.log(
       `[Engine] spawn tier=${def.tier} source=${source} totalBefore=${fruitMap.size} t=${Date.now()}`
     );
-    const rbDesc = R.RigidBodyDesc.dynamic().setTranslation(x * SCALE, y * SCALE);
+    const rbDesc = R.RigidBodyDesc.dynamic()
+      .setTranslation(x * SCALE, y * SCALE)
+      .setCcdEnabled(true);
     const rb = world.createRigidBody(rbDesc);
 
     const nameKey = (def as { nameKey?: string }).nameKey ?? def.name.toLowerCase();
@@ -198,16 +204,20 @@ export async function createEngine(
     if (mergeQueue.length > 0) {
       console.log(`[Engine] processMerges queueLen=${mergeQueue.length} t=${Date.now()}`);
     }
-    for (const [ha, hb] of mergeQueue) {
+    for (const [ha, hb, enqueuedTier] of mergeQueue) {
       const fa = fruitMap.get(ha);
       const fb = fruitMap.get(hb);
       if (!fa || !fb || fa.isMerging || fb.isMerging) continue;
-      if (fa.fruitTier !== fb.fruitTier) continue;
+      // Re-verify tiers against the snapshot captured at enqueue time.
+      // Rapier's generational arena can reuse a handle after removeRigidBody,
+      // so fruitMap.get(ha) may now point to a newly spawned body with a
+      // different tier — causing a phantom cross-tier merge if unchecked.
+      if (fa.fruitTier !== enqueuedTier || fb.fruitTier !== enqueuedTier) continue;
 
       fa.isMerging = true;
       fb.isMerging = true;
 
-      const tier = fa.fruitTier;
+      const tier = enqueuedTier;
       const rba = world.getRigidBody(ha);
       const rbb = world.getRigidBody(hb);
       if (!rba || !rbb) continue;
@@ -255,7 +265,7 @@ export async function createEngine(
         const fb = fruitMap.get(rbh2);
         if (!fa || !fb || fa.isMerging || fb.isMerging) return;
         if (fa.fruitTier === fb.fruitTier) {
-          mergeQueue.push([rbh1, rbh2]);
+          mergeQueue.push([rbh1, rbh2, fa.fruitTier]); // snapshot tier at enqueue
         }
       });
 


### PR DESCRIPTION
Three root-cause fixes for the Sentry event dd4f7144 cluster:

1. Tier snapshot in mergeQueue — store the tier at enqueue time and re-verify both body tiers in processMerges.  Guards against Rapier's generational-arena handle recycling: a body removed during a merge can have its handle reused for the newly spawned fruit, making fruitMap.get(handle) return the wrong tier for any still-pending queue entry and producing a phantom cross-tier merge.

2. CCD on fruit bodies — call setCcdEnabled(true) on every RigidBodyDesc in spawnAt(), including merge-spawned fruits.  Continuous collision detection prevents high-velocity bodies from tunnelling through the static wall colliders (the direct mechanism behind x=525 on a 400 px canvas).

3. visibilitychange reset in GameCanvas.web.tsx — reset lastFrameTimeRef to 0 whenever the tab becomes visible again.  Without this, a long suspension (foldable display-panel switch, tab backgrounded) produces a huge elapsed that — even after the engine's 1/30 s clamp — can inject an impulse spike and trigger the upward-velocity glitch. Also adds a DEV-only console.warn when dt hits the clamp boundaries to make future anomalies visible in logs.

Adds 4 new engine.test.ts cases: tier-snapshot guard (with simulated handle reuse via _forceNextHandle mock helper), and CCD call verification for both player drops and merge-spawned bodies.

## Summary

## <!-- What does this PR do? Focus on the why, not the how. -->

## Type of change

- [ ] `feat` — new feature or behaviour
- [ ] `fix` — bug fix
- [ ] `chore` — tooling, deps, config
- [ ] `test` — adding or updating tests
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that is neither fix nor feature
- [ ] `ci` — CI/CD changes
- [ ] `a11y` — accessibility improvement
- [ ] `security` — security hardening

## Testing done

<!-- What did you run? Any coverage delta? -->

- [ ] All tests pass locally
- [ ] No new lint errors

## Security checklist

- [ ] No secrets committed (gitleaks passes)
- [ ] Dependencies reviewed if new ones added
- [ ] OWASP considerations addressed if auth or data handling was touched

## Accessibility checklist _(web / frontend PRs only)_

- [ ] axe DevTools — no violations on affected pages
- [ ] Keyboard navigation tested
- [ ] Tested at 320px viewport width
- [ ] Tested at 200% zoom

## Mobile checklist _(iOS / Android PRs only)_

- [ ] Tested on iOS Simulator or physical device
- [ ] `ios-build-check` / `android-build-check` CI job passes
- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)
