### PR TITLE
feat(contract): players[] as first-class field on game records (#543)

### DIFF
--- a/backend/alembic/versions/0005_add_players_to_games.py
+++ b/backend/alembic/versions/0005_add_players_to_games.py
@@ -1,0 +1,40 @@
+"""add players[] JSONB column to games (#543)
+
+Revision ID: 0005_add_players_to_games
+Revises: 0004_add_pachisi_game_type
+Create Date: 2026-04-17
+
+Adds a first-class ``players`` JSONB column to the ``games`` table.
+Existing rows default to ``[]``; new rows are populated by the API from
+the creating session (single-element list today, extensible for multiplayer).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0005_add_players_to_games"
+down_revision: Union[str, None] = "0004_add_pachisi_game_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# JSONB on Postgres, JSON on SQLite (mirrors db/models.py _JSONB pattern).
+_JSONB_TYPE = sa.JSON().with_variant(JSONB(), "postgresql")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "games",
+        sa.Column(
+            "players",
+            _JSONB_TYPE,
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("games", "players")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -128,6 +128,7 @@ class Game(Base):
     game_metadata: Mapped[dict] = mapped_column(
         "metadata", _JSONB, nullable=False, server_default="{}"
     )
+    players: Mapped[list] = mapped_column(_JSONB, nullable=False, server_default="[]")
 
     game_type: Mapped[GameType] = relationship(back_populates="games")
     events: Mapped[list["GameEvent"]] = relationship(

--- a/backend/games/router.py
+++ b/backend/games/router.py
@@ -56,6 +56,7 @@ def _to_row(g) -> GameRowResponse:
         outcome=g.outcome,
         duration_ms=g.duration_ms,
         metadata=g.metadata,
+        players=g.players,
     )
 
 
@@ -113,6 +114,7 @@ async def get_game_detail(
         outcome=row.outcome,
         duration_ms=row.duration_ms,
         metadata=row.metadata,
+        players=row.players,
         events=events,
     )
 
@@ -126,6 +128,8 @@ async def get_game_detail(
 @limiter.limit("10/minute", key_func=session_key)
 async def create_game(request: Request, body: CreateGameRequest) -> CreateGameResponse:
     sid = get_session_id(request)
+    # Default to the creating session when the client omits players (#543).
+    players = [p.model_dump() for p in body.players] if body.players else [{"player_id": sid}]
     factory = get_session_factory()
     async with factory() as db:
         try:
@@ -135,6 +139,7 @@ async def create_game(request: Request, body: CreateGameRequest) -> CreateGameRe
                 client_id=body.id,
                 game_type_name=body.game_type,
                 metadata=body.metadata,
+                players=players,
             )
         except service.GameServiceError as e:
             raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/backend/games/schemas.py
+++ b/backend/games/schemas.py
@@ -11,6 +11,22 @@ from pydantic import BaseModel, Field, model_validator
 from games.registry import get_module
 
 # ---------------------------------------------------------------------------
+# Shared sub-models
+# ---------------------------------------------------------------------------
+
+
+class PlayerRef(BaseModel):
+    """A player participating in a game (#543).
+
+    Today all games are single-player, so ``players`` is always length 1.
+    The model is intentionally minimal so multiplayer can extend it without
+    a breaking change (add ``display_name``, ``role``, etc. later).
+    """
+
+    player_id: str = Field(..., min_length=1, max_length=128)
+
+
+# ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
 
@@ -19,6 +35,7 @@ class CreateGameRequest(BaseModel):
     id: uuid.UUID | None = None
     game_type: str = Field(..., min_length=1, max_length=64)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    players: list[PlayerRef] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def validate_game_metadata(self) -> "CreateGameRequest":
@@ -106,6 +123,7 @@ class GameRowResponse(BaseModel):
     outcome: str | None
     duration_ms: int | None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    players: list[PlayerRef] = Field(default_factory=list)
 
 
 class GameHistoryResponse(BaseModel):

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -72,6 +72,7 @@ async def create_game(
     client_id: uuid.UUID | None,
     game_type_name: str,
     metadata: dict[str, Any],
+    players: list[dict[str, Any]],
 ) -> Game:
     gt = await _resolve_game_type(session, game_type_name)
 
@@ -89,6 +90,7 @@ async def create_game(
         session_id=session_id,
         game_type_id=gt.id,
         game_metadata=metadata or {},
+        players=players,
     )
     session.add(game)
     await session.commit()
@@ -325,6 +327,7 @@ class GameRow:
     outcome: str | None
     duration_ms: int | None
     metadata: dict[str, Any]
+    players: list[dict[str, Any]]
 
 
 @dataclass
@@ -361,6 +364,7 @@ async def list_games_for_session(
             outcome=g.outcome,
             duration_ms=g.duration_ms,
             metadata=g.game_metadata,
+            players=g.players or [],
         )
         for g, name in rows[:limit]
     ]
@@ -401,6 +405,7 @@ async def get_game_detail(
         outcome=game.outcome,
         duration_ms=game.duration_ms,
         metadata=game.game_metadata,
+        players=game.players or [],
     )
     events: list[dict[str, Any]] | None = None
     if include_events:

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0004_add_pachisi_game_type"
+        assert version == "0005_add_players_to_games"

--- a/backend/tests/test_players_field.py
+++ b/backend/tests/test_players_field.py
@@ -1,0 +1,136 @@
+"""Tests for players[] as a first-class field on game records (#543)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterator
+
+import pytest
+from pydantic import ValidationError
+
+from games.schemas import CreateGameRequest, PlayerRef
+
+# ---------------------------------------------------------------------------
+# PlayerRef unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_player_ref_valid() -> None:
+    ref = PlayerRef(player_id="abc-123")
+    assert ref.player_id == "abc-123"
+
+
+def test_player_ref_empty_string_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PlayerRef(player_id="")
+
+
+def test_player_ref_too_long_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PlayerRef(player_id="x" * 129)
+
+
+# ---------------------------------------------------------------------------
+# CreateGameRequest — players field
+# ---------------------------------------------------------------------------
+
+
+def test_create_game_request_defaults_players_to_empty_list() -> None:
+    req = CreateGameRequest(game_type="yacht")
+    assert req.players == []
+
+
+def test_create_game_request_accepts_explicit_players() -> None:
+    req = CreateGameRequest(
+        game_type="yacht",
+        players=[{"player_id": "user-abc"}],
+    )
+    assert len(req.players) == 1
+    assert req.players[0].player_id == "user-abc"
+
+
+def test_create_game_request_rejects_invalid_player_ref() -> None:
+    with pytest.raises(ValidationError):
+        CreateGameRequest(game_type="yacht", players=[{"player_id": ""}])
+
+
+# ---------------------------------------------------------------------------
+# API-level tests (require DATABASE_URL)
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping live API tests",
+)
+
+
+@pytest.fixture()
+def client() -> Iterator:
+    from db.base import is_configured
+
+    assert is_configured()
+    from main import app
+    from fastapi.testclient import TestClient
+
+    with TestClient(app) as c:
+        yield c
+
+
+def _headers(sid: str) -> dict[str, str]:
+    return {"X-Session-ID": sid, "Content-Type": "application/json"}
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping live API tests",
+)
+def test_create_game_stores_players_from_session(client) -> None:
+    """When players is omitted, the session id is stored as the sole player."""
+    sid = str(uuid.uuid4())
+    r = client.post("/games", headers=_headers(sid), json={"game_type": "yacht"})
+    assert r.status_code == 200
+    gid = r.json()["id"]
+
+    r2 = client.get(f"/games/{gid}", headers=_headers(sid))
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["players"] == [{"player_id": sid}]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping live API tests",
+)
+def test_create_game_stores_explicit_players(client) -> None:
+    """When players is provided, the given list is persisted."""
+    sid = str(uuid.uuid4())
+    custom_id = str(uuid.uuid4())
+    r = client.post(
+        "/games",
+        headers=_headers(sid),
+        json={"game_type": "yacht", "players": [{"player_id": custom_id}]},
+    )
+    assert r.status_code == 200
+    gid = r.json()["id"]
+
+    r2 = client.get(f"/games/{gid}", headers=_headers(sid))
+    assert r2.status_code == 200
+    assert r2.json()["players"] == [{"player_id": custom_id}]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set — skipping live API tests",
+)
+def test_game_history_includes_players(client) -> None:
+    """GET /games/me items include the players field."""
+    sid = str(uuid.uuid4())
+    client.post("/games", headers=_headers(sid), json={"game_type": "yacht"})
+
+    r = client.get("/games/me", headers=_headers(sid))
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) >= 1
+    assert "players" in items[0]
+    assert items[0]["players"] == [{"player_id": sid}]

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -7,6 +7,11 @@
 
 export type { GameOutcome, GameType } from "./vocab";
 
+/** A player participating in a game (#543). Mirrors backend PlayerRef. */
+export interface PlayerRef {
+  player_id: string;
+}
+
 export interface GameTypeStats {
   played: number;
   best: number | null;
@@ -31,6 +36,7 @@ export interface GameRow {
   outcome: GameOutcome | null;
   duration_ms: number | null;
   metadata: Record<string, unknown>;
+  players: PlayerRef[];
 }
 
 export interface GameHistoryResponse {


### PR DESCRIPTION
## Linked issue
Closes #543
Epic: #520

## Design decision: JSONB column on games table
\`players\` is stored as a dedicated JSONB column on \`games\` (not in \`metadata\`, not a join table). This keeps it a first-class field — queryable, indexed if needed, and schema-visible — without the migration complexity of a \`game_players\` join table. Upgrading to a join table for true multiplayer is a single migration when that time comes.

## Summary
- **\`games\` table**: new \`players\` JSONB column, \`NOT NULL DEFAULT '[]'\` — existing rows get \`[]\`
- **Alembic \`0005_add_players_to_games\`**: adds the column; \`downgrade()\` drops it
- **\`PlayerRef\`** Pydantic model (\`player_id: str\`, 1–128 chars) in \`games/schemas.py\`
- **\`CreateGameRequest\`**: new optional \`players: list[PlayerRef]\` field (default \`[]\`)
- **Router auto-fill**: when \`players\` is omitted or empty, the router stores \`[{\"player_id\": session_id}]\` — no change in behavior for existing callers
- **\`GameRowResponse\` / \`GameDetailResponse\`**: include \`players: list[PlayerRef]\`
- **Frontend \`types.ts\`**: \`PlayerRef\` interface + \`players\` on \`GameRow\`
- **Tests**: \`test_players_field.py\` — \`PlayerRef\` validation, \`CreateGameRequest\` unit tests, 3 API-level tests (auto-fill, explicit list, history endpoint)

## Test plan
- [x] Full suite: 569 passed, 26 skipped, 94.67% coverage
- [x] \`black --check\` clean on all changed Python files
- [x] \`npx prettier --write\` — \`types.ts\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)