### PR TITLE
fix(storage,sync): resolve four Sentry warnings (#569, #570, #571, #572)

### DIFF
--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -271,19 +271,14 @@ describe("httpClient — Sentry reporting (#513)", () => {
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
-  it("network failure (TypeError) emits captureMessage warning, not captureException", async () => {
+  it("network failure (TypeError) skips captureMessage in dev mode (#571)", async () => {
     mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     const request = makeRequest();
     await expect(request("/x")).rejects.toThrow("Failed to fetch");
     expect(Sentry.captureException).not.toHaveBeenCalled();
-    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      expect.stringContaining("network failure"),
-      expect.objectContaining({
-        level: "warning",
-        tags: expect.objectContaining({ errorType: "network" }),
-      })
-    );
+    // __DEV__ is true in the test environment — network failures are
+    // suppressed to avoid flooding Sentry with dev-mode localhost noise.
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
   it("genuine unexpected JS error (non-Api, non-Type) is captured as an exception with stack", async () => {

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -368,16 +368,14 @@ describe("SyncWorker", () => {
     expect(patch!.body).not.toHaveProperty("durationMs");
   });
 
-  // #514: include the 400 response body in the Sentry warning so the next
-  // occurrence self-explains. The original Sentry event only said
-  // "400 on PATCH /complete" with no hint that the root cause was an
-  // invalid `outcome` value.
-  // #519: Sentry extra now also includes attempt/maxAttempts/isFinal.
-  it("400 on PATCH /complete surfaces the response body via captureMessage", async () => {
+  // #572: Sentry warning is only emitted on the final retry attempt to avoid
+  // flooding the dashboard with per-retry noise during deployment windows.
+  it("400 on PATCH /complete does NOT emit captureMessage until final attempt", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Sentry = require("@sentry/react-native");
     Sentry.captureMessage.mockClear();
 
+    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
     api.defaultResponse = ok();
     api.onNext((p) => p.endsWith("/complete"), {
       status: 400,
@@ -390,6 +388,18 @@ describe("SyncWorker", () => {
     await flushMicro();
     await worker.flush();
 
+    // First attempt — no Sentry warning yet.
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+
+    // Second attempt (final) — dead-letters and emits warning.
+    api.onNext((p) => p.endsWith("/complete"), {
+      status: 400,
+      ok: false,
+      retryAfterMs: null,
+      body: { detail: "Invalid outcome: 'completed'" },
+    });
+    await worker.flush();
+
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
       expect.stringContaining("400 on PATCH /complete"),
       expect.objectContaining({
@@ -399,8 +409,8 @@ describe("SyncWorker", () => {
           body: { detail: "Invalid outcome: 'completed'" },
           gameId: gid,
           sentOutcome: "completed",
-          attempt: 1,
-          isFinal: false,
+          attempt: 2,
+          maxAttempts: 2,
         }),
       })
     );

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -141,11 +141,17 @@ export function createGameClient(options: HttpClientOptions) {
         // message, not a captured exception with a stack. The synthetic
         // stack here would otherwise group every offline user under a
         // single misleading issue.
-        Sentry.captureMessage(`API ${apiTag} network failure: ${method} ${path}`, {
-          level: "warning",
-          tags: { api: apiTag, errorType: "network" },
-          extra: { url, platform: Platform.OS, originalMessage: e.message },
-        });
+        //
+        // In dev mode, network failures against localhost are expected
+        // (backend not running) — skip Sentry to avoid flooding the
+        // dashboard with dev noise (#571).
+        if (!__DEV__) {
+          Sentry.captureMessage(`API ${apiTag} network failure: ${method} ${path}`, {
+            level: "warning",
+            tags: { api: apiTag, errorType: "network" },
+            extra: { url, platform: Platform.OS, originalMessage: e.message },
+          });
+        }
         throw e;
       }
       // Anything else is a genuine JS error from the request-building

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -355,19 +355,20 @@ export class SyncWorker {
       // dead-lettering gives the deployment time to roll out.
       const attempts = await this.games.incrementCompleteAttempts(gameId);
       const isFinal = attempts >= logConfig.MAX_COMPLETE_ATTEMPTS;
-      Sentry.captureMessage(`syncWorker: ${res.status} on PATCH /complete ${gameId}`, {
-        level: "warning",
-        extra: {
-          status: res.status,
-          body: res.body,
-          gameId,
-          sentOutcome: body.outcome,
-          attempt: attempts,
-          maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
-          isFinal,
-        },
-      });
+      // Only emit a Sentry warning on the final attempt to avoid flooding
+      // the dashboard with per-retry noise during deployment windows (#572).
       if (isFinal) {
+        Sentry.captureMessage(`syncWorker: ${res.status} on PATCH /complete ${gameId} (dead-lettered)`, {
+          level: "warning",
+          extra: {
+            status: res.status,
+            body: res.body,
+            gameId,
+            sentOutcome: body.outcome,
+            attempt: attempts,
+            maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
+          },
+        });
         await this.games.forget(gameId);
         result.deadLettered += 1;
       }

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -358,17 +358,20 @@ export class SyncWorker {
       // Only emit a Sentry warning on the final attempt to avoid flooding
       // the dashboard with per-retry noise during deployment windows (#572).
       if (isFinal) {
-        Sentry.captureMessage(`syncWorker: ${res.status} on PATCH /complete ${gameId} (dead-lettered)`, {
-          level: "warning",
-          extra: {
-            status: res.status,
-            body: res.body,
-            gameId,
-            sentOutcome: body.outcome,
-            attempt: attempts,
-            maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
-          },
-        });
+        Sentry.captureMessage(
+          `syncWorker: ${res.status} on PATCH /complete ${gameId} (dead-lettered)`,
+          {
+            level: "warning",
+            extra: {
+              status: res.status,
+              body: res.body,
+              gameId,
+              sentOutcome: body.outcome,
+              attempt: attempts,
+              maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
+            },
+          }
+        );
         await this.games.forget(gameId);
         result.deadLettered += 1;
       }

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -25,18 +25,41 @@ export async function loadGame(): Promise<EngineState | null> {
     const raw = await AsyncStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as EngineState;
-    // Sanity check — shape drift discards rather than crashing.
+    // Minimum viability check — only discard if the core fields are missing.
     if (
       typeof parsed.chips !== "number" ||
       typeof parsed.bet !== "number" ||
       typeof parsed.phase !== "string" ||
       !Array.isArray(parsed.deck) ||
       !Array.isArray(parsed.player_hand) ||
-      !Array.isArray(parsed.dealer_hand) ||
-      !Array.isArray(parsed.player_hands) ||
-      !Array.isArray(parsed.hand_bets)
+      !Array.isArray(parsed.dealer_hand)
     ) {
       return null;
+    }
+    // Backfill split-hand arrays for saves created before split was added (#569).
+    if (!Array.isArray(parsed.player_hands)) {
+      parsed.player_hands = [parsed.player_hand];
+    }
+    if (!Array.isArray(parsed.hand_bets)) {
+      parsed.hand_bets = [parsed.bet];
+    }
+    if (!Array.isArray(parsed.hand_outcomes)) {
+      parsed.hand_outcomes = [parsed.outcome ?? null];
+    }
+    if (!Array.isArray(parsed.hand_payouts)) {
+      parsed.hand_payouts = [parsed.payout ?? 0];
+    }
+    if (!Array.isArray(parsed.split_from_aces)) {
+      parsed.split_from_aces = [false];
+    }
+    if (typeof parsed.active_hand_index !== "number") {
+      parsed.active_hand_index = 0;
+    }
+    if (typeof parsed.split_count !== "number") {
+      parsed.split_count = 0;
+    }
+    if (typeof parsed.doubled !== "boolean") {
+      parsed.doubled = false;
     }
     // Backfill rules for saves created before configurable rules.
     if (!parsed.rules) {

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -73,11 +73,15 @@ describe("twenty48 storage", () => {
     expect(loaded).toBeNull();
   });
 
-  it("returns null for v1 payloads (missing tiles array)", async () => {
+  it("backfills tiles array for v1 payloads instead of discarding (#570)", async () => {
     const v1Payload = { board: sample.board, score: 0, game_over: false, has_won: false };
     await AsyncStorage.setItem("twenty48_game_v2", JSON.stringify(v1Payload));
     const loaded = await loadGame();
-    expect(loaded).toBeNull();
+    expect(loaded).not.toBeNull();
+    expect(Array.isArray(loaded!.tiles)).toBe(true);
+    expect(loaded!.scoreDelta).toBe(0);
+    expect(loaded!.startedAt).toBeNull();
+    expect(loaded!.accumulatedMs).toBe(0);
   });
 
   it("clearGame removes the saved state", async () => {

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -28,13 +28,33 @@ export async function loadGame(): Promise<Twenty48State | null> {
     const raw = await AsyncStorage.getItem(GAME_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Twenty48State;
+    // Minimum viability check — only discard if the core fields are missing.
     if (
       !Array.isArray(parsed.board) ||
       parsed.board.length !== 4 ||
-      typeof parsed.score !== "number" ||
-      !Array.isArray(parsed.tiles)
+      typeof parsed.score !== "number"
     ) {
       return null;
+    }
+    // Backfill tiles array for saves created before v2 tile animation data (#570).
+    if (!Array.isArray(parsed.tiles)) {
+      let nextId = 0;
+      parsed.tiles = parsed.board.flatMap((row, r) =>
+        row.map((val, c) =>
+          val > 0
+            ? { id: nextId++, value: val, row: r, col: c, prevRow: null, prevCol: null, isNew: false, isMerge: false }
+            : null,
+        ).filter((t): t is NonNullable<typeof t> => t !== null),
+      );
+    }
+    if (typeof parsed.scoreDelta !== "number") {
+      parsed.scoreDelta = 0;
+    }
+    if (typeof parsed.game_over !== "boolean") {
+      parsed.game_over = false;
+    }
+    if (typeof parsed.has_won !== "boolean") {
+      parsed.has_won = false;
     }
     // Normalize timer fields — absent in states saved before timer was added.
     parsed.startedAt = parsed.startedAt ?? null;

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -40,11 +40,22 @@ export async function loadGame(): Promise<Twenty48State | null> {
     if (!Array.isArray(parsed.tiles)) {
       let nextId = 0;
       parsed.tiles = parsed.board.flatMap((row, r) =>
-        row.map((val, c) =>
-          val > 0
-            ? { id: nextId++, value: val, row: r, col: c, prevRow: null, prevCol: null, isNew: false, isMerge: false }
-            : null,
-        ).filter((t): t is NonNullable<typeof t> => t !== null),
+        row
+          .map((val, c) =>
+            val > 0
+              ? {
+                  id: nextId++,
+                  value: val,
+                  row: r,
+                  col: c,
+                  prevRow: null,
+                  prevCol: null,
+                  isNew: false,
+                  isMerge: false,
+                }
+              : null
+          )
+          .filter((t): t is NonNullable<typeof t> => t !== null)
       );
     }
     if (typeof parsed.scoreDelta !== "number") {


### PR DESCRIPTION
## Summary
- **#569 / #570 — blackjack & twenty48 storage corruption**: Backfill missing fields (`player_hands`, `hand_bets`, `tiles`, etc.) from older save formats instead of discarding them. Users keep their in-progress games across schema migrations.
- **#571 — cascade localhost network failures**: Suppress `captureMessage` for network `TypeError`s when `__DEV__` is true — these are expected dev-mode noise, not production issues.
- **#572 — SyncWorker PATCH /complete 400 noise**: Only emit the Sentry warning on the final retry attempt (dead-letter), not on every intermediate retry during deployment windows.

## Test plan
- [x] All 1089 frontend tests pass (73 suites)
- [x] Updated tests for httpClient, syncWorker, and twenty48 storage to match new behavior
- [ ] Verify blackjack game loads correctly after upgrading from a pre-split save
- [ ] Verify twenty48 game loads correctly after upgrading from a pre-tiles save
- [ ] Confirm Sentry warning volume drops for these four issue categories

Closes #569, #570, #571, #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)