### PR TITLE
feat(types): add GameSession, Player, and GameOutcome to shared types (#544)

### DIFF
--- a/frontend/src/game/_shared/types.ts
+++ b/frontend/src/game/_shared/types.ts
@@ -6,7 +6,8 @@
  * pattern.
  */
 
-export type { GameType } from "../../api/vocab";
+import type { GameType } from "../../api/vocab";
+export type { GameType };
 
 /**
  * A score submission waiting to be sent to the server.
@@ -29,3 +30,49 @@ export interface PendingSubmission {
  * Throwing from the handler keeps the item in the queue for a later retry.
  */
 export type SubmitHandler = (item: PendingSubmission) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// Session lifecycle interfaces (#544)
+// ---------------------------------------------------------------------------
+
+/**
+ * Identity and display info for a game participant.
+ * Designed with multiplayer in mind — all games carry Player[] even when
+ * single-player (array length = 1).
+ */
+export interface Player {
+  id: string;
+  displayName: string;
+}
+
+/**
+ * The result of a completed game round.
+ *
+ * `winner` uses the house/player vocabulary from OutcomeVocabulary; null
+ * means the outcome is not yet determined or the game type has no winner
+ * concept (e.g. pure score-chase games).
+ */
+export interface GameOutcome {
+  winner: "player" | "house" | "draw" | null;
+  finalScore: number | null;
+}
+
+/**
+ * A live or completed game session bound to a specific game type.
+ *
+ * `TState`  — the game's server-side (or local) state snapshot.
+ * `TAction` — reserved for typed action dispatch via useGameSync (#549).
+ *             Use the `_actionType` phantom field in per-game session types
+ *             to bind this parameter without forcing runtime allocation.
+ */
+export interface GameSession<TState, TAction = unknown> {
+  id: string;
+  gameType: GameType;
+  state: TState;
+  status: "active" | "completed" | "abandoned";
+  /**
+   * Phantom field — never assigned at runtime.
+   * Binds TAction so useGameSync can infer the dispatch type from a session.
+   */
+  readonly _actionType?: TAction;
+}

--- a/frontend/src/game/blackjack/types.ts
+++ b/frontend/src/game/blackjack/types.ts
@@ -2,6 +2,8 @@
  * Blackjack API response shapes.
  */
 
+import type { GameOutcome, GameSession } from "../_shared/types";
+
 export interface CardResponse {
   rank: string;
   suit: string;
@@ -41,4 +43,12 @@ export interface BlackjackState {
   rules: GameRules;
   /** Net chip delta from the previously completed hand. Null until at least one hand resolves. */
   last_win: number | null;
+}
+
+export type BlackjackSession = GameSession<BlackjackState>;
+
+/** Outcome for a completed Blackjack hand. */
+export interface BlackjackOutcome extends GameOutcome {
+  /** Raw outcome string from the server ("blackjack" | "win" | "lose" | "push"). */
+  handResult: string | null;
 }

--- a/frontend/src/game/cascade/types.ts
+++ b/frontend/src/game/cascade/types.ts
@@ -2,6 +2,8 @@
  * Cascade API response shapes.
  */
 
+import type { GameSession } from "../_shared/types";
+
 export interface ScoreEntry {
   player_name: string;
   score: number;
@@ -12,3 +14,7 @@ export interface ScoreEntry {
 export interface LeaderboardResponse {
   scores: ScoreEntry[];
 }
+
+// Cascade maintains no server-side game state during play;
+// gameplay is frontend-only. Session is used for lifecycle tracking only.
+export type CascadeSession = GameSession<null>;

--- a/frontend/src/game/pachisi/types.ts
+++ b/frontend/src/game/pachisi/types.ts
@@ -2,6 +2,8 @@
  * Pachisi API response shapes.
  */
 
+import type { GameSession } from "../_shared/types";
+
 export interface PieceResponse {
   index: number;
   position: number; // -1=base, 0-51=outer track, 52-57=red home col, 64-69=yellow home col, 100=finished
@@ -28,3 +30,5 @@ export interface PachisiState {
   cpu_player: string | null;
   last_event: string | null;
 }
+
+export type PachisiSession = GameSession<PachisiState>;

--- a/frontend/src/game/twenty48/types.ts
+++ b/frontend/src/game/twenty48/types.ts
@@ -2,6 +2,8 @@
  * Twenty48 state types.
  */
 
+import type { GameOutcome, GameSession } from "../_shared/types";
+
 export interface TileData {
   id: number;
   value: number;
@@ -28,4 +30,12 @@ export interface Twenty48State {
   startedAt: number | null;
   /** Total elapsed milliseconds accumulated across all sessions before the current one. */
   accumulatedMs: number;
+}
+
+export type Twenty48Session = GameSession<Twenty48State>;
+
+/** Outcome for a completed Twenty48 game. */
+export interface Twenty48Outcome extends GameOutcome {
+  /** Whether the player reached the 2048 tile. */
+  hasWon: boolean;
 }

--- a/frontend/src/game/yacht/types.ts
+++ b/frontend/src/game/yacht/types.ts
@@ -2,6 +2,8 @@
  * Yacht API response shapes.
  */
 
+import type { GameOutcome, GameSession } from "../_shared/types";
+
 export interface GameState {
   dice: number[];
   held: boolean[];
@@ -18,4 +20,13 @@ export interface GameState {
 
 export interface PossibleScores {
   possible_scores: Record<string, number>;
+}
+
+export type YachtSession = GameSession<GameState>;
+
+/** Outcome for a completed Yacht game. */
+export interface YachtOutcome extends GameOutcome {
+  /** Breakdown of upper and lower section totals. */
+  upperTotal: number;
+  lowerTotal: number;
 }


### PR DESCRIPTION
Closes #544. Part of epic #522.

## Summary

- Adds `Player`, `GameOutcome`, and `GameSession<TState, TAction>` to `frontend/src/game/_shared/types.ts`
- `TAction` is held as a phantom type parameter (reserved for typed dispatch via `useGameSync` #549)
- All five per-game `types.ts` files import the shared interfaces and export typed session/outcome aliases (`BlackjackSession`, `CascadeSession`, `Twenty48Session`, `YachtSession`, `PachisiSession`)
- Fixes a pre-existing `GameType` local-use error in `_shared/types.ts` (re-export → import + export)

## Test plan

- [ ] `npx tsc --noEmit` passes with no new errors (53 total, one fewer than baseline)
- [ ] 115 `_shared` and per-game tests pass
- [ ] `GameSession`, `Player`, `GameOutcome` are importable from `game/_shared/types`
- [ ] Each per-game `types.ts` exports its `*Session` alias (and `*Outcome` where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)