### PR TITLE
feat(metrics): send cold-start timing to Sentry metrics (#582)

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -74,6 +74,12 @@ jest.mock("@sentry/react-native", () => ({
   wrap: (c: unknown) => c,
   ReactNavigationInstrumentation: jest.fn(),
   ReactNativeTracing: jest.fn(),
+  metrics: {
+    distribution: jest.fn(),
+    increment: jest.fn(),
+    gauge: jest.fn(),
+    set: jest.fn(),
+  },
 }));
 
 // AsyncStorage mock (replaces localStorage in ThemeContext / FruitSetContext)

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { LinearGradient } from "expo-linear-gradient";
+import * as Sentry from "@sentry/react-native";
 import { HomeStackParamList } from "../../App";
 import { newGame as newYachtGame } from "../game/yacht/engine";
 import { loadGame as loadYachtGame } from "../game/yacht/storage";
@@ -37,7 +38,7 @@ export default function HomeScreen() {
   useEffect(() => {
     if (APP_START_MS > 0) {
       const coldStartMs = performance.now() - APP_START_MS;
-      console.log(`[cold-start] HomeScreen ready: ${coldStartMs.toFixed(1)} ms`);
+      Sentry.metrics.distribution("cold_start_ms", coldStartMs, { unit: "millisecond" });
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Adds `import * as Sentry from "@sentry/react-native"` to `HomeScreen.tsx`
- Replaces `console.log` cold-start line with `Sentry.metrics.distribution("cold_start_ms", coldStartMs, { unit: "millisecond" })`
- No `metricsAggregatorIntegration` added to `Sentry.init` — the API doesn't exist in `@sentry/react-native`; the `metrics` object is available via the bundled `@sentry/core@10.37.0` dependency without any extra integration

## Notes
No package upgrade required. `@sentry/react-native@7.11.0` already ships `Sentry.metrics.distribution` through its `@sentry/browser` → `@sentry/core` dependency chain.

## Test plan
- [ ] Build and run on a real device; open Sentry → Metrics → search `cold_start_ms` to confirm measurements appear
- [ ] Verify no regression in cold-start time (metrics flush is async/batched)

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)