### PR TITLE
docs: add Size Budget section to GAME-CONTRACT.md (#558)

### DIFF
--- a/docs/GAME-CONTRACT.md
+++ b/docs/GAME-CONTRACT.md
@@ -254,8 +254,16 @@ Use this checklist when adding a new game. Each item links to the file to create
 - [ ] **`frontend/src/game/mygame/types.ts`** — per-game state and action types extending `GameSession<TState, TAction>`
 - [ ] **Screen** — uses `GameShell` and `useGameSync`; passes ESLint import zone check
 - [ ] **`noUncheckedIndexedAccess`** clean — no suppression comments
-- [ ] **Size budget gate** — bundle does not exceed the per-game chunk budget (Epic #524 / #558)
 - [ ] **Icon assets are WebP** — any new icons added to `assets/fruit-icons/` or `assets/celestial-icons/` must be converted before committing: `python frontend/scripts/convert_icons_to_webp.py <dir>`. Raw PNGs in non-exempt asset directories will fail CI (`assetTransparency.test.ts`).
+
+### Size Budget
+
+Before merging a new game, verify all four items below. The `android-bundle-check` CI job enforces the hard limit automatically; the remaining items are reviewer responsibilities. See [`docs/PERFORMANCE.md` — JS Bundle Size Guardrail](PERFORMANCE.md#js-bundle-size-guardrail) for full details on the tooling and how to update thresholds.
+
+- [ ] **JS bundle delta ≤ 200 KB** — the `android-bundle-check` PR comment must show Δ ≤ +200 KB vs the 4.5 MB baseline. If exceeded, justify in the PR description with a measurement showing the addition is unavoidable.
+- [ ] **No new PNG assets in `assets/`** — all new icon/image assets must be WebP. Exception: Skia pre-composited textures in `*-baked/` directories (separate pipeline — document the exception explicitly in the PR if used).
+- [ ] **New asset directories audited** — confirm new assets are not accidentally bundled via an unintended import. Check the Metro bundle output (`--assets-dest`) before opening the PR.
+- [ ] **`docs/PERFORMANCE.md` asset inventory updated** — add new directories to the Directory Map table with size, file count, and "Bundled?" column.
 
 ### Validation
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -537,6 +537,8 @@ Commit the update in the same PR as the size-increasing change so reviewers can 
 
 Every pull request receives an automated comment from `android-bundle-check` showing the current bundle size and delta vs the 4.5 MB baseline. No action is needed unless the delta is large or the hard limit is breached.
 
+For new game additions specifically, the reviewer checklist in [`docs/GAME-CONTRACT.md` — Size Budget](GAME-CONTRACT.md#size-budget) requires the delta to stay ≤ 200 KB.
+
 ### WebP icon enforcement
 
 A separate CI gate in `test-frontend` (`assetTransparency.test.ts`) asserts that no raw PNGs exist in non-exempt icon subdirectories under `frontend/assets/`. To convert new PNGs before staging:


### PR DESCRIPTION
## Summary

Closes #558. Part of Epic #524.

- Replaces the placeholder "Size budget gate" bullet in the Frontend checklist with a full **Size Budget** subsection containing the four reviewer checkpoints from the issue spec: JS bundle delta ≤ 200 KB, no new PNG assets, asset directory audit, new directory added to PERFORMANCE.md inventory.
- Adds a cross-reference from `docs/PERFORMANCE.md` → JS Bundle Size Guardrail section back to the GAME-CONTRACT checklist.

Both dependencies are satisfied: #551 (GAME-CONTRACT.md created) and #556/#581 (CI guardrail + bundlesize config in place).

## Test plan

- [ ] Docs-only change — all CI checks pass
- [ ] GAME-CONTRACT.md Size Budget section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)