### PR TITLE
feat(sudoku): integration — route, lobby card, PERFORMANCE.md (#622)

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -295,7 +295,9 @@ Expected large contributors (approximate arm64-v8a sizes based on published rele
 | `assets/fruit-vertices.json`                    | 58 KB        | 1 JSON   | **Yes**       | Cascade physics polygon vertices for Fruits theme.                                                  |
 | `assets/*.png` (Android icons, splash, favicon) | ~0.2 MB      | 4 PNG    | Platform only | App store / launcher assets.                                                                        |
 | Hearts                                          | —            | —        | No            | No dedicated asset directory — lobby card uses Unicode ♥ emoji; all card rendering is programmatic. |
-| **Repo total**                                  | **248.9 MB** | 82 files |               |                                                                                                     |
+| `src/game/sudoku/puzzles.json`                  | ~261 KB      | 1 JSON   | **Yes**       | Sudoku puzzle bank — 3 000 unique-solution puzzles (1 000 per difficulty). ~60 KB gzipped over the wire. Imported by `src/game/sudoku/engine.ts`. |
+| Sudoku (lobby card)                             | —            | —        | No            | No dedicated asset directory — lobby card uses Unicode 🧩 emoji; the board and cells are programmatic. |
+| **Repo total**                                  | **249.1 MB** | 83 files |               |                                                                                                     |
 | **Bundled game assets**                         | **~72 MB**   |          |               | `celestial-icons` + `fruit-icons` + `logo` + `*-baked` + JSON                                       |
 | **Not bundled (pipeline inputs)**               | **162.4 MB** |          |               | `source-icons/` — needed locally, not shipped                                                       |
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -32,6 +32,7 @@ const BlackjackTableScreen = React.lazy(() => import("./src/screens/BlackjackTab
 const Twenty48Screen = React.lazy(() => import("./src/screens/Twenty48Screen"));
 const SolitaireScreen = React.lazy(() => import("./src/screens/SolitaireScreen"));
 const HeartsScreen = React.lazy(() => import("./src/screens/HeartsScreen"));
+const SudokuScreen = React.lazy(() => import("./src/screens/SudokuScreen"));
 const LeaderboardScreen = React.lazy(() => import("./src/screens/LeaderboardScreen"));
 const GameDetailScreen = React.lazy(() => import("./src/screens/GameDetailScreen"));
 const SettingsScreen = React.lazy(() => import("./src/screens/SettingsScreen"));
@@ -67,6 +68,7 @@ export type HomeStackParamList = {
   Twenty48: undefined;
   Solitaire: undefined;
   Hearts: undefined;
+  Sudoku: undefined;
 };
 
 export type ProfileStackParamList = {
@@ -96,6 +98,7 @@ const LazyBlackjackTableScreen = withSuspense(BlackjackTableScreen);
 const LazyTwenty48Screen = withSuspense(Twenty48Screen);
 const LazySolitaireScreen = withSuspense(SolitaireScreen);
 const LazyHeartsScreen = withSuspense(HeartsScreen);
+const LazySudokuScreen = withSuspense(SudokuScreen);
 const LazyLeaderboardScreen = withSuspense(LeaderboardScreen);
 const LazyGameDetailScreen = withSuspense(GameDetailScreen);
 const LazySettingsScreen = withSuspense(SettingsScreen);
@@ -116,6 +119,7 @@ function LobbyStack() {
       <HomeStack.Screen name="Twenty48" component={LazyTwenty48Screen} />
       <HomeStack.Screen name="Solitaire" component={LazySolitaireScreen} />
       <HomeStack.Screen name="Hearts" component={LazyHeartsScreen} />
+      <HomeStack.Screen name="Sudoku" component={LazySudokuScreen} />
     </HomeStack.Navigator>
   );
 }

--- a/frontend/src/i18n/locales/en/sudoku.json
+++ b/frontend/src/i18n/locales/en/sudoku.json
@@ -1,5 +1,7 @@
 {
   "game.title": "Sudoku",
+  "game.description": "Classic 9x9 number puzzle across three difficulty tiers.",
+  "game.playLabel": "Play Sudoku",
 
   "cell.label": "Cell row {{row}}, column {{col}}, {{value}}",
   "cell.empty": "empty",

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -36,6 +36,7 @@ export default function HomeScreen() {
     "twenty48",
     "solitaire",
     "hearts",
+    "sudoku",
     "errors",
   ]);
   const { colors } = useTheme();
@@ -100,6 +101,15 @@ export default function HomeScreen() {
       description: t("hearts:game.description"),
       action: () => navigation.navigate("Hearts"),
     },
+    {
+      key: "sudoku",
+      // twenty48 already owns 🔢 in the lobby; the puzzle-piece glyph
+      // keeps Sudoku visually distinct while staying puzzle-coded.
+      emoji: "🧩",
+      title: t("sudoku:game.title"),
+      description: t("sudoku:game.description"),
+      action: () => navigation.navigate("Sudoku"),
+    },
   ];
 
   const playLabels: Record<string, string> = {
@@ -109,6 +119,7 @@ export default function HomeScreen() {
     [t("twenty48:game.title")]: t("twenty48:game.playLabel"),
     [t("solitaire:game.title")]: t("solitaire:game.playLabel"),
     [t("hearts:game.title")]: t("hearts:game.playLabel"),
+    [t("sudoku:game.title")]: t("sudoku:game.playLabel"),
   };
 
   // Cycle through BC Arcade accent colors for the gradient top border on each card.

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -84,6 +84,7 @@ describe("HomeScreen — game cards", () => {
     expect(getByLabelText("Play Cascade")).toBeTruthy();
     expect(getByLabelText("Play Blackjack")).toBeTruthy();
     expect(getByLabelText("Play Solitaire")).toBeTruthy();
+    expect(getByLabelText("Play Sudoku")).toBeTruthy();
     // Pachisi is disabled — should not appear
     expect(queryByLabelText("Play Pachisi")).toBeNull();
   });
@@ -104,6 +105,12 @@ describe("HomeScreen — game cards", () => {
     const { getByLabelText } = renderScreen();
     fireEvent.press(getByLabelText("Play Solitaire"));
     expect(mockNavigate).toHaveBeenCalledWith("Solitaire");
+  });
+
+  it("navigates to Sudoku when Sudoku card pressed", () => {
+    const { getByLabelText } = renderScreen();
+    fireEvent.press(getByLabelText("Play Sudoku"));
+    expect(mockNavigate).toHaveBeenCalledWith("Sudoku");
   });
 
   it("navigates to Game with a new state when Yacht card pressed (no saved game)", async () => {


### PR DESCRIPTION
## Summary
- Part of Epic #613. Closes #622.
- Adds the \`Sudoku\` route to \`HomeStackParamList\`, lazy-loads \`SudokuScreen\`, wires it into \`LobbyStack\`.
- New lobby card (🧩 emoji; twenty48 already owns 🔢).
- \`sudoku.json\` gains \`game.description\` + \`game.playLabel\` keys.
- PERFORMANCE.md asset inventory updated with the \`puzzles.json\` row and a Sudoku lobby-card note.

## Decisions vs. issue spec
- **No dedicated WebP icon directory.** Hearts and Solitaire both integrated without one (lobby card uses a Unicode glyph, rendering is programmatic). Sudoku follows that precedent. The \`assetTransparency\` test stays green since no new asset dir is introduced.
- **3 000 puzzles kept (bundle delta exception).** \`puzzles.json\` is ~261 KB raw / ~60 KB gzipped — over the 200 KB soft target the issue mentions, but well inside the CI \`bundlesize\` gate (5 MB). Keeping the full 3 000 matches the #616 AC and preserves per-difficulty diversity; the 500-per-tier fallback isn't needed for CI to pass. Flagged in PERFORMANCE.md for future awareness.

## Test plan
- [x] \`jest src/screens/__tests__/HomeScreen.test.tsx\` — 9/9 including new "Play Sudoku" assertion and navigate case
- [x] \`jest src/game/sudoku src/components/sudoku src/screens/__tests__/SudokuScreen.test.tsx src/screens/__tests__/HomeScreen.test.tsx\` — 86/86, no regressions
- [x] \`tsc --noEmit\` clean
- [x] \`prettier --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)