### PR TITLE
feat(cascade): migrate leaderboard submission to unified games pipeline (#477)

### DIFF
--- a/backend/cascade/models.py
+++ b/backend/cascade/models.py
@@ -4,19 +4,17 @@ from pydantic import BaseModel, ConfigDict, Field
 class CascadeMetadata(BaseModel):
     """Validated metadata shape for Cascade game rows (#539).
 
-    ``player_name`` is optional here because the generic ``POST /games``
-    endpoint may be called without a name; the Cascade-specific
-    ``POST /cascade/score`` route always supplies it internally.
-    ``extra="forbid"`` rejects unknown keys.
+    ``player_name`` is optional because a game may be created before the
+    player has entered their name; ``PATCH /cascade/score/{game_id}`` sets it
+    after game-over.  ``extra="forbid"`` rejects unknown keys.
     """
 
     model_config = ConfigDict(extra="forbid")
     player_name: str = Field(default="", max_length=64)
 
 
-class ScoreSubmitRequest(BaseModel):
+class SetPlayerNameRequest(BaseModel):
     player_name: str = Field(..., min_length=1, max_length=32)
-    score: int = Field(..., ge=0)
 
 
 class ScoreEntry(BaseModel):

--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -1,31 +1,29 @@
-"""Cascade leaderboard — now backed by the games table (#366).
+"""Cascade leaderboard — backed by the games table (#366, #477).
 
-POST /cascade/score creates and immediately completes a Game row tagged
-with `cascade` and the player name in `game_metadata`. GET /cascade/scores
-queries the top 10 by final_score, joined against the cached `game_types`
-row so we only pay one lookup per query.
-
-The response shape (`ScoreEntry`, `LeaderboardResponse`) is unchanged so the
-frontend scoreSync client needs no updates.
+PATCH /cascade/score/{game_id} sets the player_name on an existing game row
+(created by the SyncWorker via POST /games) and returns the player's rank.
+GET /cascade/scores returns the top 10 scores for the leaderboard display.
 """
 
 from __future__ import annotations
 
+import uuid
+
 from fastapi import APIRouter, HTTPException, Request
-from sqlalchemy import desc, select
+from sqlalchemy import and_, desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_session_factory
 from db.models import Game, GameType
-from limiter import limiter
+from limiter import limiter, session_key
+from session import get_session_id
 from vocab import GameType as GameTypeEnum
 
-from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+from .models import LeaderboardResponse, ScoreEntry, SetPlayerNameRequest
 
 router = APIRouter()
 
 LEADERBOARD_LIMIT = 10
-_CASCADE_SESSION = "cascade-anon"  # placeholder until SSO; rows still rank
 
 
 async def _cascade_game_type_id(db: AsyncSession) -> int:
@@ -65,34 +63,59 @@ async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
     return entries
 
 
-@router.post("/score", response_model=ScoreEntry, status_code=201)
-@limiter.limit("5/minute")
-async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+@router.patch("/score/{game_id}", response_model=ScoreEntry, status_code=200)
+@limiter.limit("10/minute", key_func=session_key)
+async def set_player_name(
+    request: Request, game_id: uuid.UUID, body: SetPlayerNameRequest
+) -> ScoreEntry:
+    sid = get_session_id(request)
     factory = get_session_factory()
     async with factory() as db:
         gt_id = await _cascade_game_type_id(db)
-        # Create + complete in a single commit. We still store the row even if
-        # it won't make the top 10 — matches the previous in-memory behavior
-        # where .rank > LEADERBOARD_LIMIT meant "dropped".
-        from datetime import datetime, timezone
+        game = (
+            await db.execute(
+                select(Game).where(
+                    Game.id == game_id,
+                    Game.session_id == sid,
+                    Game.game_type_id == gt_id,
+                )
+            )
+        ).scalar_one_or_none()
 
-        game = Game(
-            session_id=_CASCADE_SESSION,
-            game_type_id=gt_id,
-            final_score=body.score,
-            completed_at=datetime.now(timezone.utc),
-            game_metadata={"player_name": body.player_name},
-        )
-        db.add(game)
+        if game is None:
+            raise HTTPException(status_code=404, detail="Game not found.")
+
+        metadata = dict(game.game_metadata or {})
+        metadata["player_name"] = body.player_name
+        game.game_metadata = metadata
         await db.commit()
 
-        top = await _top_scores(db)
+        # Rank = 1 + count of games that outrank this one.
+        # Tie-break: equal scores rank older completed_at first (same order as
+        # the leaderboard GET), so a game ranks below existing tied entries.
+        score_val = game.final_score or 0
+        count = (
+            await db.execute(
+                select(func.count()).where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                    or_(
+                        Game.final_score > score_val,
+                        and_(
+                            Game.final_score == score_val,
+                            Game.completed_at < game.completed_at,
+                        ),
+                    ),
+                )
+            )
+        ).scalar()
 
-    for entry in top:
-        if entry.player_name == body.player_name and entry.score == body.score:
-            return entry
-    # Not in top 10 — report the truncated-off rank.
-    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+    rank = int(count or 0) + 1
+    return ScoreEntry(
+        player_name=body.player_name,
+        score=int(game.final_score or 0),
+        rank=rank,
+    )
 
 
 @router.get("/scores", response_model=LeaderboardResponse)
@@ -105,10 +128,9 @@ async def get_scores(request: Request) -> LeaderboardResponse:
 
 
 def reset_leaderboard() -> None:
-    """Test helper — no-op now that the leaderboard lives in the DB.
+    """Test helper — no-op; leaderboard lives in the DB.
 
-    Kept for backward compatibility with the existing
-    `test_cascade_api.py` autouse fixture, which calls it on setup/teardown.
-    The conftest clean_db_tables fixture handles the actual cleanup.
+    Kept for backward compatibility with the autouse fixture in
+    test_cascade_api.py. The conftest clean_db_tables fixture handles cleanup.
     """
     return None

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -1,9 +1,25 @@
+"""Tests for the Cascade leaderboard API (#477).
+
+All leaderboard entries are now created via the unified games pipeline:
+  1. POST /games          → creates the game row (handled by SyncWorker in prod)
+  2. PATCH /games/:id/complete → records final_score
+  3. PATCH /cascade/score/:id  → sets player_name, returns rank
+
+GET /cascade/scores remains unchanged.
+"""
+
+import uuid
+
 import pytest
 from fastapi.testclient import TestClient
+
 import cascade.router as cascade_router_module
 from main import app
 
 client = TestClient(app)
+
+TEST_SESSION = str(uuid.uuid4())
+SESSION_HEADERS = {"X-Session-ID": TEST_SESSION}
 
 
 @pytest.fixture(autouse=True)
@@ -13,39 +29,104 @@ def reset_leaderboard():
     cascade_router_module.reset_leaderboard()
 
 
-def _submit(player_name: str, score: int):
-    return client.post("/cascade/score", json={"player_name": player_name, "score": score})
+def _create_game(session_id: str = TEST_SESSION) -> str:
+    """POST /games and return the new game_id."""
+    res = client.post(
+        "/games",
+        json={"game_type": "cascade"},
+        headers={"X-Session-ID": session_id},
+    )
+    assert res.status_code in (200, 201), res.text
+    return res.json()["id"]
+
+
+def _complete_game(game_id: str, score: int, session_id: str = TEST_SESSION) -> None:
+    """PATCH /games/:id/complete."""
+    from limiter import limiter
+
+    limiter.reset()
+    res = client.patch(
+        f"/games/{game_id}/complete",
+        json={"final_score": score, "outcome": "completed"},
+        headers={"X-Session-ID": session_id},
+    )
+    assert res.status_code == 200, res.text
+
+
+def _set_name(game_id: str, player_name: str, session_id: str = TEST_SESSION):
+    """PATCH /cascade/score/:id — sets player_name, returns ScoreEntry."""
+    return client.patch(
+        f"/cascade/score/{game_id}",
+        json={"player_name": player_name},
+        headers={"X-Session-ID": session_id},
+    )
+
+
+def _submit(player_name: str, score: int, session_id: str = TEST_SESSION):
+    """Create + complete + name a game in one call. Returns the PATCH response."""
+    from limiter import limiter
+
+    limiter.reset()
+    gid = _create_game(session_id)
+    _complete_game(gid, score, session_id)
+    return _set_name(gid, player_name, session_id)
 
 
 # ---------------------------------------------------------------------------
-# POST /cascade/score
+# PATCH /cascade/score/{game_id}
 # ---------------------------------------------------------------------------
 
 
-class TestSubmitScore:
-    def test_valid_submission_returns_201(self):
-        res = _submit("Alice", 500)
-        assert res.status_code == 201
+class TestSetPlayerName:
+    def test_valid_update_returns_200_with_score_entry(self):
+        gid = _create_game()
+        _complete_game(gid, 500)
+        res = _set_name(gid, "Alice")
+        assert res.status_code == 200
         body = res.json()
         assert body["player_name"] == "Alice"
         assert body["score"] == 500
-        assert body["rank"] == 1  # first entry
+        assert body["rank"] == 1
 
     def test_missing_player_name_returns_422(self):
-        res = client.post("/cascade/score", json={"score": 100})
-        assert res.status_code == 422
-
-    def test_missing_score_returns_422(self):
-        res = client.post("/cascade/score", json={"player_name": "Bob"})
+        gid = _create_game()
+        _complete_game(gid, 100)
+        res = client.patch(
+            f"/cascade/score/{gid}",
+            json={},
+            headers=SESSION_HEADERS,
+        )
         assert res.status_code == 422
 
     def test_empty_player_name_returns_422(self):
-        res = _submit("", 100)
+        gid = _create_game()
+        _complete_game(gid, 100)
+        res = _set_name(gid, "")
         assert res.status_code == 422
 
-    def test_negative_score_returns_422(self):
-        res = _submit("Alice", -1)
-        assert res.status_code == 422
+    def test_unknown_game_id_returns_404(self):
+        unknown_id = str(uuid.uuid4())
+        res = _set_name(unknown_id, "Alice")
+        assert res.status_code == 404
+
+    def test_wrong_session_returns_404(self):
+        gid = _create_game(session_id=str(uuid.uuid4()))
+        res = _set_name(gid, "Alice", session_id=str(uuid.uuid4()))
+        assert res.status_code == 404
+
+    def test_missing_session_header_returns_400(self):
+        gid = _create_game()
+        _complete_game(gid, 100)
+        res = client.patch(f"/cascade/score/{gid}", json={"player_name": "Alice"})
+        assert res.status_code == 400
+
+    def test_can_update_player_name_on_already_named_game(self):
+        gid = _create_game()
+        _complete_game(gid, 200)
+        _set_name(gid, "Alice")
+        res = _set_name(gid, "AliceUpdated")
+        assert res.status_code == 200
+        assert res.json()["player_name"] == "AliceUpdated"
 
 
 # ---------------------------------------------------------------------------
@@ -79,11 +160,11 @@ class TestGetScores:
         from limiter import limiter
 
         for i in range(15):
-            limiter.reset()  # bypass rate limit — this test targets cap logic, not limiting
+            limiter.reset()
             _submit(f"Player{i}", i * 10)
         scores = client.get("/cascade/scores").json()["scores"]
         assert len(scores) == 10
-        assert scores[0]["score"] == 140  # top score kept
+        assert scores[0]["score"] == 140
 
 
 # ---------------------------------------------------------------------------
@@ -96,153 +177,114 @@ class TestSubmitRank:
         assert _submit("Alice", 500).json()["rank"] == 1
 
     def test_lower_score_ranked_lower(self):
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 500)
-        limiter.reset()
         body = _submit("Bob", 200).json()
         assert body["rank"] == 2
 
     def test_highest_score_takes_rank_1(self):
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 200)
-        limiter.reset()
         body = _submit("Bob", 500).json()
         assert body["rank"] == 1
 
     def test_middle_insert(self):
-        from limiter import limiter
-
         for name, score in [("A", 500), ("B", 300), ("C", 100)]:
-            limiter.reset()
             _submit(name, score)
-        limiter.reset()
         body = _submit("Middle", 400).json()
-        # 500, 400, 300, 100 → Middle is rank 2
         assert body["rank"] == 2
 
     def test_new_tie_ranks_below_existing(self):
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 500)
-        limiter.reset()
         body = _submit("Tied", 500).json()
-        # Stable sort: older entry stays first, new entry takes rank 2.
         assert body["rank"] == 2
 
     def test_off_leaderboard_returns_rank_11(self):
-        """Submit 10 high scores then an 11th lower one — rank should be 11."""
-        from limiter import limiter
-
         for i in range(10):
-            limiter.reset()
             _submit(f"Top{i}", 1000)
-        limiter.reset()
         body = _submit("Lowly", 1).json()
         assert body["rank"] == 11
 
     def test_middle_insert_renumbers_tail(self):
-        """Inserting into the middle shifts everyone below by one rank."""
-        from limiter import limiter
-
         for name, score in [("A", 500), ("B", 300), ("C", 100)]:
-            limiter.reset()
             _submit(name, score)
-        limiter.reset()
         _submit("Middle", 400)
         scores = client.get("/cascade/scores").json()["scores"]
-        # A@500 rank=1, Middle@400 rank=2, B@300 rank=3, C@100 rank=4
         ranks_by_name = {s["player_name"]: s["rank"] for s in scores}
         assert ranks_by_name == {"A": 1, "Middle": 2, "B": 3, "C": 4}
 
     def test_leaderboard_returns_sequential_ranks(self):
-        from limiter import limiter
-
         for name, score in [("A", 500), ("B", 300), ("C", 100)]:
-            limiter.reset()
             _submit(name, score)
         scores = client.get("/cascade/scores").json()["scores"]
         assert [s["rank"] for s in scores] == [1, 2, 3]
 
 
 # ---------------------------------------------------------------------------
-# Rate limiter (#204)
+# Rate limiter
 # ---------------------------------------------------------------------------
 
 
 class TestRateLimit:
-    def test_sixth_submission_returns_429(self):
-        """POST /cascade/score is limited to 5/minute; 6th call must 429."""
+    def test_eleventh_set_name_returns_429(self):
+        """PATCH /cascade/score/:id is limited to 10/minute per (session, URL).
+
+        slowapi uses URL-based key scoping by default, so the bucket is keyed
+        on (session_id, /cascade/score/<game_id>). We exhaust the limit by
+        calling set_name 11 times on the *same* game ID.
+        """
         from limiter import limiter
 
-        # 5 allowed submissions
-        for i in range(5):
-            res = _submit(f"Player{i}", i * 10)
-            assert res.status_code == 201
+        limiter.reset()
+        gid = _create_game()
+        _complete_game(gid, 100)
+        limiter.reset()
 
-        # 6th should be rate-limited
-        res = _submit("Excess", 999)
+        # First 10 set-name calls on the same game should succeed
+        for i in range(10):
+            res = _set_name(gid, f"Player{i}")
+            assert res.status_code == 200, f"call {i+1} returned {res.status_code}"
+
+        # 11th on the same URL should be rate-limited
+        res = _set_name(gid, "Excess")
         assert res.status_code == 429
 
-        # Cleanup: reset so other tests aren't affected
         limiter.reset()
 
 
 # ---------------------------------------------------------------------------
-# Tie-break ordering (#204)
+# Tie-break ordering
 # ---------------------------------------------------------------------------
 
 
 class TestTieBreak:
     def test_older_score_ranks_higher_on_tie(self):
-        """When two entries share the same score, insertion order decides rank.
-        The first-inserted entry wins (stable sort on score descending)."""
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 100)
-        limiter.reset()
-        body = _submit("Bob", 100).json()
-
+        _submit("Bob", 100)
         scores = client.get("/cascade/scores").json()["scores"]
-        assert scores[0]["player_name"] == "Alice"  # older entry is rank 1
-        assert scores[1]["player_name"] == "Bob"  # newer entry is rank 2
-        assert body["rank"] == 2  # confirmed in submission response too
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"
+
+    def test_new_tie_response_rank_is_2(self):
+        _submit("Alice", 100)
+        body = _submit("Bob", 100).json()
+        assert body["rank"] == 2
 
 
 # ---------------------------------------------------------------------------
-# Duplicate player names (#204)
+# Duplicate player names
 # ---------------------------------------------------------------------------
 
 
 class TestDuplicateNames:
     def test_duplicate_name_both_entries_kept(self):
-        """Policy: append-only. Two submissions from the same name both appear
-        on the leaderboard (neither overwrites the other)."""
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 100)
-        limiter.reset()
         _submit("Alice", 200)
-
         scores = client.get("/cascade/scores").json()["scores"]
         alice_entries = [s for s in scores if s["player_name"] == "Alice"]
         assert len(alice_entries) == 2
 
     def test_duplicate_name_ordered_by_score(self):
-        """Both Alice entries appear, higher score ranked first."""
-        from limiter import limiter
-
-        limiter.reset()
         _submit("Alice", 100)
-        limiter.reset()
         _submit("Alice", 200)
-
         scores = client.get("/cascade/scores").json()["scores"]
         alice_scores = [s["score"] for s in scores if s["player_name"] == "Alice"]
-        assert alice_scores == [200, 100]  # descending
+        assert alice_scores == [200, 100]

--- a/backend/tests/test_cascade_leaderboard_persistence.py
+++ b/backend/tests/test_cascade_leaderboard_persistence.py
@@ -2,16 +2,17 @@
 
 The in-memory leaderboard that preceded #366 lost every score on restart.
 This test exercises the DB-backed replacement by:
-  1. POSTing a score via one TestClient
-  2. Disposing the engine pool (proxy for a process restart — drops all
-     open connections)
+  1. Creating and completing a game via the unified games pipeline
+  2. Disposing the engine pool (proxy for a process restart)
   3. Re-opening a fresh TestClient and asserting the score is still visible
 
-Uses a dedicated SQLite file so autouse clean_db_tables fixture in
+Uses a dedicated SQLite file so the autouse clean_db_tables fixture in
 conftest.py does NOT wipe the row (we disable that fixture for this module).
 """
 
 from __future__ import annotations
+
+import uuid
 
 import pytest
 from fastapi.testclient import TestClient
@@ -19,8 +20,6 @@ from fastapi.testclient import TestClient
 from db.base import get_engine
 
 
-# Disable the autouse table-clearing fixture for this file: the whole point
-# is that data survives across in-process "restarts".
 @pytest.fixture(autouse=True)
 async def _clean_db_tables():
     yield
@@ -29,12 +28,30 @@ async def _clean_db_tables():
 async def test_cascade_score_survives_engine_dispose() -> None:
     from main import app
 
+    sid = str(uuid.uuid4())
+    headers = {"X-Session-ID": sid}
+
     with TestClient(app) as c1:
-        r = c1.post(
-            "/cascade/score",
-            json={"player_name": "PersistenceTester", "score": 4242},
+        # Create game
+        r = c1.post("/games", json={"game_type": "cascade"}, headers=headers)
+        assert r.status_code in (200, 201), r.text
+        game_id = r.json()["id"]
+
+        # Complete with score
+        r = c1.patch(
+            f"/games/{game_id}/complete",
+            json={"final_score": 4242, "outcome": "completed"},
+            headers=headers,
         )
-        assert r.status_code == 201, r.text
+        assert r.status_code == 200, r.text
+
+        # Set player name
+        r = c1.patch(
+            f"/cascade/score/{game_id}",
+            json={"player_name": "PersistenceTester"},
+            headers=headers,
+        )
+        assert r.status_code == 200, r.text
 
     # Proxy for "backend restart" — drop connection pool.
     engine = get_engine()

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -349,13 +349,19 @@ def test_rate_limit_429_has_retry_after(client_default):
 
 @pytest.mark.security
 def test_cascade_score_strict_limit(client_default):
-    """POST /cascade/score has a 5/minute limit."""
+    """PATCH /cascade/score/:id has a 10/minute limit per (session, URL).
+
+    All 11 requests target the same game_id so they share one rate-limit bucket.
+    """
+    fake_id = str(uuid.uuid4())
+    sid = _sid()
     responses = [
-        client_default.post(
-            "/cascade/score",
-            json={"player_name": "tester", "score": i},
+        client_default.patch(
+            f"/cascade/score/{fake_id}",
+            json={"player_name": "tester"},
+            headers={"X-Session-ID": sid},
         )
-        for i in range(7)
+        for _ in range(11)
     ]
     assert any(r.status_code == 429 for r in responses)
 

--- a/e2e/tests/cascade-game-over.spec.ts
+++ b/e2e/tests/cascade-game-over.spec.ts
@@ -18,7 +18,7 @@ import {
 } from "./helpers/cascade";
 
 const API_BASE = "http://localhost:8000";
-const SCORE_ENDPOINT = `${API_BASE}/cascade/score`;
+const SCORE_ENDPOINT_GLOB = `${API_BASE}/cascade/score/**`;
 
 test.describe("Cascade — game-over overlay", () => {
   test.beforeEach(async ({ page }) => {
@@ -70,9 +70,8 @@ test.describe("Cascade — game-over overlay", () => {
   test("Save Score with valid name → shows 'Saved! #1' confirmation", async ({
     page,
   }) => {
-    // Override leaderboard mock for the score POST to return rank 1
-    await page.route(SCORE_ENDPOINT, async (route) => {
-      if (route.request().method() === "POST") {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
+      if (route.request().method() === "PATCH") {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -98,7 +97,7 @@ test.describe("Cascade — game-over overlay", () => {
     page,
   }) => {
     // Delay the response so we can observe the busy state
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await new Promise((r) => setTimeout(r, 800));
       await route.fulfill({
         status: 200,
@@ -128,7 +127,7 @@ test.describe("Cascade — game-over overlay", () => {
   test("fetch TypeError (network down) queues score locally → shows savedLocally text", async ({
     page,
   }) => {
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await route.abort("failed");
     });
 
@@ -150,7 +149,7 @@ test.describe("Cascade — game-over overlay", () => {
   // ---------------------------------------------------------------------------
 
   test("non-2xx response → shows error message", async ({ page }) => {
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await route.fulfill({
         status: 500,
         contentType: "application/json",

--- a/e2e/tests/cascade-leaderboard.spec.ts
+++ b/e2e/tests/cascade-leaderboard.spec.ts
@@ -3,7 +3,7 @@
  *
  * Leaderboard integration: verifies that
  *   1. GET /cascade/scores is fetched when the game screen loads.
- *   2. POST /cascade/score is called with the correct payload when a score is
+ *   2. PATCH /cascade/score/:id is called with the correct payload when a score is
  *      submitted from the game-over overlay.
  *   3. The rank returned by the server is surfaced in the overlay.
  *   4. Rank 1 vs. mid-table ranks both render correctly.
@@ -17,7 +17,7 @@ import { gotoCascade, triggerGameOver } from "./helpers/cascade";
 
 const API_BASE = "http://localhost:8000";
 const SCORES_ENDPOINT = `${API_BASE}/cascade/scores`;
-const SCORE_ENDPOINT = `${API_BASE}/cascade/score`;
+const SCORE_ENDPOINT_GLOB = `${API_BASE}/cascade/score/**`;
 
 test.describe("Cascade — leaderboard API integration", () => {
   // ---------------------------------------------------------------------------
@@ -50,16 +50,16 @@ test.describe("Cascade — leaderboard API integration", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // POST /cascade/score payload and rank display
+  // PATCH /cascade/score/:id payload and rank display
   // ---------------------------------------------------------------------------
 
-  test("submitting a score POSTs the correct payload to /cascade/score", async ({
+  test("submitting a score PATCHes the correct payload to /cascade/score/:id", async ({
     page,
   }) => {
     let capturedBody: Record<string, unknown> | null = null;
 
     await page.route(`${API_BASE}/cascade/**`, async (route) => {
-      if (route.request().method() === "POST") {
+      if (route.request().method() === "PATCH") {
         capturedBody = JSON.parse(route.request().postData() ?? "{}");
         await route.fulfill({
           status: 200,
@@ -89,7 +89,6 @@ test.describe("Cascade — leaderboard API integration", () => {
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!.player_name).toBe("Alice");
-    expect(typeof capturedBody!.score).toBe("number");
   });
 
   // ---------------------------------------------------------------------------
@@ -97,7 +96,7 @@ test.describe("Cascade — leaderboard API integration", () => {
   // ---------------------------------------------------------------------------
 
   test("rank 1 response renders 'Saved! #1'", async ({ page }) => {
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -125,7 +124,7 @@ test.describe("Cascade — leaderboard API integration", () => {
   });
 
   test("rank 42 response renders 'Saved! #42'", async ({ page }) => {
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -159,7 +158,7 @@ test.describe("Cascade — leaderboard API integration", () => {
   test("429 response from server → queues score locally for retry", async ({
     page,
   }) => {
-    await page.route(SCORE_ENDPOINT, async (route) => {
+    await page.route(SCORE_ENDPOINT_GLOB, async (route) => {
       await route.fulfill({
         status: 429,
         contentType: "application/json",
@@ -193,11 +192,11 @@ test.describe("Cascade — leaderboard API integration", () => {
   // ---------------------------------------------------------------------------
 
   test("Save Score button is disabled when name is empty", async ({ page }) => {
-    let postCalled = false;
+    let patchCalled = false;
 
     await page.route(`${API_BASE}/cascade/**`, async (route) => {
-      if (route.request().method() === "POST") {
-        postCalled = true;
+      if (route.request().method() === "PATCH") {
+        patchCalled = true;
       }
       await route.fulfill({
         status: 200,
@@ -216,9 +215,9 @@ test.describe("Cascade — leaderboard API integration", () => {
     const saveBtn = page.getByRole("button", { name: "Save score" });
     await expect(saveBtn).toBeDisabled();
 
-    // Attempt a click anyway — no POST should fire
+    // Attempt a click anyway — no PATCH should fire
     await saveBtn.click({ force: true });
     await expect(saveBtn).toBeDisabled();
-    expect(postCalled).toBe(false);
+    expect(patchCalled).toBe(false);
   });
 });

--- a/frontend/src/components/cascade/GameOverOverlay.tsx
+++ b/frontend/src/components/cascade/GameOverOverlay.tsx
@@ -17,10 +17,11 @@ import { scoreQueue } from "../../game/_shared/scoreQueue";
 
 interface Props {
   score: number;
+  gameId: string | null;
   onRestart: () => void;
 }
 
-export default function GameOverOverlay({ score, onRestart }: Props) {
+export default function GameOverOverlay({ score, gameId, onRestart }: Props) {
   const { t } = useTranslation("cascade");
   const { colors } = useTheme();
   const { isOnline, isInitialized } = useNetwork();
@@ -32,13 +33,17 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
 
   async function handleSubmit() {
     if (!name.trim()) return;
+    if (!gameId) {
+      setError(t("errors:score.save"));
+      return;
+    }
     setSubmitting(true);
     setError(null);
     const playerName = name.trim();
     // If we know we're offline, skip the fetch and queue immediately.
     if (isInitialized && !isOnline) {
       try {
-        await scoreQueue.enqueue("cascade", { player_name: playerName, score });
+        await scoreQueue.enqueue("cascade", { game_id: gameId, player_name: playerName });
         setSavedLocally(true);
       } catch {
         setError(t("errors:score.save"));
@@ -48,7 +53,7 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
       return;
     }
     try {
-      const entry = await cascadeApi.submitScore(playerName, score);
+      const entry = await cascadeApi.submitPlayerName(gameId, playerName);
       setSubmitted(entry);
     } catch (e) {
       // Network/fetch failures (TypeError) and transient server errors (429)
@@ -57,7 +62,7 @@ export default function GameOverOverlay({ score, onRestart }: Props) {
       const isTransient = e instanceof TypeError || (e instanceof ApiError && e.status === 429);
       if (isTransient) {
         try {
-          await scoreQueue.enqueue("cascade", { player_name: playerName, score });
+          await scoreQueue.enqueue("cascade", { game_id: gameId, player_name: playerName });
           setSavedLocally(true);
         } catch {
           setError(t("errors:score.save"));

--- a/frontend/src/components/cascade/__tests__/GameOverOverlay.test.tsx
+++ b/frontend/src/components/cascade/__tests__/GameOverOverlay.test.tsx
@@ -18,7 +18,7 @@ import { scoreQueue } from "../../../game/_shared/scoreQueue";
 
 jest.mock("../../../game/cascade/api", () => ({
   cascadeApi: {
-    submitScore: jest.fn(),
+    submitPlayerName: jest.fn(),
   },
 }));
 
@@ -53,10 +53,12 @@ jest.mock("../../../theme/ThemeContext", () => ({
   }),
 }));
 
-const mockSubmitScore = cascadeApi.submitScore as jest.Mock;
+const mockSubmitPlayerName = cascadeApi.submitPlayerName as jest.Mock;
 
-function renderOverlay(score = 1234, onRestart = jest.fn()) {
-  return render(<GameOverOverlay score={score} onRestart={onRestart} />);
+const GAME_ID = "test-game-id-abc";
+
+function renderOverlay(score = 1234, gameId: string | null = GAME_ID, onRestart = jest.fn()) {
+  return render(<GameOverOverlay score={score} gameId={gameId} onRestart={onRestart} />);
 }
 
 // ---------------------------------------------------------------------------
@@ -65,7 +67,7 @@ function renderOverlay(score = 1234, onRestart = jest.fn()) {
 
 describe("GameOverOverlay", () => {
   beforeEach(() => {
-    mockSubmitScore.mockReset();
+    mockSubmitPlayerName.mockReset();
     mockEnqueue.mockReset();
     mockEnqueue.mockResolvedValue(undefined);
     useNetworkMock.mockReturnValue({ isOnline: true, isInitialized: true });
@@ -80,21 +82,21 @@ describe("GameOverOverlay", () => {
   it("pressing save with no name does not call the API", () => {
     renderOverlay();
     fireEvent.press(screen.getByLabelText("Save score"));
-    expect(mockSubmitScore).not.toHaveBeenCalled();
+    expect(mockSubmitPlayerName).not.toHaveBeenCalled();
   });
 
-  it("pressing save after entering a name calls the API", async () => {
-    mockSubmitScore.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 1 });
+  it("pressing save after entering a name calls the API with gameId and player_name", async () => {
+    mockSubmitPlayerName.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 1 });
     renderOverlay(1234);
     fireEvent.changeText(screen.getByLabelText("Your name"), "Alice");
     fireEvent.press(screen.getByLabelText("Save score"));
-    await waitFor(() => expect(mockSubmitScore).toHaveBeenCalledWith("Alice", 1234));
+    await waitFor(() => expect(mockSubmitPlayerName).toHaveBeenCalledWith(GAME_ID, "Alice"));
   });
 
   it("shows saved confirmation with the leaderboard rank (#2), not the score", async () => {
     // Regression guard for #195: previously the score was displayed where
     // rank belonged ("Saved! #1234" for a score=1234 / rank=2).
-    mockSubmitScore.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 2 });
+    mockSubmitPlayerName.mockResolvedValueOnce({ player_name: "Alice", score: 1234, rank: 2 });
     renderOverlay(1234);
 
     fireEvent.changeText(screen.getByLabelText("Your name"), "Alice");
@@ -103,11 +105,11 @@ describe("GameOverOverlay", () => {
     await waitFor(() => {
       expect(screen.getByText("Saved! #2")).toBeTruthy();
     });
-    expect(mockSubmitScore).toHaveBeenCalledWith("Alice", 1234);
+    expect(mockSubmitPlayerName).toHaveBeenCalledWith(GAME_ID, "Alice");
   });
 
   it("shows error message when submit fails", async () => {
-    mockSubmitScore.mockRejectedValueOnce(new Error("Network error"));
+    mockSubmitPlayerName.mockRejectedValueOnce(new Error("Invalid score"));
     renderOverlay(1234);
 
     fireEvent.changeText(screen.getByLabelText("Your name"), "Bob");
@@ -118,9 +120,19 @@ describe("GameOverOverlay", () => {
     });
   });
 
+  it("shows error when gameId is null", async () => {
+    renderOverlay(1234, null);
+    fireEvent.changeText(screen.getByLabelText("Your name"), "Alice");
+    fireEvent.press(screen.getByLabelText("Save score"));
+    await waitFor(() => {
+      expect(screen.getByText(/Could not save score/i)).toBeTruthy();
+    });
+    expect(mockSubmitPlayerName).not.toHaveBeenCalled();
+  });
+
   it("calls onRestart when Play Again is pressed", () => {
     const onRestart = jest.fn();
-    renderOverlay(100, onRestart);
+    renderOverlay(100, GAME_ID, onRestart);
     fireEvent.press(screen.getByLabelText("Play again"));
     expect(onRestart).toHaveBeenCalledTimes(1);
   });
@@ -134,16 +146,16 @@ describe("GameOverOverlay", () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith("cascade", {
+        game_id: GAME_ID,
         player_name: "Alice",
-        score: 4850,
       });
     });
-    expect(mockSubmitScore).not.toHaveBeenCalled();
+    expect(mockSubmitPlayerName).not.toHaveBeenCalled();
     expect(screen.getByText(/Saved locally/i)).toBeTruthy();
   });
 
   it("queues score when online submit fails with a network error (TypeError)", async () => {
-    mockSubmitScore.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    mockSubmitPlayerName.mockRejectedValueOnce(new TypeError("Failed to fetch"));
     renderOverlay(1234);
 
     fireEvent.changeText(screen.getByLabelText("Your name"), "Bob");
@@ -151,15 +163,15 @@ describe("GameOverOverlay", () => {
 
     await waitFor(() => {
       expect(mockEnqueue).toHaveBeenCalledWith("cascade", {
+        game_id: GAME_ID,
         player_name: "Bob",
-        score: 1234,
       });
     });
     expect(screen.getByText(/Saved locally/i)).toBeTruthy();
   });
 
   it("shows error (no queue) when online submit fails with an app error", async () => {
-    mockSubmitScore.mockRejectedValueOnce(new Error("Invalid score"));
+    mockSubmitPlayerName.mockRejectedValueOnce(new Error("Invalid score"));
     renderOverlay(1234);
 
     fireEvent.changeText(screen.getByLabelText("Your name"), "Bob");

--- a/frontend/src/game/_shared/useGameSync.ts
+++ b/frontend/src/game/_shared/useGameSync.ts
@@ -57,6 +57,8 @@ export interface UseGameSyncReturn {
     message: string,
     context?: Record<string, unknown>
   ) => void;
+  /** Return the current game ID, or null if no session is open. */
+  getGameId: () => string | null;
 }
 
 export function useGameSync(gameType: GameType): UseGameSyncReturn {
@@ -137,5 +139,7 @@ export function useGameSync(gameType: GameType): UseGameSyncReturn {
     []
   );
 
-  return { start, enqueue, complete, restart, reportBug };
+  const getGameId = useCallback(() => gameIdRef.current, []);
+
+  return { start, enqueue, complete, restart, reportBug, getGameId };
 }

--- a/frontend/src/game/cascade/__tests__/api.test.ts
+++ b/frontend/src/game/cascade/__tests__/api.test.ts
@@ -16,21 +16,21 @@ describe("cascadeApi — endpoints", () => {
     } as Response);
   }
 
-  it("submitScore POSTs player_name and score to /cascade/score", async () => {
+  it("submitPlayerName PATCHes player_name to /cascade/score/:gameId", async () => {
     respondWith({ player_name: "Alice", score: 500, rank: 1 });
-    await cascadeApi.submitScore("Alice", 500);
+    await cascadeApi.submitPlayerName("game-abc-123", "Alice");
     expect(mockFetch).toHaveBeenCalledWith(
-      expect.stringContaining("/cascade/score"),
+      expect.stringContaining("/cascade/score/game-abc-123"),
       expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ player_name: "Alice", score: 500 }),
+        method: "PATCH",
+        body: JSON.stringify({ player_name: "Alice" }),
       })
     );
   });
 
-  it("submitScore returns rank from response", async () => {
+  it("submitPlayerName returns rank from response", async () => {
     respondWith({ player_name: "Alice", score: 500, rank: 3 });
-    const entry = await cascadeApi.submitScore("Alice", 500);
+    const entry = await cascadeApi.submitPlayerName("game-abc-123", "Alice");
     expect(entry.rank).toBe(3);
   });
 

--- a/frontend/src/game/cascade/api.ts
+++ b/frontend/src/game/cascade/api.ts
@@ -8,10 +8,10 @@ import { LeaderboardResponse, ScoreEntry } from "./types";
 const request = createGameClient({ apiTag: "cascade" });
 
 export const cascadeApi = {
-  submitScore: (player_name: string, score: number) =>
-    request<ScoreEntry>("/cascade/score", {
-      method: "POST",
-      body: JSON.stringify({ player_name, score }),
+  submitPlayerName: (gameId: string, player_name: string) =>
+    request<ScoreEntry>(`/cascade/score/${gameId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ player_name }),
     }),
 
   getLeaderboard: () => request<LeaderboardResponse>("/cascade/scores"),

--- a/frontend/src/game/cascade/scoreSync.ts
+++ b/frontend/src/game/cascade/scoreSync.ts
@@ -11,13 +11,11 @@ import { PendingSubmission } from "../_shared/types";
 
 export function registerCascadeScoreHandler(): void {
   scoreQueue.registerHandler("cascade", async (item: PendingSubmission) => {
-    const { player_name, score } = item.payload as { player_name: string; score: number };
-    if (typeof player_name !== "string" || typeof score !== "number") {
+    const { game_id, player_name } = item.payload as { game_id: string; player_name: string };
+    if (typeof game_id !== "string" || typeof player_name !== "string") {
       // Malformed payload — drop by "succeeding" (throwing would keep retrying forever).
       return;
     }
-    // Backend idempotency (passing item.id as game_id) is tracked in #155.
-    // For now we submit using the existing contract.
-    await cascadeApi.submitScore(player_name, score);
+    await cascadeApi.submitPlayerName(game_id, player_name);
   });
 }

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -58,7 +58,14 @@ function CascadeGame() {
 
   // Instrumentation session state (#371 / #549). One session spans from mount
   // until handleGameOver, a fruit-set switch, New Game, or unmount.
-  const { start: syncStart, enqueue: syncEnqueue, complete: syncComplete } = useGameSync("cascade");
+  const {
+    start: syncStart,
+    enqueue: syncEnqueue,
+    complete: syncComplete,
+    getGameId,
+  } = useGameSync("cascade");
+  // Holds the game ID captured at game-over so GameOverOverlay can PATCH /cascade/score/{id}.
+  const completedGameIdRef = useRef<string | null>(null);
   const gameStartTimeRef = useRef<number>(Date.now());
   const mergeCountRef = useRef(0);
 
@@ -244,11 +251,13 @@ function CascadeGame() {
     canvasRef.current?.announceEvent(t("cascade:event.gameOver"));
     gameOverRef.current = true;
     setGameOver(true);
+    // Capture game ID before complete() nulls it out — overlay needs it for PATCH /cascade/score/:id.
+    completedGameIdRef.current = getGameId();
     endInstrumentedSession("completed");
     // #216 — game over: clear the saved snapshot so the next mount
     // starts with a fresh board instead of resuming a lost game.
     clearCascadeGame().catch(() => {});
-  }, [t, endInstrumentedSession]);
+  }, [t, endInstrumentedSession, getGameId]);
 
   const handleTap = useCallback(
     (x: number) => {
@@ -452,7 +461,13 @@ function CascadeGame() {
         )}
       </View>
 
-      {gameOver && <GameOverOverlay score={score} onRestart={handleRestart} />}
+      {gameOver && (
+        <GameOverOverlay
+          score={score}
+          gameId={completedGameIdRef.current}
+          onRestart={handleRestart}
+        />
+      )}
 
       <NewGameConfirmModal
         visible={confirmNewGameVisible}

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -335,6 +335,7 @@ function CascadeGame() {
       canvasRef.current?.fastForward?.(ms);
     };
     g.__cascade_triggerGameOver = () => {
+      completedGameIdRef.current = getGameId();
       gameOverRef.current = true;
       setGameOver(true);
     };


### PR DESCRIPTION
## Summary

- Removes `POST /cascade/score` endpoint; adds `PATCH /cascade/score/{game_id}` that sets `player_name` on an existing game row created by the SyncWorker
- `CascadeScreen` captures the game ID from `useGameSync.getGameId()` before `complete()` nulls it, then passes it to `GameOverOverlay` as a prop
- `GameOverOverlay` calls `cascadeApi.submitPlayerName(gameId, playerName)` instead of the old `submitScore(name, score)`; offline queue payload updated to include `game_id`
- `scoreSync.ts` handler updated to read `{ game_id, player_name }` from queue payload
- Rate-limit test fixed: slowapi uses URL-based key scoping by default, so the test now calls the same game ID 11 times to exhaust the per-(session, URL) bucket

## Test plan

- [ ] Backend: `python -m pytest tests/test_cascade_api.py tests/test_cascade_leaderboard_persistence.py tests/test_security.py` — all pass (522 total backend passing)
- [ ] Frontend: `npx jest --no-coverage` — 1060 tests passing
- [ ] E2e: `cascade-leaderboard.spec.ts` updated from `POST /cascade/score` → `PATCH /cascade/score/**`
- [ ] Manual: trigger game over in Cascade, enter name, confirm rank appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)