### PR TITLE
chore(release): bump app version to 1.0.9 (build 10009)

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -96,8 +96,8 @@ android {
         applicationId 'com.buffingchi.games'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10008
-        versionName "1.0.8"
+        versionCode 10009
+        versionName "1.0.9"
 
         buildConfigField "String", "REACT_NATIVE_RELEASE_LEVEL", "\"${findProperty('reactNativeReleaseLevel') ?: 'stable'}\""
     }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Gaming App",
     "slug": "gaming-app",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -14,7 +14,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.buffingchi.games",
-      "buildNumber": "10008",
+      "buildNumber": "10009",
       "privacyManifests": {
         "NSPrivacyAccessedAPITypes": [
           {

--- a/frontend/ios/GamingApp.xcodeproj/project.pbxproj
+++ b/frontend/ios/GamingApp.xcodeproj/project.pbxproj
@@ -342,7 +342,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 10008;
+				CURRENT_PROJECT_VERSION = 10009;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -354,7 +354,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.8;
+				MARKETING_VERSION = 1.0.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -378,14 +378,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
-				CURRENT_PROJECT_VERSION = 10008;
+				CURRENT_PROJECT_VERSION = 10009;
 				INFOPLIST_FILE = GamingApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.8;
+				MARKETING_VERSION = 1.0.9;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary
- Bump marketing version from `1.0.8` to `1.0.9` and build number from `10008` to `10009` across `app.json`, the iOS Xcode project, and the Android `build.gradle`.

## Test plan
- [ ] Confirm Xcode Cloud iOS build picks up `MARKETING_VERSION = 1.0.9` / `CURRENT_PROJECT_VERSION = 10009`.
- [ ] Confirm Android Gradle build produces `versionName "1.0.9"` / `versionCode 10009`.
- [ ] CI green (android-bundle-check, android-build-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)