### PR TITLE
feat(vocab): GameType enum, pachisi DB seed, and TS contract

### DIFF
--- a/backend/alembic/versions/0004_add_pachisi_game_type.py
+++ b/backend/alembic/versions/0004_add_pachisi_game_type.py
@@ -1,0 +1,49 @@
+"""add pachisi to game_types lookup table (#538)
+
+Revision ID: 0004_add_pachisi_game_type
+Revises: 0003_relax_games_outcome_constraint
+Create Date: 2026-04-15
+
+Pachisi was shipping as a frontend game type and had its own backend module
+before the game_types lookup table existed. This migration brings the DB row
+into sync with the GameType enum in backend/vocab.py.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_add_pachisi_game_type"
+down_revision: Union[str, None] = "0003_relax_games_outcome_constraint"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    game_types = sa.table(
+        "game_types",
+        sa.column("id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("icon_emoji", sa.Text),
+        sa.column("sort_order", sa.SmallInteger),
+        sa.column("is_active", sa.Boolean),
+    )
+    op.bulk_insert(
+        game_types,
+        [
+            {
+                "id": 5,
+                "name": "pachisi",
+                "display_name": "Pachisi",
+                "icon_emoji": "🎯",
+                "sort_order": 50,
+                "is_active": True,
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM game_types WHERE name = 'pachisi'")

--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -18,19 +18,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db.base import get_session_factory
 from db.models import Game, GameType
 from limiter import limiter
+from vocab import GameType as GameTypeEnum
 
 from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
 
 router = APIRouter()
 
 LEADERBOARD_LIMIT = 10
-_CASCADE_GAME_TYPE = "cascade"
 _CASCADE_SESSION = "cascade-anon"  # placeholder until SSO; rows still rank
 
 
 async def _cascade_game_type_id(db: AsyncSession) -> int:
     row = (
-        await db.execute(select(GameType.id).where(GameType.name == _CASCADE_GAME_TYPE))
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.CASCADE))
     ).scalar_one_or_none()
     if row is None:
         raise HTTPException(

--- a/backend/scripts/gen_vocab_ts.py
+++ b/backend/scripts/gen_vocab_ts.py
@@ -13,21 +13,28 @@ from pathlib import Path
 # Allow importing from backend/ without installing the package.
 sys.path.insert(0, str(Path(__file__).parents[1]))
 
-from vocab import GameOutcome
+from vocab import GameOutcome, GameType
 
+_TYPES = "\n".join(f'  "{v.value}",' for v in GameType)
 _OUTCOMES = "\n".join(f'  "{v.value}",' for v in GameOutcome)
 
 print(f"""\
 /**
  * Shared vocabulary constants — DO NOT edit by hand.
  *
- * Source of truth: backend/vocab.py (GameOutcome enum).
+ * Source of truth: backend/vocab.py (GameType, GameOutcome enums).
  * To update: edit backend/vocab.py, then run:
  *   python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts
  *
  * The backend CI test (tests/test_vocab.py) will fail if this file
- * drifts from the Python enum.
+ * drifts from the Python enums (GameType, GameOutcome).
  */
+
+export const GAME_TYPES = [
+{_TYPES}
+] as const;
+
+export type GameType = (typeof GAME_TYPES)[number];
 
 export const GAME_OUTCOMES = [
 {_OUTCOMES}

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0003_relax_games_outcome_constraint"
+        assert version == "0004_add_pachisi_game_type"

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -33,7 +33,7 @@ async def test_seed_data_present() -> None:
     factory = get_session_factory()
     async with factory() as s:
         gt_names = (await s.execute(select(GameType.name).order_by(GameType.id))).scalars().all()
-        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade"]
+        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade", "pachisi"]
 
         total = (await s.execute(select(func.count()).select_from(EventType))).scalar_one()
         assert total >= 17

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -1,8 +1,11 @@
-"""Contract tests for shared vocabulary (#537).
+"""Contract tests for shared vocabulary (#537, #538).
 
-Verifies that frontend/src/api/vocab.ts stays in sync with backend/vocab.py.
-These tests run in CI on every push — a drift between the Python enum and the
-committed TypeScript file will fail the build with an actionable error message.
+Verifies that frontend/src/api/vocab.ts stays in sync with backend/vocab.py,
+and that the GameType enum stays in sync with the game_types DB table.
+
+These tests run in CI on every push — a drift between the Python enums and
+the committed TypeScript file (or the DB rows) will fail the build with an
+actionable error message.
 """
 
 from __future__ import annotations
@@ -10,18 +13,25 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from vocab import GameOutcome
+import pytest
+from sqlalchemy import select
+
+from vocab import GameOutcome, GameType
 
 _REPO_ROOT = Path(__file__).parents[2]
 _VOCAB_TS = _REPO_ROOT / "frontend" / "src" / "api" / "vocab.ts"
 
 
-def _parse_ts_outcomes() -> set[str]:
-    """Extract string literals from the GAME_OUTCOMES array in vocab.ts."""
+# ---------------------------------------------------------------------------
+# TypeScript file sync (file-based, no DB required)
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts_array(array_name: str) -> set[str]:
+    """Extract string literals from a named const array in vocab.ts."""
     content = _VOCAB_TS.read_text(encoding="utf-8")
-    # Grab everything between `GAME_OUTCOMES = [` and the closing `]`
-    match = re.search(r"GAME_OUTCOMES\s*=\s*\[(.*?)\]", content, re.DOTALL)
-    assert match, f"Could not find GAME_OUTCOMES array in {_VOCAB_TS}"
+    match = re.search(rf"{array_name}\s*=\s*\[(.*?)\]", content, re.DOTALL)
+    assert match, f"Could not find {array_name} array in {_VOCAB_TS}"
     return set(re.findall(r'"([^"]+)"', match.group(1)))
 
 
@@ -29,10 +39,10 @@ def test_ts_vocab_file_exists() -> None:
     assert _VOCAB_TS.exists(), f"Missing {_VOCAB_TS} — run: python backend/scripts/gen_vocab_ts.py"
 
 
-def test_game_outcome_ts_in_sync() -> None:
-    """GAME_OUTCOMES in vocab.ts must exactly match GameOutcome in vocab.py."""
-    py_values = {v.value for v in GameOutcome}
-    ts_values = _parse_ts_outcomes()
+def test_game_type_ts_in_sync() -> None:
+    """GAME_TYPES in vocab.ts must exactly match GameType in vocab.py."""
+    py_values = {v.value for v in GameType}
+    ts_values = _parse_ts_array("GAME_TYPES")
     assert ts_values == py_values, (
         "frontend/src/api/vocab.ts is out of sync with backend/vocab.py.\n"
         f"  In Python only: {py_values - ts_values}\n"
@@ -41,7 +51,62 @@ def test_game_outcome_ts_in_sync() -> None:
     )
 
 
+def test_game_outcome_ts_in_sync() -> None:
+    """GAME_OUTCOMES in vocab.ts must exactly match GameOutcome in vocab.py."""
+    py_values = {v.value for v in GameOutcome}
+    ts_values = _parse_ts_array("GAME_OUTCOMES")
+    assert ts_values == py_values, (
+        "frontend/src/api/vocab.ts is out of sync with backend/vocab.py.\n"
+        f"  In Python only: {py_values - ts_values}\n"
+        f"  In TypeScript only: {ts_values - py_values}\n"
+        "Re-generate: python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts"
+    )
+
+
+def test_game_type_enum_values() -> None:
+    """Regression guard — no value should be silently removed from GameType."""
+    expected = {"yacht", "twenty48", "blackjack", "cascade", "pachisi"}
+    assert {v.value for v in GameType} == expected
+
+
 def test_game_outcome_enum_values() -> None:
     """Regression guard — no value should be silently removed from GameOutcome."""
     expected = {"win", "loss", "push", "blackjack", "completed", "abandoned", "kept_playing"}
     assert {v.value for v in GameOutcome} == expected
+
+
+# ---------------------------------------------------------------------------
+# DB sync (requires DATABASE_URL — always set by conftest.py in CI)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_game_type_enum_matches_db() -> None:
+    """Every GameType enum member must have an active row in game_types, and
+    every active row must have a corresponding enum member.
+
+    This test catches a game being added to the DB without updating the enum,
+    or vice versa. The conftest provisions a SQLite DB via alembic migrations
+    so this runs in CI without an external Postgres instance.
+    """
+    from db.base import get_session_factory
+    from db.models import GameType as GameTypeModel
+
+    factory = get_session_factory()
+    async with factory() as session:
+        db_names = set(
+            (
+                await session.execute(
+                    select(GameTypeModel.name).where(GameTypeModel.is_active.is_(True))
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    enum_values = {v.value for v in GameType}
+    assert enum_values == db_names, (
+        "GameType enum and active game_types DB rows are out of sync.\n"
+        f"  In enum only (needs a migration): {enum_values - db_names}\n"
+        f"  In DB only (needs an enum member): {db_names - enum_values}"
+    )

--- a/backend/vocab.py
+++ b/backend/vocab.py
@@ -5,6 +5,11 @@ Import from here, never redefine elsewhere. The DB CHECK constraint in
 db/models.py and the TypeScript types in frontend/src/api/vocab.ts are both
 derived from these enums.
 
+To add a new game type:
+  1. Add a member to GameType below.
+  2. Write an Alembic migration that inserts the new row into game_types.
+  3. Re-run: python scripts/gen_vocab_ts.py > ../frontend/src/api/vocab.ts
+
 To add or rename an outcome:
   1. Update GameOutcome below.
   2. Generate a new Alembic migration (the CHECK constraint rebuilds from the enum).
@@ -14,6 +19,21 @@ To add or rename an outcome:
 from __future__ import annotations
 
 from enum import Enum
+
+
+class GameType(str, Enum):
+    """All active game types. Authority: this enum + the game_types DB table.
+
+    The CI test tests/test_vocab.py asserts that every member here has a
+    matching row in game_types, and vice versa. Adding a game requires both
+    a new member here and an Alembic migration that inserts the DB row.
+    """
+
+    YACHT = "yacht"
+    TWENTY48 = "twenty48"
+    BLACKJACK = "blackjack"
+    CASCADE = "cascade"
+    PACHISI = "pachisi"
 
 
 class GameOutcome(str, Enum):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -5,7 +5,7 @@
  * these in sync when the backend contract changes.
  */
 
-export type { GameOutcome } from "./vocab";
+export type { GameOutcome, GameType } from "./vocab";
 
 export interface GameTypeStats {
   played: number;
@@ -24,7 +24,7 @@ export interface StatsResponse {
 
 export interface GameRow {
   id: string;
-  game_type: string;
+  game_type: GameType;
   started_at: string;
   completed_at: string | null;
   final_score: number | null;

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -6,8 +6,12 @@
  *   python backend/scripts/gen_vocab_ts.py > frontend/src/api/vocab.ts
  *
  * The backend CI test (tests/test_vocab.py) will fail if this file
- * drifts from the Python enum.
+ * drifts from the Python enums (GameType, GameOutcome).
  */
+
+export const GAME_TYPES = ["yacht", "twenty48", "blackjack", "cascade", "pachisi"] as const;
+
+export type GameType = (typeof GAME_TYPES)[number];
 
 export const GAME_OUTCOMES = [
   "win",

--- a/frontend/src/game/_shared/types.ts
+++ b/frontend/src/game/_shared/types.ts
@@ -6,7 +6,7 @@
  * pattern.
  */
 
-export type GameType = "cascade" | "yacht" | "blackjack" | "twenty48" | "pachisi";
+export type { GameType } from "../../api/vocab";
 
 /**
  * A score submission waiting to be sent to the server.


### PR DESCRIPTION
## Summary
- Adds `GameType(str, Enum)` to `backend/vocab.py` as the single source of truth for game type identifiers
- Seeds `pachisi` into `game_types` via migration `0004` — it existed as a module and TS type but was never in the DB lookup table
- `frontend/src/api/vocab.ts` gains `GAME_TYPES as const` and a `GameType` type
- Hand-written `GameType` union in `frontend/src/game/_shared/types.ts` replaced with a re-export from `vocab.ts`
- `GameRow.game_type` tightened from `string` to `GameType` in `types.ts`
- `_CASCADE_GAME_TYPE = "cascade"` literal in `cascade/router.py` replaced with `GameType.CASCADE`
- `tests/test_vocab.py` extended with TS-sync and DB-sync contract tests (build fails on drift)
- `test_db_schema.py` updated to expect all 5 active game types

## Closes
Closes #538. Part of epic #520.

## Notes
- Pachisi inclusion decision: included — game module and TS type already existed, DB row was the only missing piece
- The `games/service.py` blackjack string literals are intentionally left for #541 (remove blackjack stats branch)

## Test plan
- [ ] `test_vocab.py::test_game_type_ts_in_sync` — TS file matches Python enum
- [ ] `test_vocab.py::test_game_type_enum_values` — regression guard on enum members
- [ ] `test_vocab.py::test_game_type_enum_matches_db` — DB rows match enum (requires alembic migration to run first)
- [ ] `test_db_schema.py::test_seed_data_present` — now expects 5 game types including pachisi
- [ ] Existing cascade and games API tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)