### PR TITLE
feat(sudoku): leaderboard endpoints — POST /score, GET /scores/{difficulty} (#615)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
 from hearts.router import router as hearts_router
 from solitaire.router import router as solitaire_router
+from sudoku.router import router as sudoku_router
 from yacht.router import router as yacht_router
 from games.router import router as games_router
 from logs.router import router as logs_router
@@ -54,6 +55,7 @@ app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
 app.include_router(hearts_router, prefix="/hearts")
 app.include_router(solitaire_router, prefix="/solitaire")
+app.include_router(sudoku_router, prefix="/sudoku")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")
 app.include_router(stats_router, prefix="/stats")

--- a/backend/sudoku/models.py
+++ b/backend/sudoku/models.py
@@ -2,6 +2,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+Difficulty = Literal["easy", "medium", "hard"]
+
 
 class SudokuMetadata(BaseModel):
     """Validated metadata shape for Sudoku game rows (#614).
@@ -13,4 +15,20 @@ class SudokuMetadata(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     player_name: str = Field(default="", max_length=64)
-    difficulty: Literal["easy", "medium", "hard"]
+    difficulty: Difficulty
+
+
+class ScoreSubmitRequest(BaseModel):
+    player_name: str = Field(..., min_length=1, max_length=32)
+    score: int = Field(..., ge=0)
+    difficulty: Difficulty
+
+
+class ScoreEntry(BaseModel):
+    player_name: str
+    score: int
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/sudoku/router.py
+++ b/backend/sudoku/router.py
@@ -1,0 +1,117 @@
+"""Sudoku leaderboards (#615) — difficulty-scoped top-10 lists.
+
+Each difficulty tier (easy / medium / hard) has its own leaderboard.
+Scores are stored in the shared ``games`` table tagged with the
+``sudoku`` game_type_id and a ``difficulty`` key in
+``game_metadata``; the GET endpoint filters on that key so the three
+tiers stay isolated.
+
+Mirrors the Solitaire/Hearts leaderboard shape (POST returns the
+caller's rank, GET returns the top 10). The only structural difference
+is the ``difficulty`` parameter — required on submit, a path param on
+read.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Path, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import Difficulty, LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+_SUDOKU_SESSION = "sudoku-anon"  # placeholder until SSO
+
+
+async def _sudoku_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.SUDOKU))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="sudoku game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession, difficulty: Difficulty) -> list[ScoreEntry]:
+    gt_id = await _sudoku_game_type_id(db)
+    # `as_string()` produces json_extract(...) on SQLite and ->> on JSONB,
+    # so this filter works under both the test harness and prod Postgres.
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                    Game.game_metadata["difficulty"].as_string() == difficulty,
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _sudoku_game_type_id(db)
+        game = Game(
+            session_id=_SUDOKU_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name, "difficulty": body.difficulty},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db, body.difficulty)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    # Not in top 10 — report the truncated-off rank.
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/scores/{difficulty}", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(
+    request: Request,
+    difficulty: Difficulty = Path(..., description="One of: easy, medium, hard"),
+) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db, difficulty)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. The leaderboard lives in the DB; conftest's
+    ``clean_db_tables`` fixture handles per-test isolation.
+    """
+    return None

--- a/backend/tests/test_sudoku_api.py
+++ b/backend/tests/test_sudoku_api.py
@@ -1,0 +1,173 @@
+"""Tests for /sudoku/score and /sudoku/scores/{difficulty} (#615).
+
+Adapts the Solitaire leaderboard test pattern to Sudoku's
+difficulty-partitioned model: each of easy / medium / hard is its own
+top-10 list, enforced at the query level via ``game_metadata->>'difficulty'``.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def _submit(player_name: str, score: int, difficulty: str = "easy"):
+    return client.post(
+        "/sudoku/score",
+        json={"player_name": player_name, "score": score, "difficulty": difficulty},
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /sudoku/score — validation
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 80, "easy")
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["score"] == 80
+        assert body["rank"] == 1
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/sudoku/score", json={"score": 100, "difficulty": "easy"})
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post(
+            "/sudoku/score", json={"player_name": "Bob", "difficulty": "easy"}
+        )
+        assert res.status_code == 422
+
+    def test_missing_difficulty_returns_422(self):
+        res = client.post("/sudoku/score", json={"player_name": "Bob", "score": 100})
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        assert _submit("", 100).status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        assert _submit("x" * 33, 100).status_code == 422
+
+    def test_negative_score_returns_422(self):
+        assert _submit("Alice", -1).status_code == 422
+
+    def test_invalid_difficulty_returns_422(self):
+        assert _submit("Alice", 100, "impossible").status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /sudoku/scores/{difficulty}
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/sudoku/scores/easy")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries_for_difficulty(self):
+        _submit("Alice", 90, "easy")
+        _submit("Bob", 60, "easy")
+        scores = client.get("/sudoku/scores/easy").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_score_descending(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 40, "medium")
+        limiter.reset()
+        _submit("Bob", 180, "medium")
+        limiter.reset()
+        _submit("Carol", 120, "medium")
+        scores = client.get("/sudoku/scores/medium").json()["scores"]
+        assert [s["score"] for s in scores] == [180, 120, 40]
+
+    def test_invalid_difficulty_path_returns_422(self):
+        assert client.get("/sudoku/scores/impossible").status_code == 422
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()
+            _submit(f"Player{i}", i * 10, "hard")
+        scores = client.get("/sudoku/scores/hard").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["score"] == 140
+
+
+# ---------------------------------------------------------------------------
+# Difficulty isolation — the critical contract
+# ---------------------------------------------------------------------------
+
+
+class TestDifficultyIsolation:
+    def test_easy_submission_absent_from_hard(self):
+        _submit("EasyPlayer", 100, "easy")
+        hard = client.get("/sudoku/scores/hard").json()["scores"]
+        assert hard == []
+
+    def test_hard_submission_absent_from_easy(self):
+        _submit("HardPlayer", 290, "hard")
+        easy = client.get("/sudoku/scores/easy").json()["scores"]
+        assert easy == []
+
+    def test_three_tiers_kept_separate(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("E", 100, "easy")
+        limiter.reset()
+        _submit("M", 200, "medium")
+        limiter.reset()
+        _submit("H", 300, "hard")
+
+        easy = client.get("/sudoku/scores/easy").json()["scores"]
+        medium = client.get("/sudoku/scores/medium").json()["scores"]
+        hard = client.get("/sudoku/scores/hard").json()["scores"]
+
+        assert [s["player_name"] for s in easy] == ["E"]
+        assert [s["player_name"] for s in medium] == ["M"]
+        assert [s["player_name"] for s in hard] == ["H"]
+
+
+# ---------------------------------------------------------------------------
+# Rank semantics
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 90, "easy").json()["rank"] == 1
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000, "medium")
+        limiter.reset()
+        assert _submit("Lowly", 1, "medium").json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — POST /sudoku/score is 5/min
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"P{i}", i * 10, "easy").status_code == 201
+        assert _submit("Excess", 999, "easy").status_code == 429
+        limiter.reset()

--- a/backend/tests/test_sudoku_api.py
+++ b/backend/tests/test_sudoku_api.py
@@ -5,7 +5,6 @@ difficulty-partitioned model: each of easy / medium / hard is its own
 top-10 list, enforced at the query level via ``game_metadata->>'difficulty'``.
 """
 
-import pytest
 from fastapi.testclient import TestClient
 
 from main import app
@@ -39,9 +38,7 @@ class TestSubmitScore:
         assert res.status_code == 422
 
     def test_missing_score_returns_422(self):
-        res = client.post(
-            "/sudoku/score", json={"player_name": "Bob", "difficulty": "easy"}
-        )
+        res = client.post("/sudoku/score", json={"player_name": "Bob", "difficulty": "easy"})
         assert res.status_code == 422
 
     def test_missing_difficulty_returns_422(self):


### PR DESCRIPTION
## Summary
- Part of Epic #613. Closes #615.
- Adds `POST /sudoku/score` (5/min) — body `{player_name, score, difficulty}` stores difficulty in `game_metadata`, returns rank.
- Adds `GET /sudoku/scores/{difficulty}` (60/min) — path param validated against `easy|medium|hard` (→ 422 otherwise), filters at query level on `metadata->>'difficulty'`.
- Mirrors the solitaire/hearts leaderboard shape. 19 new tests: validation, difficulty isolation (easy ↛ hard etc.), rank math, top-10 cap, rate-limit 429.

## Test plan
- [x] `pytest tests/` — 620 passed, 2 skipped, 86% total coverage
- [x] `pytest tests/test_sudoku_api.py -v` — 19/19 green
- [x] Three-tier isolation verified: submitting to easy leaves medium/hard empty
- [x] Invalid `difficulty` on both POST body and GET path → 422
- [x] Negative score → 422; empty `player_name` → 422; `player_name > 32` → 422
- [x] 6th POST within 1 min → 429

## Notes
- `sudoku/router.py` shows 73% file coverage — same pattern as `solitaire/router.py` (73%) and `hearts/router.py`. Coverage.py mis-attributes async-def bodies under the `@limiter.limit` decorator; the code paths are exercised by the tests (otherwise POST would never insert a row and GET would always be empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)