### PR TITLE
feat(solitaire): leaderboard endpoints — POST /score, GET /scores (#594)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from db.base import DATABASE_URL, get_engine, is_configured
 from limiter import _real_ip, limiter
 from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
+from solitaire.router import router as solitaire_router
 from yacht.router import router as yacht_router
 from games.router import router as games_router
 from logs.router import router as logs_router
@@ -50,6 +51,7 @@ app = FastAPI(title="Gaming App API")
 app.include_router(yacht_router, prefix="/yacht")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
+app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")
 app.include_router(stats_router, prefix="/stats")

--- a/backend/solitaire/models.py
+++ b/backend/solitaire/models.py
@@ -12,3 +12,20 @@ class SolitaireMetadata(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     player_name: str = Field(default="", max_length=64)
+
+
+class ScoreSubmitRequest(BaseModel):
+    player_name: str = Field(..., min_length=1, max_length=32)
+    score: int = Field(..., ge=0)
+
+
+class ScoreEntry(BaseModel):
+    player_name: str
+    score: int
+    # 1-indexed position in the sorted leaderboard. A submit that didn't make
+    # the top 10 will have rank == 11 (the truncated-off position).
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/solitaire/router.py
+++ b/backend/solitaire/router.py
@@ -1,0 +1,111 @@
+"""Solitaire leaderboard (#594) — mirrors the Cascade pattern.
+
+POST /solitaire/score inserts-and-completes a Game row tagged with
+``solitaire`` and the player name in ``game_metadata``.
+GET /solitaire/scores returns the top 10 rows for this game type,
+sorted by ``final_score`` descending (older entries break ties).
+
+The leaderboard is shared across Draw-1 and Draw-3 per epic #591 — the
+router doesn't partition on ``drawMode``. If that ever changes, a draw
+mode would need to be recorded in metadata and filtered here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+_SOLITAIRE_SESSION = "solitaire-anon"  # placeholder until SSO
+
+
+async def _solitaire_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.SOLITAIRE))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="solitaire game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _solitaire_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _solitaire_game_type_id(db)
+        game = Game(
+            session_id=_SOLITAIRE_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    # Not in top 10 — report the truncated-off rank.
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/scores", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. The leaderboard lives in the DB; conftest's
+    ``clean_db_tables`` fixture handles per-test isolation. Kept so the
+    autouse fixture in ``test_solitaire_api.py`` can call it symmetrically
+    with the Cascade tests.
+    """
+    return None

--- a/backend/tests/test_solitaire_api.py
+++ b/backend/tests/test_solitaire_api.py
@@ -1,0 +1,160 @@
+"""Tests for /solitaire/score and /solitaire/scores (#594).
+
+Mirrors ``test_cascade_api.py`` — the Solitaire leaderboard was ported
+from the Cascade pattern. Every behavior we lock in for Cascade (rank
+math, top-10 capping, rate limit, duplicate names) has to hold here
+too.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import solitaire.router as solitaire_router_module
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    solitaire_router_module.reset_leaderboard()
+    yield
+    solitaire_router_module.reset_leaderboard()
+
+
+def _submit(player_name: str, score: int):
+    return client.post("/solitaire/score", json={"player_name": player_name, "score": score})
+
+
+# ---------------------------------------------------------------------------
+# POST /solitaire/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 500)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["score"] == 500
+        assert body["rank"] == 1
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/solitaire/score", json={"score": 100})
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post("/solitaire/score", json={"player_name": "Bob"})
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        res = _submit("", 100)
+        assert res.status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        res = _submit("x" * 33, 100)
+        assert res.status_code == 422
+
+    def test_negative_score_returns_422(self):
+        res = _submit("Alice", -1)
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /solitaire/scores
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/solitaire/scores")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("Alice", 300)
+        _submit("Bob", 100)
+        scores = client.get("/solitaire/scores").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_score_descending(self):
+        _submit("Alice", 100)
+        _submit("Bob", 500)
+        _submit("Carol", 250)
+        scores = client.get("/solitaire/scores").json()["scores"]
+        assert [s["score"] for s in scores] == [500, 250, 100]
+
+    def test_capped_at_ten_entries(self):
+        """An 11th submission must not appear in the returned list."""
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()  # bypass rate limit — this test targets cap logic
+            _submit(f"Player{i}", i * 10)
+        scores = client.get("/solitaire/scores").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["score"] == 140  # top score kept
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 500).json()["rank"] == 1
+
+    def test_lower_score_ranked_lower(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 500)
+        limiter.reset()
+        assert _submit("Bob", 200).json()["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000)
+        limiter.reset()
+        assert _submit("Lowly", 1).json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — POST /solitaire/score is 5/min
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"Player{i}", i * 10).status_code == 201
+
+        assert _submit("Excess", 999).status_code == 429
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)
+        limiter.reset()
+        body = _submit("Bob", 100).json()
+
+        scores = client.get("/solitaire/scores").json()["scores"]
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"
+        assert body["rank"] == 2


### PR DESCRIPTION
## Summary
Part of epic #591 — Klondike Solitaire. Ports the Cascade leaderboard pattern to Solitaire. Started stacked on #626, rebased onto `dev` after #626 merged.

- `backend/solitaire/models.py` — adds `ScoreSubmitRequest` (player_name 1..32, score ≥ 0), `ScoreEntry`, `LeaderboardResponse`
- `backend/solitaire/router.py` — `POST /score` (5/min, 201), `GET /scores` (60/min); shared leaderboard across Draw-1 / Draw-3 per the epic
- `backend/main.py` — mounts router at `/solitaire`
- `backend/tests/test_solitaire_api.py` — 15 tests covering happy path, every validation error (missing/empty name, name too long, missing/negative score), top-10 cap, rank math (including off-leaderboard rank=11), tie-break ordering (older wins), 429 after the 5th POST

## Coverage
`solitaire/` package under the new tests: models 100%, module 89%, router 73%. Same shape as `cascade/router.py` — pytest-cov under-measures slowapi-wrapped async bodies. Global coverage 86.78% (CI threshold: 80%).

## Test plan
- [x] `pytest tests/test_solitaire_api.py` — 15 passed
- [x] `pytest tests/` — 544 passed, 2 skipped (was 529 on `dev` pre-epic)
- [x] `black --check` + `ruff check` clean on new files
- [ ] CI green on this PR

Closes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)