### PR TITLE
fix(blackjack): navigate explicitly in New Game confirm (#498)

### DIFF
--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -55,13 +55,15 @@ export default function BlackjackTableScreen({ navigation }: Props) {
       setConfirmNewGameVisible(true);
     } else {
       handlePlayAgain();
+      navigation.replace("BlackjackBetting");
     }
-  }, [currentPhase, handlePlayAgain]);
+  }, [currentPhase, handlePlayAgain, navigation]);
 
   const handleConfirmNewGame = useCallback(() => {
     setConfirmNewGameVisible(false);
     handlePlayAgain();
-  }, [handlePlayAgain]);
+    navigation.replace("BlackjackBetting");
+  }, [handlePlayAgain, navigation]);
 
   const state = engine ? toViewState(engine) : null;
   const isSplit = (state?.player_hands?.length ?? 0) > 1;


### PR DESCRIPTION
## Summary

- `handleConfirmNewGame` (modal confirm) and `handleNewGamePress` (direct press in betting phase) now call `navigation.replace("BlackjackBetting")` immediately after `handlePlayAgain()`, rather than relying on the betting-phase `useEffect` to pick up the engine state change on the next render cycle
- The `useEffect` redirect is still in place for the **Next Hand** flow (`engineNewHand` → betting phase → effect fires → navigate)
- `navigation` added to both `useCallback` dependency arrays

## Why

Issue #498 reports the New Game button occasionally becoming unresponsive. The previous implementation was indirect: `handlePlayAgain()` set engine state, which triggered a re-render, which fired the `useEffect`, which then called `navigation.replace()`. That render-cycle gap is where silent failures can hide. Making the navigation call immediate and explicit eliminates the indirection.

## Test plan

- [ ] Existing `BlackjackTableScreen.test.tsx` — `#498 — new game redirect` test still passes (handlePlayAgain via context → effect path still works for Next Hand)
- [ ] All CI checks green
- [ ] Manual: press New Game mid-hand → confirm modal → navigates to Betting screen immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)