### PR TITLE
feat(solitaire): card components — CardView, TableauPile, FoundationPile, StockWastePile (#595)

### DIFF
--- a/frontend/src/game/solitaire/components/CardView.tsx
+++ b/frontend/src/game/solitaire/components/CardView.tsx
@@ -1,0 +1,146 @@
+/**
+ * Solitaire CardView (#595).
+ *
+ * Stateless visual. Renders a single card in one of three visual states:
+ * face-up (rank + suit symbol, color varies by suit), face-down (solid
+ * placeholder), or selected (accent border — used when tap-to-select is
+ * active). All colors come from `useTheme()`; no hardcoded hex.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View, ViewStyle } from "react-native";
+
+import { useTheme } from "../../../theme/ThemeContext";
+import type { Card, Suit } from "../types";
+import { cardColor } from "../types";
+
+const RANK_LABEL: Record<number, string> = {
+  1: "A",
+  11: "J",
+  12: "Q",
+  13: "K",
+};
+
+const SUIT_SYMBOL: Record<Suit, string> = {
+  spades: "♠",
+  hearts: "♥",
+  diamonds: "♦",
+  clubs: "♣",
+};
+
+const SUIT_NAME: Record<Suit, string> = {
+  spades: "Spades",
+  hearts: "Hearts",
+  diamonds: "Diamonds",
+  clubs: "Clubs",
+};
+
+function rankLabel(rank: number): string {
+  return RANK_LABEL[rank] ?? String(rank);
+}
+
+export interface CardViewProps {
+  /** Card to render. Pass the card's own `faceUp` to control orientation. */
+  readonly card: Card;
+  /** Draws an accent-colored border. Used when the card is tap-selected. */
+  readonly selected?: boolean;
+  /** Optional press handler — when provided, the card is wrapped in a
+   * `Pressable` with `accessibilityRole="button"` instead of the default
+   * `"image"` so screen readers announce it as actionable. */
+  readonly onPress?: () => void;
+}
+
+export default function CardView({ card, selected = false, onPress }: CardViewProps) {
+  const { colors } = useTheme();
+
+  const borderColor = selected ? colors.accent : colors.border;
+  const borderWidth = selected ? 2 : 1;
+  const faceUpBg = colors.surface;
+  const faceDownBg = colors.surfaceAlt;
+
+  const containerStyle: ViewStyle = {
+    ...styles.card,
+    borderColor,
+    borderWidth,
+    backgroundColor: card.faceUp ? faceUpBg : faceDownBg,
+  };
+
+  if (!card.faceUp) {
+    return (
+      <Wrapper
+        onPress={onPress}
+        label={selected ? "Selected face-down card" : "Face-down card"}
+        style={containerStyle}
+      >
+        {null}
+      </Wrapper>
+    );
+  }
+
+  const suitSymbol = SUIT_SYMBOL[card.suit];
+  const rank = rankLabel(card.rank);
+  const textColor = cardColor(card) === "red" ? colors.error : colors.text;
+  const label = `${rank} of ${SUIT_NAME[card.suit]}${selected ? " (selected)" : ""}`;
+
+  return (
+    <Wrapper onPress={onPress} label={label} style={containerStyle}>
+      <Text style={[styles.rank, { color: textColor }]}>{rank}</Text>
+      <Text style={[styles.suit, { color: textColor }]}>{suitSymbol}</Text>
+    </Wrapper>
+  );
+}
+
+/** Chooses between Pressable (when `onPress`) and View — keeps a11y role
+ * semantics correct. */
+function Wrapper({
+  onPress,
+  label,
+  style,
+  children,
+}: {
+  readonly onPress?: () => void;
+  readonly label: string;
+  readonly style: ViewStyle;
+  readonly children: React.ReactNode;
+}) {
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        {children}
+      </Pressable>
+    );
+  }
+  return (
+    <View style={style} accessibilityRole="image" accessibilityLabel={label}>
+      {children}
+    </View>
+  );
+}
+
+export const CARD_WIDTH = 52;
+export const CARD_HEIGHT = 72;
+
+const styles = StyleSheet.create({
+  card: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 2,
+  },
+  rank: {
+    fontSize: 18,
+    fontWeight: "700",
+    lineHeight: 22,
+  },
+  suit: {
+    fontSize: 20,
+    lineHeight: 24,
+  },
+});

--- a/frontend/src/game/solitaire/components/FoundationPile.tsx
+++ b/frontend/src/game/solitaire/components/FoundationPile.tsx
@@ -1,0 +1,105 @@
+/**
+ * FoundationPile (#595) — one of four suit-specific foundation slots.
+ *
+ * Stateless. Shows the top card if the pile is non-empty; otherwise a
+ * placeholder with the expected suit symbol in `colors.textMuted` — this
+ * is how the player identifies which foundation is for which suit.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "../../../theme/ThemeContext";
+import type { Card, Suit } from "../types";
+import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+
+const SUIT_SYMBOL: Record<Suit, string> = {
+  spades: "♠",
+  hearts: "♥",
+  diamonds: "♦",
+  clubs: "♣",
+};
+
+const SUIT_NAME: Record<Suit, string> = {
+  spades: "Spades",
+  hearts: "Hearts",
+  diamonds: "Diamonds",
+  clubs: "Clubs",
+};
+
+export interface FoundationPileProps {
+  readonly pile: readonly Card[];
+  readonly suit: Suit;
+  readonly selected?: boolean;
+  readonly onPress?: (suit: Suit) => void;
+}
+
+export default function FoundationPile({
+  pile,
+  suit,
+  selected = false,
+  onPress,
+}: FoundationPileProps) {
+  const { colors } = useTheme();
+
+  // Non-empty: show the top card (always face-up on foundations).
+  if (pile.length > 0) {
+    const top = pile[pile.length - 1];
+    if (top !== undefined) {
+      return (
+        <CardView
+          card={top}
+          selected={selected}
+          onPress={onPress ? () => onPress(suit) : undefined}
+        />
+      );
+    }
+  }
+
+  // Empty: suit-symbol placeholder.
+  const label = `Empty ${SUIT_NAME[suit]} foundation`;
+  const style = [
+    styles.empty,
+    {
+      borderColor: selected ? colors.accent : colors.border,
+      borderWidth: selected ? 2 : 1,
+      backgroundColor: colors.background,
+    },
+  ];
+
+  const content = (
+    <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={() => onPress(suit)}
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+  return (
+    <View style={style} accessibilityRole="image" accessibilityLabel={label}>
+      {content}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  suit: {
+    fontSize: 32,
+    lineHeight: 36,
+  },
+});

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -1,0 +1,148 @@
+/**
+ * StockWastePile (#595) — the stock and waste piles rendered side by side.
+ *
+ * Stateless. Two callbacks: `onStockPress` drives draw/recycle (the parent
+ * screen decides which), and `onWastePress` selects the top of the waste.
+ * The stock is always face-down; when empty it shows a recycle symbol so
+ * the player knows they can recycle. Waste shows only its top card
+ * face-up (matches tap-target semantics — the player can only play the
+ * top waste card).
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { useTheme } from "../../../theme/ThemeContext";
+import type { Card, DrawMode } from "../types";
+import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+
+export interface StockWastePileProps {
+  readonly stock: readonly Card[];
+  readonly waste: readonly Card[];
+  readonly drawMode: DrawMode;
+  readonly wasteSelected?: boolean;
+  readonly onStockPress?: () => void;
+  readonly onWastePress?: () => void;
+}
+
+export default function StockWastePile({
+  stock,
+  waste,
+  drawMode,
+  wasteSelected = false,
+  onStockPress,
+  onWastePress,
+}: StockWastePileProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.row}>
+      <Stock count={stock.length} colors={colors} onPress={onStockPress} drawMode={drawMode} />
+      <Waste waste={waste} selected={wasteSelected} onPress={onWastePress} />
+    </View>
+  );
+}
+
+function Stock({
+  count,
+  colors,
+  onPress,
+  drawMode,
+}: {
+  readonly count: number;
+  readonly colors: ReturnType<typeof useTheme>["colors"];
+  readonly onPress?: () => void;
+  readonly drawMode: DrawMode;
+}) {
+  const isEmpty = count === 0;
+  const label = isEmpty
+    ? `Recycle waste back to stock (draw ${drawMode})`
+    : `Draw ${drawMode} from stock, ${count} cards remaining`;
+
+  const style = [
+    styles.slot,
+    {
+      backgroundColor: isEmpty ? colors.background : colors.surfaceAlt,
+      borderColor: colors.border,
+      borderWidth: 1,
+      borderStyle: isEmpty ? ("dashed" as const) : ("solid" as const),
+    },
+  ];
+
+  const content = isEmpty ? (
+    <Text style={[styles.recycleSymbol, { color: colors.textMuted }]}>↻</Text>
+  ) : (
+    <>
+      <Text style={[styles.countText, { color: colors.textMuted }]}>{count}</Text>
+    </>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+  return (
+    <View style={style} accessibilityRole="image" accessibilityLabel={label}>
+      {content}
+    </View>
+  );
+}
+
+function Waste({
+  waste,
+  selected,
+  onPress,
+}: {
+  readonly waste: readonly Card[];
+  readonly selected: boolean;
+  readonly onPress?: () => void;
+}) {
+  if (waste.length === 0) {
+    return (
+      <View
+        style={styles.wasteEmpty}
+        accessibilityRole="image"
+        accessibilityLabel="Empty waste pile"
+      />
+    );
+  }
+  const top = waste[waste.length - 1];
+  if (top === undefined) {
+    return null;
+  }
+  return <CardView card={top} selected={selected} onPress={onPress} />;
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  slot: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  wasteEmpty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+  },
+  recycleSymbol: {
+    fontSize: 28,
+    lineHeight: 32,
+  },
+  countText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/frontend/src/game/solitaire/components/TableauPile.tsx
+++ b/frontend/src/game/solitaire/components/TableauPile.tsx
@@ -1,0 +1,108 @@
+/**
+ * TableauPile (#595) — one column of a 7-column Klondike tableau.
+ *
+ * Stateless. Vertically offsets cards so all are visible; empty columns
+ * render a dashed placeholder. Bubbles taps up as `(colIndex, cardIndex)`
+ * so the parent screen can run its tap-to-select state machine.
+ */
+
+import React from "react";
+import { Pressable, StyleSheet, View, ViewStyle } from "react-native";
+
+import { useTheme } from "../../../theme/ThemeContext";
+import type { Card } from "../types";
+import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+
+/** Vertical offset between stacked cards. Face-up cards overlap more
+ * tightly than face-down ones so the rank/suit of each face-up card stays
+ * readable even in long columns. */
+const FACE_UP_OFFSET = 24;
+const FACE_DOWN_OFFSET = 14;
+
+export interface TableauPileProps {
+  readonly pile: readonly Card[];
+  readonly colIndex: number;
+  /** Index of the card that is currently tap-selected in this column, if
+   * any. When the selected card is not at the top of the pile, the entire
+   * sub-run from that index to the end is highlighted — that matches
+   * Klondike's tap-to-select-run semantics. */
+  readonly selectedIndex?: number;
+  readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
+  readonly onEmptyPress?: (colIndex: number) => void;
+}
+
+export default function TableauPile({
+  pile,
+  colIndex,
+  selectedIndex,
+  onCardPress,
+  onEmptyPress,
+}: TableauPileProps) {
+  const { colors } = useTheme();
+
+  if (pile.length === 0) {
+    return (
+      <Pressable
+        onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
+        style={[
+          styles.empty,
+          {
+            borderColor: colors.border,
+            backgroundColor: colors.background,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Empty tableau column ${colIndex + 1}`}
+      />
+    );
+  }
+
+  // Compute cumulative vertical offset so the container height matches the
+  // visible extent of the pile — needed because child absolute positioning
+  // doesn't contribute to layout on web.
+  const offsets: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < pile.length; i++) {
+    offsets.push(acc);
+    const card = pile[i];
+    if (card === undefined) break;
+    acc += card.faceUp ? FACE_UP_OFFSET : FACE_DOWN_OFFSET;
+  }
+  const containerHeight = CARD_HEIGHT + (offsets[pile.length - 1] ?? 0);
+
+  const containerStyle: ViewStyle = {
+    width: CARD_WIDTH,
+    height: containerHeight,
+  };
+
+  return (
+    <View
+      style={containerStyle}
+      accessibilityLabel={`Tableau column ${colIndex + 1}, ${pile.length} cards`}
+    >
+      {pile.map((card, cardIndex) => {
+        const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
+        const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
+        return (
+          <View key={cardIndex} style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}>
+            <CardView card={card} selected={isSelected} onPress={handlePress} />
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: "dashed",
+  },
+  cardSlot: {
+    position: "absolute",
+    left: 0,
+  },
+});

--- a/frontend/src/game/solitaire/components/__tests__/CardView.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/CardView.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../../theme/ThemeContext";
+import type { Card } from "../../types";
+import CardView from "../CardView";
+
+function withTheme(children: React.ReactNode) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function c(overrides: Partial<Card> = {}): Card {
+  return { suit: "spades", rank: 1, faceUp: true, ...overrides };
+}
+
+describe("CardView", () => {
+  it("renders rank and suit for a face-up spade ace", () => {
+    const { getByText } = render(withTheme(<CardView card={c()} />));
+    expect(getByText("A")).toBeTruthy();
+    expect(getByText("♠")).toBeTruthy();
+  });
+
+  it("renders J/Q/K labels for royals", () => {
+    const { getByText: getJ } = render(withTheme(<CardView card={c({ rank: 11 })} />));
+    expect(getJ("J")).toBeTruthy();
+    const { getByText: getQ } = render(withTheme(<CardView card={c({ rank: 12 })} />));
+    expect(getQ("Q")).toBeTruthy();
+    const { getByText: getK } = render(withTheme(<CardView card={c({ rank: 13 })} />));
+    expect(getK("K")).toBeTruthy();
+  });
+
+  it("renders numeric labels for 2-10", () => {
+    const { getByText } = render(withTheme(<CardView card={c({ rank: 7 })} />));
+    expect(getByText("7")).toBeTruthy();
+  });
+
+  it("renders no rank/suit text when face-down", () => {
+    const { queryByText } = render(withTheme(<CardView card={c({ faceUp: false, rank: 5 })} />));
+    expect(queryByText("5")).toBeNull();
+    expect(queryByText("♠")).toBeNull();
+  });
+
+  it("has an accessibility label describing the face-up card", () => {
+    const { getByLabelText } = render(
+      withTheme(<CardView card={c({ rank: 13, suit: "hearts" })} />)
+    );
+    expect(getByLabelText(/K of Hearts/)).toBeTruthy();
+  });
+
+  it("labels a face-down card as such", () => {
+    const { getByLabelText } = render(withTheme(<CardView card={c({ faceUp: false })} />));
+    expect(getByLabelText(/face-down/i)).toBeTruthy();
+  });
+
+  it("annotates 'selected' in the label when selected", () => {
+    const { getByLabelText } = render(withTheme(<CardView card={c()} selected />));
+    expect(getByLabelText(/\(selected\)/)).toBeTruthy();
+  });
+
+  it("fires onPress when tapped", () => {
+    const onPress = jest.fn();
+    const { getByRole } = render(withTheme(<CardView card={c()} onPress={onPress} />));
+    fireEvent.press(getByRole("button"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not register a button role when no onPress is provided", () => {
+    const { queryByRole } = render(withTheme(<CardView card={c()} />));
+    expect(queryByRole("button")).toBeNull();
+  });
+});

--- a/frontend/src/game/solitaire/components/__tests__/FoundationPile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/FoundationPile.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../../theme/ThemeContext";
+import type { Card } from "../../types";
+import FoundationPile from "../FoundationPile";
+
+function withTheme(children: React.ReactNode) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function card(rank: number): Card {
+  return { suit: "hearts", rank: rank as Card["rank"], faceUp: true };
+}
+
+describe("FoundationPile", () => {
+  it("renders a suit-symbol placeholder when empty", () => {
+    const { getByText, getByLabelText } = render(
+      withTheme(<FoundationPile pile={[]} suit="diamonds" />)
+    );
+    expect(getByText("♦")).toBeTruthy();
+    expect(getByLabelText(/Empty Diamonds foundation/)).toBeTruthy();
+  });
+
+  it("fires onPress with the suit when the empty placeholder is tapped", () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = render(
+      withTheme(<FoundationPile pile={[]} suit="clubs" onPress={onPress} />)
+    );
+    fireEvent.press(getByLabelText(/Empty Clubs foundation/));
+    expect(onPress).toHaveBeenCalledWith("clubs");
+  });
+
+  it("renders the top card when the pile is non-empty", () => {
+    const pile = [card(1), card(2), card(3)];
+    const { getByText } = render(withTheme(<FoundationPile pile={pile} suit="hearts" />));
+    // Top card is 3♥
+    expect(getByText("3")).toBeTruthy();
+    expect(getByText("♥")).toBeTruthy();
+  });
+
+  it("fires onPress with the suit when the top card is tapped", () => {
+    const onPress = jest.fn();
+    const pile = [card(1), card(2)];
+    const { getByRole } = render(
+      withTheme(<FoundationPile pile={pile} suit="hearts" onPress={onPress} />)
+    );
+    fireEvent.press(getByRole("button"));
+    expect(onPress).toHaveBeenCalledWith("hearts");
+  });
+});

--- a/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../../theme/ThemeContext";
+import type { Card } from "../../types";
+import StockWastePile from "../StockWastePile";
+
+function withTheme(children: React.ReactNode) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function card(rank: number): Card {
+  return { suit: "spades", rank: rank as Card["rank"], faceUp: true };
+}
+
+describe("StockWastePile", () => {
+  it("shows the remaining stock count and the waste top card", () => {
+    const stock = [card(1), card(2), card(3), card(4), card(5)];
+    const waste = [card(6), card(7)];
+    const { getByText, getByLabelText } = render(
+      withTheme(<StockWastePile stock={stock} waste={waste} drawMode={1} />)
+    );
+    expect(getByText("5")).toBeTruthy(); // stock count
+    expect(getByLabelText(/Draw 1 from stock, 5 cards remaining/)).toBeTruthy();
+    expect(getByText("7")).toBeTruthy(); // waste top rank
+  });
+
+  it("shows the recycle symbol when stock is empty and labels the action accordingly", () => {
+    const { getByText, getByLabelText } = render(
+      withTheme(<StockWastePile stock={[]} waste={[card(1)]} drawMode={3} />)
+    );
+    expect(getByText("↻")).toBeTruthy();
+    expect(getByLabelText(/Recycle waste back to stock \(draw 3\)/)).toBeTruthy();
+  });
+
+  it("fires onStockPress when the stock is tapped", () => {
+    const onStockPress = jest.fn();
+    const { getByLabelText } = render(
+      withTheme(
+        <StockWastePile stock={[card(1)]} waste={[]} drawMode={1} onStockPress={onStockPress} />
+      )
+    );
+    fireEvent.press(getByLabelText(/Draw 1 from stock/));
+    expect(onStockPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onWastePress when the waste top is tapped", () => {
+    const onWastePress = jest.fn();
+    const { getByRole } = render(
+      withTheme(
+        <StockWastePile
+          stock={[card(1)]}
+          waste={[card(7)]}
+          drawMode={1}
+          onWastePress={onWastePress}
+        />
+      )
+    );
+    // Two buttons rendered: stock (no onStockPress => View, not button) and
+    // waste (onWastePress => button). So there should be exactly one button.
+    fireEvent.press(getByRole("button"));
+    expect(onWastePress).toHaveBeenCalledTimes(1);
+  });
+
+  it("labels the waste as empty when the waste pile is empty", () => {
+    const { getByLabelText } = render(
+      withTheme(<StockWastePile stock={[card(1)]} waste={[]} drawMode={1} />)
+    );
+    expect(getByLabelText(/Empty waste pile/)).toBeTruthy();
+  });
+});

--- a/frontend/src/game/solitaire/components/__tests__/TableauPile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/TableauPile.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../../theme/ThemeContext";
+import type { Card, Rank, Suit } from "../../types";
+import TableauPile from "../TableauPile";
+
+function withTheme(children: React.ReactNode) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+function card(suit: Suit, rank: Rank, faceUp = true): Card {
+  return { suit, rank, faceUp };
+}
+
+describe("TableauPile", () => {
+  it("renders a dashed placeholder when the column is empty", () => {
+    const { getByLabelText } = render(withTheme(<TableauPile pile={[]} colIndex={0} />));
+    expect(getByLabelText(/Empty tableau column 1/)).toBeTruthy();
+  });
+
+  it("fires onEmptyPress when the empty placeholder is tapped", () => {
+    const onEmptyPress = jest.fn();
+    const { getByLabelText } = render(
+      withTheme(<TableauPile pile={[]} colIndex={2} onEmptyPress={onEmptyPress} />)
+    );
+    fireEvent.press(getByLabelText(/Empty tableau column 3/));
+    expect(onEmptyPress).toHaveBeenCalledWith(2);
+  });
+
+  it("renders every card in the pile and exposes the pile-size label", () => {
+    const pile = [card("spades", 5, false), card("hearts", 6), card("clubs", 5)];
+    const { getByText, getByLabelText } = render(
+      withTheme(<TableauPile pile={pile} colIndex={1} />)
+    );
+    // Face-up cards contribute their rank text; the face-down one does not.
+    expect(getByText("6")).toBeTruthy();
+    expect(getByText("5")).toBeTruthy(); // clubs 5 (top)
+    expect(getByLabelText(/Tableau column 2, 3 cards/)).toBeTruthy();
+  });
+
+  it("fires onCardPress with (colIndex, cardIndex) when a card is tapped", () => {
+    const onCardPress = jest.fn();
+    const pile = [card("spades", 1), card("hearts", 2)];
+    const { getAllByRole } = render(
+      withTheme(<TableauPile pile={pile} colIndex={4} onCardPress={onCardPress} />)
+    );
+    const buttons = getAllByRole("button");
+    fireEvent.press(buttons[1]!); // second card (index 1)
+    expect(onCardPress).toHaveBeenCalledWith(4, 1);
+  });
+
+  it("highlights the selected card and every card stacked on top of it", () => {
+    const pile = [card("spades", 5), card("hearts", 4), card("clubs", 3)];
+    const { getAllByLabelText } = render(
+      withTheme(<TableauPile pile={pile} colIndex={0} selectedIndex={1} />)
+    );
+    // Index 0 not selected; indices 1 and 2 are.
+    const selectedLabels = getAllByLabelText(/\(selected\)/);
+    expect(selectedLabels).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
Part of epic #591. Stateless card components — zero game logic. Every tap bubbles up via a callback so the screen (#596) can drive its tap-to-select state machine. Theme tokens only; WCAG AA roles + labels everywhere.

- **CardView** — face-up (rank + suit; red suits in `colors.error`), face-down (`colors.surfaceAlt` fill + faint `colors.border` outline), selected (`colors.accent` border). Renders as `Pressable` with `accessibilityRole="button"` when `onPress` is provided, else `accessibilityRole="image"`.
- **TableauPile** — vertically fans cards (tighter overlap for face-down vs face-up so readable ranks stay visible). Empty column = dashed placeholder. `onCardPress(colIndex, cardIndex)` + selecting a card highlights that card and every card stacked on top.
- **FoundationPile** — top card when non-empty; otherwise a suit-symbol placeholder in `colors.textMuted`. `onPress(suit)`.
- **StockWastePile** — stock count badge; empty stock shows `↻` glyph and relabels to "Recycle". Waste renders only its top card face-up. `onStockPress` + `onWastePress`.

## Acceptance criteria
- [x] Render without error on web (no RN-only APIs without platform guards — uses only core `View` / `Text` / `Pressable`)
- [x] 23 tests pass (render, a11y labels, callback wiring, empty/partial/full states)
- [x] WCAG 2.2 AA: every interactive element has an `accessibilityLabel` and `accessibilityRole`
- [x] Zero hardcoded hex — all colors via `useTheme()`

Accessibility strings are English-only for now; the full i18n pass with `solitaire.json` translations lands in #598.

## Test plan
- [x] `npx jest src/game/solitaire/components/` — 23 passed
- [x] `npx prettier --check` + `eslint` — clean
- [x] `tsc --noEmit` — no solitaire errors
- [ ] CI green

Closes #595.

🤖 Generated with [Claude Code](https://claude.com/claude-code)