### PR TITLE
feat(sudoku): backend foundation — GameType, module, metadata, migration (#614)

### DIFF
--- a/backend/alembic/versions/0009_add_sudoku_game_type.py
+++ b/backend/alembic/versions/0009_add_sudoku_game_type.py
@@ -1,0 +1,49 @@
+"""add sudoku to game_types lookup table (#614)
+
+Revision ID: 0009_add_sudoku_game_type
+Revises: 0008_add_hearts_game_type
+Create Date: 2026-04-19
+
+Part of Epic #613 — Sudoku. Seeds the DB row so the GameType.SUDOKU enum
+member stays in sync with the game_types lookup table. The per-game
+module lives in backend/sudoku/.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009_add_sudoku_game_type"
+down_revision: Union[str, None] = "0008_add_hearts_game_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    game_types = sa.table(
+        "game_types",
+        sa.column("id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("icon_emoji", sa.Text),
+        sa.column("sort_order", sa.SmallInteger),
+        sa.column("is_active", sa.Boolean),
+    )
+    op.bulk_insert(
+        game_types,
+        [
+            {
+                "id": 8,
+                "name": "sudoku",
+                "display_name": "Sudoku",
+                "icon_emoji": "🔢",
+                "sort_order": 80,
+                "is_active": True,
+            }
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM game_types WHERE name = 'sudoku'")

--- a/backend/games/registry.py
+++ b/backend/games/registry.py
@@ -12,6 +12,7 @@ from blackjack.module import module as blackjack_module
 from cascade.module import module as cascade_module
 from hearts.module import module as hearts_module
 from solitaire.module import module as solitaire_module
+from sudoku.module import module as sudoku_module
 
 from games.protocol import GameModule
 
@@ -22,6 +23,7 @@ _REGISTRY: dict[str, GameModule] = {
     cascade_module.game_type.value: cascade_module,
     hearts_module.game_type.value: hearts_module,
     solitaire_module.game_type.value: solitaire_module,
+    sudoku_module.game_type.value: sudoku_module,
 }
 
 

--- a/backend/scripts/gen_vocab_ts.py
+++ b/backend/scripts/gen_vocab_ts.py
@@ -40,5 +40,4 @@ export const GAME_OUTCOMES = [
 {_OUTCOMES}
 ] as const;
 
-export type GameOutcome = (typeof GAME_OUTCOMES)[number];
-""")
+export type GameOutcome = (typeof GAME_OUTCOMES)[number];""")

--- a/backend/sudoku/models.py
+++ b/backend/sudoku/models.py
@@ -1,0 +1,16 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SudokuMetadata(BaseModel):
+    """Validated metadata shape for Sudoku game rows (#614).
+
+    ``extra="forbid"`` rejects unknown keys.  ``difficulty`` is the only
+    required game-specific field; it's constrained to the three tiers
+    defined in Epic #613.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    player_name: str = Field(default="", max_length=64)
+    difficulty: Literal["easy", "medium", "hard"]

--- a/backend/sudoku/module.py
+++ b/backend/sudoku/module.py
@@ -1,0 +1,27 @@
+"""Sudoku GameModule descriptor (#614).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from sudoku.models import SudokuMetadata
+from vocab import GameType
+
+
+class SudokuModule:
+    """GameModule implementation for Sudoku.
+
+    Uses the default pass-through stats shape: raw aggregate fields are
+    forwarded as-is; ``latest_score`` is stripped (not exposed in API).
+    """
+
+    game_type = GameType.SUDOKU
+    metadata_model = SudokuMetadata
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = SudokuModule()

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0008_add_hearts_game_type"
+        assert version == "0009_add_sudoku_game_type"

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -33,7 +33,15 @@ async def test_seed_data_present() -> None:
     factory = get_session_factory()
     async with factory() as s:
         gt_names = (await s.execute(select(GameType.name).order_by(GameType.id))).scalars().all()
-        assert gt_names == ["yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts"]
+        assert gt_names == [
+            "yacht",
+            "twenty48",
+            "blackjack",
+            "cascade",
+            "solitaire",
+            "hearts",
+            "sudoku",
+        ]
 
         total = (await s.execute(select(func.count()).select_from(EventType))).scalar_one()
         assert total >= 17

--- a/backend/tests/test_game_metadata.py
+++ b/backend/tests/test_game_metadata.py
@@ -14,6 +14,7 @@ from cascade.models import CascadeMetadata
 from games.schemas import CreateGameRequest
 from hearts.models import HeartsMetadata
 from solitaire.models import SolitaireMetadata
+from sudoku.models import SudokuMetadata
 
 # ---------------------------------------------------------------------------
 # BlackjackMetadata unit tests
@@ -102,6 +103,48 @@ def test_hearts_metadata_rejects_unknown_field() -> None:
 
 
 # ---------------------------------------------------------------------------
+# SudokuMetadata unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_sudoku_metadata_valid_easy() -> None:
+    m = SudokuMetadata.model_validate({"difficulty": "easy"})
+    assert m.difficulty == "easy"
+    assert m.player_name == ""
+
+
+def test_sudoku_metadata_valid_with_player_name() -> None:
+    m = SudokuMetadata.model_validate({"player_name": "Alice", "difficulty": "hard"})
+    assert m.player_name == "Alice"
+    assert m.difficulty == "hard"
+
+
+def test_sudoku_metadata_all_difficulty_values_accepted() -> None:
+    for d in ("easy", "medium", "hard"):
+        assert SudokuMetadata.model_validate({"difficulty": d}).difficulty == d
+
+
+def test_sudoku_metadata_missing_difficulty_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SudokuMetadata.model_validate({})
+
+
+def test_sudoku_metadata_invalid_difficulty_rejected() -> None:
+    with pytest.raises(ValidationError):
+        SudokuMetadata.model_validate({"difficulty": "impossible"})
+
+
+def test_sudoku_metadata_player_name_too_long() -> None:
+    with pytest.raises(ValidationError):
+        SudokuMetadata.model_validate({"difficulty": "easy", "player_name": "x" * 65})
+
+
+def test_sudoku_metadata_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        SudokuMetadata.model_validate({"difficulty": "easy", "score": 9999})
+
+
+# ---------------------------------------------------------------------------
 # CreateGameRequest metadata validation
 # ---------------------------------------------------------------------------
 
@@ -134,6 +177,18 @@ def test_create_game_request_valid_solitaire_metadata() -> None:
 def test_create_game_request_invalid_solitaire_metadata_raises_422() -> None:
     with pytest.raises(ValidationError):
         CreateGameRequest(game_type="solitaire", metadata={"player_name": "x" * 65})
+
+
+def test_create_game_request_valid_sudoku_metadata() -> None:
+    req = CreateGameRequest(
+        game_type="sudoku", metadata={"player_name": "Bob", "difficulty": "medium"}
+    )
+    assert req.metadata["difficulty"] == "medium"
+
+
+def test_create_game_request_invalid_sudoku_metadata_raises_422() -> None:
+    with pytest.raises(ValidationError):
+        CreateGameRequest(game_type="sudoku", metadata={"difficulty": "impossible"})
 
 
 def test_create_game_request_unregistered_game_type_skips_validation() -> None:

--- a/backend/tests/test_game_module_protocol.py
+++ b/backend/tests/test_game_module_protocol.py
@@ -10,6 +10,7 @@ from games.protocol import GameModule
 from games.registry import get_module
 from hearts.module import module as hearts_module
 from solitaire.module import module as solitaire_module
+from sudoku.module import module as sudoku_module
 from vocab import GameType
 
 # ---------------------------------------------------------------------------
@@ -19,8 +20,8 @@ from vocab import GameType
 
 @pytest.mark.parametrize(
     "mod",
-    [blackjack_module, cascade_module, hearts_module, solitaire_module],
-    ids=["blackjack", "cascade", "hearts", "solitaire"],
+    [blackjack_module, cascade_module, hearts_module, solitaire_module, sudoku_module],
+    ids=["blackjack", "cascade", "hearts", "solitaire", "sudoku"],
 )
 def test_module_satisfies_protocol(mod) -> None:
     assert isinstance(mod, GameModule), f"{mod!r} does not satisfy the GameModule Protocol"
@@ -42,6 +43,10 @@ def test_hearts_module_game_type() -> None:
     assert hearts_module.game_type == GameType.HEARTS
 
 
+def test_sudoku_module_game_type() -> None:
+    assert sudoku_module.game_type == GameType.SUDOKU
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -52,6 +57,7 @@ def test_registry_returns_correct_modules() -> None:
     assert get_module("cascade") is cascade_module
     assert get_module("hearts") is hearts_module
     assert get_module("solitaire") is solitaire_module
+    assert get_module("sudoku") is sudoku_module
 
 
 def test_registry_returns_none_for_unknown() -> None:
@@ -171,4 +177,29 @@ def test_hearts_stats_shape_preserves_aggregate_fields() -> None:
 
 def test_hearts_stats_shape_strips_latest_score() -> None:
     shaped = hearts_module.stats_shape(_RAW_HEARTS)
+    assert "latest_score" not in shaped
+
+
+# ---------------------------------------------------------------------------
+# SudokuModule.stats_shape — pass-through, strips latest_score
+# ---------------------------------------------------------------------------
+
+_RAW_SUDOKU = {
+    "played": 6,
+    "best": 290,
+    "avg": 180.0,
+    "last_played_at": None,
+    "latest_score": 200,
+}
+
+
+def test_sudoku_stats_shape_preserves_aggregate_fields() -> None:
+    shaped = sudoku_module.stats_shape(_RAW_SUDOKU)
+    assert shaped["played"] == 6
+    assert shaped["best"] == 290
+    assert shaped["avg"] == 180.0
+
+
+def test_sudoku_stats_shape_strips_latest_score() -> None:
+    shaped = sudoku_module.stats_shape(_RAW_SUDOKU)
     assert "latest_score" not in shaped

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -65,7 +65,7 @@ def test_game_outcome_ts_in_sync() -> None:
 
 def test_game_type_enum_values() -> None:
     """Regression guard — no value should be silently removed from GameType."""
-    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts"}
+    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts", "sudoku"}
     assert {v.value for v in GameType} == expected
 
 

--- a/backend/vocab.py
+++ b/backend/vocab.py
@@ -35,6 +35,7 @@ class GameType(str, Enum):
     CASCADE = "cascade"
     SOLITAIRE = "solitaire"
     HEARTS = "hearts"
+    SUDOKU = "sudoku"
 
 
 class GameOutcome(str, Enum):

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -16,6 +16,7 @@ export const GAME_TYPES = [
   "cascade",
   "solitaire",
   "hearts",
+  "sudoku",
 ] as const;
 
 export type GameType = (typeof GAME_TYPES)[number];
@@ -31,3 +32,4 @@ export const GAME_OUTCOMES = [
 ] as const;
 
 export type GameOutcome = (typeof GAME_OUTCOMES)[number];
+

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -32,4 +32,3 @@ export const GAME_OUTCOMES = [
 ] as const;
 
 export type GameOutcome = (typeof GAME_OUTCOMES)[number];
-


### PR DESCRIPTION
## Summary
- Part of Epic #613. Closes #614.
- Adds `GameType.SUDOKU`, `backend/sudoku/` package (`SudokuMetadata` with `difficulty: easy|medium|hard`, `SudokuModule` with default pass-through stats shape), and registers it in `games/registry.py`.
- Alembic migration 0009 seeds the `game_types` row (id=8, 🔢, sort_order=80). Regenerates `frontend/src/api/vocab.ts`.

## Test plan
- [x] `pytest tests/` — 601 passed, 2 skipped
- [x] `alembic upgrade head` then `alembic downgrade 0008_add_hearts_game_type` then back up — applies and reverses cleanly
- [x] `SudokuMetadata` rejects missing/invalid `difficulty`, extras, and `player_name > 64` chars
- [x] `isinstance(sudoku_module, GameModule)` holds; registry lookup returns the singleton
- [x] `test_vocab.py` GameType ↔ DB ↔ TS drift guard passes with new member

🤖 Generated with [Claude Code](https://claude.com/claude-code)