### PR TITLE
feat(hearts): leaderboard endpoints — POST /score, GET /scores (#605)

### DIFF
--- a/backend/hearts/router.py
+++ b/backend/hearts/router.py
@@ -1,0 +1,104 @@
+"""Hearts leaderboard (#605) — mirrors the Solitaire/Cascade pattern.
+
+POST /hearts/score inserts-and-completes a Game row tagged with
+``hearts`` and the player name in ``game_metadata``.
+GET /hearts/scores returns the top 10 rows for this game type,
+sorted by ``final_score`` descending (older entries break ties).
+
+Score stored as max(0, 100 − human_cumulative_score) so higher = better.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+_HEARTS_SESSION = "hearts-anon"
+
+
+async def _hearts_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.HEARTS))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="hearts game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _hearts_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _hearts_game_type_id(db)
+        game = Game(
+            session_id=_HEARTS_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/scores", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. DB isolation handled by conftest ``clean_db_tables``."""
+    return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from db.base import DATABASE_URL, get_engine, is_configured
 from limiter import _real_ip, limiter
 from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
+from hearts.router import router as hearts_router
 from solitaire.router import router as solitaire_router
 from yacht.router import router as yacht_router
 from games.router import router as games_router
@@ -51,6 +52,7 @@ app = FastAPI(title="Gaming App API")
 app.include_router(yacht_router, prefix="/yacht")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
+app.include_router(hearts_router, prefix="/hearts")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")

--- a/backend/tests/test_hearts_api.py
+++ b/backend/tests/test_hearts_api.py
@@ -1,0 +1,162 @@
+"""Tests for /hearts/score and /hearts/scores (#605).
+
+Mirrors ``test_solitaire_api.py`` — the Hearts leaderboard follows the
+same Cascade/Solitaire pattern. Score is max(0, 100 − human_cumulative)
+so higher = better performance.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import hearts.router as hearts_router_module
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    hearts_router_module.reset_leaderboard()
+    yield
+    hearts_router_module.reset_leaderboard()
+
+
+def _submit(player_name: str, score: int):
+    return client.post("/hearts/score", json={"player_name": player_name, "score": score})
+
+
+# ---------------------------------------------------------------------------
+# POST /hearts/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 80)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["score"] == 80
+        assert body["rank"] == 1
+
+    def test_zero_score_accepted(self):
+        res = _submit("Alice", 0)
+        assert res.status_code == 201
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/hearts/score", json={"score": 50})
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post("/hearts/score", json={"player_name": "Bob"})
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        res = _submit("", 50)
+        assert res.status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        res = _submit("x" * 33, 50)
+        assert res.status_code == 422
+
+    def test_negative_score_returns_422(self):
+        res = _submit("Alice", -1)
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /hearts/scores
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/hearts/scores")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("Alice", 80)
+        _submit("Bob", 60)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_score_descending(self):
+        _submit("Alice", 40)
+        _submit("Bob", 90)
+        _submit("Carol", 70)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert [s["score"] for s in scores] == [90, 70, 40]
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()
+            _submit(f"Player{i}", i * 5)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["score"] == 70  # top score is 14 * 5
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 80).json()["rank"] == 1
+
+    def test_lower_score_ranked_lower(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 80)
+        limiter.reset()
+        assert _submit("Bob", 50).json()["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000)
+        limiter.reset()
+        assert _submit("Lowly", 1).json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"Player{i}", i * 10).status_code == 201
+
+        assert _submit("Excess", 99).status_code == 429
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 75)
+        limiter.reset()
+        body = _submit("Bob", 75).json()
+
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"
+        assert body["rank"] == 2


### PR DESCRIPTION
## Summary
- `backend/hearts/router.py` — `POST /hearts/score` (5/min) + `GET /hearts/scores` (60/min), top-10 cap, rank math, tie-break by insertion order
- `backend/main.py` — mounts hearts router at `/hearts`
- `backend/tests/test_hearts_api.py` — 16 tests: happy path, 422 validation, rate limiting, top-10 cap, rank 11, tie-break ordering

Score stored as `max(0, 100 − human_cumulative_score)` — higher = better.

Closes #605. Part of Epic #602.

## Test plan
- [ ] `POST /hearts/score` returns 201 on valid payload
- [ ] 422 on missing fields, empty name, name > 32 chars, negative score
- [ ] `GET /hearts/scores` returns ≤ 10 entries sorted descending
- [ ] 11th entry reports rank 11
- [ ] 6th POST within a minute returns 429
- [ ] Tie-break: older entry ranks higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)