### PR TITLE
feat(hearts): AI strategy — passing, play heuristics, moon blocking (#606)

### DIFF
--- a/backend/hearts/router.py
+++ b/backend/hearts/router.py
@@ -1,0 +1,104 @@
+"""Hearts leaderboard (#605) — mirrors the Solitaire/Cascade pattern.
+
+POST /hearts/score inserts-and-completes a Game row tagged with
+``hearts`` and the player name in ``game_metadata``.
+GET /hearts/scores returns the top 10 rows for this game type,
+sorted by ``final_score`` descending (older entries break ties).
+
+Score stored as max(0, 100 − human_cumulative_score) so higher = better.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+_HEARTS_SESSION = "hearts-anon"
+
+
+async def _hearts_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.HEARTS))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="hearts game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _hearts_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _hearts_game_type_id(db)
+        game = Game(
+            session_id=_HEARTS_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/scores", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. DB isolation handled by conftest ``clean_db_tables``."""
+    return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from db.base import DATABASE_URL, get_engine, is_configured
 from limiter import _real_ip, limiter
 from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
+from hearts.router import router as hearts_router
 from solitaire.router import router as solitaire_router
 from yacht.router import router as yacht_router
 from games.router import router as games_router
@@ -51,6 +52,7 @@ app = FastAPI(title="Gaming App API")
 app.include_router(yacht_router, prefix="/yacht")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
+app.include_router(hearts_router, prefix="/hearts")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")

--- a/backend/tests/test_hearts_api.py
+++ b/backend/tests/test_hearts_api.py
@@ -1,0 +1,162 @@
+"""Tests for /hearts/score and /hearts/scores (#605).
+
+Mirrors ``test_solitaire_api.py`` — the Hearts leaderboard follows the
+same Cascade/Solitaire pattern. Score is max(0, 100 − human_cumulative)
+so higher = better performance.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import hearts.router as hearts_router_module
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    hearts_router_module.reset_leaderboard()
+    yield
+    hearts_router_module.reset_leaderboard()
+
+
+def _submit(player_name: str, score: int):
+    return client.post("/hearts/score", json={"player_name": player_name, "score": score})
+
+
+# ---------------------------------------------------------------------------
+# POST /hearts/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 80)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["score"] == 80
+        assert body["rank"] == 1
+
+    def test_zero_score_accepted(self):
+        res = _submit("Alice", 0)
+        assert res.status_code == 201
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/hearts/score", json={"score": 50})
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post("/hearts/score", json={"player_name": "Bob"})
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        res = _submit("", 50)
+        assert res.status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        res = _submit("x" * 33, 50)
+        assert res.status_code == 422
+
+    def test_negative_score_returns_422(self):
+        res = _submit("Alice", -1)
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /hearts/scores
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/hearts/scores")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("Alice", 80)
+        _submit("Bob", 60)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_score_descending(self):
+        _submit("Alice", 40)
+        _submit("Bob", 90)
+        _submit("Carol", 70)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert [s["score"] for s in scores] == [90, 70, 40]
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()
+            _submit(f"Player{i}", i * 5)
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["score"] == 70  # top score is 14 * 5
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 80).json()["rank"] == 1
+
+    def test_lower_score_ranked_lower(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 80)
+        limiter.reset()
+        assert _submit("Bob", 50).json()["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000)
+        limiter.reset()
+        assert _submit("Lowly", 1).json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"Player{i}", i * 10).status_code == 201
+
+        assert _submit("Excess", 99).status_code == 429
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 75)
+        limiter.reset()
+        body = _submit("Bob", 75).json()
+
+        scores = client.get("/hearts/scores").json()["scores"]
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"
+        assert body["rank"] == 2

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Hearts AI unit tests (#606).
+ *
+ * Covers all acceptance criteria from the issue:
+ *   - Pass: Q♠ passed when unprotected; kept when holding A♠ + K♠
+ *   - Pass: high hearts prioritized
+ *   - Play: Q♠ discarded when void in led suit
+ *   - Play: highest losing card played when following and trick has points
+ *   - Play: valid card always returned (never an illegal move)
+ *   - Moon block: AI dumps heart when potential moon detected
+ *   - Edge: only one valid card → that card returned
+ *   - Edge: no hearts/Q♠ → discards highest card of longest suit
+ */
+
+import { detectPotentialMoon, selectCardToPlay, selectCardsToPass } from "../ai";
+import { getValidPlays } from "../engine";
+import type { Card, HeartsState, Rank, Suit, TrickCard } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function c(suit: Suit, rank: Rank): Card {
+  return { suit, rank };
+}
+
+function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
+  return {
+    _v: 1,
+    phase: "playing",
+    handNumber: 1,
+    passDirection: "left",
+    playerHands: [[], [], [], []],
+    cumulativeScores: [0, 0, 0, 0],
+    handScores: [0, 0, 0, 0],
+    passSelections: [[], [], [], []],
+    passingComplete: true,
+    currentTrick: [],
+    currentLeaderIndex: 0,
+    currentPlayerIndex: 0,
+    wonCards: [[], [], [], []],
+    heartsBroken: true,
+    tricksPlayedInHand: 1,
+    isComplete: false,
+    winnerIndex: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// selectCardsToPass
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass", () => {
+  it("always returns exactly 3 cards", () => {
+    const hand = [
+      c("spades", 1),
+      c("spades", 12),
+      c("spades", 13),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("clubs", 7),
+      c("diamonds", 5),
+      c("diamonds", 9),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("diamonds", 3),
+      c("hearts", 5),
+    ];
+    expect(selectCardsToPass(hand, "left")).toHaveLength(3);
+  });
+
+  it("passes Q♠ when unprotected (no A♠ + K♠)", () => {
+    const hand = [
+      c("spades", 12),
+      c("spades", 3),
+      c("spades", 4),
+      c("hearts", 2),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("hearts", 3),
+      c("hearts", 4),
+      c("hearts", 6),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).toContainEqual(c("spades", 12));
+  });
+
+  it("keeps Q♠ when holding both A♠ and K♠", () => {
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("clubs", 7),
+      c("diamonds", 5),
+      c("diamonds", 9),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("diamonds", 3),
+      c("hearts", 5),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).not.toContainEqual(c("spades", 12));
+  });
+
+  it("passes A♥ and K♥ as high-priority danger cards", () => {
+    const hand = [
+      c("hearts", 1),
+      c("hearts", 13),
+      c("hearts", 2),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("diamonds", 9),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).toContainEqual(c("hearts", 1));
+    expect(passed).toContainEqual(c("hearts", 13));
+  });
+
+  it("never passes 2♣", () => {
+    const hand = [
+      c("clubs", 2),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("diamonds", 9),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).not.toContainEqual(c("clubs", 2));
+  });
+
+  it("never passes clubs below 6", () => {
+    const hand = [
+      c("clubs", 3),
+      c("clubs", 4),
+      c("clubs", 5),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("spades", 8),
+      c("spades", 9),
+      c("spades", 10),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("diamonds", 9),
+      c("diamonds", 10),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    passed.forEach((card) => {
+      if (card.suit === "clubs") expect(card.rank).toBeGreaterThanOrEqual(6);
+    });
+  });
+
+  it("returned cards are all from the hand", () => {
+    const hand = [
+      c("spades", 1),
+      c("spades", 12),
+      c("spades", 13),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("clubs", 7),
+      c("diamonds", 5),
+      c("diamonds", 9),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("diamonds", 3),
+      c("hearts", 5),
+    ];
+    const passed = selectCardsToPass(hand, "right");
+    passed.forEach((p) => expect(hand).toContainEqual(p));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectCardToPlay — void (discarding)
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — void in led suit", () => {
+  it("discards Q♠ when void and Q♠ is a valid play", () => {
+    const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 0 },
+      { card: c("clubs", 7), playerIndex: 1 },
+      { card: c("clubs", 9), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    expect(pick).toEqual(c("spades", 12));
+  });
+
+  it("discards highest heart when void and no Q♠", () => {
+    const hand = [c("hearts", 5), c("hearts", 11), c("diamonds", 7)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 0 },
+      { card: c("clubs", 7), playerIndex: 1 },
+      { card: c("clubs", 9), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    expect(pick).toEqual(c("hearts", 11));
+  });
+
+  it("discards highest card of longest suit when no hearts or Q♠", () => {
+    const hand = [c("diamonds", 5), c("diamonds", 10), c("spades", 3)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 0 },
+      { card: c("clubs", 7), playerIndex: 1 },
+      { card: c("clubs", 9), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    // Longest suit is diamonds (2 cards); highest diamond is 10
+    expect(pick).toEqual(c("diamonds", 10));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectCardToPlay — following suit
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — following suit with points in trick", () => {
+  it("plays highest card that still loses when trick has points", () => {
+    // Trick: p0 leads spades 8, p1 plays hearts (void → discard, already there)
+    // Actually let's make a simpler scenario: p0 leads spades 10 with a heart discard in it
+    const hand = [c("spades", 5), c("spades", 7), c("spades", 9)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 10), playerIndex: 0 },
+      { card: c("hearts", 1), playerIndex: 1 }, // discard — has points
+      { card: c("spades", 3), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    // Winning rank is 10; losing cards: 5, 7, 9 → play highest losing = 9
+    expect(pick).toEqual(c("spades", 9));
+  });
+
+  it("plays lowest when forced to win a trick with points", () => {
+    const hand = [c("spades", 11), c("spades", 13)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 10), playerIndex: 0 },
+      { card: c("hearts", 2), playerIndex: 1 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [hand[0]!, hand[1]!], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 2,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 2);
+    // Both 11 and 13 beat 10; play lowest = 11
+    expect(pick).toEqual(c("spades", 11));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectCardToPlay — moon blocking
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — moon blocking", () => {
+  it("dumps a heart when potential moon detected", () => {
+    // Player 0 has taken all 5 points so far — potential moon
+    // Player 3 is void in the led suit (spades) so can discard freely
+    const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 4), playerIndex: 0 },
+      { card: c("spades", 5), playerIndex: 1 },
+      { card: c("spades", 6), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      handScores: [5, 0, 0, 0],
+      wonCards: [allHearts5, [], [], []],
+      currentPlayerIndex: 3,
+    });
+
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    // Should dump hearts 9 to block potential moon
+    expect(pick).toEqual(c("hearts", 9));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectCardToPlay — always returns a valid card
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — always valid", () => {
+  it("returns a card that passes getValidPlays (first trick lead)", () => {
+    const hand = [c("clubs", 2), c("hearts", 5), c("spades", 7)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      tricksPlayedInHand: 0,
+      heartsBroken: false,
+      currentTrick: [],
+      currentPlayerIndex: 0,
+    });
+    const pick = selectCardToPlay(hand, [], state, 0);
+    const valid = getValidPlays(state, 0);
+    expect(valid).toContainEqual(pick);
+  });
+
+  it("returns a card that passes getValidPlays (following, must follow suit)", () => {
+    const hand = [c("hearts", 3), c("hearts", 7), c("clubs", 9)];
+    const trick: TrickCard[] = [{ card: c("hearts", 2), playerIndex: 0 }];
+    const state = mkState({
+      playerHands: [[], [hand[0]!, hand[1]!, hand[2]!], [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1);
+    const valid = getValidPlays(state, 1);
+    expect(valid).toContainEqual(pick);
+  });
+
+  it("returns the only valid card when just one option", () => {
+    const hand = [c("clubs", 2)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      tricksPlayedInHand: 0,
+      currentTrick: [],
+      currentPlayerIndex: 0,
+    });
+    const pick = selectCardToPlay(hand, [], state, 0);
+    expect(pick).toEqual(c("clubs", 2));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectPotentialMoon
+// ---------------------------------------------------------------------------
+
+describe("detectPotentialMoon", () => {
+  it("returns null when no points taken", () => {
+    const state = mkState({ handScores: [0, 0, 0, 0], wonCards: [[], [], [], []] });
+    expect(detectPotentialMoon(state)).toBeNull();
+  });
+
+  it("returns player index when they have all points and ≥ 4 hearts", () => {
+    const hearts4 = Array.from({ length: 4 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const state = mkState({
+      handScores: [4, 0, 0, 0],
+      wonCards: [hearts4, [], [], []],
+    });
+    expect(detectPotentialMoon(state)).toBe(0);
+  });
+
+  it("returns null when points are split between players", () => {
+    const state = mkState({
+      handScores: [2, 2, 0, 0],
+      wonCards: [[c("hearts", 1), c("hearts", 2)], [c("hearts", 3), c("hearts", 4)], [], []],
+    });
+    expect(detectPotentialMoon(state)).toBeNull();
+  });
+
+  it("returns null when dominant player has fewer than 4 point cards", () => {
+    const state = mkState({
+      handScores: [3, 0, 0, 0],
+      wonCards: [[c("hearts", 1), c("hearts", 2), c("hearts", 3)], [], [], []],
+    });
+    expect(detectPotentialMoon(state)).toBeNull();
+  });
+});

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -1,0 +1,315 @@
+/**
+ * Hearts AI (#606).
+ *
+ * Pure TypeScript rule-based strategy for the 3 computer opponents.
+ * Medium difficulty — human-beatable but not trivial (~1-in-4 AI win rate).
+ * No randomness beyond deterministic tie-breaking. No React/AsyncStorage.
+ */
+
+import { getValidPlays } from "./engine";
+import type { Card, HeartsState, PassDirection, TrickCard } from "./types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isQueenOfSpades(c: Card): boolean {
+  return c.suit === "spades" && c.rank === 12;
+}
+
+function cardPoints(c: Card): number {
+  if (c.suit === "hearts") return 1;
+  if (isQueenOfSpades(c)) return 13;
+  return 0;
+}
+
+function trickPoints(trick: readonly TrickCard[]): number {
+  return trick.reduce((sum, tc) => sum + cardPoints(tc.card), 0);
+}
+
+/** Index of the current trick winner (highest card of led suit). */
+function trickWinnerIndex(trick: readonly TrickCard[]): number {
+  const first = trick[0];
+  if (!first) return 0;
+  const ledSuit = first.card.suit;
+  let winnerIdx = 0;
+  let winnerRank = first.card.rank;
+  let winnerPlayerIndex = first.playerIndex;
+  for (let i = 1; i < trick.length; i++) {
+    const tc = trick[i]!;
+    if (tc.card.suit === ledSuit && tc.card.rank > winnerRank) {
+      winnerRank = tc.card.rank;
+      winnerPlayerIndex = tc.playerIndex;
+      winnerIdx = i;
+    }
+  }
+  void winnerIdx;
+  return winnerPlayerIndex;
+}
+
+/** Highest card in array, or undefined if empty. */
+function highest(cards: Card[]): Card | undefined {
+  return cards.reduce<Card | undefined>((best, c) => {
+    if (!best) return c;
+    return c.rank > best.rank ? c : best;
+  }, undefined);
+}
+
+/** Lowest card in array, or undefined if empty. */
+function lowest(cards: Card[]): Card | undefined {
+  return cards.reduce<Card | undefined>((best, c) => {
+    if (!best) return c;
+    return c.rank < best.rank ? c : best;
+  }, undefined);
+}
+
+/** Group cards by suit, returning an array of [suit, cards] sorted by count desc. */
+function bySuitDescending(cards: Card[]): Array<[string, Card[]]> {
+  const map = new Map<string, Card[]>();
+  for (const c of cards) {
+    const group = map.get(c.suit) ?? [];
+    group.push(c);
+    map.set(c.suit, group);
+  }
+  return [...map.entries()].sort((a, b) => b[1].length - a[1].length);
+}
+
+// ---------------------------------------------------------------------------
+// Passing strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Select exactly 3 cards to pass. Priority order per issue spec:
+ * 1. Q♠ — unless protected (holding A♠ + K♠) or void in spades
+ * 2. A♥, K♥ — highest hearts first
+ * 3. A♠, K♠ — if not needed to protect Q♠
+ * 4. High cards of suit being voided (longest suit)
+ * 5. Never pass: 2♣ or clubs below 6
+ */
+export function selectCardsToPass(hand: Card[], _direction: PassDirection): Card[] {
+  const selected: Card[] = [];
+
+  const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
+
+  const spades = hand.filter((c) => c.suit === "spades");
+  const hasQSpades = spades.some(isQueenOfSpades);
+  const hasASpades = has("spades", 1);
+  const hasKSpades = has("spades", 13);
+  const qSpadeProtected = hasASpades && hasKSpades;
+  const voidInSpades = spades.length === 0;
+
+  // 1. Pass Q♠ if unprotected and not void
+  if (hasQSpades && !qSpadeProtected && !voidInSpades) {
+    selected.push({ suit: "spades", rank: 12 });
+  }
+
+  // Cards eligible to pass (never 2♣, never clubs < 6)
+  const safe = (c: Card) => {
+    if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) return false;
+    if (c.suit === "clubs" && c.rank === 2) return false;
+    if (c.suit === "clubs" && c.rank < 6) return false;
+    return true;
+  };
+
+  // 2. High hearts (A=1, K=13 — pass rank 13 first, then rank 1 as highest)
+  const dangerHearts = hand
+    .filter((c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= 11) && safe(c))
+    .sort((a, b) => {
+      // Treat ace (rank 1) as 14 for sorting purposes
+      const ra = a.rank === 1 ? 14 : a.rank;
+      const rb = b.rank === 1 ? 14 : b.rank;
+      return rb - ra;
+    });
+  for (const c of dangerHearts) {
+    if (selected.length >= 3) break;
+    selected.push(c);
+  }
+
+  // 3. A♠, K♠ — if not protecting Q♠
+  if (selected.length < 3 && !hasQSpades) {
+    for (const rank of [1, 13] as const) {
+      if (selected.length >= 3) break;
+      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c));
+      if (card) selected.push(card);
+    }
+  }
+
+  // 4. High cards toward voiding a suit
+  if (selected.length < 3) {
+    const candidates = hand.filter(safe).sort((a, b) => {
+      // Prefer high ranks, prefer non-clubs
+      const ra = a.rank === 1 ? 14 : a.rank;
+      const rb = b.rank === 1 ? 14 : b.rank;
+      if (rb !== ra) return rb - ra;
+      if (a.suit === "clubs" && b.suit !== "clubs") return 1;
+      if (b.suit === "clubs" && a.suit !== "clubs") return -1;
+      return 0;
+    });
+    for (const c of candidates) {
+      if (selected.length >= 3) break;
+      selected.push(c);
+    }
+  }
+
+  return selected.slice(0, 3);
+}
+
+// ---------------------------------------------------------------------------
+// Moon detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the player index who is on track to shoot the moon, or null.
+ * Fires when a player has ≥ 4 hearts (or Q♠) and no other player has
+ * taken any points yet this hand.
+ */
+export function detectPotentialMoon(state: HeartsState): number | null {
+  const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
+  if (totalPointsTaken === 0) return null;
+
+  for (let i = 0; i < 4; i++) {
+    const myPoints = state.handScores[i] ?? 0;
+    if (myPoints === 0) continue;
+    // This player has all the points so far
+    if (myPoints === totalPointsTaken) {
+      const myCards = state.wonCards[i] ?? [];
+      const hearts = myCards.filter((c) => c.suit === "hearts").length;
+      const hasQ = myCards.some(isQueenOfSpades);
+      if (hearts + (hasQ ? 1 : 0) >= 4) return i;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Play strategy
+// ---------------------------------------------------------------------------
+
+/**
+ * Choose a card to play. Always returns a card from getValidPlays.
+ *
+ * Priority when void (discarding):
+ *   1. Dump Q♠ if unprotected
+ *   2. Dump highest ♥
+ *   3. Dump highest card of longest suit (work toward voiding)
+ *
+ * Priority when following suit:
+ *   - Trick safe (no points) and last to play → play highest to exhaust high cards
+ *   - Trick has points → play highest card that still loses
+ *   - Would win regardless → play lowest
+ *
+ * Priority when leading:
+ *   - Moon blocking: dump hearts/Q♠ immediately
+ *   - First trick: 2♣ (forced by getValidPlays)
+ *   - Hearts not broken: lead lowest of longest non-heart suit
+ *   - Otherwise: lead lowest non-dangerous card
+ */
+export function selectCardToPlay(
+  hand: Card[],
+  trick: TrickCard[],
+  state: HeartsState,
+  playerIndex: number
+): Card {
+  const valid = getValidPlays(state, playerIndex);
+  if (valid.length === 1) return valid[0]!;
+
+  const moonTarget = detectPotentialMoon(state);
+  const isLeading = trick.length === 0;
+
+  // Moon blocking — dump points cards ASAP
+  if (moonTarget !== null && moonTarget !== playerIndex) {
+    const pointCards = valid.filter((c) => cardPoints(c) > 0).sort((a, b) => b.rank - a.rank);
+    if (pointCards.length > 0) return pointCards[0]!;
+  }
+
+  if (isLeading) {
+    return chooseLead(valid, state);
+  }
+
+  return chooseFollow(valid, trick, state);
+}
+
+function chooseLead(valid: Card[], state: HeartsState): Card {
+  // Avoid leading hearts or Q♠ unless forced
+  const safe = valid.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
+  const pool = safe.length > 0 ? safe : valid;
+
+  // Lead lowest of longest non-heart suit (exhaust safe suits first)
+  const suitGroups = bySuitDescending(pool);
+  const longestGroup = suitGroups[0];
+  if (longestGroup) {
+    const card = lowest(longestGroup[1]);
+    if (card) return card;
+  }
+
+  return lowest(pool) ?? valid[0]!;
+}
+
+function chooseFollow(valid: Card[], trick: readonly TrickCard[], state: HeartsState): Card {
+  const first = trick[0];
+  if (!first) return valid[0]!;
+
+  const ledSuit = first.card.suit;
+  const inSuit = valid.filter((c) => c.suit === ledSuit);
+  const isVoid = inSuit.length === 0;
+
+  if (isVoid) {
+    return chooseDiscard(valid);
+  }
+
+  // Following suit
+  const currentWinner = trickWinnerIndex(trick);
+  const isLastToPlay = trick.length === 3;
+  const pts = trickPoints(trick);
+
+  // Find the highest card currently winning the trick in led suit
+  let winningRank = 0;
+  for (const tc of trick) {
+    if (tc.card.suit === ledSuit && tc.card.rank > winningRank) {
+      winningRank = tc.card.rank;
+    }
+  }
+
+  // Cards that would lose (rank < winning rank)
+  const losing = inSuit.filter((c) => c.rank < winningRank);
+  // Cards that would win
+  const winning = inSuit.filter((c) => c.rank > winningRank);
+
+  if (pts === 0 && isLastToPlay) {
+    // Safe trick, last to play — exhaust high cards
+    return highest(inSuit) ?? valid[0]!;
+  }
+
+  if (pts > 0) {
+    // Trick has points — try to lose
+    if (losing.length > 0) {
+      // Play highest card that still loses
+      return highest(losing) ?? valid[0]!;
+    }
+    // Must win — play lowest to minimize damage
+    return lowest(inSuit) ?? valid[0]!;
+  }
+
+  // No points, not last — play lowest to stay safe
+  return lowest(inSuit) ?? valid[0]!;
+}
+
+function chooseDiscard(valid: Card[]): Card {
+  // 1. Dump Q♠ if in valid plays
+  const qSpades = valid.find(isQueenOfSpades);
+  if (qSpades) return qSpades;
+
+  // 2. Dump highest heart
+  const hearts = valid.filter((c) => c.suit === "hearts").sort((a, b) => b.rank - a.rank);
+  if (hearts.length > 0) return hearts[0]!;
+
+  // 3. Dump highest card of longest suit
+  const groups = bySuitDescending(valid);
+  const longestGroup = groups[0];
+  if (longestGroup) {
+    const card = highest(longestGroup[1]);
+    if (card) return card;
+  }
+
+  return valid[0]!;
+}

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -27,26 +27,6 @@ function trickPoints(trick: readonly TrickCard[]): number {
   return trick.reduce((sum, tc) => sum + cardPoints(tc.card), 0);
 }
 
-/** Index of the current trick winner (highest card of led suit). */
-function trickWinnerIndex(trick: readonly TrickCard[]): number {
-  const first = trick[0];
-  if (!first) return 0;
-  const ledSuit = first.card.suit;
-  let winnerIdx = 0;
-  let winnerRank = first.card.rank;
-  let winnerPlayerIndex = first.playerIndex;
-  for (let i = 1; i < trick.length; i++) {
-    const tc = trick[i]!;
-    if (tc.card.suit === ledSuit && tc.card.rank > winnerRank) {
-      winnerRank = tc.card.rank;
-      winnerPlayerIndex = tc.playerIndex;
-      winnerIdx = i;
-    }
-  }
-  void winnerIdx;
-  return winnerPlayerIndex;
-}
-
 /** Highest card in array, or undefined if empty. */
 function highest(cards: Card[]): Card | undefined {
   return cards.reduce<Card | undefined>((best, c) => {
@@ -86,7 +66,8 @@ function bySuitDescending(cards: Card[]): Array<[string, Card[]]> {
  * 4. High cards of suit being voided (longest suit)
  * 5. Never pass: 2♣ or clubs below 6
  */
-export function selectCardsToPass(hand: Card[], _direction: PassDirection): Card[] {
+export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[] {
+  void direction;
   const selected: Card[] = [];
 
   const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
@@ -223,13 +204,13 @@ export function selectCardToPlay(
   }
 
   if (isLeading) {
-    return chooseLead(valid, state);
+    return chooseLead(valid);
   }
 
-  return chooseFollow(valid, trick, state);
+  return chooseFollow(valid, trick);
 }
 
-function chooseLead(valid: Card[], state: HeartsState): Card {
+function chooseLead(valid: Card[]): Card {
   // Avoid leading hearts or Q♠ unless forced
   const safe = valid.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
   const pool = safe.length > 0 ? safe : valid;
@@ -245,7 +226,7 @@ function chooseLead(valid: Card[], state: HeartsState): Card {
   return lowest(pool) ?? valid[0]!;
 }
 
-function chooseFollow(valid: Card[], trick: readonly TrickCard[], state: HeartsState): Card {
+function chooseFollow(valid: Card[], trick: readonly TrickCard[]): Card {
   const first = trick[0];
   if (!first) return valid[0]!;
 
@@ -258,7 +239,6 @@ function chooseFollow(valid: Card[], trick: readonly TrickCard[], state: HeartsS
   }
 
   // Following suit
-  const currentWinner = trickWinnerIndex(trick);
   const isLastToPlay = trick.length === 3;
   const pts = trickPoints(trick);
 
@@ -272,8 +252,6 @@ function chooseFollow(valid: Card[], trick: readonly TrickCard[], state: HeartsS
 
   // Cards that would lose (rank < winning rank)
   const losing = inSuit.filter((c) => c.rank < winningRank);
-  // Cards that would win
-  const winning = inSuit.filter((c) => c.rank > winningRank);
 
   if (pts === 0 && isLastToPlay) {
     // Safe trick, last to play — exhaust high cards


### PR DESCRIPTION
## Summary
- Implements `selectCardsToPass`: priority-ordered passing (Q♠ unprotected → high ♥ → A♠/K♠ → high cards; never 2♣ or clubs <6)
- Implements `selectCardToPlay`: moon blocking → lead heuristics → follow-suit (lose high, win low) → discard (Q♠ → high ♥ → longest suit)
- Implements `detectPotentialMoon`: flags when one player holds all points with ≥4 point cards
- 20+ unit tests covering all acceptance criteria from #606; all 1228 frontend tests pass

## Test plan
- [ ] All passing strategy cases covered (Q♠ protected/unprotected, high hearts, never 2♣)
- [ ] All play strategy cases covered (void discard, follow suit losing/winning, moon block)
- [ ] `detectPotentialMoon` null cases and positive detection
- [ ] Every `selectCardToPlay` result validated against `getValidPlays` (always legal)
- [ ] CI green

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)