### PR TITLE
feat(solitaire): integration — lazy route + lobby card (#599)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -30,6 +30,7 @@ const CascadeScreen = React.lazy(() => import("./src/screens/CascadeScreen"));
 const BlackjackBettingScreen = React.lazy(() => import("./src/screens/BlackjackBettingScreen"));
 const BlackjackTableScreen = React.lazy(() => import("./src/screens/BlackjackTableScreen"));
 const Twenty48Screen = React.lazy(() => import("./src/screens/Twenty48Screen"));
+const SolitaireScreen = React.lazy(() => import("./src/screens/SolitaireScreen"));
 const LeaderboardScreen = React.lazy(() => import("./src/screens/LeaderboardScreen"));
 const GameDetailScreen = React.lazy(() => import("./src/screens/GameDetailScreen"));
 const SettingsScreen = React.lazy(() => import("./src/screens/SettingsScreen"));
@@ -63,6 +64,7 @@ export type HomeStackParamList = {
   BlackjackBetting: undefined;
   BlackjackTable: undefined;
   Twenty48: undefined;
+  Solitaire: undefined;
 };
 
 export type ProfileStackParamList = {
@@ -90,6 +92,7 @@ const LazyCascadeScreen = withSuspense(CascadeScreen);
 const LazyBlackjackBettingScreen = withSuspense(BlackjackBettingScreen);
 const LazyBlackjackTableScreen = withSuspense(BlackjackTableScreen);
 const LazyTwenty48Screen = withSuspense(Twenty48Screen);
+const LazySolitaireScreen = withSuspense(SolitaireScreen);
 const LazyLeaderboardScreen = withSuspense(LeaderboardScreen);
 const LazyGameDetailScreen = withSuspense(GameDetailScreen);
 const LazySettingsScreen = withSuspense(SettingsScreen);
@@ -108,6 +111,7 @@ function LobbyStack() {
       <HomeStack.Screen name="BlackjackBetting" component={LazyBlackjackBettingScreen} />
       <HomeStack.Screen name="BlackjackTable" component={LazyBlackjackTableScreen} />
       <HomeStack.Screen name="Twenty48" component={LazyTwenty48Screen} />
+      <HomeStack.Screen name="Solitaire" component={LazySolitaireScreen} />
     </HomeStack.Navigator>
   );
 }

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -28,7 +28,15 @@ interface GameCard {
 
 export default function HomeScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList, "Home">>();
-  const { t } = useTranslation(["common", "yacht", "cascade", "blackjack", "twenty48", "errors"]);
+  const { t } = useTranslation([
+    "common",
+    "yacht",
+    "cascade",
+    "blackjack",
+    "twenty48",
+    "solitaire",
+    "errors",
+  ]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -77,6 +85,13 @@ export default function HomeScreen() {
       description: t("twenty48:game.description"),
       action: () => navigation.navigate("Twenty48"),
     },
+    {
+      key: "solitaire",
+      emoji: "♠",
+      title: t("solitaire:game.title"),
+      description: t("solitaire:game.description"),
+      action: () => navigation.navigate("Solitaire"),
+    },
   ];
 
   const playLabels: Record<string, string> = {
@@ -84,6 +99,7 @@ export default function HomeScreen() {
     [t("cascade:game.title")]: t("cascade:game.playLabel"),
     [t("blackjack:game.title")]: t("blackjack:game.playLabel"),
     [t("twenty48:game.title")]: t("twenty48:game.playLabel"),
+    [t("solitaire:game.title")]: t("solitaire:game.playLabel"),
   };
 
   // Cycle through BC Arcade accent colors for the gradient top border on each card.

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -448,7 +448,7 @@ export default function SolitaireScreen() {
       title={t("solitaire:game.title")}
       requireBack
       loading={loading}
-      onBack={() => navigation.goBack()}
+      onBack={() => navigation.popToTop()}
       style={{
         paddingBottom: Math.max(insets.bottom, 16),
         paddingLeft: Math.max(insets.left, 12),

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -83,6 +83,7 @@ describe("HomeScreen — game cards", () => {
     expect(getByLabelText("Play Yacht")).toBeTruthy();
     expect(getByLabelText("Play Cascade")).toBeTruthy();
     expect(getByLabelText("Play Blackjack")).toBeTruthy();
+    expect(getByLabelText("Play Solitaire")).toBeTruthy();
     // Pachisi is disabled — should not appear
     expect(queryByLabelText("Play Pachisi")).toBeNull();
   });
@@ -97,6 +98,12 @@ describe("HomeScreen — game cards", () => {
     const { getByLabelText } = renderScreen();
     fireEvent.press(getByLabelText("Play Cascade"));
     expect(mockNavigate).toHaveBeenCalledWith("Cascade");
+  });
+
+  it("navigates to Solitaire when Solitaire card pressed", () => {
+    const { getByLabelText } = renderScreen();
+    fireEvent.press(getByLabelText("Play Solitaire"));
+    expect(mockNavigate).toHaveBeenCalledWith("Solitaire");
   });
 
   it("navigates to Game with a new state when Yacht card pressed (no saved game)", async () => {
@@ -131,6 +138,7 @@ describe("HomeScreen — responsive layout (Galaxy Fold fix, #356)", () => {
     expect(getByLabelText("Play Cascade")).toBeTruthy();
     expect(getByLabelText("Play Blackjack")).toBeTruthy();
     expect(getByLabelText("Play 2048")).toBeTruthy();
+    expect(getByLabelText("Play Solitaire")).toBeTruthy();
   });
 
   it("renders all game cards at 360 px viewport width", () => {
@@ -139,5 +147,6 @@ describe("HomeScreen — responsive layout (Galaxy Fold fix, #356)", () => {
     expect(getByLabelText("Play Cascade")).toBeTruthy();
     expect(getByLabelText("Play Blackjack")).toBeTruthy();
     expect(getByLabelText("Play 2048")).toBeTruthy();
+    expect(getByLabelText("Play Solitaire")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `Solitaire: undefined` to `HomeStackParamList`; lazy-loads `SolitaireScreen` via `withSuspense`; registers `<HomeStack.Screen name="Solitaire" component={LazySolitaireScreen} />`.
- Appends a Solitaire card (emoji ♠, title/description from the `solitaire` namespace, navigates to `"Solitaire"`) to `HomeScreen.games[]` and wires the matching `playLabel`.
- Changes `SolitaireScreen`'s back handler from `goBack()` to `popToTop()` so the hardware back / header back returns to the lobby — matches Cascade / Twenty48 / Blackjack.

**No new image assets.** The lobby card uses the same emoji pattern as the other games, so no WebP asset is created and the `PERFORMANCE.md` Directory Map is unchanged. Game ships as code + text only; `assetTransparency.test.ts` remains green as-is.

Closes #599.

## Test plan
- [x] `npx jest --testPathPattern='HomeScreen|solitaire'` — 106 tests pass (adds "Solitaire card renders + navigates" assertions in 3 existing test groups).
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — no new errors.
- [x] `npx prettier --check` — clean.
- [ ] Manual: Lobby shows 5 cards; tap Solitaire → draw-mode modal → deal → back returns to lobby (iOS/Android/web).
- [ ] `android-bundle-check` CI comment: verify Δ ≤ +200 KB vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)