### PR TITLE
fix(sync): dead-letter PATCH /complete 400s immediately (#572 #553)

### DIFF
--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -369,14 +369,14 @@ describe("SyncWorker", () => {
     expect(patch!.body).not.toHaveProperty("durationMs");
   });
 
-  // #572: Sentry warning is only emitted on the final retry attempt to avoid
-  // flooding the dashboard with per-retry noise during deployment windows.
-  it("400 on PATCH /complete does NOT emit captureMessage until final attempt", async () => {
+  // #572/#553: 400 on PATCH /complete is now terminal — dead-letter immediately.
+  // The backend has accepted "completed" since #514; a 400 is a permanent
+  // bad-request that retrying cannot fix.
+  it("400 on PATCH /complete dead-letters immediately and emits Sentry error", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Sentry = require("@sentry/react-native");
     Sentry.captureMessage.mockClear();
 
-    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
     api.defaultResponse = ok();
     api.onNext((p) => p.endsWith("/complete"), {
       status: 400,
@@ -387,81 +387,22 @@ describe("SyncWorker", () => {
     const gid = client.startGame("yacht");
     client.completeGame(gid, { finalScore: 100, outcome: "completed" });
     await flushMicro();
-    await worker.flush();
+    const result = await worker.flush();
 
-    // First attempt — no Sentry warning yet.
-    expect(Sentry.captureMessage).not.toHaveBeenCalled();
-
-    // Second attempt (final) — dead-letters and emits warning.
-    api.onNext((p) => p.endsWith("/complete"), {
-      status: 400,
-      ok: false,
-      retryAfterMs: null,
-      body: { detail: "Invalid outcome: 'completed'" },
-    });
-    await worker.flush();
-
+    expect(games.get(gid)).toBeUndefined();
+    expect(result.deadLettered).toBe(1);
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
       expect.stringContaining("400 on PATCH /complete"),
       expect.objectContaining({
-        level: "warning",
+        level: "error",
         extra: expect.objectContaining({
           status: 400,
           body: { detail: "Invalid outcome: 'completed'" },
           gameId: gid,
           sentOutcome: "completed",
-          attempt: 2,
-          maxAttempts: 2,
         }),
       })
     );
-  });
-
-  // -------------------------------------------------------------------------
-  // #519 — PATCH /complete retry on 400 (deployment-window resilience)
-  // -------------------------------------------------------------------------
-
-  // 400 on PATCH /complete must NOT immediately dead-letter the game.
-  // The root cause of #519 was a deployment-window mismatch: the server
-  // was running old code that rejected outcome="completed" while the new
-  // code was still being deployed. Retrying gives the deployment time to
-  // roll out.
-  it("400 on PATCH /complete retains the game after the first failure", async () => {
-    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
-    api.defaultResponse = ok();
-    api.onNext((p) => p.endsWith("/complete"), err(400));
-
-    const gid = client.startGame("yacht");
-    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
-    await flushMicro();
-    await worker.flush();
-
-    // Game must still be tracked — not forgotten yet.
-    expect(games.get(gid)).toBeDefined();
-    expect(games.get(gid)?.completeAttempts).toBe(1);
-    // This second flush will succeed (api.defaultResponse = ok()).
-    await worker.flush();
-    expect(games.get(gid)).toBeUndefined(); // forgotten after 2xx
-  });
-
-  it("400 on PATCH /complete dead-letters after MAX_COMPLETE_ATTEMPTS", async () => {
-    logConfig.MAX_COMPLETE_ATTEMPTS = 2;
-    api.defaultResponse = ok();
-    api.onNext((p) => p.endsWith("/complete"), err(400));
-    api.onNext((p) => p.endsWith("/complete"), err(400));
-
-    const gid = client.startGame("yacht");
-    client.completeGame(gid, { finalScore: 100, outcome: "completed" });
-    await flushMicro();
-
-    // First failure — game kept.
-    await worker.flush();
-    expect(games.get(gid)).toBeDefined();
-
-    // Second failure — hits the cap, game forgotten.
-    const result = await worker.flush();
-    expect(games.get(gid)).toBeUndefined();
-    expect(result.deadLettered).toBe(1);
   });
 
   it("403 on PATCH /complete is immediately dead-lettered (permanent session mismatch)", async () => {

--- a/frontend/src/game/_shared/eventQueueConfig.ts
+++ b/frontend/src/game/_shared/eventQueueConfig.ts
@@ -62,11 +62,6 @@ export interface LogConfig {
   /** Rows exceeding this retry count are dead-lettered. */
   MAX_RETRY_COUNT: number;
 
-  /** How many 4xx failures on PATCH /complete before a game is dead-lettered.
-   * Kept above 1 so a deployment-window mismatch (old server rejecting a
-   * valid outcome) doesn't permanently lose the game on the first try. */
-  MAX_COMPLETE_ATTEMPTS: number;
-
   /** Per-row payload caps — oversized payloads are truncated on enqueue. */
   MAX_EVENT_PAYLOAD_BYTES: number;
   MAX_BUG_CONTEXT_BYTES: number;
@@ -94,7 +89,6 @@ export const logConfig: LogConfig = {
   BACKOFF_BASE_MS: 1000,
   BACKOFF_MAX_MS: 30 * 60 * 1000, // 30 min
   MAX_RETRY_COUNT: 10,
-  MAX_COMPLETE_ATTEMPTS: 3,
   MAX_EVENT_PAYLOAD_BYTES: 8 * 1024, // 8 KB
   MAX_BUG_CONTEXT_BYTES: 16 * 1024, // 16 KB
   REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,
@@ -123,7 +117,6 @@ export function resetLogConfig(): void {
     BACKOFF_BASE_MS: 1000,
     BACKOFF_MAX_MS: 30 * 60 * 1000,
     MAX_RETRY_COUNT: 10,
-    MAX_COMPLETE_ATTEMPTS: 3,
     MAX_EVENT_PAYLOAD_BYTES: 8 * 1024,
     MAX_BUG_CONTEXT_BYTES: 16 * 1024,
     REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,

--- a/frontend/src/game/_shared/pendingGamesStore.ts
+++ b/frontend/src/game/_shared/pendingGamesStore.ts
@@ -40,11 +40,6 @@ export interface PendingGame {
   completed: boolean;
   completeSummary: CompleteSummary | null;
   completeSynced: boolean;
-  /** How many times PATCH /complete has returned a non-retryable 4xx. Used
-   * to survive deployment-window mismatches where the server temporarily
-   * rejects a valid outcome value. Missing on pre-#519 persisted records —
-   * always read as `game.completeAttempts ?? 0`. */
-  completeAttempts: number;
 }
 
 export class PendingGamesStore {
@@ -103,7 +98,6 @@ export class PendingGamesStore {
       completed: false,
       completeSummary: null,
       completeSynced: false,
-      completeAttempts: 0,
     });
     return this.persist();
   }
@@ -151,16 +145,6 @@ export class PendingGamesStore {
     if (!game || game.startedSynced) return Promise.resolve();
     game.startedSynced = true;
     return this.persist();
-  }
-
-  /** SyncWorker calls this after a non-403 4xx on PATCH /complete.
-   * Increments the attempt counter, persists, and returns the new count. */
-  incrementCompleteAttempts(gameId: string): Promise<number> {
-    const game = this.games.get(gameId);
-    if (!game) return Promise.resolve(0);
-    const next = (game.completeAttempts ?? 0) + 1;
-    game.completeAttempts = next;
-    return this.persist().then(() => next);
   }
 
   /** SyncWorker marks PATCH /complete confirmed. */

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -350,33 +350,23 @@ export class SyncWorker {
         result.deadLettered += 1;
         continue;
       }
-      // 400 (and other non-403 4xx): retryable up to MAX_COMPLETE_ATTEMPTS.
-      // The original #519 Sentry event was a deployment-window mismatch —
-      // the server was running old code that rejected outcome="completed"
-      // before the #514 fix was deployed. Retrying instead of immediately
-      // dead-lettering gives the deployment time to roll out.
-      const attempts = await this.games.incrementCompleteAttempts(gameId);
-      const isFinal = attempts >= logConfig.MAX_COMPLETE_ATTEMPTS;
-      // Only emit a Sentry warning on the final attempt to avoid flooding
-      // the dashboard with per-retry noise during deployment windows (#572).
-      if (isFinal) {
-        Sentry.captureMessage(
-          `syncWorker: ${res.status} on PATCH /complete ${gameId} (dead-lettered)`,
-          {
-            level: "warning",
-            extra: {
-              status: res.status,
-              body: res.body,
-              gameId,
-              sentOutcome: body.outcome,
-              attempt: attempts,
-              maxAttempts: logConfig.MAX_COMPLETE_ATTEMPTS,
-            },
-          }
-        );
-        await this.games.forget(gameId);
-        result.deadLettered += 1;
-      }
+      // 400 (and other non-403 4xx): permanent — dead-letter immediately.
+      // The backend has accepted "completed" in _VALID_OUTCOMES since #514;
+      // a 400 now means a genuine bad request that won't be fixed by retrying.
+      Sentry.captureMessage(
+        `syncWorker: ${res.status} on PATCH /complete ${gameId} (dead-lettered)`,
+        {
+          level: "error",
+          extra: {
+            status: res.status,
+            body: res.body,
+            gameId,
+            sentOutcome: body.outcome,
+          },
+        }
+      );
+      await this.games.forget(gameId);
+      result.deadLettered += 1;
     }
     return true;
   }


### PR DESCRIPTION
## Summary

- `PATCH /games/:id/complete` 400 responses are now **terminal** — the game is dead-lettered immediately rather than retried up to `MAX_COMPLETE_ATTEMPTS`
- Sentry severity upgraded from `warning` (final attempt only) to `error` (immediately)
- Removes `MAX_COMPLETE_ATTEMPTS` config, `completeAttempts` `PendingGame` field, and `incrementCompleteAttempts` store method

## Why

The 3-retry strategy was added in #519 for a deployment-window mismatch where the server temporarily rejected `outcome="completed"` before the #514 fix was deployed. The backend has accepted `"completed"` in `_VALID_OUTCOMES` since #514. A 400 now means a genuine bad request (wrong session, malformed body) that retrying cannot fix — and the existing retry loop was causing 10+ users to silently dead-letter game sessions after 3 noisy Sentry warnings each.

## Test plan

- [ ] `npx jest src/game/_shared/__tests__/syncWorker.test.ts` — all pass (updated tests verify immediate dead-letter + `level:"error"` Sentry)
- [ ] `npx jest src/game/_shared/__tests__/pendingGamesStore.test.ts` — all pass
- [ ] CI green

Closes #572, closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)