### PR TITLE
feat(hearts): FE engine — types, state machine, rules, scoring, moon detection (#604)

### DIFF
--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -38,7 +38,12 @@ function c(suit: Suit, rank: Rank): Card {
 }
 
 /** Build a 4-player hands array, defaulting missing slots to []. */
-function h4(p0: Card[] = [], p1: Card[] = [], p2: Card[] = [], p3: Card[] = []): readonly (readonly Card[])[] {
+function h4(
+  p0: Card[] = [],
+  p1: Card[] = [],
+  p2: Card[] = [],
+  p3: Card[] = []
+): readonly (readonly Card[])[] {
   return [p0, p1, p2, p3];
 }
 
@@ -150,7 +155,14 @@ describe("commitPass — left", () => {
     // Give each player a club 2 so find2ClubsHolder can locate it, and extra cards
     const hands = [
       [...p0Cards, c("clubs", 2), c("clubs", 7), c("clubs", 8), c("clubs", 9), c("clubs", 10)],
-      [...p1Cards, c("clubs", 11), c("clubs", 12), c("clubs", 13), c("diamonds", 4), c("diamonds", 5)],
+      [
+        ...p1Cards,
+        c("clubs", 11),
+        c("clubs", 12),
+        c("clubs", 13),
+        c("diamonds", 4),
+        c("diamonds", 5),
+      ],
       [...p2Cards, c("hearts", 4), c("hearts", 5), c("hearts", 6), c("hearts", 7), c("hearts", 8)],
       [...p3Cards, c("spades", 4), c("spades", 5), c("spades", 6), c("spades", 7), c("spades", 8)],
     ] as Card[][];
@@ -225,7 +237,7 @@ describe("commitPass — none", () => {
   it("skips exchange and transitions to playing", () => {
     const hands = [
       [c("clubs", 3), c("clubs", 4), c("clubs", 5)],
-      [c("clubs", 2), c("clubs", 6), c("clubs", 7)],  // p1 has 2♣
+      [c("clubs", 2), c("clubs", 6), c("clubs", 7)], // p1 has 2♣
       [c("clubs", 8), c("clubs", 9), c("clubs", 10)],
       [c("clubs", 11), c("clubs", 12), c("clubs", 13)],
     ] as Card[][];
@@ -412,7 +424,7 @@ describe("trick resolution", () => {
     // P2 should win
     const hands = [
       [c("spades", 5), c("clubs", 2)],
-      [c("hearts", 1), c("clubs", 3)],      // void in spades
+      [c("hearts", 1), c("clubs", 3)], // void in spades
       [c("spades", 10), c("clubs", 4)],
       [c("spades", 3), c("clubs", 5)],
     ] as Card[][];
@@ -459,8 +471,8 @@ describe("trick resolution", () => {
 
   it("Q♠ awards 13 points to the trick winner", () => {
     const hands = [
-      [c("spades", 13), c("clubs", 2)],     // p0 leads K♠
-      [c("spades", 12), c("clubs", 3)],     // p1 plays Q♠
+      [c("spades", 13), c("clubs", 2)], // p0 leads K♠
+      [c("spades", 12), c("clubs", 3)], // p1 plays Q♠
       [c("spades", 3), c("clubs", 4)],
       [c("spades", 4), c("clubs", 5)],
     ] as Card[][];
@@ -487,32 +499,18 @@ describe("trick resolution", () => {
 
 describe("detectMoon", () => {
   it("returns player index when they took all 13 hearts and Q♠", () => {
-    const allHearts = Array.from({ length: 13 }, (_, i) =>
-      c("hearts", (i + 1) as Rank)
-    );
-    const wonCards = [
-      [...allHearts, c("spades", 12)],
-      [],
-      [],
-      [],
-    ];
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const wonCards = [[...allHearts, c("spades", 12)], [], [], []];
     expect(detectMoon(wonCards)).toBe(0);
   });
 
   it("returns null when hearts are split", () => {
-    const wonCards = [
-      [c("hearts", 1), c("hearts", 2), c("spades", 12)],
-      [c("hearts", 3)],
-      [],
-      [],
-    ];
+    const wonCards = [[c("hearts", 1), c("hearts", 2), c("spades", 12)], [c("hearts", 3)], [], []];
     expect(detectMoon(wonCards)).toBe(null);
   });
 
   it("returns null when Q♠ is missing", () => {
-    const allHearts = Array.from({ length: 13 }, (_, i) =>
-      c("hearts", (i + 1) as Rank)
-    );
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
     const wonCards = [allHearts, [], [], []];
     expect(detectMoon(wonCards)).toBe(null);
   });
@@ -528,9 +526,7 @@ describe("detectMoon", () => {
 
 describe("applyHandScoring — normal", () => {
   it("adds handScores to cumulativeScores", () => {
-    const allHearts = Array.from({ length: 13 }, (_, i) =>
-      c("hearts", (i + 1) as Rank)
-    );
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
     const state = mkState({
       phase: "hand_end",
       handScores: [10, 8, 5, 3],
@@ -550,25 +546,18 @@ describe("applyHandScoring — normal", () => {
 
 describe("applyHandScoring — moon shot", () => {
   it("shooter gets 0 pts added; everyone else gets +26", () => {
-    const allHearts = Array.from({ length: 13 }, (_, i) =>
-      c("hearts", (i + 1) as Rank)
-    );
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
     const state = mkState({
       phase: "hand_end",
       handScores: [26, 0, 0, 0],
       cumulativeScores: [10, 20, 30, 40],
-      wonCards: [
-        [...allHearts, c("spades", 12)],
-        [],
-        [],
-        [],
-      ],
+      wonCards: [[...allHearts, c("spades", 12)], [], [], []],
     });
     const next = applyHandScoring(state);
-    expect(next.cumulativeScores[0]).toBe(10);  // shooter unchanged
-    expect(next.cumulativeScores[1]).toBe(46);  // +26
-    expect(next.cumulativeScores[2]).toBe(56);  // +26
-    expect(next.cumulativeScores[3]).toBe(66);  // +26
+    expect(next.cumulativeScores[0]).toBe(10); // shooter unchanged
+    expect(next.cumulativeScores[1]).toBe(46); // +26
+    expect(next.cumulativeScores[2]).toBe(56); // +26
+    expect(next.cumulativeScores[3]).toBe(66); // +26
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -1,0 +1,664 @@
+/**
+ * Hearts engine unit tests (#604).
+ *
+ * Covers all acceptance criteria from the issue:
+ *   - Deal: 52 unique cards, 13 per player
+ *   - Pass exchange: correct direction (left/right/across), none skips exchange
+ *   - getValidPlays: first-trick restriction, suit-following, void freedom, hearts-locked
+ *   - Trick winner: highest of led suit wins regardless of discards
+ *   - heartsBroken set when heart discarded
+ *   - Moon detection: true when all 26 pts taken, false otherwise
+ *   - Moon scoring: shooter gets 0, others +26
+ *   - isGameOver: triggers at exactly ≥ 100
+ *   - getWinner: returns lowest-score player
+ */
+
+import {
+  applyHandScoring,
+  commitPass,
+  dealGame,
+  dealNextHand,
+  detectMoon,
+  getPassDirection,
+  getValidPlays,
+  isGameOver,
+  getWinner,
+  playCard,
+  selectPassCard,
+  setRng,
+} from "../engine";
+import type { Card, HeartsState, Suit, Rank } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function c(suit: Suit, rank: Rank): Card {
+  return { suit, rank };
+}
+
+/** Build a 4-player hands array, defaulting missing slots to []. */
+function h4(p0: Card[] = [], p1: Card[] = [], p2: Card[] = [], p3: Card[] = []): readonly (readonly Card[])[] {
+  return [p0, p1, p2, p3];
+}
+
+function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
+  return {
+    _v: 1,
+    phase: "playing",
+    handNumber: 1,
+    passDirection: "left",
+    playerHands: [[], [], [], []],
+    cumulativeScores: [0, 0, 0, 0],
+    handScores: [0, 0, 0, 0],
+    passSelections: [[], [], [], []],
+    passingComplete: true,
+    currentTrick: [],
+    currentLeaderIndex: 0,
+    currentPlayerIndex: 0,
+    wonCards: [[], [], [], []],
+    heartsBroken: false,
+    tricksPlayedInHand: 0,
+    isComplete: false,
+    winnerIndex: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  setRng(Math.random);
+});
+
+// ---------------------------------------------------------------------------
+// dealGame
+// ---------------------------------------------------------------------------
+
+describe("dealGame", () => {
+  it("deals 52 unique cards across 4 players with 13 each", () => {
+    const state = dealGame();
+    const allCards = state.playerHands.flatMap((h) => h);
+    expect(allCards).toHaveLength(52);
+    const ids = new Set(allCards.map((c) => `${c.suit}-${c.rank}`));
+    expect(ids.size).toBe(52);
+    state.playerHands.forEach((hand) => expect(hand).toHaveLength(13));
+  });
+
+  it("starts in passing phase for hand 1 (left direction)", () => {
+    const state = dealGame();
+    expect(state.phase).toBe("passing");
+    expect(state.passDirection).toBe("left");
+    expect(state.handNumber).toBe(1);
+  });
+
+  it("initialises cumulative scores to zero", () => {
+    const state = dealGame();
+    expect(state.cumulativeScores).toEqual([0, 0, 0, 0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPassDirection
+// ---------------------------------------------------------------------------
+
+describe("getPassDirection", () => {
+  it("returns left for hand 1", () => expect(getPassDirection(1)).toBe("left"));
+  it("returns right for hand 2", () => expect(getPassDirection(2)).toBe("right"));
+  it("returns across for hand 3", () => expect(getPassDirection(3)).toBe("across"));
+  it("returns none for hand 4", () => expect(getPassDirection(4)).toBe("none"));
+  it("cycles correctly for hand 5", () => expect(getPassDirection(5)).toBe("left"));
+  it("cycles correctly for hand 8", () => expect(getPassDirection(8)).toBe("none"));
+});
+
+// ---------------------------------------------------------------------------
+// selectPassCard
+// ---------------------------------------------------------------------------
+
+describe("selectPassCard", () => {
+  it("adds a card to the selection", () => {
+    const hand = [c("spades", 1), c("hearts", 2), c("clubs", 3)];
+    const state = mkState({ playerHands: h4(hand), passSelections: [[], [], [], []] });
+    const next = selectPassCard(state, 0, c("spades", 1));
+    expect(next.passSelections[0]).toHaveLength(1);
+  });
+
+  it("removes a card already selected (toggle)", () => {
+    const card = c("spades", 1);
+    const state = mkState({ passSelections: [[card], [], [], []] });
+    const next = selectPassCard(state, 0, card);
+    expect(next.passSelections[0]).toHaveLength(0);
+  });
+
+  it("does not add a 4th card", () => {
+    const sel = [c("spades", 1), c("hearts", 2), c("clubs", 3)];
+    const state = mkState({ passSelections: [sel, [], [], []] });
+    const next = selectPassCard(state, 0, c("diamonds", 4));
+    expect(next.passSelections[0]).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commitPass
+// ---------------------------------------------------------------------------
+
+describe("commitPass — left", () => {
+  it("player 0's cards go to player 1, player 1's to 2, etc.", () => {
+    const p0Cards = [c("spades", 1), c("spades", 2), c("spades", 3)];
+    const p1Cards = [c("hearts", 1), c("hearts", 2), c("hearts", 3)];
+    const p2Cards = [c("diamonds", 1), c("diamonds", 2), c("diamonds", 3)];
+    const p3Cards = [c("clubs", 4), c("clubs", 5), c("clubs", 6)];
+
+    // Give each player a club 2 so find2ClubsHolder can locate it, and extra cards
+    const hands = [
+      [...p0Cards, c("clubs", 2), c("clubs", 7), c("clubs", 8), c("clubs", 9), c("clubs", 10)],
+      [...p1Cards, c("clubs", 11), c("clubs", 12), c("clubs", 13), c("diamonds", 4), c("diamonds", 5)],
+      [...p2Cards, c("hearts", 4), c("hearts", 5), c("hearts", 6), c("hearts", 7), c("hearts", 8)],
+      [...p3Cards, c("spades", 4), c("spades", 5), c("spades", 6), c("spades", 7), c("spades", 8)],
+    ] as Card[][];
+
+    const state = mkState({
+      phase: "passing",
+      passDirection: "left",
+      playerHands: hands,
+      passSelections: [p0Cards, p1Cards, p2Cards, p3Cards],
+    });
+
+    const next = commitPass(state);
+    expect(next.phase).toBe("playing");
+    // p0's cards went to p1
+    p0Cards.forEach((card) => expect(next.playerHands[1]).toContainEqual(card));
+    // p1's cards went to p2
+    p1Cards.forEach((card) => expect(next.playerHands[2]).toContainEqual(card));
+    // p2's cards went to p3
+    p2Cards.forEach((card) => expect(next.playerHands[3]).toContainEqual(card));
+    // p3's cards went to p0
+    p3Cards.forEach((card) => expect(next.playerHands[0]).toContainEqual(card));
+  });
+});
+
+describe("commitPass — right", () => {
+  it("player 0's cards go to player 3", () => {
+    const p0Cards = [c("spades", 1), c("spades", 2), c("spades", 3)];
+    const others = [
+      [c("clubs", 2), c("clubs", 7), c("clubs", 8)],
+      [c("hearts", 1), c("hearts", 2), c("hearts", 3)],
+      [c("diamonds", 1), c("diamonds", 2), c("diamonds", 3)],
+    ] as Card[][];
+    const state = mkState({
+      passDirection: "right",
+      playerHands: [
+        [...p0Cards, c("clubs", 9), c("clubs", 10)],
+        [...others[0]!, c("clubs", 11), c("clubs", 12)],
+        [...others[1]!, c("clubs", 13), c("diamonds", 4)],
+        [...others[2]!, c("diamonds", 5), c("diamonds", 6)],
+      ],
+      passSelections: [p0Cards, others[0]!, others[1]!, others[2]!],
+    });
+    const next = commitPass(state);
+    p0Cards.forEach((card) => expect(next.playerHands[3]).toContainEqual(card));
+  });
+});
+
+describe("commitPass — across", () => {
+  it("player 0's cards go to player 2", () => {
+    const p0Cards = [c("spades", 1), c("spades", 2), c("spades", 3)];
+    const others = [
+      [c("clubs", 2), c("clubs", 7), c("clubs", 8)],
+      [c("hearts", 1), c("hearts", 2), c("hearts", 3)],
+      [c("diamonds", 1), c("diamonds", 2), c("diamonds", 3)],
+    ] as Card[][];
+    const state = mkState({
+      passDirection: "across",
+      playerHands: [
+        [...p0Cards, c("clubs", 9), c("clubs", 10)],
+        [...others[0]!, c("clubs", 11), c("clubs", 12)],
+        [...others[1]!, c("clubs", 13), c("diamonds", 4)],
+        [...others[2]!, c("diamonds", 5), c("diamonds", 6)],
+      ],
+      passSelections: [p0Cards, others[0]!, others[1]!, others[2]!],
+    });
+    const next = commitPass(state);
+    p0Cards.forEach((card) => expect(next.playerHands[2]).toContainEqual(card));
+  });
+});
+
+describe("commitPass — none", () => {
+  it("skips exchange and transitions to playing", () => {
+    const hands = [
+      [c("clubs", 3), c("clubs", 4), c("clubs", 5)],
+      [c("clubs", 2), c("clubs", 6), c("clubs", 7)],  // p1 has 2♣
+      [c("clubs", 8), c("clubs", 9), c("clubs", 10)],
+      [c("clubs", 11), c("clubs", 12), c("clubs", 13)],
+    ] as Card[][];
+    const state = mkState({
+      passDirection: "none",
+      playerHands: hands,
+      passSelections: [[], [], [], []],
+    });
+    const next = commitPass(state);
+    expect(next.phase).toBe("playing");
+    expect(next.currentLeaderIndex).toBe(1);
+    // Hands unchanged
+    hands.forEach((hand, i) => {
+      hand.forEach((card) => expect(next.playerHands[i]).toContainEqual(card));
+    });
+  });
+
+  it("throws if selection is missing on a non-none hand", () => {
+    const state = mkState({ passDirection: "left", passSelections: [[], [], [], []] });
+    expect(() => commitPass(state)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getValidPlays
+// ---------------------------------------------------------------------------
+
+describe("getValidPlays — first trick", () => {
+  it("leader can only play 2♣", () => {
+    const hand = [c("clubs", 2), c("spades", 1), c("hearts", 3)];
+    const state = mkState({ playerHands: h4(hand), tricksPlayedInHand: 0 });
+    expect(getValidPlays(state, 0)).toEqual([c("clubs", 2)]);
+  });
+
+  it("follower with clubs must follow suit", () => {
+    const hand = [c("clubs", 5), c("hearts", 3), c("spades", 1)];
+    const state = mkState({
+      playerHands: h4([], hand),
+      tricksPlayedInHand: 0,
+      currentTrick: [{ card: c("clubs", 2), playerIndex: 0 }],
+    });
+    expect(getValidPlays(state, 1)).toEqual([c("clubs", 5)]);
+  });
+
+  it("follower void in clubs cannot play hearts or Q♠", () => {
+    const hand = [c("hearts", 1), c("spades", 12), c("spades", 1), c("diamonds", 5)];
+    const state = mkState({
+      playerHands: h4([], hand),
+      tricksPlayedInHand: 0,
+      currentTrick: [{ card: c("clubs", 2), playerIndex: 0 }],
+    });
+    const valid = getValidPlays(state, 1);
+    expect(valid).not.toContainEqual(c("hearts", 1));
+    expect(valid).not.toContainEqual(c("spades", 12));
+    expect(valid).toContainEqual(c("spades", 1));
+    expect(valid).toContainEqual(c("diamonds", 5));
+  });
+
+  it("follower void in clubs with only hearts/Q♠ may play anything", () => {
+    const hand = [c("hearts", 1), c("hearts", 2), c("spades", 12)];
+    const state = mkState({
+      playerHands: h4([], hand),
+      tricksPlayedInHand: 0,
+      currentTrick: [{ card: c("clubs", 2), playerIndex: 0 }],
+    });
+    expect(getValidPlays(state, 1)).toHaveLength(3);
+  });
+});
+
+describe("getValidPlays — later tricks", () => {
+  it("must follow led suit when holding it", () => {
+    const hand = [c("spades", 5), c("spades", 7), c("hearts", 3)];
+    const state = mkState({
+      playerHands: h4([], hand),
+      tricksPlayedInHand: 1,
+      currentTrick: [{ card: c("spades", 2), playerIndex: 0 }],
+    });
+    const valid = getValidPlays(state, 1);
+    expect(valid).toHaveLength(2);
+    valid.forEach((c) => expect(c.suit).toBe("spades"));
+  });
+
+  it("void in led suit may play any card", () => {
+    const hand = [c("hearts", 1), c("clubs", 3), c("diamonds", 7)];
+    const state = mkState({
+      playerHands: h4([], hand),
+      tricksPlayedInHand: 1,
+      currentTrick: [{ card: c("spades", 2), playerIndex: 0 }],
+    });
+    expect(getValidPlays(state, 1)).toHaveLength(3);
+  });
+
+  it("cannot lead hearts before they are broken", () => {
+    const hand = [c("hearts", 1), c("hearts", 2), c("clubs", 5)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 1,
+      heartsBroken: false,
+    });
+    const valid = getValidPlays(state, 0);
+    expect(valid).not.toContainEqual(c("hearts", 1));
+    expect(valid).toContainEqual(c("clubs", 5));
+  });
+
+  it("can lead hearts once broken", () => {
+    const hand = [c("hearts", 1), c("clubs", 5)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+    });
+    expect(getValidPlays(state, 0)).toHaveLength(2);
+  });
+
+  it("can lead hearts even if not broken when hand is all hearts", () => {
+    const hand = [c("hearts", 1), c("hearts", 2), c("hearts", 3)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 3,
+      heartsBroken: false,
+    });
+    expect(getValidPlays(state, 0)).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// playCard
+// ---------------------------------------------------------------------------
+
+describe("playCard", () => {
+  it("removes card from hand and adds to trick", () => {
+    const hand = [c("clubs", 2), c("clubs", 5)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 0,
+    });
+    const next = playCard(state, 0, c("clubs", 2));
+    expect(next.playerHands[0]).not.toContainEqual(c("clubs", 2));
+    expect(next.currentTrick).toHaveLength(1);
+    expect(next.currentTrick[0]?.card).toEqual(c("clubs", 2));
+  });
+
+  it("throws on invalid play", () => {
+    const hand = [c("clubs", 2)];
+    const state = mkState({ playerHands: h4(hand), tricksPlayedInHand: 0 });
+    expect(() => playCard(state, 0, c("hearts", 5))).toThrow();
+  });
+
+  it("sets heartsBroken when a heart is played", () => {
+    const hand = [c("hearts", 5), c("clubs", 3)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 1,
+      heartsBroken: false,
+      currentTrick: [
+        { card: c("hearts", 2), playerIndex: 3 },
+        { card: c("hearts", 3), playerIndex: 1 },
+        { card: c("hearts", 4), playerIndex: 2 },
+      ],
+    });
+    const next = playCard(state, 0, c("hearts", 5));
+    expect(next.heartsBroken).toBe(true);
+  });
+
+  it("does not set heartsBroken for non-heart cards", () => {
+    const hand = [c("clubs", 2), c("clubs", 5)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 0,
+      heartsBroken: false,
+    });
+    const next = playCard(state, 0, c("clubs", 2));
+    expect(next.heartsBroken).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trick resolution
+// ---------------------------------------------------------------------------
+
+describe("trick resolution", () => {
+  it("highest card of led suit wins (discards ignored)", () => {
+    // P0 leads spades 5; P1 discards hearts ace; P2 plays spades 10; P3 plays spades 3
+    // P2 should win
+    const hands = [
+      [c("spades", 5), c("clubs", 2)],
+      [c("hearts", 1), c("clubs", 3)],      // void in spades
+      [c("spades", 10), c("clubs", 4)],
+      [c("spades", 3), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 5));
+    state = playCard(state, 1, c("hearts", 1));
+    state = playCard(state, 2, c("spades", 10));
+    state = playCard(state, 3, c("spades", 3));
+
+    expect(state.currentLeaderIndex).toBe(2);
+    expect(state.wonCards[2]).toContainEqual(c("spades", 10));
+    expect(state.currentTrick).toHaveLength(0);
+  });
+
+  it("awards trick points to winner's handScores", () => {
+    const hands = [
+      [c("spades", 5), c("clubs", 2)],
+      [c("hearts", 1), c("clubs", 3)],
+      [c("spades", 10), c("clubs", 4)],
+      [c("spades", 3), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 5));
+    state = playCard(state, 1, c("hearts", 1));
+    state = playCard(state, 2, c("spades", 10));
+    state = playCard(state, 3, c("spades", 3));
+
+    // P2 won the heart (1 pt)
+    expect(state.handScores[2]).toBe(1);
+    expect(state.handScores[0]).toBe(0);
+  });
+
+  it("Q♠ awards 13 points to the trick winner", () => {
+    const hands = [
+      [c("spades", 13), c("clubs", 2)],     // p0 leads K♠
+      [c("spades", 12), c("clubs", 3)],     // p1 plays Q♠
+      [c("spades", 3), c("clubs", 4)],
+      [c("spades", 4), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 13));
+    state = playCard(state, 1, c("spades", 12));
+    state = playCard(state, 2, c("spades", 3));
+    state = playCard(state, 3, c("spades", 4));
+
+    // P0 led K♠ and won (K > Q)
+    expect(state.handScores[0]).toBe(13);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectMoon
+// ---------------------------------------------------------------------------
+
+describe("detectMoon", () => {
+  it("returns player index when they took all 13 hearts and Q♠", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) =>
+      c("hearts", (i + 1) as Rank)
+    );
+    const wonCards = [
+      [...allHearts, c("spades", 12)],
+      [],
+      [],
+      [],
+    ];
+    expect(detectMoon(wonCards)).toBe(0);
+  });
+
+  it("returns null when hearts are split", () => {
+    const wonCards = [
+      [c("hearts", 1), c("hearts", 2), c("spades", 12)],
+      [c("hearts", 3)],
+      [],
+      [],
+    ];
+    expect(detectMoon(wonCards)).toBe(null);
+  });
+
+  it("returns null when Q♠ is missing", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) =>
+      c("hearts", (i + 1) as Rank)
+    );
+    const wonCards = [allHearts, [], [], []];
+    expect(detectMoon(wonCards)).toBe(null);
+  });
+
+  it("returns null for an empty wonCards state", () => {
+    expect(detectMoon([[], [], [], []])).toBe(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyHandScoring
+// ---------------------------------------------------------------------------
+
+describe("applyHandScoring — normal", () => {
+  it("adds handScores to cumulativeScores", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) =>
+      c("hearts", (i + 1) as Rank)
+    );
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [10, 8, 5, 3],
+      cumulativeScores: [20, 15, 10, 5],
+      wonCards: [
+        [c("hearts", 1), c("hearts", 2)],
+        [c("hearts", 3), c("spades", 12)],
+        [c("hearts", 4), c("hearts", 5)],
+        allHearts.slice(5),
+      ],
+    });
+    const next = applyHandScoring(state);
+    expect(next.cumulativeScores).toEqual([30, 23, 15, 8]);
+    expect(next.phase).toBe("dealing");
+  });
+});
+
+describe("applyHandScoring — moon shot", () => {
+  it("shooter gets 0 pts added; everyone else gets +26", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) =>
+      c("hearts", (i + 1) as Rank)
+    );
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [26, 0, 0, 0],
+      cumulativeScores: [10, 20, 30, 40],
+      wonCards: [
+        [...allHearts, c("spades", 12)],
+        [],
+        [],
+        [],
+      ],
+    });
+    const next = applyHandScoring(state);
+    expect(next.cumulativeScores[0]).toBe(10);  // shooter unchanged
+    expect(next.cumulativeScores[1]).toBe(46);  // +26
+    expect(next.cumulativeScores[2]).toBe(56);  // +26
+    expect(next.cumulativeScores[3]).toBe(66);  // +26
+  });
+});
+
+describe("applyHandScoring — game over", () => {
+  it("transitions to game_over when any score reaches 100", () => {
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [30, 0, 0, 0],
+      cumulativeScores: [80, 20, 10, 5],
+      wonCards: [[], [], [], []],
+    });
+    const next = applyHandScoring(state);
+    expect(next.phase).toBe("game_over");
+    expect(next.isComplete).toBe(true);
+  });
+
+  it("picks the winner correctly on game over", () => {
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [30, 0, 0, 0],
+      cumulativeScores: [80, 20, 10, 5],
+      wonCards: [[], [], [], []],
+    });
+    const next = applyHandScoring(state);
+    expect(next.winnerIndex).toBe(3); // lowest cumulative (5+0)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGameOver
+// ---------------------------------------------------------------------------
+
+describe("isGameOver", () => {
+  it("returns false when all scores are below 100", () => {
+    expect(isGameOver([99, 50, 30, 10])).toBe(false);
+  });
+
+  it("returns true when exactly one score is 100", () => {
+    expect(isGameOver([100, 50, 30, 10])).toBe(true);
+  });
+
+  it("returns true when a score exceeds 100", () => {
+    expect(isGameOver([120, 50, 30, 10])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWinner
+// ---------------------------------------------------------------------------
+
+describe("getWinner", () => {
+  it("returns the index of the lowest score", () => {
+    expect(getWinner([80, 60, 40, 20])).toBe(3);
+  });
+
+  it("returns lowest index on a tie", () => {
+    expect(getWinner([20, 20, 50, 80])).toBe(0);
+  });
+
+  it("handles a single minimum score anywhere", () => {
+    expect(getWinner([100, 90, 5, 80])).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dealNextHand
+// ---------------------------------------------------------------------------
+
+describe("dealNextHand", () => {
+  it("preserves cumulative scores and increments handNumber", () => {
+    const state = mkState({ cumulativeScores: [10, 20, 30, 40], handNumber: 1, phase: "dealing" });
+    const next = dealNextHand(state);
+    expect(next.cumulativeScores).toEqual([10, 20, 30, 40]);
+    expect(next.handNumber).toBe(2);
+  });
+
+  it("resets hand state for the new hand", () => {
+    const state = mkState({ handScores: [10, 5, 3, 8], tricksPlayedInHand: 13, phase: "dealing" });
+    const next = dealNextHand(state);
+    expect(next.handScores).toEqual([0, 0, 0, 0]);
+    expect(next.tricksPlayedInHand).toBe(0);
+    expect(next.heartsBroken).toBe(false);
+  });
+
+  it("deals 52 unique cards with 13 per player", () => {
+    const state = mkState({ phase: "dealing", handNumber: 1 });
+    const next = dealNextHand(state);
+    const allCards = next.playerHands.flatMap((h) => h);
+    expect(allCards).toHaveLength(52);
+    const ids = new Set(allCards.map((c) => `${c.suit}-${c.rank}`));
+    expect(ids.size).toBe(52);
+  });
+});

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -1,0 +1,420 @@
+/**
+ * Hearts engine (#604).
+ *
+ * Pure TypeScript. No React, AsyncStorage, HTTP, timers, or other
+ * side-effect imports. The UI replaces the entire HeartsState object
+ * on each transition — state is immutable.
+ */
+
+import type { Card, HeartsState, PassDirection, Rank, Suit, TrickCard } from "./types";
+import { RANKS, SUITS } from "./types";
+
+// ---------------------------------------------------------------------------
+// Seedable RNG — tests can pin shuffles via setRng(createSeededRng(seed)).
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deck helpers
+// ---------------------------------------------------------------------------
+
+function createDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ suit, rank });
+    }
+  }
+  return deck;
+}
+
+function shuffle<T>(arr: readonly T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(_rng() * (i + 1));
+    const tmp = a[i]!;
+    a[i] = a[j]!;
+    a[j] = tmp;
+  }
+  return a;
+}
+
+function dealHands(): readonly (readonly Card[])[] {
+  const deck = shuffle(createDeck());
+  return [
+    deck.slice(0, 13),
+    deck.slice(13, 26),
+    deck.slice(26, 39),
+    deck.slice(39, 52),
+  ];
+}
+
+function cardEquals(a: Card, b: Card): boolean {
+  return a.suit === b.suit && a.rank === b.rank;
+}
+
+function isQueenOfSpades(c: Card): boolean {
+  return c.suit === "spades" && c.rank === 12;
+}
+
+function find2ClubsHolder(hands: readonly (readonly Card[])[]): number {
+  for (let i = 0; i < hands.length; i++) {
+    if (hands[i]?.some((c) => c.suit === "clubs" && c.rank === 2)) return i;
+  }
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the pass direction for a given 1-based hand number.
+ * Cycle: left → right → across → none → repeat.
+ */
+export function getPassDirection(handNumber: number): PassDirection {
+  const dirs: readonly PassDirection[] = ["left", "right", "across", "none"];
+  return dirs[(handNumber - 1) % 4]!;
+}
+
+/** Initial game state for a fresh game (hand 1). */
+export function dealGame(): HeartsState {
+  const hands = dealHands();
+  const passDirection = getPassDirection(1);
+  const leaderIndex = passDirection === "none" ? find2ClubsHolder(hands) : 0;
+  return {
+    _v: 1,
+    phase: passDirection === "none" ? "playing" : "passing",
+    handNumber: 1,
+    passDirection,
+    playerHands: hands,
+    cumulativeScores: [0, 0, 0, 0],
+    handScores: [0, 0, 0, 0],
+    passSelections: [[], [], [], []],
+    passingComplete: false,
+    currentTrick: [],
+    currentLeaderIndex: leaderIndex,
+    currentPlayerIndex: leaderIndex,
+    wonCards: [[], [], [], []],
+    heartsBroken: false,
+    tricksPlayedInHand: 0,
+    isComplete: false,
+    winnerIndex: null,
+  };
+}
+
+/**
+ * Deal a new hand in an ongoing game (preserves cumulativeScores).
+ * Called from the "dealing" phase to transition to "passing"/"playing".
+ */
+export function dealNextHand(state: HeartsState): HeartsState {
+  const handNumber = state.handNumber + 1;
+  const passDirection = getPassDirection(handNumber);
+  const hands = dealHands();
+  const leaderIndex = passDirection === "none" ? find2ClubsHolder(hands) : 0;
+  return {
+    ...state,
+    phase: passDirection === "none" ? "playing" : "passing",
+    handNumber,
+    passDirection,
+    playerHands: hands,
+    handScores: [0, 0, 0, 0],
+    passSelections: [[], [], [], []],
+    passingComplete: false,
+    currentTrick: [],
+    currentLeaderIndex: leaderIndex,
+    currentPlayerIndex: leaderIndex,
+    wonCards: [[], [], [], []],
+    heartsBroken: false,
+    tricksPlayedInHand: 0,
+  };
+}
+
+/**
+ * Toggle a card in/out of a player's pass selection (max 3).
+ * Does nothing if the card is not in the player's hand or 3 are already selected
+ * and the card is not already selected.
+ */
+export function selectPassCard(
+  state: HeartsState,
+  playerIndex: number,
+  card: Card
+): HeartsState {
+  const current = [...(state.passSelections[playerIndex] ?? [])];
+  const existingIdx = current.findIndex((c) => cardEquals(c, card));
+  if (existingIdx >= 0) {
+    current.splice(existingIdx, 1);
+  } else if (current.length < 3) {
+    current.push(card);
+  }
+  const newSelections = state.passSelections.map((s, i) =>
+    i === playerIndex ? current : [...s]
+  );
+  return { ...state, passSelections: newSelections };
+}
+
+/**
+ * Exchange selected cards per pass direction and transition to "playing".
+ * Throws if any player (in a non-"none" hand) has fewer than 3 cards selected.
+ */
+export function commitPass(state: HeartsState): HeartsState {
+  if (state.passDirection === "none") {
+    const leaderIndex = find2ClubsHolder(state.playerHands);
+    return {
+      ...state,
+      phase: "playing",
+      passingComplete: true,
+      currentLeaderIndex: leaderIndex,
+      currentPlayerIndex: leaderIndex,
+    };
+  }
+
+  for (let i = 0; i < 4; i++) {
+    if ((state.passSelections[i]?.length ?? 0) < 3) {
+      throw new Error(`Player ${i} has not selected 3 cards to pass`);
+    }
+  }
+
+  const offset =
+    state.passDirection === "left" ? 1 :
+    state.passDirection === "right" ? 3 : 2; // across
+
+  const newHands: Card[][] = state.playerHands.map((h) => [...h]);
+
+  // Remove passed cards from each sender
+  for (let i = 0; i < 4; i++) {
+    const sel = state.passSelections[i] ?? [];
+    newHands[i] = (newHands[i] ?? []).filter(
+      (c) => !sel.some((s) => cardEquals(c, s))
+    );
+  }
+
+  // Add passed cards to each recipient
+  for (let from = 0; from < 4; from++) {
+    const to = (from + offset) % 4;
+    const sel = state.passSelections[from] ?? [];
+    newHands[to] = [...(newHands[to] ?? []), ...sel];
+  }
+
+  const leaderIndex = find2ClubsHolder(newHands);
+
+  return {
+    ...state,
+    phase: "playing",
+    playerHands: newHands,
+    passSelections: [[], [], [], []],
+    passingComplete: true,
+    currentLeaderIndex: leaderIndex,
+    currentPlayerIndex: leaderIndex,
+  };
+}
+
+/**
+ * Returns all legal cards a player may play in the current game state.
+ *
+ * Rules:
+ * - Trick 0 leader must play 2♣.
+ * - Trick 0 followers must follow clubs; if void, may play anything except ♥ or Q♠
+ *   (unless the entire hand is ♥/Q♠).
+ * - Later leads: may play any suit; hearts banned until broken (unless hand is all hearts).
+ * - Later follows: must follow led suit; if void, may play anything.
+ */
+export function getValidPlays(state: HeartsState, playerIndex: number): Card[] {
+  const hand = [...(state.playerHands[playerIndex] ?? [])];
+  const isFirstTrick = state.tricksPlayedInHand === 0;
+  const isLeading = state.currentTrick.length === 0;
+
+  if (isLeading) {
+    if (isFirstTrick) {
+      return hand.filter((c) => c.suit === "clubs" && c.rank === 2);
+    }
+    if (!state.heartsBroken) {
+      const nonHearts = hand.filter((c) => c.suit !== "hearts");
+      return nonHearts.length > 0 ? nonHearts : hand;
+    }
+    return hand;
+  }
+
+  // Following — must follow led suit if possible
+  const ledSuit = state.currentTrick[0]?.card.suit;
+  if (!ledSuit) return hand;
+
+  const suitCards = hand.filter((c) => c.suit === ledSuit);
+  if (suitCards.length > 0) return suitCards;
+
+  // Void in led suit
+  if (isFirstTrick) {
+    const safe = hand.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
+    return safe.length > 0 ? safe : hand;
+  }
+
+  return hand;
+}
+
+/**
+ * Play a card for a player. Validates the card is a legal play.
+ * Automatically resolves the trick and hand when complete.
+ */
+export function playCard(
+  state: HeartsState,
+  playerIndex: number,
+  card: Card
+): HeartsState {
+  const validPlays = getValidPlays(state, playerIndex);
+  if (!validPlays.some((c) => cardEquals(c, card))) {
+    throw new Error(`Invalid play: ${card.suit} ${card.rank} for player ${playerIndex}`);
+  }
+
+  const newHands = state.playerHands.map((h, i) =>
+    i === playerIndex ? h.filter((c) => !cardEquals(c, card)) : [...h]
+  );
+
+  const newTrick: TrickCard[] = [...state.currentTrick, { card, playerIndex }];
+  const newHeartsBroken = state.heartsBroken || card.suit === "hearts";
+
+  let next: HeartsState = {
+    ...state,
+    playerHands: newHands,
+    currentTrick: newTrick,
+    heartsBroken: newHeartsBroken,
+    currentPlayerIndex: (playerIndex + 1) % 4,
+  };
+
+  if (newTrick.length === 4) {
+    next = resolveTrick(next, newTrick);
+  }
+
+  return next;
+}
+
+function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsState {
+  const first = trick[0]!;
+  const ledSuit = first.card.suit;
+
+  let winnerPlayerIndex = first.playerIndex;
+  let winnerRank: Rank = first.card.rank;
+
+  for (let i = 1; i < trick.length; i++) {
+    const tc = trick[i]!;
+    if (tc.card.suit === ledSuit && tc.card.rank > winnerRank) {
+      winnerRank = tc.card.rank;
+      winnerPlayerIndex = tc.playerIndex;
+    }
+  }
+
+  const trickCards = trick.map((tc) => tc.card);
+
+  const pointsWon = trickCards.reduce((sum, c) => {
+    if (c.suit === "hearts") return sum + 1;
+    if (isQueenOfSpades(c)) return sum + 13;
+    return sum;
+  }, 0);
+
+  const newWonCards = state.wonCards.map((wc, i) =>
+    i === winnerPlayerIndex ? [...wc, ...trickCards] : [...wc]
+  );
+
+  const newHandScores = state.handScores.map((s, i) =>
+    i === winnerPlayerIndex ? (s ?? 0) + pointsWon : s ?? 0
+  );
+
+  const newTricksPlayed = state.tricksPlayedInHand + 1;
+
+  let next: HeartsState = {
+    ...state,
+    currentTrick: [],
+    currentLeaderIndex: winnerPlayerIndex,
+    currentPlayerIndex: winnerPlayerIndex,
+    wonCards: newWonCards,
+    handScores: newHandScores,
+    tricksPlayedInHand: newTricksPlayed,
+  };
+
+  if (newTricksPlayed === 13) {
+    next = { ...next, phase: "hand_end" };
+    next = applyHandScoring(next);
+  }
+
+  return next;
+}
+
+/**
+ * Returns the player index who shot the moon (took all 13 ♥ + Q♠),
+ * or null if no moon was shot this hand.
+ */
+export function detectMoon(wonCards: readonly (readonly Card[])[]): number | null {
+  for (let i = 0; i < wonCards.length; i++) {
+    const cards = wonCards[i] ?? [];
+    const hearts = cards.filter((c) => c.suit === "hearts").length;
+    const hasQ = cards.some(isQueenOfSpades);
+    if (hearts === 13 && hasQ) return i;
+  }
+  return null;
+}
+
+/**
+ * Apply hand scores to cumulative totals, detect moon, check game over.
+ * Transitions phase to "dealing" (show score screen) or "game_over".
+ * Call dealNextHand() after this to start the next hand.
+ */
+export function applyHandScoring(state: HeartsState): HeartsState {
+  const moonShooter = detectMoon(state.wonCards);
+
+  const newCumulative = state.cumulativeScores.map((s, i) => {
+    const base = s ?? 0;
+    if (moonShooter !== null) {
+      return moonShooter === i ? base : base + 26;
+    }
+    return base + (state.handScores[i] ?? 0);
+  });
+
+  if (isGameOver(newCumulative)) {
+    return {
+      ...state,
+      cumulativeScores: newCumulative,
+      phase: "game_over",
+      isComplete: true,
+      winnerIndex: getWinner(newCumulative),
+    };
+  }
+
+  return {
+    ...state,
+    cumulativeScores: newCumulative,
+    phase: "dealing",
+  };
+}
+
+/** Returns true when any player has reached or exceeded 100 points. */
+export function isGameOver(scores: readonly number[]): boolean {
+  return scores.some((s) => (s ?? 0) >= 100);
+}
+
+/** Returns the index of the player with the lowest score (ties: lowest index). */
+export function getWinner(scores: readonly number[]): number {
+  let minScore = Infinity;
+  let minIdx = 0;
+  for (let i = 0; i < scores.length; i++) {
+    const s = scores[i] ?? Infinity;
+    if (s < minScore) {
+      minScore = s;
+      minIdx = i;
+    }
+  }
+  return minIdx;
+}

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -6,7 +6,7 @@
  * on each transition — state is immutable.
  */
 
-import type { Card, HeartsState, PassDirection, Rank, Suit, TrickCard } from "./types";
+import type { Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
 import { RANKS, SUITS } from "./types";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -56,12 +56,7 @@ function shuffle<T>(arr: readonly T[]): T[] {
 
 function dealHands(): readonly (readonly Card[])[] {
   const deck = shuffle(createDeck());
-  return [
-    deck.slice(0, 13),
-    deck.slice(13, 26),
-    deck.slice(26, 39),
-    deck.slice(39, 52),
-  ];
+  return [deck.slice(0, 13), deck.slice(13, 26), deck.slice(26, 39), deck.slice(39, 52)];
 }
 
 function cardEquals(a: Card, b: Card): boolean {
@@ -150,11 +145,7 @@ export function dealNextHand(state: HeartsState): HeartsState {
  * Does nothing if the card is not in the player's hand or 3 are already selected
  * and the card is not already selected.
  */
-export function selectPassCard(
-  state: HeartsState,
-  playerIndex: number,
-  card: Card
-): HeartsState {
+export function selectPassCard(state: HeartsState, playerIndex: number, card: Card): HeartsState {
   const current = [...(state.passSelections[playerIndex] ?? [])];
   const existingIdx = current.findIndex((c) => cardEquals(c, card));
   if (existingIdx >= 0) {
@@ -162,9 +153,7 @@ export function selectPassCard(
   } else if (current.length < 3) {
     current.push(card);
   }
-  const newSelections = state.passSelections.map((s, i) =>
-    i === playerIndex ? current : [...s]
-  );
+  const newSelections = state.passSelections.map((s, i) => (i === playerIndex ? current : [...s]));
   return { ...state, passSelections: newSelections };
 }
 
@@ -190,18 +179,14 @@ export function commitPass(state: HeartsState): HeartsState {
     }
   }
 
-  const offset =
-    state.passDirection === "left" ? 1 :
-    state.passDirection === "right" ? 3 : 2; // across
+  const offset = state.passDirection === "left" ? 1 : state.passDirection === "right" ? 3 : 2; // across
 
   const newHands: Card[][] = state.playerHands.map((h) => [...h]);
 
   // Remove passed cards from each sender
   for (let i = 0; i < 4; i++) {
     const sel = state.passSelections[i] ?? [];
-    newHands[i] = (newHands[i] ?? []).filter(
-      (c) => !sel.some((s) => cardEquals(c, s))
-    );
+    newHands[i] = (newHands[i] ?? []).filter((c) => !sel.some((s) => cardEquals(c, s)));
   }
 
   // Add passed cards to each recipient
@@ -270,11 +255,7 @@ export function getValidPlays(state: HeartsState, playerIndex: number): Card[] {
  * Play a card for a player. Validates the card is a legal play.
  * Automatically resolves the trick and hand when complete.
  */
-export function playCard(
-  state: HeartsState,
-  playerIndex: number,
-  card: Card
-): HeartsState {
+export function playCard(state: HeartsState, playerIndex: number, card: Card): HeartsState {
   const validPlays = getValidPlays(state, playerIndex);
   if (!validPlays.some((c) => cardEquals(c, card))) {
     throw new Error(`Invalid play: ${card.suit} ${card.rank} for player ${playerIndex}`);
@@ -330,7 +311,7 @@ function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsSt
   );
 
   const newHandScores = state.handScores.map((s, i) =>
-    i === winnerPlayerIndex ? (s ?? 0) + pointsWon : s ?? 0
+    i === winnerPlayerIndex ? (s ?? 0) + pointsWon : (s ?? 0)
   );
 
   const newTricksPlayed = state.tricksPlayedInHand + 1;

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -26,10 +26,10 @@ export interface TrickCard {
 export type PassDirection = "left" | "right" | "across" | "none";
 
 export type HeartsPhase =
-  | "dealing"    // between hands — UI shows hand scores before next deal
-  | "passing"    // players select 3 cards to pass
-  | "playing"    // trick-taking in progress
-  | "hand_end"   // 13th trick complete, scoring in progress (transient)
+  | "dealing" // between hands — UI shows hand scores before next deal
+  | "passing" // players select 3 cards to pass
+  | "playing" // trick-taking in progress
+  | "hand_end" // 13th trick complete, scoring in progress (transient)
   | "game_over"; // any player reached ≥ 100; lowest score wins
 
 /**

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Hearts — shared types (#604).
+ *
+ * Pure data. No React, no AsyncStorage, no side effects. Imported by the
+ * engine, AI, UI components, and persistence layer alike.
+ */
+
+export type Suit = "spades" | "hearts" | "diamonds" | "clubs";
+export type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
+
+export const SUITS: readonly Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+export const RANKS: readonly Rank[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+export interface Card {
+  readonly suit: Suit;
+  readonly rank: Rank;
+}
+
+/** One card played in a trick, annotated with which player played it. */
+export interface TrickCard {
+  readonly card: Card;
+  readonly playerIndex: number;
+}
+
+/** Pass direction cycles per hand: Left → Right → Across → Keep, repeat. */
+export type PassDirection = "left" | "right" | "across" | "none";
+
+export type HeartsPhase =
+  | "dealing"    // between hands — UI shows hand scores before next deal
+  | "passing"    // players select 3 cards to pass
+  | "playing"    // trick-taking in progress
+  | "hand_end"   // 13th trick complete, scoring in progress (transient)
+  | "game_over"; // any player reached ≥ 100; lowest score wins
+
+/**
+ * Immutable snapshot of the full Hearts game.
+ * Players: index 0 = human, 1 = left AI, 2 = top AI, 3 = right AI.
+ * `_v` is a schema version so persisted saves can be migrated or rejected.
+ */
+export interface HeartsState {
+  readonly _v: 1;
+  readonly phase: HeartsPhase;
+  /** 1-based. Pass direction = getPassDirection(handNumber). */
+  readonly handNumber: number;
+  readonly passDirection: PassDirection;
+  /** Current cards held per player (index 0–3). */
+  readonly playerHands: readonly (readonly Card[])[];
+  /** Running point totals across all hands [human, ai1, ai2, ai3]. Lower is better. */
+  readonly cumulativeScores: readonly number[];
+  /** Points taken this hand per player (hearts + Q♠). Reset each hand. */
+  readonly handScores: readonly number[];
+  /** Cards each player has chosen to pass (up to 3). Empty until selection made. */
+  readonly passSelections: readonly (readonly Card[])[];
+  readonly passingComplete: boolean;
+  /** Cards played in the current trick, in play order. */
+  readonly currentTrick: readonly TrickCard[];
+  /** Player index of whoever led the current trick (or leads next). */
+  readonly currentLeaderIndex: number;
+  /** Player index whose turn it is to act. */
+  readonly currentPlayerIndex: number;
+  /** All cards taken per player this hand (for moon detection). */
+  readonly wonCards: readonly (readonly Card[])[];
+  readonly heartsBroken: boolean;
+  /** Number of tricks played so far this hand (0–13). */
+  readonly tricksPlayedInHand: number;
+  readonly isComplete: boolean;
+  readonly winnerIndex: number | null;
+}


### PR DESCRIPTION
## Summary
- `frontend/src/game/hearts/types.ts` — exports `Suit`, `Rank`, `Card`, `TrickCard`, `PassDirection`, `HeartsPhase`, `HeartsState`, `SUITS`, `RANKS`
- `frontend/src/game/hearts/engine.ts` — pure TypeScript: `dealGame`, `dealNextHand`, `getPassDirection`, `selectPassCard`, `commitPass`, `getValidPlays`, `playCard`, `detectMoon`, `applyHandScoring`, `isGameOver`, `getWinner`, `setRng`/`createSeededRng` for test determinism
- `frontend/src/game/hearts/__tests__/engine.test.ts` — full unit test suite covering all 9 acceptance criteria

No React, no AsyncStorage, no side effects. `noUncheckedIndexedAccess` clean — zero TS errors.

Closes #604. Part of Epic #602.

## Test plan
- [ ] 52 unique cards dealt, 13 per player
- [ ] Pass exchange: left/right/across directions correct; none skips exchange
- [ ] `getValidPlays`: first-trick 2♣ lead, clubs-follow, void restrictions, hearts-locked lead
- [ ] Trick winner: highest led-suit card wins regardless of discards
- [ ] `heartsBroken` set on first heart played
- [ ] Moon detection: all 13♥ + Q♠ → shooter found; splits → null
- [ ] Moon scoring: shooter +0, others +26
- [ ] `isGameOver` at 99 (false), 100 (true)
- [ ] `getWinner`: lowest score; ties go to lowest index

🤖 Generated with [Claude Code](https://claude.com/claude-code)