### PR TITLE
feat(perf): lazy-load non-initial screens to defer cold-start work (#557)

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -438,3 +438,77 @@ A Galaga-style arcade shooter is listed as a potential future paid game. Evaluat
 **Status: Resolved — removed in #550.**
 
 Pachisi was removed from the codebase (Path A). All frontend directories (`src/game/pachisi/`, `src/components/pachisi/`, `src/screens/PachisiScreen.tsx`), the backend router, and DB seed row were deleted. The Android bundle is unaffected.
+
+---
+
+## Lazy Loading Decision
+
+> **Epic 2a — Story #557** | Implemented: 2026-04-18 | Branch: `feat/lazy-loading-557` | Expo SDK 55 / Hermes / Android + iOS
+
+### Methodology
+
+Cold-start time is measured from the JS-side start time (captured in `src/utils/appTiming.ts` at module-load — the earliest reachable JS timestamp) to when `HomeScreen`'s `useEffect` fires on first render. The delta is logged via:
+
+```
+[cold-start] HomeScreen ready: <N> ms
+```
+
+**Android — read from device:**
+
+```bash
+# With static imports (baseline — checkout commit before this PR):
+adb logcat -s ReactNativeJS | grep cold-start
+
+# With lazy imports (this branch):
+adb logcat -s ReactNativeJS | grep cold-start
+```
+
+Build for release before measuring: `cd frontend/android && ./gradlew assembleRelease`
+
+**iOS — read from device:**
+
+```bash
+# Physical device (Xcode must be open and device connected):
+# Xcode → Window → Devices and Simulators → select device → open Console
+# Filter by "cold-start"
+
+# Simulator (faster iteration, less representative):
+xcrun simctl spawn booted log stream --level debug 2>/dev/null | grep cold-start
+```
+
+Build via Xcode for a Release scheme before measuring — debug builds include the Metro bundler and are not representative of cold-start.
+
+Navigation-to-game-screen time (jank check) is measured manually: note the timestamp when the navigation gesture is initiated and when the screen's first frame renders (visible as a spinner duration).
+
+### Measurements
+
+Cold-start timing via `performance.now()` instrumentation (`src/utils/appTiming.ts` + `HomeScreen` `useEffect`) was not capturable in the Expo Go dev-server environment: Metro's own `lazy=true` bundle splitting loads `appTiming.ts` as a deferred chunk, so the timestamp is not set before `HomeScreen` mounts. This instrumentation is correct for a production build (where Metro lazy bundling is not active) — see methodology above for how to measure against a release build.
+
+| Metric | Platform | Static imports (baseline) | Lazy imports | Notes |
+|---|---|---|---|---|
+| Cold-start: JS start → HomeScreen ready | Android | not captured | not captured | Expo Go dev server — see above |
+| Cold-start: JS start → HomeScreen ready | iOS | not captured | not captured | Expo Go dev server — see above |
+| Navigation → lazy screen (tab): first visit | iOS simulator | no spinner | brief spinner | Correct — module loads once, cached thereafter |
+| Navigation → lazy screen (tab): repeat visit | iOS simulator | no spinner | no spinner | Correct — cached module renders synchronously |
+| Navigation → `Twenty48Screen` (stack): every visit | iOS simulator | no spinner | **visible spinner** | ⚠️ See stack-screen finding below |
+
+### Stack-screen spinner finding
+
+**Observed:** `Twenty48Screen` shows a visible loading spinner on every navigation, not just the first. This is because React Navigation unmounts stack screens when the user presses back — so on each return visit, React mounts a fresh component tree with a new `Suspense` boundary. Even though `React.lazy()` caches the resolved module, the new Suspense boundary evaluates it synchronously and should not flash in theory; in practice a brief spinner is visible in the dev build, likely exaggerated by Metro's dev-mode overhead.
+
+**Risk in production:** In a production Hermes build (no Metro dev server), the cached lazy module resolves synchronously and the Suspense fallback should not render at all on repeat visits. This needs verification against a release build before ship.
+
+**If the spinner persists in release:** convert `CascadeScreen`, `BlackjackBettingScreen`, `BlackjackTableScreen`, and `Twenty48Screen` back to static imports. Tab screens (`LeaderboardScreen`, `SettingsScreen`, `GameDetailScreen`) do not have this problem and can remain lazy regardless.
+
+### Decision
+
+**Lazy loading adopted** — `React.lazy()` applied to 7 non-initial screens: `CascadeScreen`, `BlackjackBettingScreen`, `BlackjackTableScreen`, `Twenty48Screen`, `LeaderboardScreen`, `GameDetailScreen`, `SettingsScreen`. `HomeScreen`, `GameScreen`, and `ProfileScreen` remain eager.
+
+**Rationale:** Even if the Hermes cold-start delta is small (expected, per issue #557 notes: "Hermes bytecode already strips most parse-time cost"), lazy loading provides a structural benefit: module-level side-effects in game screens (Matter.js world setup, Skia canvas initialization, context providers) are deferred until the user navigates to those screens. This reduces work before `HomeScreen` is interactive regardless of parse-time savings.
+
+**Implementation notes:**
+- A `withSuspense` HOC wraps each lazy component at the `Screen` registration site, so the spinner is scoped to the navigating screen rather than replacing the entire app.
+- `HomeScreen` and `GameScreen` (Yacht) are kept eager — they are the two most common landing destinations and must never show a spinner.
+- `ProfileScreen` is kept eager as it is the initial screen of `ProfileStack` and is always pre-mounted when the tab bar renders.
+- The `appTiming.ts` module (`src/utils/appTiming.ts`) remains in the codebase as timing infrastructure for future cold-start regression checks against release builds.
+- **Follow-up required:** verify the stack-screen spinner finding against a release build before merging to `main`.

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,3 +1,4 @@
+import "./src/utils/appTiming"; // must be first — captures JS-side cold-start timestamp
 import "./src/i18n/i18n";
 import React, { Suspense } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
@@ -16,14 +17,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
 import GameScreen from "./src/screens/GameScreen";
-import CascadeScreen from "./src/screens/CascadeScreen";
-import BlackjackBettingScreen from "./src/screens/BlackjackBettingScreen";
-import BlackjackTableScreen from "./src/screens/BlackjackTableScreen";
-import Twenty48Screen from "./src/screens/Twenty48Screen";
-import LeaderboardScreen from "./src/screens/LeaderboardScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
-import GameDetailScreen from "./src/screens/GameDetailScreen";
-import SettingsScreen from "./src/screens/SettingsScreen";
 import BottomTabBar from "./src/components/shared/BottomTabBar";
 import { GameState } from "./src/game/yacht/types";
 import { ThemeProvider } from "./src/theme/ThemeContext";
@@ -31,6 +25,14 @@ import { useHtmlAttributes } from "./src/i18n/useHtmlAttributes";
 import { NetworkProvider } from "./src/game/_shared/NetworkContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
+
+const CascadeScreen = React.lazy(() => import("./src/screens/CascadeScreen"));
+const BlackjackBettingScreen = React.lazy(() => import("./src/screens/BlackjackBettingScreen"));
+const BlackjackTableScreen = React.lazy(() => import("./src/screens/BlackjackTableScreen"));
+const Twenty48Screen = React.lazy(() => import("./src/screens/Twenty48Screen"));
+const LeaderboardScreen = React.lazy(() => import("./src/screens/LeaderboardScreen"));
+const GameDetailScreen = React.lazy(() => import("./src/screens/GameDetailScreen"));
+const SettingsScreen = React.lazy(() => import("./src/screens/SettingsScreen"));
 
 // Start capturing console.warn / console.error for feedback submissions
 SessionLogger.init();
@@ -68,6 +70,28 @@ export type ProfileStackParamList = {
   GameDetail: { gameId: string };
 };
 
+function withSuspense<P extends object>(Component: React.ComponentType<P>): React.FC<P> {
+  return (props: P) => (
+    <Suspense
+      fallback={
+        <View style={{ flex: 1 }}>
+          <ActivityIndicator style={{ flex: 1 }} />
+        </View>
+      }
+    >
+      <Component {...props} />
+    </Suspense>
+  );
+}
+
+const LazyCascadeScreen = withSuspense(CascadeScreen);
+const LazyBlackjackBettingScreen = withSuspense(BlackjackBettingScreen);
+const LazyBlackjackTableScreen = withSuspense(BlackjackTableScreen);
+const LazyTwenty48Screen = withSuspense(Twenty48Screen);
+const LazyLeaderboardScreen = withSuspense(LeaderboardScreen);
+const LazyGameDetailScreen = withSuspense(GameDetailScreen);
+const LazySettingsScreen = withSuspense(SettingsScreen);
+
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const HomeStack = createNativeStackNavigator<HomeStackParamList>();
 const ProfileStackNav = createNativeStackNavigator<ProfileStackParamList>();
@@ -78,10 +102,10 @@ function LobbyStack() {
     <HomeStack.Navigator screenOptions={{ headerShown: false }}>
       <HomeStack.Screen name="Home" component={HomeScreen} />
       <HomeStack.Screen name="Game" component={GameScreen} />
-      <HomeStack.Screen name="Cascade" component={CascadeScreen} />
-      <HomeStack.Screen name="BlackjackBetting" component={BlackjackBettingScreen} />
-      <HomeStack.Screen name="BlackjackTable" component={BlackjackTableScreen} />
-      <HomeStack.Screen name="Twenty48" component={Twenty48Screen} />
+      <HomeStack.Screen name="Cascade" component={LazyCascadeScreen} />
+      <HomeStack.Screen name="BlackjackBetting" component={LazyBlackjackBettingScreen} />
+      <HomeStack.Screen name="BlackjackTable" component={LazyBlackjackTableScreen} />
+      <HomeStack.Screen name="Twenty48" component={LazyTwenty48Screen} />
     </HomeStack.Navigator>
   );
 }
@@ -90,7 +114,7 @@ function ProfileStack() {
   return (
     <ProfileStackNav.Navigator screenOptions={{ headerShown: false }}>
       <ProfileStackNav.Screen name="ProfileHome" component={ProfileScreen} />
-      <ProfileStackNav.Screen name="GameDetail" component={GameDetailScreen} />
+      <ProfileStackNav.Screen name="GameDetail" component={LazyGameDetailScreen} />
     </ProfileStackNav.Navigator>
   );
 }
@@ -102,9 +126,9 @@ function MainTabs() {
       screenOptions={{ headerShown: false }}
     >
       <Tab.Screen name="Lobby" component={LobbyStack} />
-      <Tab.Screen name="Ranks" component={LeaderboardScreen} />
+      <Tab.Screen name="Ranks" component={LazyLeaderboardScreen} />
       <Tab.Screen name="Profile" component={ProfileStack} />
-      <Tab.Screen name="Settings" component={SettingsScreen} />
+      <Tab.Screen name="Settings" component={LazySettingsScreen} />
     </Tab.Navigator>
   );
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -71,7 +71,7 @@ export type ProfileStackParamList = {
 };
 
 function withSuspense<P extends object>(Component: React.ComponentType<P>): React.FC<P> {
-  return (props: P) => (
+  const Wrapped = (props: P) => (
     <Suspense
       fallback={
         <View style={{ flex: 1 }}>
@@ -82,6 +82,8 @@ function withSuspense<P extends object>(Component: React.ComponentType<P>): Reac
       <Component {...props} />
     </Suspense>
   );
+  Wrapped.displayName = `WithSuspense(${Component.displayName ?? Component.name ?? "Component"})`;
+  return Wrapped;
 }
 
 const LazyCascadeScreen = withSuspense(CascadeScreen);

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { View, Text, Pressable, StyleSheet, FlatList, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
@@ -12,6 +12,7 @@ import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import OfflineBanner from "../components/OfflineBanner";
+import { APP_START_MS } from "../utils/appTiming";
 
 /** Below this viewport width the grid collapses to a single column. */
 const SINGLE_COL_BREAKPOINT = 360;
@@ -32,6 +33,11 @@ export default function HomeScreen() {
   const { width } = useWindowDimensions();
 
   const numColumns = width < SINGLE_COL_BREAKPOINT ? 1 : 2;
+
+  useEffect(() => {
+    const coldStartMs = performance.now() - APP_START_MS;
+    console.log(`[cold-start] HomeScreen ready: ${coldStartMs.toFixed(1)} ms`);
+  }, []);
 
   async function startYacht() {
     const saved = await loadYachtGame();

--- a/frontend/src/utils/appTiming.ts
+++ b/frontend/src/utils/appTiming.ts
@@ -1,0 +1,3 @@
+// Captured at module-load time — import this before any other app module
+// to get the earliest possible JS-side timestamp for cold-start measurement.
+export const APP_START_MS = performance.now();


### PR DESCRIPTION
Part of epic #524. Closes #557.

## Summary

- Converts 7 non-initial screens to `React.lazy()` so their module-level code (Matter.js setup, Skia init, context providers) is deferred until first navigation
- `HomeScreen`, `GameScreen`, and `ProfileScreen` remain eager
- Adds a `withSuspense` HOC so loading spinners are scoped to the navigating screen, not the full app
- Adds cold-start timing instrumentation (`src/utils/appTiming.ts` + `HomeScreen` `useEffect`) for future release-build measurement
- Documents the lazy-loading decision, methodology, and observed findings in `docs/PERFORMANCE.md`

## Lazy screens

| Screen | Navigator type | Spinner behavior |
|---|---|---|
| `CascadeScreen` | Stack | First visit only (release); every visit in dev (see findings) |
| `BlackjackBettingScreen` | Stack | Same as above |
| `BlackjackTableScreen` | Stack | Same as above |
| `Twenty48Screen` | Stack | Same as above |
| `LeaderboardScreen` | Tab | First visit only |
| `GameDetailScreen` | Stack | Same as Cascade |
| `SettingsScreen` | Tab | First visit only |

## Findings (iOS simulator, Expo Go dev build)

- **Cold-start timing not captured:** Metro's `lazy=true` dev-server flag loads `appTiming.ts` as a deferred chunk, causing it to execute after `HomeScreen` mounts. Instrumentation is correct for release builds — see `docs/PERFORMANCE.md` for methodology.
- **Stack screens show spinner on every visit in dev:** `Twenty48Screen` showed a visible spinner on each navigation. This is expected in dev (Metro overhead exaggerates it). Needs verification against a release build before merging to `main` — if the spinner persists in release, the 4 stack-based game screens should be reverted to static imports. Tab screens are unaffected.

## Follow-up

- #582 — send cold-start metric to Sentry automatically from real devices

## Test plan

- [ ] App loads on Android — HomeScreen visible with no spinner
- [ ] App loads on iOS — HomeScreen visible with no spinner
- [ ] Navigate to each lazy screen — brief spinner on first visit is acceptable, no crash
- [ ] Navigate back and revisit each lazy screen — no spinner on repeat visit (release build)
- [ ] All CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)