### PR TITLE
feat(hearts): backend foundation — GameType, module, migration (#603)

### DIFF
--- a/backend/alembic/versions/0008_add_hearts_game_type.py
+++ b/backend/alembic/versions/0008_add_hearts_game_type.py
@@ -1,0 +1,49 @@
+"""add hearts to game_types lookup table (#603)
+
+Revision ID: 0008_add_hearts_game_type
+Revises: 0007_add_solitaire_game_type
+Create Date: 2026-04-19
+
+Part of Epic #602 — Hearts. Seeds the DB row so the
+GameType.HEARTS enum member stays in sync with the game_types lookup
+table. The per-game module lives in backend/hearts/.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0008_add_hearts_game_type"
+down_revision: Union[str, None] = "0007_add_solitaire_game_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    game_types = sa.table(
+        "game_types",
+        sa.column("id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("icon_emoji", sa.Text),
+        sa.column("sort_order", sa.SmallInteger),
+        sa.column("is_active", sa.Boolean),
+    )
+    op.bulk_insert(
+        game_types,
+        [
+            {
+                "id": 7,
+                "name": "hearts",
+                "display_name": "Hearts",
+                "icon_emoji": "♥️",
+                "sort_order": 70,
+                "is_active": True,
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM game_types WHERE name = 'hearts'")

--- a/backend/games/registry.py
+++ b/backend/games/registry.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from blackjack.module import module as blackjack_module
 from cascade.module import module as cascade_module
+from hearts.module import module as hearts_module
 from solitaire.module import module as solitaire_module
 
 from games.protocol import GameModule
@@ -19,6 +20,7 @@ from games.protocol import GameModule
 _REGISTRY: dict[str, GameModule] = {
     blackjack_module.game_type.value: blackjack_module,
     cascade_module.game_type.value: cascade_module,
+    hearts_module.game_type.value: hearts_module,
     solitaire_module.game_type.value: solitaire_module,
 }
 

--- a/backend/hearts/models.py
+++ b/backend/hearts/models.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class HeartsMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    player_name: str = Field(default="", max_length=64)
+
+
+class ScoreSubmitRequest(BaseModel):
+    player_name: str = Field(..., min_length=1, max_length=32)
+    score: int = Field(..., ge=0)
+
+
+class ScoreEntry(BaseModel):
+    player_name: str
+    score: int
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/hearts/module.py
+++ b/backend/hearts/module.py
@@ -1,0 +1,23 @@
+"""Hearts GameModule descriptor (#603).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from hearts.models import HeartsMetadata
+from vocab import GameType
+
+
+class HeartsModule:
+    """GameModule implementation for Hearts."""
+
+    game_type = GameType.HEARTS
+    metadata_model = HeartsMetadata
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = HeartsModule()

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0007_add_solitaire_game_type"
+        assert version == "0008_add_hearts_game_type"

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -33,7 +33,7 @@ async def test_seed_data_present() -> None:
     factory = get_session_factory()
     async with factory() as s:
         gt_names = (await s.execute(select(GameType.name).order_by(GameType.id))).scalars().all()
-        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade", "solitaire"]
+        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts"]
 
         total = (await s.execute(select(func.count()).select_from(EventType))).scalar_one()
         assert total >= 17

--- a/backend/tests/test_game_metadata.py
+++ b/backend/tests/test_game_metadata.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from blackjack.models import BlackjackMetadata
 from cascade.models import CascadeMetadata
 from games.schemas import CreateGameRequest
+from hearts.models import HeartsMetadata
 from solitaire.models import SolitaireMetadata
 
 # ---------------------------------------------------------------------------
@@ -74,6 +75,30 @@ def test_solitaire_metadata_player_name_too_long() -> None:
 def test_solitaire_metadata_rejects_unknown_field() -> None:
     with pytest.raises(ValidationError):
         SolitaireMetadata.model_validate({"score": 9999})
+
+
+# ---------------------------------------------------------------------------
+# HeartsMetadata unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_hearts_metadata_empty_dict_valid() -> None:
+    HeartsMetadata.model_validate({})
+
+
+def test_hearts_metadata_player_name_valid() -> None:
+    m = HeartsMetadata.model_validate({"player_name": "Alice"})
+    assert m.player_name == "Alice"
+
+
+def test_hearts_metadata_player_name_too_long() -> None:
+    with pytest.raises(ValidationError):
+        HeartsMetadata.model_validate({"player_name": "x" * 65})
+
+
+def test_hearts_metadata_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        HeartsMetadata.model_validate({"score": 9999})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_game_module_protocol.py
+++ b/backend/tests/test_game_module_protocol.py
@@ -8,6 +8,7 @@ from blackjack.module import module as blackjack_module
 from cascade.module import module as cascade_module
 from games.protocol import GameModule
 from games.registry import get_module
+from hearts.module import module as hearts_module
 from solitaire.module import module as solitaire_module
 from vocab import GameType
 
@@ -18,8 +19,8 @@ from vocab import GameType
 
 @pytest.mark.parametrize(
     "mod",
-    [blackjack_module, cascade_module, solitaire_module],
-    ids=["blackjack", "cascade", "solitaire"],
+    [blackjack_module, cascade_module, hearts_module, solitaire_module],
+    ids=["blackjack", "cascade", "hearts", "solitaire"],
 )
 def test_module_satisfies_protocol(mod) -> None:
     assert isinstance(mod, GameModule), f"{mod!r} does not satisfy the GameModule Protocol"
@@ -37,6 +38,10 @@ def test_solitaire_module_game_type() -> None:
     assert solitaire_module.game_type == GameType.SOLITAIRE
 
 
+def test_hearts_module_game_type() -> None:
+    assert hearts_module.game_type == GameType.HEARTS
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -45,6 +50,7 @@ def test_solitaire_module_game_type() -> None:
 def test_registry_returns_correct_modules() -> None:
     assert get_module("blackjack") is blackjack_module
     assert get_module("cascade") is cascade_module
+    assert get_module("hearts") is hearts_module
     assert get_module("solitaire") is solitaire_module
 
 
@@ -140,4 +146,29 @@ def test_solitaire_stats_shape_preserves_aggregate_fields() -> None:
 
 def test_solitaire_stats_shape_strips_latest_score() -> None:
     shaped = solitaire_module.stats_shape(_RAW_SOLITAIRE)
+    assert "latest_score" not in shaped
+
+
+# ---------------------------------------------------------------------------
+# HeartsModule.stats_shape — pass-through, strips latest_score
+# ---------------------------------------------------------------------------
+
+_RAW_HEARTS = {
+    "played": 7,
+    "best": 95,
+    "avg": 72.0,
+    "last_played_at": None,
+    "latest_score": 80,
+}
+
+
+def test_hearts_stats_shape_preserves_aggregate_fields() -> None:
+    shaped = hearts_module.stats_shape(_RAW_HEARTS)
+    assert shaped["played"] == 7
+    assert shaped["best"] == 95
+    assert shaped["avg"] == 72.0
+
+
+def test_hearts_stats_shape_strips_latest_score() -> None:
+    shaped = hearts_module.stats_shape(_RAW_HEARTS)
     assert "latest_score" not in shaped

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -65,7 +65,7 @@ def test_game_outcome_ts_in_sync() -> None:
 
 def test_game_type_enum_values() -> None:
     """Regression guard — no value should be silently removed from GameType."""
-    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire"}
+    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts"}
     assert {v.value for v in GameType} == expected
 
 

--- a/backend/vocab.py
+++ b/backend/vocab.py
@@ -34,6 +34,7 @@ class GameType(str, Enum):
     BLACKJACK = "blackjack"
     CASCADE = "cascade"
     SOLITAIRE = "solitaire"
+    HEARTS = "hearts"
 
 
 class GameOutcome(str, Enum):

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -9,7 +9,14 @@
  * drifts from the Python enums (GameType, GameOutcome).
  */
 
-export const GAME_TYPES = ["yacht", "twenty48", "blackjack", "cascade", "solitaire"] as const;
+export const GAME_TYPES = [
+  "yacht",
+  "twenty48",
+  "blackjack",
+  "cascade",
+  "solitaire",
+  "hearts",
+] as const;
 
 export type GameType = (typeof GAME_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- Adds `GameType.HEARTS = "hearts"` to `backend/vocab.py`
- Creates `backend/hearts/` package with `HeartsMetadata` and `HeartsModule` (satisfies `GameModule` protocol)
- Alembic migration `0008_add_hearts_game_type` inserts the `hearts` row into `game_types`
- Registers `hearts_module` in `backend/games/registry.py`
- Regenerates `frontend/src/api/vocab.ts` with `"hearts"` added to `GAME_TYPES`
- Updates all affected tests: `test_vocab`, `test_game_metadata`, `test_game_module_protocol`, `test_db_connection`, `test_db_schema`

Closes #603. Part of Epic #602.

## Test plan
- [ ] `test_game_metadata` — 4 new HeartsMetadata tests (valid payload, name too long, unknown field)
- [ ] `test_game_module_protocol` — Hearts added to parametrized protocol conformance test; game_type and stats_shape tests added
- [ ] `test_vocab` — regression guard updated; TS sync tests pass
- [ ] `test_db_connection` / `test_db_schema` — alembic head and seed data assertions updated
- [ ] All existing backend tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)