### PR TITLE
refactor(protocol): GameModule Protocol, registry, and stats_shape dispatch (#540, #541)

### DIFF
--- a/backend/blackjack/module.py
+++ b/backend/blackjack/module.py
@@ -1,0 +1,34 @@
+"""Blackjack GameModule descriptor (#540).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from vocab import GameType
+
+
+class BlackjackModule:
+    """GameModule implementation for Blackjack.
+
+    Stats shape differences from the generic pattern:
+    - ``best``  → renamed to ``best_chips``
+    - ``avg``   → dropped (chip counts don't aggregate meaningfully)
+    - ``current_chips`` ← ``latest_score`` (chips at end of last session)
+    """
+
+    game_type = GameType.BLACKJACK
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {
+            "played": raw_stats["played"],
+            "best": None,
+            "avg": None,
+            "last_played_at": raw_stats["last_played_at"],
+            "best_chips": raw_stats["best"],
+            "current_chips": raw_stats["latest_score"],
+        }
+
+
+module = BlackjackModule()

--- a/backend/cascade/module.py
+++ b/backend/cascade/module.py
@@ -1,0 +1,25 @@
+"""Cascade GameModule descriptor (#540).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from vocab import GameType
+
+
+class CascadeModule:
+    """GameModule implementation for Cascade.
+
+    Uses the default pass-through stats shape: raw aggregate fields are
+    forwarded as-is; ``latest_score`` is stripped (not exposed in API).
+    """
+
+    game_type = GameType.CASCADE
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = CascadeModule()

--- a/backend/games/protocol.py
+++ b/backend/games/protocol.py
@@ -1,0 +1,55 @@
+"""GameModule Protocol — single contract for all game modules (#540).
+
+Any object with a ``game_type`` attribute and a ``stats_shape`` method
+satisfies this Protocol without inheriting from it (structural subtyping).
+
+Adding a new game
+-----------------
+1. Create ``backend/<game>/module.py`` with a class whose instance passes
+   ``isinstance(instance, GameModule)``.
+2. Register it in ``backend/games/registry.py``.
+3. Implement ``stats_shape`` to transform the raw aggregate dict into the
+   game's final API shape.  See ``backend/blackjack/module.py`` for an
+   example that renames keys; see ``backend/cascade/module.py`` for the
+   default pass-through pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from vocab import GameType
+
+
+@runtime_checkable
+class GameModule(Protocol):
+    """Structural interface every game module must satisfy.
+
+    Attributes
+    ----------
+    game_type:
+        The ``GameType`` enum value that identifies this module in the DB and
+        the registry.  Must be a class-level constant so it is accessible
+        without instantiation.
+
+    Methods
+    -------
+    stats_shape(raw_stats):
+        Transform a raw aggregate stats dict (produced by
+        ``games/service.py``) into the final shape for the ``/stats/me``
+        API response.
+
+        ``raw_stats`` keys
+            played         int
+            best           int | None   (highest ``final_score``)
+            avg            float | None (mean ``final_score``)
+            last_played_at datetime | None
+            latest_score   int | None   (``final_score`` of most-recent game)
+
+        Return a dict whose keys are a subset of ``GameTypeStats`` fields.
+        Omitted keys default to ``None`` in the caller.
+    """
+
+    game_type: GameType
+
+    def stats_shape(self, raw_stats: dict) -> dict: ...

--- a/backend/games/registry.py
+++ b/backend/games/registry.py
@@ -1,0 +1,28 @@
+"""Game module registry (#540).
+
+Maps each ``GameType`` string value to its ``GameModule`` instance.
+``service.py`` uses this for generic dispatch instead of ``if name ==`` branches.
+
+To register a new game: import its module singleton and add an entry below.
+"""
+
+from __future__ import annotations
+
+from blackjack.module import module as blackjack_module
+from cascade.module import module as cascade_module
+from pachisi.module import module as pachisi_module
+
+from games.protocol import GameModule
+
+# Keyed by GameType.value (str) so lookups work directly against the name
+# column returned by DB queries.
+_REGISTRY: dict[str, GameModule] = {
+    blackjack_module.game_type.value: blackjack_module,
+    cascade_module.game_type.value: cascade_module,
+    pachisi_module.game_type.value: pachisi_module,
+}
+
+
+def get_module(game_type_name: str) -> GameModule | None:
+    """Return the GameModule for *game_type_name*, or None if unregistered."""
+    return _REGISTRY.get(game_type_name)

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -272,8 +272,7 @@ async def get_stats_for_session(session: AsyncSession, *, session_id: str) -> St
         )
     ).all()
     latest_score_by_name: dict[str, int | None] = {
-        name: (int(score) if score is not None else None)
-        for name, score in latest_score_rows
+        name: (int(score) if score is not None else None) for name, score in latest_score_rows
     }
 
     # --- build per-game stats via module dispatch -------------------------
@@ -294,9 +293,11 @@ async def get_stats_for_session(session: AsyncSession, *, session_id: str) -> St
         }
 
         game_module = get_module(name)
-        shaped = game_module.stats_shape(raw) if game_module is not None else {
-            k: v for k, v in raw.items() if k != "latest_score"
-        }
+        shaped = (
+            game_module.stats_shape(raw)
+            if game_module is not None
+            else {k: v for k, v in raw.items() if k != "latest_score"}
+        )
 
         by_game[name] = GameTypeStats(
             played=shaped.get("played", 0),

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from db.models import EventType, Game, GameEvent, GameType
+from games.registry import get_module
 from vocab import GameOutcome
 
 _VALID_OUTCOMES = frozenset(v.value for v in GameOutcome)
@@ -219,7 +220,11 @@ async def get_stats_for_session(session: AsyncSession, *, session_id: str) -> St
 
     Only counts completed games — in-progress games are excluded from
     played/best/avg so the leaderboard stays stable until a game finishes.
+
+    Per-game stat shaping is delegated to each module's ``stats_shape()``
+    method via the registry (#541).  No game-name branches live here.
     """
+    # --- aggregate query -------------------------------------------------
     rows = (
         await session.execute(
             select(
@@ -239,6 +244,39 @@ async def get_stats_for_session(session: AsyncSession, *, session_id: str) -> St
         )
     ).all()
 
+    # --- pre-fetch latest final_score per game type in one query ---------
+    # Used by modules (e.g. Blackjack) that need the most-recent score.
+    # Subquery: per game_type_id, find the max(completed_at).
+    latest_sq = (
+        select(
+            Game.game_type_id,
+            func.max(Game.completed_at).label("max_completed_at"),
+        )
+        .where(
+            Game.session_id == session_id,
+            Game.completed_at.is_not(None),
+        )
+        .group_by(Game.game_type_id)
+        .subquery()
+    )
+    latest_score_rows = (
+        await session.execute(
+            select(GameType.name, Game.final_score)
+            .join(GameType, Game.game_type_id == GameType.id)
+            .join(
+                latest_sq,
+                (Game.game_type_id == latest_sq.c.game_type_id)
+                & (Game.completed_at == latest_sq.c.max_completed_at),
+            )
+            .where(Game.session_id == session_id)
+        )
+    ).all()
+    latest_score_by_name: dict[str, int | None] = {
+        name: (int(score) if score is not None else None)
+        for name, score in latest_score_rows
+    }
+
+    # --- build per-game stats via module dispatch -------------------------
     by_game: dict[str, GameTypeStats] = {}
     total = 0
     favorite: str | None = None
@@ -246,38 +284,29 @@ async def get_stats_for_session(session: AsyncSession, *, session_id: str) -> St
 
     for name, played, best, avg, last_played in rows:
         total += played
-        stats = GameTypeStats(
-            played=played,
-            best=int(best) if best is not None else None,
-            avg=round(float(avg), 1) if avg is not None else None,
-            last_played_at=last_played,
+
+        raw: dict = {
+            "played": played,
+            "best": int(best) if best is not None else None,
+            "avg": round(float(avg), 1) if avg is not None else None,
+            "last_played_at": last_played,
+            "latest_score": latest_score_by_name.get(name),
+        }
+
+        game_module = get_module(name)
+        shaped = game_module.stats_shape(raw) if game_module is not None else {
+            k: v for k, v in raw.items() if k != "latest_score"
+        }
+
+        by_game[name] = GameTypeStats(
+            played=shaped.get("played", 0),
+            best=shaped.get("best"),
+            avg=shaped.get("avg"),
+            last_played_at=shaped.get("last_played_at"),
+            best_chips=shaped.get("best_chips"),
+            current_chips=shaped.get("current_chips"),
         )
-        # Blackjack renames `best` → `best_chips` and adds `current_chips`
-        # (latest completed game's final_score). Keep generic fields None so
-        # the JSON output reflects the spec shape per game type.
-        if name == "blackjack":
-            stats.best_chips = stats.best
-            stats.best = None
-            stats.avg = None
-            latest = (
-                await session.execute(
-                    select(Game.final_score)
-                    .where(
-                        Game.session_id == session_id,
-                        Game.game_type_id
-                        == (
-                            select(GameType.id)
-                            .where(GameType.name == "blackjack")
-                            .scalar_subquery()
-                        ),
-                        Game.completed_at.is_not(None),
-                    )
-                    .order_by(Game.completed_at.desc())
-                    .limit(1)
-                )
-            ).scalar_one_or_none()
-            stats.current_chips = int(latest) if latest is not None else None
-        by_game[name] = stats
+
         if played > favorite_count:
             favorite = name
             favorite_count = played

--- a/backend/pachisi/module.py
+++ b/backend/pachisi/module.py
@@ -1,0 +1,25 @@
+"""Pachisi GameModule descriptor (#540).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from vocab import GameType
+
+
+class PachisiModule:
+    """GameModule implementation for Pachisi.
+
+    Uses the default pass-through stats shape: raw aggregate fields are
+    forwarded as-is; ``latest_score`` is stripped (not exposed in API).
+    """
+
+    game_type = GameType.PACHISI
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = PachisiModule()

--- a/backend/tests/test_game_module_protocol.py
+++ b/backend/tests/test_game_module_protocol.py
@@ -11,7 +11,6 @@ from games.registry import get_module
 from pachisi.module import module as pachisi_module
 from vocab import GameType
 
-
 # ---------------------------------------------------------------------------
 # Protocol conformance
 # ---------------------------------------------------------------------------
@@ -23,9 +22,7 @@ from vocab import GameType
     ids=["blackjack", "cascade", "pachisi"],
 )
 def test_module_satisfies_protocol(mod) -> None:
-    assert isinstance(mod, GameModule), (
-        f"{mod!r} does not satisfy the GameModule Protocol"
-    )
+    assert isinstance(mod, GameModule), f"{mod!r} does not satisfy the GameModule Protocol"
 
 
 def test_blackjack_module_game_type() -> None:

--- a/backend/tests/test_game_module_protocol.py
+++ b/backend/tests/test_game_module_protocol.py
@@ -1,0 +1,145 @@
+"""Tests for the GameModule Protocol and per-game stats_shape() (#540, #541)."""
+
+from __future__ import annotations
+
+import pytest
+
+from blackjack.module import module as blackjack_module
+from cascade.module import module as cascade_module
+from games.protocol import GameModule
+from games.registry import get_module
+from pachisi.module import module as pachisi_module
+from vocab import GameType
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mod",
+    [blackjack_module, cascade_module, pachisi_module],
+    ids=["blackjack", "cascade", "pachisi"],
+)
+def test_module_satisfies_protocol(mod) -> None:
+    assert isinstance(mod, GameModule), (
+        f"{mod!r} does not satisfy the GameModule Protocol"
+    )
+
+
+def test_blackjack_module_game_type() -> None:
+    assert blackjack_module.game_type == GameType.BLACKJACK
+
+
+def test_cascade_module_game_type() -> None:
+    assert cascade_module.game_type == GameType.CASCADE
+
+
+def test_pachisi_module_game_type() -> None:
+    assert pachisi_module.game_type == GameType.PACHISI
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_returns_correct_modules() -> None:
+    assert get_module("blackjack") is blackjack_module
+    assert get_module("cascade") is cascade_module
+    assert get_module("pachisi") is pachisi_module
+
+
+def test_registry_returns_none_for_unknown() -> None:
+    assert get_module("unknown_game") is None
+
+
+# ---------------------------------------------------------------------------
+# BlackjackModule.stats_shape — key renames and chip logic
+# ---------------------------------------------------------------------------
+
+_RAW_BJ = {
+    "played": 5,
+    "best": 2400,
+    "avg": 1800.0,
+    "last_played_at": None,
+    "latest_score": 2100,
+}
+
+
+def test_blackjack_stats_shape_renames_best_to_best_chips() -> None:
+    shaped = blackjack_module.stats_shape(_RAW_BJ)
+    assert shaped["best_chips"] == 2400
+    assert shaped.get("best") is None
+
+
+def test_blackjack_stats_shape_drops_avg() -> None:
+    shaped = blackjack_module.stats_shape(_RAW_BJ)
+    assert shaped.get("avg") is None
+
+
+def test_blackjack_stats_shape_maps_latest_score_to_current_chips() -> None:
+    shaped = blackjack_module.stats_shape(_RAW_BJ)
+    assert shaped["current_chips"] == 2100
+
+
+def test_blackjack_stats_shape_preserves_played_and_last_played_at() -> None:
+    shaped = blackjack_module.stats_shape(_RAW_BJ)
+    assert shaped["played"] == 5
+    assert shaped["last_played_at"] is None
+
+
+def test_blackjack_stats_shape_none_latest_score() -> None:
+    raw = {**_RAW_BJ, "latest_score": None}
+    shaped = blackjack_module.stats_shape(raw)
+    assert shaped["current_chips"] is None
+
+
+# ---------------------------------------------------------------------------
+# CascadeModule.stats_shape — pass-through, strips latest_score
+# ---------------------------------------------------------------------------
+
+_RAW_CASCADE = {
+    "played": 3,
+    "best": 9500,
+    "avg": 7000.0,
+    "last_played_at": None,
+    "latest_score": 8000,
+}
+
+
+def test_cascade_stats_shape_preserves_aggregate_fields() -> None:
+    shaped = cascade_module.stats_shape(_RAW_CASCADE)
+    assert shaped["played"] == 3
+    assert shaped["best"] == 9500
+    assert shaped["avg"] == 7000.0
+
+
+def test_cascade_stats_shape_strips_latest_score() -> None:
+    shaped = cascade_module.stats_shape(_RAW_CASCADE)
+    assert "latest_score" not in shaped
+
+
+# ---------------------------------------------------------------------------
+# PachisiModule.stats_shape — pass-through, strips latest_score
+# ---------------------------------------------------------------------------
+
+_RAW_PACHISI = {
+    "played": 2,
+    "best": 1,
+    "avg": 1.0,
+    "last_played_at": None,
+    "latest_score": 1,
+}
+
+
+def test_pachisi_stats_shape_preserves_aggregate_fields() -> None:
+    shaped = pachisi_module.stats_shape(_RAW_PACHISI)
+    assert shaped["played"] == 2
+    assert shaped["best"] == 1
+
+
+def test_pachisi_stats_shape_strips_latest_score() -> None:
+    shaped = pachisi_module.stats_shape(_RAW_PACHISI)
+    assert "latest_score" not in shaped

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5693,9 +5693,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Linked issues
Closes #540, closes #541
Epic: #520

## Summary
- **`games/protocol.py`** — `@runtime_checkable GameModule` Protocol declaring `game_type: GameType` and `stats_shape(raw_stats: dict) -> dict`
- **`blackjack/module.py`**, **`cascade/module.py`**, **`pachisi/module.py`** — each satisfies the Protocol via structural subtyping; no forced inheritance
- **`games/registry.py`** — maps `GameType` string values → module singletons; `get_module(name)` used by the service layer
- **`games/service.py`** — `get_stats_for_session` refactored: pre-fetches `latest_score` per game type in one subquery, then calls `module.stats_shape(raw_stats)` generically — the `if name == "blackjack":` branch is gone
- **`tests/test_game_module_protocol.py`** — 17 tests: Protocol `isinstance` conformance for all three modules, Blackjack key-rename and chip-mapping coverage, pass-through coverage for Cascade/Pachisi

## How stats_shape works
`get_stats_for_session` builds a `raw_stats` dict per game type:
```
{ played, best, avg, last_played_at, latest_score }
```
Each module's `stats_shape()` transforms this into its final API shape.  Blackjack renames `best → best_chips`, maps `latest_score → current_chips`, and drops `avg`.  Cascade/Pachisi are pass-through (strip `latest_score`).  Unregistered game types (yacht, twenty48) also pass through via a fallback in the service.

## Test plan
- [x] `python -m pytest tests/test_game_module_protocol.py -v` → 17/17 pass
- [x] Full suite `python -m pytest tests/` → 543 passed, 26 skipped, 93% coverage
- [x] `test_stats_me_blackjack_uses_chip_shape` (existing integration test) still passes — API response shape unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)