### PR TITLE
feat(android): enable R8 minification + resource shrinking (#554)

### DIFF
--- a/frontend/android/app/proguard-rules.pro
+++ b/frontend/android/app/proguard-rules.pro
@@ -14,8 +14,10 @@
 # Expo modules — auto-linking uses reflection to instantiate module classes
 -keep class expo.modules.** { *; }
 
-# Sentry — native crash handler and ANR detection rely on reflection
+# Sentry — native crash handler and ANR detection rely on reflection;
+# annotations used for integration configuration at runtime
 -keep class io.sentry.** { *; }
+-keepattributes *Annotation*
 -dontwarn io.sentry.**
 
 # Preserve source file names and line numbers for readable Sentry crash reports

--- a/frontend/android/app/proguard-rules.pro
+++ b/frontend/android/app/proguard-rules.pro
@@ -11,4 +11,13 @@
 -keep class com.swmansion.reanimated.** { *; }
 -keep class com.facebook.react.turbomodule.** { *; }
 
-# Add any project specific keep options here:
+# Expo modules — auto-linking uses reflection to instantiate module classes
+-keep class expo.modules.** { *; }
+
+# Sentry — native crash handler and ANR detection rely on reflection
+-keep class io.sentry.** { *; }
+-dontwarn io.sentry.**
+
+# Preserve source file names and line numbers for readable Sentry crash reports
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/frontend/android/gradle.properties
+++ b/frontend/android/gradle.properties
@@ -25,6 +25,10 @@ android.useAndroidX=true
 # Enable AAPT2 PNG crunching
 android.enablePngCrunchInReleaseBuilds=true
 
+# Enable R8 minification and resource shrinking for release builds (#554)
+android.enableMinifyInReleaseBuilds=true
+android.enableShrinkResourcesInReleaseBuilds=true
+
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64


### PR DESCRIPTION
## Summary

- Sets `android.enableMinifyInReleaseBuilds=true` and `android.enableShrinkResourcesInReleaseBuilds=true` in `gradle.properties`, activating the `findProperty` wiring already present in `app/build.gradle`
- Adds ProGuard keep-rules for Expo module auto-linking, Sentry crash handler + annotation preservation, and source file/line number attributes for readable Sentry stack traces

## Before / After AAB size

| | AAB size |
|---|---|
| Before (R8 off) | TBD — populate after `android-release-smoke` completes |
| After (R8 on) | TBD |

*Will update before merge.*

## Files changed

- `frontend/android/gradle.properties` — two new properties
- `frontend/android/app/proguard-rules.pro` — keep-rules for Expo, Sentry, and debug attributes

## Risk

- `android-release-smoke` runs `assembleRelease` (arm64-v8a only) — any R8 stripping regression will surface as a build or startup crash
- Resource shrinking only removes XML resources unreferenced by code — no dynamic resource names are used in this project

## Test plan

- [ ] `android-release-smoke` CI job passes
- [ ] All five game flows (Yacht, Blackjack, Twenty-48, Cascade, Leaderboard) verified via E2E
- [ ] Before/after AAB size noted above

Closes #554. Part of epic #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)