### PR TITLE
feat(shell): add GameShell component and migrate all 4 game screens (#548)

### DIFF
--- a/frontend/src/components/shared/GameShell.tsx
+++ b/frontend/src/components/shared/GameShell.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { View, ActivityIndicator, Text, StyleSheet, StyleProp, ViewStyle } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "../../theme/ThemeContext";
+import { AppHeader, APP_HEADER_HEIGHT, AppHeaderProps } from "./AppHeader";
+
+export interface GameShellProps extends Pick<
+  AppHeaderProps,
+  "title" | "onBack" | "requireBack" | "rightSlot"
+> {
+  /** When true renders a full-screen loading spinner instead of children. */
+  loading?: boolean;
+  /** When non-empty renders an error banner above the game content. */
+  error?: string | null;
+  /** Additional styles merged onto the outer container (e.g. paddingBottom). */
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+}
+
+/**
+ * GameShell — shared wrapper for all game screens.
+ *
+ * Renders AppHeader, a loading spinner, and an optional error banner so each
+ * game screen only needs to provide its game-specific content as children.
+ */
+export function GameShell({
+  title,
+  onBack,
+  requireBack,
+  rightSlot,
+  loading = false,
+  error,
+  style,
+  children,
+}: GameShellProps) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  if (loading) {
+    return (
+      <View style={[styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator color={colors.accent} size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          paddingTop: APP_HEADER_HEIGHT + insets.top,
+        },
+        style,
+      ]}
+    >
+      <AppHeader title={title} onBack={onBack} requireBack={requireBack} rightSlot={rightSlot} />
+      {!!error && (
+        <Text
+          style={[styles.errorBanner, { color: colors.error }]}
+          accessibilityRole="alert"
+          accessibilityLiveRegion="assertive"
+        >
+          {error}
+        </Text>
+      )}
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  container: {
+    flex: 1,
+  },
+  errorBanner: {
+    fontSize: 13,
+    textAlign: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+});

--- a/frontend/src/components/shared/__tests__/GameShell.test.tsx
+++ b/frontend/src/components/shared/__tests__/GameShell.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+import { GameShell } from "../GameShell";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === "common:nav.back") return "← Back";
+      if (key === "common:nav.backLabel") return "Go back to home screen";
+      if (key === "fab_label") return "Send feedback";
+      return key;
+    },
+  }),
+}));
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 44, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("../../../theme/ThemeContext", () => ({
+  useTheme: () => ({
+    colors: {
+      background: "#0e0e13",
+      accent: "#8ff5ff",
+      text: "#e8e8f0",
+      textMuted: "#9090a8",
+      error: "#ff6b6b",
+      textOnAccent: "#0e0e13",
+    },
+    theme: "dark",
+  }),
+}));
+
+jest.mock("../../FeedbackWidget/FeedbackWidget", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Text: RNText } = require("react-native");
+  const FeedbackWidgetMock = ({ visible }: { visible: boolean; onClose: () => void }) =>
+    visible ? <RNText>FeedbackWidget</RNText> : null;
+  FeedbackWidgetMock.displayName = "FeedbackWidget";
+  return FeedbackWidgetMock;
+});
+
+const noop = () => {};
+
+describe("GameShell", () => {
+  it("renders the AppHeader with the given title", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop}>
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.getByText("Yacht")).toBeTruthy();
+  });
+
+  it("renders children when not loading", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop}>
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.getByText("game content")).toBeTruthy();
+  });
+
+  it("renders a loading spinner and hides children when loading=true", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop} loading>
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.queryByText("game content")).toBeNull();
+    expect(screen.queryByText("Yacht")).toBeNull();
+  });
+
+  it("renders an error banner when error is a non-empty string", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop} error="Something went wrong">
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    // Children still render alongside the error banner
+    expect(screen.getByText("game content")).toBeTruthy();
+  });
+
+  it("does not render an error banner when error is null", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop} error={null}>
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.queryByText(/Something went wrong/)).toBeNull();
+  });
+
+  it("does not render an error banner when error is an empty string", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop} error="">
+        <Text>game content</Text>
+      </GameShell>
+    );
+    // empty string is falsy — no banner
+    expect(screen.getByText("game content")).toBeTruthy();
+  });
+
+  it("renders rightSlot content in the header area", () => {
+    render(
+      <GameShell title="Yacht" onBack={noop} rightSlot={<Text>Round 3</Text>}>
+        <Text>game content</Text>
+      </GameShell>
+    );
+    expect(screen.getByText("Round 3")).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import {
-  View,
-  Text,
-  Pressable,
-  StyleSheet,
-  ActivityIndicator,
-  useWindowDimensions,
-} from "react-native";
+import { View, Text, Pressable, StyleSheet, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -27,7 +20,7 @@ import ResultBanner from "../components/blackjack/ResultBanner";
 import GameOverModal from "../components/blackjack/GameOverModal";
 import HudSidebar from "../components/blackjack/HudSidebar";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
-import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+import { GameShell } from "../components/shared/GameShell";
 
 // Below this viewport height, card sizes, action-button sizes, and table
 // padding collapse to compact variants so the dealer hand, player hand, and
@@ -70,14 +63,6 @@ export default function BlackjackTableScreen({ navigation }: Props) {
     handlePlayAgain();
   }, [handlePlayAgain]);
 
-  if (!engine && loading) {
-    return (
-      <View style={[styles.centered, { backgroundColor: colors.background }]}>
-        <ActivityIndicator color={colors.accent} size="large" />
-      </View>
-    );
-  }
-
   const state = engine ? toViewState(engine) : null;
   const isSplit = (state?.player_hands?.length ?? 0) > 1;
 
@@ -88,39 +73,30 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   const handleNextHand = () => apply(engineNewHand);
 
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          backgroundColor: colors.background,
-          paddingTop: APP_HEADER_HEIGHT + insets.top,
-          paddingBottom: Math.max(insets.bottom, 16),
-        },
-      ]}
+    <GameShell
+      title={t("game.title")}
+      requireBack
+      onBack={() => navigation.popToTop()}
+      loading={!engine && loading}
+      style={{ paddingBottom: Math.max(insets.bottom, 16) }}
+      rightSlot={
+        state ? (
+          <View style={styles.bankroll}>
+            <Text style={[styles.bankrollLabel, { color: colors.textMuted }]}>
+              {t("header.bankrollLabel")}
+            </Text>
+            <Text
+              style={[styles.bankrollValue, { color: colors.text }]}
+              accessibilityLabel={t("header.bankrollAccessibilityLabel", {
+                chips: state.chips,
+              })}
+            >
+              {state.chips.toLocaleString()}
+            </Text>
+          </View>
+        ) : undefined
+      }
     >
-      <AppHeader
-        title={t("game.title")}
-        requireBack
-        onBack={() => navigation.popToTop()}
-        rightSlot={
-          state ? (
-            <View style={styles.bankroll}>
-              <Text style={[styles.bankrollLabel, { color: colors.textMuted }]}>
-                {t("header.bankrollLabel")}
-              </Text>
-              <Text
-                style={[styles.bankrollValue, { color: colors.text }]}
-                accessibilityLabel={t("header.bankrollAccessibilityLabel", {
-                  chips: state.chips,
-                })}
-              >
-                {state.chips.toLocaleString()}
-              </Text>
-            </View>
-          ) : undefined
-        }
-      />
-
       {/* Phase label */}
       {state && (
         <Text style={[styles.phaseLabel, { color: colors.textMuted }]}>
@@ -231,16 +207,11 @@ export default function BlackjackTableScreen({ navigation }: Props) {
         onConfirm={handleConfirmNewGame}
         onCancel={() => setConfirmNewGameVisible(false)}
       />
-    </View>
+    </GameShell>
   );
 }
 
 const styles = StyleSheet.create({
-  centered: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
   container: {
     flex: 1,
   },

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
-import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+import { GameShell } from "../components/shared/GameShell";
 import { FruitSetProvider, useFruitSet } from "../theme/FruitSetContext";
 import { FruitQueue } from "../game/cascade/fruitQueue";
 import { ControlledSpawnSelector, createSeededRng } from "../game/cascade/spawnSelector";
@@ -425,36 +425,28 @@ function CascadeGame() {
       : 0;
 
   return (
-    <View
-      style={[
-        styles.screen,
-        {
-          backgroundColor: colors.background,
-          paddingTop: APP_HEADER_HEIGHT + insets.top,
-          paddingBottom: Math.max(insets.bottom, 16),
-          paddingLeft: Math.max(insets.left, 16),
-          paddingRight: Math.max(insets.right, 16),
-        },
-      ]}
+    <GameShell
+      title={t("game.title")}
+      requireBack
+      onBack={() => navigation.popToTop()}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 16),
+        paddingLeft: Math.max(insets.left, 16),
+        paddingRight: Math.max(insets.right, 16),
+      }}
+      rightSlot={
+        <Pressable
+          onPress={handleNewGamePress}
+          style={[styles.newGameBtn, { borderColor: colors.accent }]}
+          accessibilityRole="button"
+          accessibilityLabel={t("common:newGame.button")}
+        >
+          <Text style={[styles.newGameText, { color: colors.accent }]}>
+            {t("common:newGame.button")}
+          </Text>
+        </Pressable>
+      }
     >
-      <AppHeader
-        title={t("game.title")}
-        requireBack
-        onBack={() => navigation.popToTop()}
-        rightSlot={
-          <Pressable
-            onPress={handleNewGamePress}
-            style={[styles.newGameBtn, { borderColor: colors.accent }]}
-            accessibilityRole="button"
-            accessibilityLabel={t("common:newGame.button")}
-          >
-            <Text style={[styles.newGameText, { color: colors.accent }]}>
-              {t("common:newGame.button")}
-            </Text>
-          </Pressable>
-        }
-      />
-
       {/* Combined HUD: score + drop/next previews + high, all one row */}
       <ScoreDisplay score={score}>
         {currentDef !== undefined && nextDef !== undefined && (
@@ -495,7 +487,7 @@ function CascadeGame() {
         onConfirm={handleConfirmNewGame}
         onCancel={() => setConfirmNewGameVisible(false)}
       />
-    </View>
+    </GameShell>
   );
 }
 
@@ -508,9 +500,6 @@ export default function CascadeScreen() {
 }
 
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-  },
   newGameBtn: {
     paddingHorizontal: 10,
     paddingVertical: 5,

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -22,7 +22,7 @@ import Scorecard from "../components/Scorecard";
 import GameOverModal from "../components/yacht/GameOverModal";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { useTheme } from "../theme/ThemeContext";
-import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+import { GameShell } from "../components/shared/GameShell";
 
 type Props = {
   navigation: NativeStackNavigationProp<HomeStackParamList, "Game">;
@@ -211,25 +211,18 @@ export default function GameScreen({ navigation, route }: Props) {
   );
 
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          backgroundColor: colors.background,
-          paddingTop: APP_HEADER_HEIGHT + insets.top,
-          paddingBottom: Math.max(insets.bottom, 16),
-          paddingLeft: Math.max(insets.left, 16),
-          paddingRight: Math.max(insets.right, 16),
-        },
-      ]}
+    <GameShell
+      title={t("game.title")}
+      rightSlot={roundPill}
+      requireBack
+      onBack={() => navigation.popToTop()}
+      error={error}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 16),
+        paddingLeft: Math.max(insets.left, 16),
+        paddingRight: Math.max(insets.right, 16),
+      }}
     >
-      <AppHeader
-        title={t("game.title")}
-        rightSlot={roundPill}
-        requireBack
-        onBack={() => navigation.popToTop()}
-      />
-
       {/* New Game */}
       <View style={styles.actionRow}>
         <Pressable
@@ -243,16 +236,6 @@ export default function GameScreen({ navigation, route }: Props) {
           </Text>
         </Pressable>
       </View>
-
-      {error && (
-        <Text
-          style={[styles.errorText, { color: colors.error }]}
-          accessibilityLiveRegion="assertive"
-          accessibilityRole="alert"
-        >
-          {error}
-        </Text>
-      )}
 
       {/* Dice */}
       <DiceRow
@@ -296,12 +279,11 @@ export default function GameScreen({ navigation, route }: Props) {
         onConfirm={handleConfirmNewGame}
         onCancel={() => setConfirmNewGameVisible(false)}
       />
-    </View>
+    </GameShell>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1 },
   actionRow: {
     flexDirection: "row",
     justifyContent: "flex-end",

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
-import { View, Text, Pressable, StyleSheet, ActivityIndicator, Platform } from "react-native";
+import { View, Text, Pressable, StyleSheet, Platform } from "react-native";
 import { GestureDetector, Gesture } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
-import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+import { GameShell } from "../components/shared/GameShell";
 import { Twenty48State } from "../game/twenty48/types";
 import { newGame, move as engineMove, Direction } from "../game/twenty48/engine";
 import {
@@ -306,32 +306,22 @@ export default function Twenty48Screen({ navigation }: Props) {
     })
     .runOnJS(true);
 
-  if (!state && loading) {
-    return (
-      <View style={[styles.centered, { backgroundColor: colors.background }]}>
-        <ActivityIndicator color={colors.accent} size="large" />
-      </View>
-    );
-  }
-
   const showWinOverlay = state?.has_won && !winDismissed && !state.game_over;
   const showGameOverOverlay = state?.game_over;
 
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          backgroundColor: colors.background,
-          paddingTop: APP_HEADER_HEIGHT + insets.top,
-          paddingBottom: Math.max(insets.bottom, 16),
-          paddingLeft: Math.max(insets.left, 16),
-          paddingRight: Math.max(insets.right, 16),
-        },
-      ]}
+    <GameShell
+      title={t("game.title")}
+      requireBack
+      onBack={() => navigation.popToTop()}
+      loading={!state && loading}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 16),
+        paddingLeft: Math.max(insets.left, 16),
+        paddingRight: Math.max(insets.right, 16),
+        alignItems: "center",
+      }}
     >
-      <AppHeader title={t("game.title")} requireBack onBack={() => navigation.popToTop()} />
-
       {/* Score + New Game */}
       <View style={styles.scoreRow}>
         {state && (
@@ -410,20 +400,11 @@ export default function Twenty48Screen({ navigation }: Props) {
         onConfirm={handleConfirmNewGame}
         onCancel={() => setConfirmNewGameVisible(false)}
       />
-    </View>
+    </GameShell>
   );
 }
 
 const styles = StyleSheet.create({
-  centered: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  container: {
-    flex: 1,
-    alignItems: "center",
-  },
   scoreRow: {
     flexDirection: "row",
     alignItems: "center",


### PR DESCRIPTION
Closes #548. Part of epic #522.

## Summary

- Adds `src/components/shared/GameShell.tsx` — wraps `AppHeader`, full-screen loading spinner (`loading` prop), and error banner (`error` prop) in one component
- Migrates all 4 active game screens to use `GameShell`:
  - `BlackjackTableScreen` — removes `ActivityIndicator` import and early-return loading block
  - `Twenty48Screen` — removes `ActivityIndicator` import and early-return loading block
  - `GameScreen` (Yacht) — removes `AppHeader` + inline error text; error now passed via `error` prop
  - `CascadeScreen` — removes `AppHeader`
- Each screen passes screen-specific padding (bottom/left/right insets) via `GameShell`'s `style` prop; `paddingTop` is owned by `GameShell` internally
- 7 new unit tests in `GameShell.test.tsx`; all 97 existing screen tests continue to pass

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npx eslint .` clean
- [ ] CI `test-frontend` and `lint-frontend` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)