### PR TITLE
feat(vocab): single source of truth for outcome vocabulary

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -38,9 +38,16 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db.base import Base
+from vocab import GameOutcome
 
 # JSONB on Postgres, JSON (TEXT) on sqlite — both round-trip Python dicts.
 _JSONB = JSON().with_variant(JSONB(), "postgresql")
+
+# Built from GameOutcome in vocab.py — the single source of truth.
+# Adding a value to the enum is the only change needed; this string rebuilds automatically.
+_OUTCOME_CHECK = "outcome IS NULL OR outcome IN ({})".format(
+    ",".join(f"'{v.value}'" for v in GameOutcome)
+)
 
 
 class GameType(Base):
@@ -87,15 +94,7 @@ class EventType(Base):
 class Game(Base):
     __tablename__ = "games"
     __table_args__ = (
-        CheckConstraint(
-            # Two vocabularies coexist here — see _VALID_OUTCOMES in
-            # games/service.py for the rationale. Result vocabulary:
-            # win/loss/push/blackjack. Lifecycle vocabulary (#514):
-            # completed/abandoned/kept_playing.
-            "outcome IS NULL OR outcome IN "
-            "('win','loss','push','blackjack','completed','abandoned','kept_playing')",
-            name="ck_games_outcome",
-        ),
+        CheckConstraint(_OUTCOME_CHECK, name="ck_games_outcome"),
         Index("games_session_id_started_at_idx", "session_id", "started_at"),
         Index(
             "games_user_id_started_at_idx",

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -20,34 +20,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from db.models import EventType, Game, GameEvent, GameType
+from vocab import GameOutcome
 
-# Valid values for Game.outcome. Two vocabularies live here intentionally:
-#
-#   1. Result vocabulary — `win` / `loss` / `push` / `blackjack`. Came from
-#      blackjack where each round has a defined winner. Still used when a
-#      game surfaces a concrete player vs. dealer / player vs. house result.
-#
-#   2. Lifecycle vocabulary — `completed` / `abandoned` / `kept_playing`.
-#      Used by score-based games that have no win/loss semantics — Yacht,
-#      Cascade, Twenty48, etc. These ship whatever final score the player
-#      reached and just need to distinguish "game ended naturally" from
-#      "player quit mid-game" from "player chose to keep playing past the
-#      win condition" (2048 specifically).
-#
-# Both vocabularies are stored as-is in `game.outcome`; the backend does
-# not branch on the value, it just validates the string and records it for
-# analytics. Prior to #514 only the result vocabulary plus `abandoned`
-# were accepted, so every natural game-end PATCH from the score-based
-# games came back 400 on `outcome="completed"`.
-_VALID_OUTCOMES = {
-    "win",
-    "loss",
-    "push",
-    "blackjack",
-    "completed",
-    "abandoned",
-    "kept_playing",
-}
+_VALID_OUTCOMES = frozenset(v.value for v in GameOutcome)
 
 
 class GameServiceError(Exception):

--- a/backend/scripts/gen_vocab_ts.py
+++ b/backend/scripts/gen_vocab_ts.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""Generate frontend/src/api/vocab.ts from backend/vocab.py.
+
+Usage (run from repo root):
+    python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow importing from backend/ without installing the package.
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from vocab import GameOutcome
+
+_OUTCOMES = "\n".join(f'  "{v.value}",' for v in GameOutcome)
+
+print(f"""\
+/**
+ * Shared vocabulary constants — DO NOT edit by hand.
+ *
+ * Source of truth: backend/vocab.py (GameOutcome enum).
+ * To update: edit backend/vocab.py, then run:
+ *   python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts
+ *
+ * The backend CI test (tests/test_vocab.py) will fail if this file
+ * drifts from the Python enum.
+ */
+
+export const GAME_OUTCOMES = [
+{_OUTCOMES}
+] as const;
+
+export type GameOutcome = (typeof GAME_OUTCOMES)[number];
+""")

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -1,0 +1,47 @@
+"""Contract tests for shared vocabulary (#537).
+
+Verifies that frontend/src/api/vocab.ts stays in sync with backend/vocab.py.
+These tests run in CI on every push — a drift between the Python enum and the
+committed TypeScript file will fail the build with an actionable error message.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from vocab import GameOutcome
+
+_REPO_ROOT = Path(__file__).parents[2]
+_VOCAB_TS = _REPO_ROOT / "frontend" / "src" / "api" / "vocab.ts"
+
+
+def _parse_ts_outcomes() -> set[str]:
+    """Extract string literals from the GAME_OUTCOMES array in vocab.ts."""
+    content = _VOCAB_TS.read_text(encoding="utf-8")
+    # Grab everything between `GAME_OUTCOMES = [` and the closing `]`
+    match = re.search(r"GAME_OUTCOMES\s*=\s*\[(.*?)\]", content, re.DOTALL)
+    assert match, f"Could not find GAME_OUTCOMES array in {_VOCAB_TS}"
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def test_ts_vocab_file_exists() -> None:
+    assert _VOCAB_TS.exists(), f"Missing {_VOCAB_TS} — run: python backend/scripts/gen_vocab_ts.py"
+
+
+def test_game_outcome_ts_in_sync() -> None:
+    """GAME_OUTCOMES in vocab.ts must exactly match GameOutcome in vocab.py."""
+    py_values = {v.value for v in GameOutcome}
+    ts_values = _parse_ts_outcomes()
+    assert ts_values == py_values, (
+        "frontend/src/api/vocab.ts is out of sync with backend/vocab.py.\n"
+        f"  In Python only: {py_values - ts_values}\n"
+        f"  In TypeScript only: {ts_values - py_values}\n"
+        "Re-generate: python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts"
+    )
+
+
+def test_game_outcome_enum_values() -> None:
+    """Regression guard — no value should be silently removed from GameOutcome."""
+    expected = {"win", "loss", "push", "blackjack", "completed", "abandoned", "kept_playing"}
+    assert {v.value for v in GameOutcome} == expected

--- a/backend/vocab.py
+++ b/backend/vocab.py
@@ -1,0 +1,29 @@
+"""Shared vocabulary enums — single source of truth for string constants that
+cross system boundaries (Python ↔ DB ↔ TypeScript).
+
+Import from here, never redefine elsewhere. The DB CHECK constraint in
+db/models.py and the TypeScript types in frontend/src/api/vocab.ts are both
+derived from these enums.
+
+To add or rename an outcome:
+  1. Update GameOutcome below.
+  2. Generate a new Alembic migration (the CHECK constraint rebuilds from the enum).
+  3. Re-run: python scripts/gen_vocab_ts.py > ../frontend/src/api/vocab.ts
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class GameOutcome(str, Enum):
+    # Result vocabulary — games with a concrete winner/loser (Blackjack).
+    WIN = "win"
+    LOSS = "loss"
+    PUSH = "push"
+    BLACKJACK = "blackjack"
+
+    # Lifecycle vocabulary — score-based games (Yacht, Cascade, Twenty48, …).
+    COMPLETED = "completed"
+    ABANDONED = "abandoned"
+    KEPT_PLAYING = "kept_playing"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -5,6 +5,8 @@
  * these in sync when the backend contract changes.
  */
 
+export type { GameOutcome } from "./vocab";
+
 export interface GameTypeStats {
   played: number;
   best: number | null;
@@ -26,7 +28,7 @@ export interface GameRow {
   started_at: string;
   completed_at: string | null;
   final_score: number | null;
-  outcome: string | null;
+  outcome: GameOutcome | null;
   duration_ms: number | null;
   metadata: Record<string, unknown>;
 }

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared vocabulary constants — DO NOT edit by hand.
+ *
+ * Source of truth: backend/vocab.py (GameOutcome enum).
+ * To update: edit backend/vocab.py, then run:
+ *   python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts
+ *
+ * The backend CI test (tests/test_vocab.py) will fail if this file
+ * drifts from the Python enum.
+ */
+
+export const GAME_OUTCOMES = [
+  "win",
+  "loss",
+  "push",
+  "blackjack",
+  "completed",
+  "abandoned",
+  "kept_playing",
+] as const;
+
+export type GameOutcome = (typeof GAME_OUTCOMES)[number];


### PR DESCRIPTION
## Summary
- Defines `GameOutcome(str, Enum)` in `backend/vocab.py` as the single authority for valid game outcome strings
- DB `CHECK` constraint in `db/models.py` is now generated from the enum — impossible to drift
- `_VALID_OUTCOMES` set in `games/service.py` replaced by a `frozenset` derived from the enum
- `frontend/src/api/vocab.ts` commits the matching `GAME_OUTCOMES as const` + `GameOutcome` type
- `outcome: string | null` in `types.ts` tightened to `outcome: GameOutcome | null`
- CI contract test (`tests/test_vocab.py`) fails the build if the TS file diverges from the Python enum

## Closes
Closes #537. Part of epic #520.

## Test plan
- [ ] `backend/tests/test_vocab.py` — three new tests: file exists, TS/Python values match, regression guard on enum members
- [ ] Existing backend tests continue to pass (no outcome values added or removed)
- [ ] TypeScript compiles cleanly — `outcome` fields that previously accepted bare `string` now require a valid `GameOutcome` literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)