### PR TITLE
fix(perf): guard cold-start log against Metro dev-server timing skew (#557)

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -35,8 +35,10 @@ export default function HomeScreen() {
   const numColumns = width < SINGLE_COL_BREAKPOINT ? 1 : 2;
 
   useEffect(() => {
-    const coldStartMs = performance.now() - APP_START_MS;
-    console.log(`[cold-start] HomeScreen ready: ${coldStartMs.toFixed(1)} ms`);
+    if (APP_START_MS > 0) {
+      const coldStartMs = performance.now() - APP_START_MS;
+      console.log(`[cold-start] HomeScreen ready: ${coldStartMs.toFixed(1)} ms`);
+    }
   }, []);
 
   async function startYacht() {


### PR DESCRIPTION
## Summary

- Adds `if (APP_START_MS > 0)` guard around the cold-start console log in `HomeScreen`
- Metro's `lazy=true` dev-server flag defers `appTiming.ts` as a chunk, so `APP_START_MS` is `0` in dev builds — without this guard every dev run logs a misleading `0.0 ms` cold-start time
- The log fires normally in release builds where Metro lazy bundling is not active

**Depends on #583** (lazy-loading + appTiming.ts). This PR should be merged after #583 lands on `dev`.

## Test plan

- [ ] Dev build: no `[cold-start]` log appears in console (timestamp is 0 — skip)
- [ ] Release build: `[cold-start] HomeScreen ready: <N> ms` appears in `adb logcat` / iOS Console (see `docs/PERFORMANCE.md` methodology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)