### PR TITLE
feat(sudoku): presentational components — grid, cell, number pad, difficulty selector (#617)

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -98,6 +98,7 @@ import blackjack from "./src/i18n/locales/en/blackjack.json";
 import twenty48 from "./src/i18n/locales/en/twenty48.json";
 import solitaire from "./src/i18n/locales/en/solitaire.json";
 import hearts from "./src/i18n/locales/en/hearts.json";
+import sudoku from "./src/i18n/locales/en/sudoku.json";
 import feedback from "./src/i18n/locales/en/feedback.json";
 import profile from "./src/i18n/locales/en/profile.json";
 
@@ -113,6 +114,7 @@ i18n.use(initReactI18next).init({
     "twenty48",
     "solitaire",
     "hearts",
+    "sudoku",
     "feedback",
     "profile",
   ],
@@ -127,6 +129,7 @@ i18n.use(initReactI18next).init({
       twenty48,
       solitaire,
       hearts,
+      sudoku,
       feedback,
       profile,
     },

--- a/frontend/src/components/sudoku/DifficultySelector.tsx
+++ b/frontend/src/components/sudoku/DifficultySelector.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import type { Difficulty } from "../../game/sudoku/types";
+import { DIFFICULTIES } from "../../game/sudoku/types";
+
+interface Props {
+  value: Difficulty;
+  onChange: (d: Difficulty) => void;
+}
+
+export default function DifficultySelector({ value, onChange }: Props) {
+  const { t } = useTranslation("sudoku");
+  const { colors } = useTheme();
+
+  return (
+    <View
+      accessibilityRole="radiogroup"
+      accessibilityLabel={t("difficulty.groupLabel", {
+        defaultValue: "Difficulty",
+      })}
+      style={[styles.row, { borderColor: colors.border }]}
+    >
+      {DIFFICULTIES.map((d) => {
+        const selected = d === value;
+        return (
+          <Pressable
+            key={d}
+            onPress={() => onChange(d)}
+            accessibilityRole="radio"
+            accessibilityLabel={t(`difficulty.${d}`, {
+              defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
+            })}
+            accessibilityState={{ selected }}
+            style={[
+              styles.btn,
+              {
+                backgroundColor: selected ? colors.accent : colors.surface,
+              },
+            ]}
+          >
+            <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
+              {t(`difficulty.${d}`, {
+                defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
+              })}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    borderWidth: 1,
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+});

--- a/frontend/src/components/sudoku/NumberPad.tsx
+++ b/frontend/src/components/sudoku/NumberPad.tsx
@@ -1,0 +1,148 @@
+import React, { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import type { CellValue, Grid } from "../../game/sudoku/types";
+
+interface Props {
+  /** Used to compute which digits already have all 9 instances placed. */
+  grid: Grid;
+  notesMode: boolean;
+  onDigit: (digit: CellValue) => void;
+  onErase: () => void;
+  onToggleNotes: () => void;
+}
+
+const DIGITS: readonly CellValue[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+function countValue(grid: Grid, digit: CellValue): number {
+  let n = 0;
+  for (const row of grid) for (const cell of row) if (cell.value === digit) n++;
+  return n;
+}
+
+export default function NumberPad({ grid, notesMode, onDigit, onErase, onToggleNotes }: Props) {
+  const { t } = useTranslation("sudoku");
+  const { colors } = useTheme();
+
+  // Dim digits where all 9 instances are already placed. Recomputed on
+  // every render so that placing the 9th "8" immediately dims its key
+  // without waiting for another re-render trigger.
+  const completed = useMemo<ReadonlySet<CellValue>>(() => {
+    const done = new Set<CellValue>();
+    for (const d of DIGITS) if (countValue(grid, d) === 9) done.add(d);
+    return done;
+  }, [grid]);
+
+  return (
+    <View style={styles.pad}>
+      <View style={styles.digitGrid}>
+        {DIGITS.map((d) => {
+          const disabled = completed.has(d);
+          return (
+            <Pressable
+              key={d}
+              onPress={() => onDigit(d)}
+              disabled={disabled}
+              accessibilityRole="button"
+              accessibilityLabel={t("numberPad.digit", {
+                digit: d,
+                defaultValue: `Enter digit ${d}`,
+              })}
+              accessibilityState={{ disabled }}
+              style={[
+                styles.digitBtn,
+                {
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                  opacity: disabled ? 0.35 : 1,
+                },
+              ]}
+            >
+              <Text style={[styles.digitText, { color: colors.text }]}>{d}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <View style={styles.actionRow}>
+        <Pressable
+          onPress={onToggleNotes}
+          accessibilityRole="button"
+          accessibilityLabel={t("numberPad.toggleNotes", {
+            defaultValue: "Toggle pencil marks",
+          })}
+          accessibilityState={{ selected: notesMode }}
+          style={[
+            styles.actionBtn,
+            {
+              backgroundColor: notesMode ? colors.accent : colors.surface,
+              borderColor: colors.border,
+            },
+          ]}
+        >
+          <Text
+            style={[styles.actionText, { color: notesMode ? colors.textOnAccent : colors.text }]}
+          >
+            {t("numberPad.notes", { defaultValue: "Notes" })}
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onErase}
+          accessibilityRole="button"
+          accessibilityLabel={t("numberPad.erase", {
+            defaultValue: "Erase cell",
+          })}
+          style={[
+            styles.actionBtn,
+            { backgroundColor: colors.surface, borderColor: colors.border },
+          ]}
+        >
+          <Text style={[styles.actionText, { color: colors.text }]}>
+            {t("numberPad.eraseShort", { defaultValue: "Erase" })}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pad: {
+    width: "100%",
+    gap: 8,
+  },
+  digitGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    gap: 8,
+  },
+  digitBtn: {
+    width: "31%",
+    aspectRatio: 2,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  digitText: {
+    fontSize: 22,
+    fontWeight: "600",
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  actionBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  actionText: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+});

--- a/frontend/src/components/sudoku/SudokuCell.tsx
+++ b/frontend/src/components/sudoku/SudokuCell.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import type { NoteDigit, SudokuCell as SudokuCellData } from "../../game/sudoku/types";
+
+interface Props {
+  cell: SudokuCellData;
+  row: number;
+  col: number;
+  selected: boolean;
+  /** Non-selected cell that holds the same digit as the selected cell. */
+  highlighted: boolean;
+  onPress: () => void;
+}
+
+const NOTE_DIGITS: readonly NoteDigit[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+export default function SudokuCell({ cell, row, col, selected, highlighted, onPress }: Props) {
+  const { t } = useTranslation("sudoku");
+  const { colors } = useTheme();
+
+  const background = selected
+    ? // 20% tint of the accent colour — tokens don't expose a pre-mixed
+      // "accent-dim" so we piggyback on surfaceHigh and the accent border
+      // for the selection affordance.
+      colors.surfaceHigh
+    : highlighted
+      ? colors.surfaceAlt
+      : colors.surface;
+
+  const borderColor = selected ? colors.accent : colors.border;
+
+  const valueColor = cell.given ? colors.text : cell.isError ? colors.error : colors.accent;
+
+  const label = t("cell.label", {
+    row: row + 1,
+    col: col + 1,
+    value: cell.value === 0 ? t("cell.empty") : String(cell.value),
+    defaultValue: `Cell row ${row + 1}, column ${col + 1}, ${cell.value === 0 ? "empty" : cell.value}`,
+  });
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected }}
+      style={[
+        styles.cell,
+        {
+          backgroundColor: background,
+          borderColor,
+          borderWidth: selected ? 2 : StyleSheet.hairlineWidth,
+        },
+      ]}
+    >
+      {cell.value !== 0 ? (
+        <Text style={[styles.value, { color: valueColor, fontWeight: cell.given ? "700" : "600" }]}>
+          {cell.value}
+        </Text>
+      ) : cell.notes.size > 0 ? (
+        <View style={styles.notesGrid}>
+          {NOTE_DIGITS.map((d) => (
+            <Text
+              key={d}
+              style={[styles.note, { color: cell.notes.has(d) ? colors.textMuted : "transparent" }]}
+            >
+              {d}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  cell: {
+    flex: 1,
+    aspectRatio: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  value: {
+    fontSize: 22,
+  },
+  notesGrid: {
+    width: "100%",
+    height: "100%",
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 2,
+  },
+  note: {
+    width: "33.33%",
+    textAlign: "center",
+    fontSize: 9,
+    lineHeight: 11,
+  },
+});

--- a/frontend/src/components/sudoku/SudokuGrid.tsx
+++ b/frontend/src/components/sudoku/SudokuGrid.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "../../theme/ThemeContext";
+import type { Grid } from "../../game/sudoku/types";
+import SudokuCell from "./SudokuCell";
+
+interface Props {
+  grid: Grid;
+  selectedRow: number | null;
+  selectedCol: number | null;
+  onCellPress: (row: number, col: number) => void;
+}
+
+export default function SudokuGrid({ grid, selectedRow, selectedCol, onCellPress }: Props) {
+  const { colors } = useTheme();
+
+  // Digit of the currently-selected cell (0 = empty / nothing to match).
+  const selectedValue =
+    selectedRow !== null && selectedCol !== null
+      ? (grid[selectedRow]?.[selectedCol]?.value ?? 0)
+      : 0;
+
+  return (
+    <View
+      accessibilityLabel="Sudoku board"
+      style={[styles.grid, { backgroundColor: colors.border }]}
+    >
+      {grid.map((row, r) => (
+        <View key={r} style={styles.row}>
+          {row.map((cell, c) => {
+            // Thick box borders: every 3rd internal boundary (cols 3, 6;
+            // rows 3, 6) gets the full-weight `colors.border`. Outer edges
+            // are handled by the container background showing through.
+            const boxRight = c % 3 === 2 && c !== 8 ? 2 : 0;
+            const boxBottom = r % 3 === 2 && r !== 8 ? 2 : 0;
+            const hair = StyleSheet.hairlineWidth;
+            return (
+              <View
+                key={`${r}-${c}`}
+                style={{
+                  flex: 1,
+                  marginRight: c === 8 ? 0 : boxRight || hair,
+                  marginBottom: r === 8 ? 0 : boxBottom || hair,
+                }}
+              >
+                <SudokuCell
+                  cell={cell}
+                  row={r}
+                  col={c}
+                  selected={r === selectedRow && c === selectedCol}
+                  highlighted={
+                    selectedValue !== 0 &&
+                    cell.value === selectedValue &&
+                    !(r === selectedRow && c === selectedCol)
+                  }
+                  onPress={() => onCellPress(r, c)}
+                />
+              </View>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    width: "100%",
+    aspectRatio: 1,
+    flexDirection: "column",
+  },
+  row: {
+    flex: 1,
+    flexDirection: "row",
+  },
+});

--- a/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
+++ b/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
@@ -1,0 +1,5944 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DifficultySelector matches snapshot — medium selected 1`] = `
+<View
+  accessibilityLabel="Difficulty"
+  accessibilityRole="radiogroup"
+  style={
+    [
+      {
+        "borderRadius": 8,
+        "borderWidth": 1,
+        "flexDirection": "row",
+        "overflow": "hidden",
+      },
+      {
+        "borderColor": "#2e2e38",
+      },
+    ]
+  }
+>
+  <View
+    accessibilityLabel="Easy"
+    accessibilityRole="radio"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": false,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "paddingVertical": 10,
+        },
+        {
+          "backgroundColor": "#19191f",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "fontSize": 15,
+            "fontWeight": "600",
+          },
+          {
+            "color": "#e8e8f0",
+          },
+        ]
+      }
+    >
+      Easy
+    </Text>
+  </View>
+  <View
+    accessibilityLabel="Medium"
+    accessibilityRole="radio"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": true,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "paddingVertical": 10,
+        },
+        {
+          "backgroundColor": "#8ff5ff",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "fontSize": 15,
+            "fontWeight": "600",
+          },
+          {
+            "color": "#0e0e13",
+          },
+        ]
+      }
+    >
+      Medium
+    </Text>
+  </View>
+  <View
+    accessibilityLabel="Hard"
+    accessibilityRole="radio"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": false,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      [
+        {
+          "alignItems": "center",
+          "flex": 1,
+          "justifyContent": "center",
+          "paddingVertical": 10,
+        },
+        {
+          "backgroundColor": "#19191f",
+        },
+      ]
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "fontSize": 15,
+            "fontWeight": "600",
+          },
+          {
+            "color": "#e8e8f0",
+          },
+        ]
+      }
+    >
+      Hard
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`NumberPad matches snapshot — notes mode active 1`] = `
+<View
+  style={
+    {
+      "gap": 8,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 8,
+        "justifyContent": "space-between",
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Enter digit 1"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        1
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 2"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        2
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 3"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        3
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 4"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        4
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 5"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        5
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 6"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        6
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 7"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        7
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 8"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        8
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Enter digit 9"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": false,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "aspectRatio": 2,
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "justifyContent": "center",
+            "width": "31%",
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+            "opacity": 1,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 22,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        9
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "gap": 8,
+      }
+    }
+  >
+    <View
+      accessibilityLabel="Toggle pencil marks"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": true,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingVertical": 10,
+          },
+          {
+            "backgroundColor": "#8ff5ff",
+            "borderColor": "#2e2e38",
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 15,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#0e0e13",
+            },
+          ]
+        }
+      >
+        Notes
+      </Text>
+    </View>
+    <View
+      accessibilityLabel="Erase cell"
+      accessibilityRole="button"
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        [
+          {
+            "alignItems": "center",
+            "borderRadius": 8,
+            "borderWidth": 1,
+            "flex": 1,
+            "justifyContent": "center",
+            "paddingVertical": 10,
+          },
+          {
+            "backgroundColor": "#19191f",
+            "borderColor": "#2e2e38",
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "fontSize": 15,
+              "fontWeight": "600",
+            },
+            {
+              "color": "#e8e8f0",
+            },
+          ]
+        }
+      >
+        Erase
+      </Text>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`SudokuCell matches snapshot — given value 1`] = `
+<View
+  accessibilityLabel="Cell row 1, column 1, 7"
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": false,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "aspectRatio": 1,
+        "flex": 1,
+        "justifyContent": "center",
+      },
+      {
+        "backgroundColor": "#19191f",
+        "borderColor": "#2e2e38",
+        "borderWidth": 0.5,
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontSize": 22,
+        },
+        {
+          "color": "#e8e8f0",
+          "fontWeight": "700",
+        },
+      ]
+    }
+  >
+    7
+  </Text>
+</View>
+`;
+
+exports[`SudokuCell matches snapshot — selected error cell 1`] = `
+<View
+  accessibilityLabel="Cell row 4, column 4, 2"
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": true,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    [
+      {
+        "alignItems": "center",
+        "aspectRatio": 1,
+        "flex": 1,
+        "justifyContent": "center",
+      },
+      {
+        "backgroundColor": "#25252c",
+        "borderColor": "#8ff5ff",
+        "borderWidth": 2,
+      },
+    ]
+  }
+>
+  <Text
+    style={
+      [
+        {
+          "fontSize": 22,
+        },
+        {
+          "color": "#ff716c",
+          "fontWeight": "600",
+        },
+      ]
+    }
+  >
+    2
+  </Text>
+</View>
+`;
+
+exports[`SudokuGrid matches snapshot with a typical mid-game state 1`] = `
+<View
+  accessibilityLabel="Sudoku board"
+  style={
+    [
+      {
+        "aspectRatio": 1,
+        "flexDirection": "column",
+        "width": "100%",
+      },
+      {
+        "backgroundColor": "#2e2e38",
+      },
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 1, 5"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+              },
+              {
+                "color": "#e8e8f0",
+                "fontWeight": "700",
+              },
+            ]
+          }
+        >
+          5
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 1, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 2, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 3, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 4, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 5, 3"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": true,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#25252c",
+              "borderColor": "#8ff5ff",
+              "borderWidth": 2,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+              },
+              {
+                "color": "#8ff5ff",
+                "fontWeight": "600",
+              },
+            ]
+          }
+        >
+          3
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 5, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 2,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 6, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 7, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0.5,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 8, column 9, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flex": 1,
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 1, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 2, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 3, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 4, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 5, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 2,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 6, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 7, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0.5,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 8, empty"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      style={
+        {
+          "flex": 1,
+          "marginBottom": 0,
+          "marginRight": 0,
+        }
+      }
+    >
+      <View
+        accessibilityLabel="Cell row 9, column 9, 7"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": false,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "aspectRatio": 1,
+              "flex": 1,
+              "justifyContent": "center",
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "borderWidth": 0.5,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+              },
+              {
+                "color": "#ff716c",
+                "fontWeight": "600",
+              },
+            ]
+          }
+        >
+          7
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/frontend/src/components/sudoku/__tests__/components.test.tsx
+++ b/frontend/src/components/sudoku/__tests__/components.test.tsx
@@ -1,0 +1,319 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { ThemeProvider } from "../../../theme/ThemeContext";
+import SudokuCell from "../SudokuCell";
+import SudokuGrid from "../SudokuGrid";
+import NumberPad from "../NumberPad";
+import DifficultySelector from "../DifficultySelector";
+import type {
+  CellValue,
+  Grid,
+  NoteDigit,
+  SudokuCell as SudokuCellData,
+} from "../../../game/sudoku/types";
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+function cell(overrides: Partial<SudokuCellData> = {}): SudokuCellData {
+  return {
+    value: 0,
+    given: false,
+    notes: new Set<NoteDigit>(),
+    isError: false,
+    ...overrides,
+  };
+}
+
+function emptyGrid(): SudokuCellData[][] {
+  const rows: SudokuCellData[][] = [];
+  for (let r = 0; r < 9; r++) {
+    const row: SudokuCellData[] = [];
+    for (let c = 0; c < 9; c++) row.push(cell());
+    rows.push(row);
+  }
+  return rows;
+}
+
+// Cast helper — tests need to mutate cells before passing to components, but
+// the `Grid` type is readonly-of-readonly.  The cast loses no safety because
+// components treat the grid as immutable.
+function asGrid(g: SudokuCellData[][]): Grid {
+  return g;
+}
+
+// ---------------------------------------------------------------------------
+// SudokuCell
+// ---------------------------------------------------------------------------
+
+describe("SudokuCell", () => {
+  it("renders a given digit", () => {
+    const { getByText } = wrap(
+      <SudokuCell
+        cell={cell({ value: 5, given: true })}
+        row={0}
+        col={0}
+        selected={false}
+        highlighted={false}
+        onPress={() => {}}
+      />
+    );
+    expect(getByText("5")).toBeTruthy();
+  });
+
+  it("renders pencil notes when no value is set", () => {
+    const notes = new Set<NoteDigit>([1, 4, 7]);
+    const { getByText } = wrap(
+      <SudokuCell
+        cell={cell({ notes })}
+        row={0}
+        col={0}
+        selected={false}
+        highlighted={false}
+        onPress={() => {}}
+      />
+    );
+    expect(getByText("1")).toBeTruthy();
+    expect(getByText("4")).toBeTruthy();
+    expect(getByText("7")).toBeTruthy();
+  });
+
+  it("exposes accessibility role=button with row/col label", () => {
+    const { getByRole } = wrap(
+      <SudokuCell
+        cell={cell({ value: 3 })}
+        row={4}
+        col={6}
+        selected={false}
+        highlighted={false}
+        onPress={() => {}}
+      />
+    );
+    const btn = getByRole("button");
+    expect(btn.props.accessibilityLabel).toMatch(/row 5/i);
+    expect(btn.props.accessibilityLabel).toMatch(/column 7/i);
+  });
+
+  it("calls onPress when pressed", () => {
+    const onPress = jest.fn();
+    const { getByRole } = wrap(
+      <SudokuCell
+        cell={cell()}
+        row={0}
+        col={0}
+        selected={false}
+        highlighted={false}
+        onPress={onPress}
+      />
+    );
+    fireEvent.press(getByRole("button"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches snapshot — given value", () => {
+    const tree = wrap(
+      <SudokuCell
+        cell={cell({ value: 7, given: true })}
+        row={0}
+        col={0}
+        selected={false}
+        highlighted={false}
+        onPress={() => {}}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("matches snapshot — selected error cell", () => {
+    const tree = wrap(
+      <SudokuCell
+        cell={cell({ value: 2, isError: true })}
+        row={3}
+        col={3}
+        selected={true}
+        highlighted={false}
+        onPress={() => {}}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SudokuGrid
+// ---------------------------------------------------------------------------
+
+describe("SudokuGrid", () => {
+  it("renders 81 cell buttons", () => {
+    const { getAllByRole } = wrap(
+      <SudokuGrid
+        grid={asGrid(emptyGrid())}
+        selectedRow={null}
+        selectedCol={null}
+        onCellPress={() => {}}
+      />
+    );
+    expect(getAllByRole("button")).toHaveLength(81);
+  });
+
+  it("propagates onCellPress with (row, col) args", () => {
+    const onCellPress = jest.fn();
+    const { getAllByRole } = wrap(
+      <SudokuGrid
+        grid={asGrid(emptyGrid())}
+        selectedRow={null}
+        selectedCol={null}
+        onCellPress={onCellPress}
+      />
+    );
+    // Cells are rendered row-major — index 10 is (row 1, col 1).
+    const cells = getAllByRole("button");
+    fireEvent.press(cells[10]!);
+    expect(onCellPress).toHaveBeenCalledWith(1, 1);
+  });
+
+  it("matches snapshot with a typical mid-game state", () => {
+    const g = emptyGrid();
+    g[0]![0] = cell({ value: 5, given: true });
+    g[4]![4] = cell({ value: 3 });
+    g[8]![8] = cell({ value: 7, isError: true });
+    const tree = wrap(
+      <SudokuGrid grid={asGrid(g)} selectedRow={4} selectedCol={4} onCellPress={() => {}} />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NumberPad
+// ---------------------------------------------------------------------------
+
+describe("NumberPad", () => {
+  it("renders 9 digits + erase + notes actions", () => {
+    const { getAllByRole, getByLabelText } = wrap(
+      <NumberPad
+        grid={asGrid(emptyGrid())}
+        notesMode={false}
+        onDigit={() => {}}
+        onErase={() => {}}
+        onToggleNotes={() => {}}
+      />
+    );
+    const buttons = getAllByRole("button");
+    expect(buttons.length).toBe(11);
+    expect(getByLabelText(/erase/i)).toBeTruthy();
+    expect(getByLabelText(/pencil/i)).toBeTruthy();
+  });
+
+  it("fires onDigit with the placed digit", () => {
+    const onDigit = jest.fn();
+    const { getByLabelText } = wrap(
+      <NumberPad
+        grid={asGrid(emptyGrid())}
+        notesMode={false}
+        onDigit={onDigit}
+        onErase={() => {}}
+        onToggleNotes={() => {}}
+      />
+    );
+    fireEvent.press(getByLabelText(/enter digit 5/i));
+    expect(onDigit).toHaveBeenCalledWith(5);
+  });
+
+  it("fires onErase and onToggleNotes", () => {
+    const onErase = jest.fn();
+    const onToggleNotes = jest.fn();
+    const { getByLabelText } = wrap(
+      <NumberPad
+        grid={asGrid(emptyGrid())}
+        notesMode={false}
+        onDigit={() => {}}
+        onErase={onErase}
+        onToggleNotes={onToggleNotes}
+      />
+    );
+    fireEvent.press(getByLabelText(/erase/i));
+    fireEvent.press(getByLabelText(/pencil/i));
+    expect(onErase).toHaveBeenCalledTimes(1);
+    expect(onToggleNotes).toHaveBeenCalledTimes(1);
+  });
+
+  it("dims digits where all 9 instances are placed", () => {
+    // Seed 9 cells of value 4 across different rows/cols so the count reaches 9.
+    const g = emptyGrid();
+    const positions: Array<[number, number]> = [
+      [0, 0],
+      [1, 3],
+      [2, 6],
+      [3, 1],
+      [4, 4],
+      [5, 7],
+      [6, 2],
+      [7, 5],
+      [8, 8],
+    ];
+    for (const [r, c] of positions) {
+      g[r]![c] = cell({ value: 4 as CellValue, given: true });
+    }
+    const onDigit = jest.fn();
+    const { getByLabelText } = wrap(
+      <NumberPad
+        grid={asGrid(g)}
+        notesMode={false}
+        onDigit={onDigit}
+        onErase={() => {}}
+        onToggleNotes={() => {}}
+      />
+    );
+    const btn = getByLabelText(/enter digit 4/i);
+    expect(btn.props.accessibilityState?.disabled).toBe(true);
+    fireEvent.press(btn);
+    // Disabled Pressable shouldn't fire onPress.
+    expect(onDigit).not.toHaveBeenCalled();
+  });
+
+  it("matches snapshot — notes mode active", () => {
+    const tree = wrap(
+      <NumberPad
+        grid={asGrid(emptyGrid())}
+        notesMode={true}
+        onDigit={() => {}}
+        onErase={() => {}}
+        onToggleNotes={() => {}}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DifficultySelector
+// ---------------------------------------------------------------------------
+
+describe("DifficultySelector", () => {
+  it("renders three radio buttons labelled easy/medium/hard", () => {
+    const { getByLabelText } = wrap(<DifficultySelector value="medium" onChange={() => {}} />);
+    expect(getByLabelText(/easy/i)).toBeTruthy();
+    expect(getByLabelText(/medium/i)).toBeTruthy();
+    expect(getByLabelText(/hard/i)).toBeTruthy();
+  });
+
+  it("marks the current value as selected", () => {
+    const { getByLabelText } = wrap(<DifficultySelector value="hard" onChange={() => {}} />);
+    expect(getByLabelText(/hard/i).props.accessibilityState?.selected).toBe(true);
+    expect(getByLabelText(/easy/i).props.accessibilityState?.selected).toBe(false);
+  });
+
+  it("fires onChange with the new difficulty", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = wrap(<DifficultySelector value="easy" onChange={onChange} />);
+    fireEvent.press(getByLabelText(/hard/i));
+    expect(onChange).toHaveBeenCalledWith("hard");
+  });
+
+  it("matches snapshot — medium selected", () => {
+    const tree = wrap(<DifficultySelector value="medium" onChange={() => {}} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -13,6 +13,7 @@ type Namespace =
   | "twenty48"
   | "solitaire"
   | "hearts"
+  | "sudoku"
   | "feedback"
   | "profile";
 type TranslationModule = Promise<{ default: Record<string, string> }>;
@@ -41,6 +42,7 @@ const localeLoaders: Record<string, Partial<Record<Namespace, () => TranslationM
     twenty48: () => import("./locales/en/twenty48.json") as TranslationModule,
     solitaire: () => import("./locales/en/solitaire.json") as TranslationModule,
     hearts: () => import("./locales/en/hearts.json") as TranslationModule,
+    sudoku: () => import("./locales/en/sudoku.json") as TranslationModule,
     feedback: () => import("./locales/en/feedback.json") as TranslationModule,
     profile: () => import("./locales/en/profile.json") as TranslationModule,
   },
@@ -183,6 +185,7 @@ i18n
       "twenty48",
       "solitaire",
       "hearts",
+      "sudoku",
       "feedback",
       "profile",
     ],

--- a/frontend/src/i18n/locales/en/sudoku.json
+++ b/frontend/src/i18n/locales/en/sudoku.json
@@ -1,0 +1,13 @@
+{
+  "cell.label": "Cell row {{row}}, column {{col}}, {{value}}",
+  "cell.empty": "empty",
+  "numberPad.digit": "Enter digit {{digit}}",
+  "numberPad.toggleNotes": "Toggle pencil marks",
+  "numberPad.notes": "Notes",
+  "numberPad.erase": "Erase cell",
+  "numberPad.eraseShort": "Erase",
+  "difficulty.groupLabel": "Difficulty",
+  "difficulty.easy": "Easy",
+  "difficulty.medium": "Medium",
+  "difficulty.hard": "Hard"
+}


### PR DESCRIPTION
## Summary
- Part of Epic #613. Closes #617.
- Four stateless visual components in \`frontend/src/components/sudoku/\`: \`SudokuCell\`, \`SudokuGrid\`, \`NumberPad\`, \`DifficultySelector\`. No game logic — all state flows in via props.
- All colors via \`useTheme()\`; no hardcoded hex. All interactive elements carry \`accessibilityRole\` + \`accessibilityLabel\`.
- Registers the \`sudoku\` i18n namespace (en only) and adds \`sudoku.json\` with the 11 keys these components reference. Other locales deferred to #621 — each \`t()\` call carries a \`defaultValue\` so the English-only test env doesn't need fallback wiring.
- 18 tests passing, 5 snapshot fixtures.

## Component behaviour
| Component | Visual rules |
|---|---|
| SudokuCell | given → \`colors.text\` bold; user-correct → \`colors.accent\`; user-error → \`colors.error\`; selected → \`colors.surfaceHigh\` bg + accent border; highlighted (same digit) → \`colors.surfaceAlt\` bg; notes → 3×3 micro-grid in \`colors.textMuted\` |
| SudokuGrid | 9×9 flexbox, 2px box borders at every 3rd boundary, hairline between cells; derives "same digit" highlight from selected cell |
| NumberPad | 3×3 digit grid, erase + pencil-toggle row; digit dimmed/disabled when 9 instances already placed (recomputed every render so the 9th placement takes effect immediately) |
| DifficultySelector | 3 segmented radio buttons, accent bg on selected |

## Test plan
- [x] \`jest src/components/sudoku/\` — 18/18 green, 5 snapshots
- [x] \`jest src/components/hearts src/components/sudoku src/game/sudoku\` — 80/80 no regressions
- [x] \`tsc --noEmit\` clean under \`noUncheckedIndexedAccess\`
- [x] \`eslint\` + \`prettier --check\` clean
- [x] No hardcoded hex values
- [x] All interactive elements have \`accessibilityRole\` + \`accessibilityLabel\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)