### PR TITLE
feat(#659,#661,#662): sync pipeline — client timestamps, Sudoku metadata, leaderboard queue

### DIFF
--- a/backend/games/router.py
+++ b/backend/games/router.py
@@ -140,6 +140,7 @@ async def create_game(request: Request, body: CreateGameRequest) -> CreateGameRe
                 game_type_name=body.game_type,
                 metadata=body.metadata,
                 players=players,
+                started_at=body.started_at,
             )
         except service.GameServiceError as e:
             raise HTTPException(status_code=e.status_code, detail=e.detail)
@@ -186,6 +187,7 @@ async def complete_game(
                 final_score=body.final_score,
                 outcome=body.outcome,
                 duration_ms=body.duration_ms,
+                completed_at=body.completed_at,
             )
         except service.GameServiceError as e:
             raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/backend/games/schemas.py
+++ b/backend/games/schemas.py
@@ -36,6 +36,7 @@ class CreateGameRequest(BaseModel):
     game_type: str = Field(..., min_length=1, max_length=64)
     metadata: dict[str, Any] = Field(default_factory=dict)
     players: list[PlayerRef] = Field(default_factory=list)
+    started_at: datetime | None = None
 
     @model_validator(mode="after")
     def validate_game_metadata(self) -> "CreateGameRequest":
@@ -65,6 +66,7 @@ class CompleteGameRequest(BaseModel):
     final_score: int | None = None
     outcome: str | None = None
     duration_ms: int | None = Field(default=None, ge=0)
+    completed_at: datetime | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from sqlalchemy import func, select
@@ -24,6 +24,22 @@ from games.registry import get_module
 from vocab import GameOutcome
 
 _VALID_OUTCOMES = frozenset(v.value for v in GameOutcome)
+
+_TS_WINDOW_LOW = timedelta(days=365)
+_TS_WINDOW_HIGH = timedelta(hours=24)
+
+
+def _validate_client_timestamp(ts: datetime, now: datetime) -> datetime | None:
+    """Return ts if it falls within [now − 1 year, now + 24 h]; else None.
+
+    Normalises naive datetimes to UTC. A skewed or bogus client clock falls
+    back to server-side stamping rather than poisoning the history table.
+    """
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    if ts < now - _TS_WINDOW_LOW or ts > now + _TS_WINDOW_HIGH:
+        return None
+    return ts
 
 
 class GameServiceError(Exception):
@@ -73,6 +89,7 @@ async def create_game(
     game_type_name: str,
     metadata: dict[str, Any],
     players: list[dict[str, Any]],
+    started_at: datetime | None = None,
 ) -> Game:
     gt = await _resolve_game_type(session, game_type_name)
 
@@ -85,6 +102,7 @@ async def create_game(
                 raise GameServiceError(403, "Game belongs to a different session.")
             return existing
 
+    now = datetime.now(timezone.utc)
     game = Game(
         id=client_id or uuid.uuid4(),
         session_id=session_id,
@@ -92,6 +110,9 @@ async def create_game(
         game_metadata=metadata or {},
         players=players,
     )
+    valid_started_at = _validate_client_timestamp(started_at, now) if started_at else None
+    if valid_started_at is not None:
+        game.started_at = valid_started_at
     session.add(game)
     await session.commit()
     await session.refresh(game)
@@ -429,6 +450,7 @@ async def complete_game(
     final_score: int | None,
     outcome: str | None,
     duration_ms: int | None,
+    completed_at: datetime | None = None,
 ) -> Game:
     game = await _get_owned_game(session, game_id, session_id)
     if game.completed_at is not None:
@@ -437,7 +459,9 @@ async def complete_game(
     if outcome is not None and outcome not in _VALID_OUTCOMES:
         raise GameServiceError(400, f"Invalid outcome: {outcome!r}")
 
-    game.completed_at = datetime.now(timezone.utc)
+    now = datetime.now(timezone.utc)
+    valid_completed_at = _validate_client_timestamp(completed_at, now) if completed_at else None
+    game.completed_at = valid_completed_at if valid_completed_at is not None else now
     game.final_score = final_score
     game.outcome = outcome
     game.duration_ms = duration_ms

--- a/backend/sudoku/router.py
+++ b/backend/sudoku/router.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_session_factory
 from db.models import Game, GameType
-from limiter import limiter
+from limiter import limiter, session_key
 from vocab import GameType as GameTypeEnum
 
 from .models import Difficulty, LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
@@ -74,7 +74,7 @@ async def _top_scores(db: AsyncSession, difficulty: Difficulty) -> list[ScoreEnt
 
 
 @router.post("/score", response_model=ScoreEntry, status_code=201)
-@limiter.limit("5/minute")
+@limiter.limit("30/minute", key_func=session_key)
 async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
     factory = get_session_factory()
     async with factory() as db:

--- a/backend/tests/test_game_metadata.py
+++ b/backend/tests/test_game_metadata.py
@@ -261,6 +261,7 @@ from games.service import _validate_client_timestamp
 
 def _now():
     from datetime import datetime
+
     return datetime.now(timezone.utc)
 
 
@@ -292,6 +293,7 @@ def test_validate_timestamp_just_within_future_window():
 
 def test_validate_timestamp_naive_treated_as_utc():
     from datetime import datetime
+
     now = _now()
     naive = datetime(now.year, now.month, now.day, now.hour)
     result = _validate_client_timestamp(naive, now)

--- a/backend/tests/test_game_metadata.py
+++ b/backend/tests/test_game_metadata.py
@@ -249,3 +249,52 @@ def test_post_games_valid_cascade_metadata_accepted(client) -> None:
         json={"game_type": "cascade", "metadata": {"player_name": "Eve"}},
     )
     assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# _validate_client_timestamp unit tests (#659)
+# ---------------------------------------------------------------------------
+
+from datetime import timezone, timedelta
+from games.service import _validate_client_timestamp
+
+
+def _now():
+    from datetime import datetime
+    return datetime.now(timezone.utc)
+
+
+def test_validate_timestamp_within_window_returns_ts():
+    now = _now()
+    ts = now - timedelta(hours=1)
+    result = _validate_client_timestamp(ts, now)
+    assert result == ts
+
+
+def test_validate_timestamp_too_old_returns_none():
+    now = _now()
+    ts = now - timedelta(days=400)
+    assert _validate_client_timestamp(ts, now) is None
+
+
+def test_validate_timestamp_future_beyond_window_returns_none():
+    now = _now()
+    ts = now + timedelta(hours=25)
+    assert _validate_client_timestamp(ts, now) is None
+
+
+def test_validate_timestamp_just_within_future_window():
+    now = _now()
+    ts = now + timedelta(hours=23, minutes=59)
+    result = _validate_client_timestamp(ts, now)
+    assert result is not None
+
+
+def test_validate_timestamp_naive_treated_as_utc():
+    from datetime import datetime
+    now = _now()
+    naive = datetime(now.year, now.month, now.day, now.hour)
+    result = _validate_client_timestamp(naive, now)
+    # Naive within window should be accepted and returned with UTC tzinfo.
+    assert result is not None
+    assert result.tzinfo is not None

--- a/backend/tests/test_sudoku_api.py
+++ b/backend/tests/test_sudoku_api.py
@@ -161,10 +161,14 @@ class TestSubmitRank:
 
 
 class TestRateLimit:
-    def test_sixth_submission_returns_429(self):
+    def test_rate_limit_enforced_after_threshold(self):
         from limiter import limiter
 
-        for i in range(5):
-            assert _submit(f"P{i}", i * 10, "easy").status_code == 201
+        # Limit raised to 30/minute (session-keyed) in #662.
+        # In-process tests share a single fixed session-id so we can still
+        # trigger the limit — just need 31 requests instead of 6.
+        for i in range(30):
+            r = _submit(f"P{i}", i, "easy")
+            assert r.status_code == 201, f"request {i} failed: {r.text}"
         assert _submit("Excess", 999, "easy").status_code == 429
         limiter.reset()

--- a/frontend/src/game/_shared/NetworkContext.tsx
+++ b/frontend/src/game/_shared/NetworkContext.tsx
@@ -12,6 +12,7 @@ import * as Sentry from "@sentry/react-native";
 import { NetworkStatus, useNetworkStatus } from "./useNetworkStatus";
 import { scoreQueue } from "./scoreQueue";
 import { registerCascadeScoreHandler } from "../cascade/scoreSync";
+import { registerSudokuScoreHandler } from "../sudoku/scoreSync";
 import { gameEventClient } from "./gameEventClient";
 import { syncWorker } from "./syncWorker";
 import { registerLogstoreTestHooks } from "./testHooks";
@@ -24,6 +25,7 @@ const NetworkContext = createContext<NetworkStatus>({
 
 // Register per-game handlers exactly once, module-load time.
 registerCascadeScoreHandler();
+registerSudokuScoreHandler();
 
 export function NetworkProvider({ children }: { children: React.ReactNode }) {
   const status = useNetworkStatus();

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -147,9 +147,7 @@ describe("SyncWorker", () => {
     client.completeGame(gid, { finalScore: 50, outcome: "completed" });
     await flushMicro();
     await worker.flush();
-    const patchCall = api.calls.find(
-      (c) => c.method === "PATCH" && c.path.endsWith("/complete")
-    );
+    const patchCall = api.calls.find((c) => c.method === "PATCH" && c.path.endsWith("/complete"));
     expect(patchCall).toBeDefined();
     const body = patchCall!.body as Record<string, unknown>;
     expect(typeof body["completed_at"]).toBe("string");

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -125,6 +125,39 @@ describe("SyncWorker", () => {
     expect(result.accepted).toBeGreaterThan(0);
   });
 
+  it("step-1 POST /games body includes started_at ISO string", async () => {
+    const before = Date.now();
+    const gid = client.startGame("yacht", {});
+    await flushMicro();
+    await worker.flush();
+    const createCall = api.calls.find((c) => c.method === "POST" && c.path === "/games");
+    expect(createCall).toBeDefined();
+    const body = createCall!.body as Record<string, unknown>;
+    expect(typeof body["started_at"]).toBe("string");
+    const ts = new Date(body["started_at"] as string).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(Date.now());
+    expect(gid).toBeTruthy();
+  });
+
+  it("step-3 PATCH /complete body includes completed_at ISO string", async () => {
+    api.defaultResponse = ok({ accepted: 1, duplicates: 0 });
+    const gid = client.startGame("yacht", {});
+    const before = Date.now();
+    client.completeGame(gid, { finalScore: 50, outcome: "completed" });
+    await flushMicro();
+    await worker.flush();
+    const patchCall = api.calls.find(
+      (c) => c.method === "PATCH" && c.path.endsWith("/complete")
+    );
+    expect(patchCall).toBeDefined();
+    const body = patchCall!.body as Record<string, unknown>;
+    expect(typeof body["completed_at"]).toBe("string");
+    const ts = new Date(body["completed_at"] as string).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(Date.now());
+  });
+
   it("batches 150 rapid events into a single POST", async () => {
     logConfig.GAME_EVENT_BATCH_SIZE = 200;
     const gid = client.startGame("yacht");
@@ -357,11 +390,13 @@ describe("SyncWorker", () => {
       (c) => c.method === "PATCH" && c.path === `/games/${gid}/complete`
     );
     expect(patch).toBeDefined();
-    expect(patch!.body).toEqual({
+    expect(patch!.body).toMatchObject({
       final_score: 312,
       outcome: "completed",
       duration_ms: 45_000,
     });
+    // completed_at must be an ISO string (client-captured timestamp).
+    expect(typeof (patch!.body as Record<string, unknown>)["completed_at"]).toBe("string");
     // And the old camelCase keys must NOT be present — otherwise Pydantic
     // would still ignore them, but it would leave us with a confusing
     // double-keyed payload.

--- a/frontend/src/game/_shared/__tests__/useGameSync.test.ts
+++ b/frontend/src/game/_shared/__tests__/useGameSync.test.ts
@@ -42,6 +42,18 @@ describe("useGameSync", () => {
     expect(mockStartGame).toHaveBeenCalledWith("twenty48", {}, {});
   });
 
+  it("start() with metadata passes it as the second arg to startGame", () => {
+    const { result } = renderHook(() => useGameSync("sudoku"));
+    act(() => {
+      result.current.start({ difficulty: "hard" }, { difficulty: "hard" });
+    });
+    expect(mockStartGame).toHaveBeenCalledWith(
+      "sudoku",
+      { difficulty: "hard" },
+      { difficulty: "hard" }
+    );
+  });
+
   // ---------------------------------------------------------------------------
   // enqueue
   // ---------------------------------------------------------------------------

--- a/frontend/src/game/_shared/pendingGamesStore.ts
+++ b/frontend/src/game/_shared/pendingGamesStore.ts
@@ -38,6 +38,7 @@ export interface PendingGame {
   startedSynced: boolean;
   nextEventIndex: number;
   completed: boolean;
+  completedAt: number | null;
   completeSummary: CompleteSummary | null;
   completeSynced: boolean;
 }
@@ -96,6 +97,7 @@ export class PendingGamesStore {
       startedSynced: false,
       nextEventIndex: 0,
       completed: false,
+      completedAt: null,
       completeSummary: null,
       completeSynced: false,
     });
@@ -120,6 +122,7 @@ export class PendingGamesStore {
     if (!game) return Promise.resolve();
     if (game.completed) return Promise.resolve();
     game.completed = true;
+    game.completedAt = Date.now();
     game.completeSummary = summary;
     return this.persist();
   }

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -144,6 +144,7 @@ export class SyncWorker {
           id: gameId,
           game_type: game.gameType,
           metadata: game.metadata,
+          started_at: new Date(game.startedAt).toISOString(),
         },
         now
       );
@@ -316,6 +317,7 @@ export class SyncWorker {
         final_score: summary.finalScore ?? null,
         outcome: summary.outcome ?? null,
         duration_ms: summary.durationMs ?? null,
+        completed_at: game.completedAt != null ? new Date(game.completedAt).toISOString() : null,
       };
       const res = await this.api.request("PATCH", `/games/${gameId}/complete`, body, now);
       result.attempted += 1;

--- a/frontend/src/game/_shared/useGameSync.ts
+++ b/frontend/src/game/_shared/useGameSync.ts
@@ -37,7 +37,7 @@ import type { BugLevel } from "./eventQueueConfig";
 
 export interface UseGameSyncReturn {
   /** Start a new instrumented session. Call once after the game state is ready. */
-  start: (eventData?: Record<string, unknown>) => void;
+  start: (eventData?: Record<string, unknown>, metadata?: Record<string, unknown>) => void;
   /** Enqueue a gameplay event. No-ops if no session is open. */
   enqueue: (event: EnqueueEventInput) => void;
   /**
@@ -49,7 +49,7 @@ export interface UseGameSyncReturn {
    * End the current session (as abandoned if still open) and immediately
    * start a fresh one. Use this for New Game / theme-switch flows.
    */
-  restart: (newEventData?: Record<string, unknown>) => void;
+  restart: (newEventData?: Record<string, unknown>, newMetadata?: Record<string, unknown>) => void;
   /** Delegate to gameEventClient.reportBug with try/catch isolation. */
   reportBug: (
     level: BugLevel,
@@ -86,10 +86,17 @@ export function useGameSync(gameType: GameType): UseGameSyncReturn {
     };
   }, []);
 
-  const start = useCallback((eventData?: Record<string, unknown>) => {
-    gameIdRef.current = gameEventClient.startGame(gameTypeRef.current, {}, eventData ?? {});
-    completedRef.current = false;
-  }, []);
+  const start = useCallback(
+    (eventData?: Record<string, unknown>, metadata?: Record<string, unknown>) => {
+      gameIdRef.current = gameEventClient.startGame(
+        gameTypeRef.current,
+        metadata ?? {},
+        eventData ?? {}
+      );
+      completedRef.current = false;
+    },
+    []
+  );
 
   const enqueue = useCallback((event: EnqueueEventInput) => {
     const gid = gameIdRef.current;
@@ -113,20 +120,27 @@ export function useGameSync(gameType: GameType): UseGameSyncReturn {
     gameIdRef.current = null;
   }, []);
 
-  const restart = useCallback((newEventData?: Record<string, unknown>) => {
-    // Close the current session if still open.
-    const gid = gameIdRef.current;
-    if (gid && !completedRef.current) {
-      try {
-        gameEventClient.completeGame(gid, { outcome: "abandoned" }, { outcome: "abandoned" });
-      } catch {
-        // Isolation.
+  const restart = useCallback(
+    (newEventData?: Record<string, unknown>, newMetadata?: Record<string, unknown>) => {
+      // Close the current session if still open.
+      const gid = gameIdRef.current;
+      if (gid && !completedRef.current) {
+        try {
+          gameEventClient.completeGame(gid, { outcome: "abandoned" }, { outcome: "abandoned" });
+        } catch {
+          // Isolation.
+        }
       }
-    }
-    // Open a fresh session.
-    gameIdRef.current = gameEventClient.startGame(gameTypeRef.current, {}, newEventData ?? {});
-    completedRef.current = false;
-  }, []);
+      // Open a fresh session.
+      gameIdRef.current = gameEventClient.startGame(
+        gameTypeRef.current,
+        newMetadata ?? {},
+        newEventData ?? {}
+      );
+      completedRef.current = false;
+    },
+    []
+  );
 
   const reportBug = useCallback(
     (level: BugLevel, source: string, message: string, context?: Record<string, unknown>) => {

--- a/frontend/src/game/sudoku/scoreSync.ts
+++ b/frontend/src/game/sudoku/scoreSync.ts
@@ -1,0 +1,30 @@
+/**
+ * Sudoku's handler for flushing queued score submissions.
+ *
+ * Registered once at module load by NetworkContext. Keeps queue-flush
+ * logic co-located with Sudoku rather than in a central switch.
+ */
+
+import { sudokuApi } from "./api";
+import { scoreQueue } from "../_shared/scoreQueue";
+import type { PendingSubmission } from "../_shared/types";
+import type { Difficulty } from "./types";
+
+export function registerSudokuScoreHandler(): void {
+  scoreQueue.registerHandler("sudoku", async (item: PendingSubmission) => {
+    const { player_name, score, difficulty } = item.payload as {
+      player_name: string;
+      score: number;
+      difficulty: Difficulty;
+    };
+    if (
+      typeof player_name !== "string" ||
+      typeof score !== "number" ||
+      typeof difficulty !== "string"
+    ) {
+      // Malformed payload — drop by "succeeding" (throwing would retry forever).
+      return;
+    }
+    await sudokuApi.submitScore(player_name, score, difficulty);
+  });
+}

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -53,7 +53,7 @@ import {
 } from "../game/sudoku/engine";
 import type { CellValue, Difficulty, SudokuState } from "../game/sudoku/types";
 import { clearGame, loadGame, saveGame } from "../game/sudoku/storage";
-import { sudokuApi, type ScoreEntry } from "../game/sudoku/api";
+import { scoreQueue } from "../game/_shared/scoreQueue";
 import { useGameSync } from "../game/_shared/useGameSync";
 
 const FLASH_MS = 200;
@@ -248,7 +248,7 @@ export default function SudokuScreen() {
     (next: SudokuState) => {
       if (syncStartedRef.current) return;
       syncStartedRef.current = true;
-      syncStart({ difficulty: next.difficulty });
+      syncStart({ difficulty: next.difficulty }, { difficulty: next.difficulty });
     },
     [syncStart]
   );
@@ -535,7 +535,7 @@ function WinModal({
 
   const [name, setName] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState<ScoreEntry | null>(null);
+  const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const gradient: ViewStyle =
@@ -553,8 +553,10 @@ function WinModal({
     setSubmitting(true);
     setError(null);
     try {
-      const entry = await sudokuApi.submitScore(trimmed, score, difficulty);
-      setSubmitted(entry);
+      await scoreQueue.enqueue("sudoku", { player_name: trimmed, score, difficulty });
+      setSubmitted(true);
+      // Kick off a background flush; failures are retried on next reconnect.
+      scoreQueue.flush().catch(() => undefined);
     } catch {
       setError(t("win.submitFailed", { defaultValue: "Couldn't save your score. Tap to retry." }));
     } finally {
@@ -591,7 +593,7 @@ function WinModal({
             {t("win.elapsed", { time: formatElapsed(elapsed) })}
           </Text>
 
-          {submitted === null ? (
+          {!submitted ? (
             <>
               <TextInput
                 style={[
@@ -645,10 +647,7 @@ function WinModal({
               style={[styles.winSaved, { color: colors.bonus }]}
               accessibilityLiveRegion="polite"
             >
-              {t("win.rank", {
-                rank: submitted.rank,
-                defaultValue: `Saved! #${submitted.rank}`,
-              })}
+              {t("win.saved", { defaultValue: "Saved! Score submitted." })}
             </Text>
           )}
 

--- a/frontend/src/screens/__tests__/SudokuScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SudokuScreen.test.tsx
@@ -97,7 +97,12 @@ beforeEach(async () => {
   (scoreQueue.enqueue as jest.Mock).mockReset();
   (scoreQueue.enqueue as jest.Mock).mockResolvedValue({ id: "q-1" });
   (scoreQueue.flush as jest.Mock).mockReset();
-  (scoreQueue.flush as jest.Mock).mockResolvedValue({ attempted: 0, succeeded: 0, failed: 0, remaining: 0 });
+  (scoreQueue.flush as jest.Mock).mockResolvedValue({
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    remaining: 0,
+  });
 });
 
 describe("SudokuScreen — pre-game (after load)", () => {

--- a/frontend/src/screens/__tests__/SudokuScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SudokuScreen.test.tsx
@@ -46,9 +46,17 @@ jest.mock("../../game/sudoku/api", () => ({
     getLeaderboard: jest.fn(),
   },
 }));
-// Import after the mock so the test file gets the jest.fn() flavour.
+
+jest.mock("../../game/_shared/scoreQueue", () => ({
+  scoreQueue: {
+    enqueue: jest.fn().mockResolvedValue({ id: "q-1" }),
+    flush: jest.fn().mockResolvedValue({ attempted: 0, succeeded: 0, failed: 0, remaining: 0 }),
+    registerHandler: jest.fn(),
+  },
+}));
+// Import after mocks so the test file gets the jest.fn() flavour.
 // eslint-disable-next-line import/order
-import { sudokuApi } from "../../game/sudoku/api";
+import { scoreQueue } from "../../game/_shared/scoreQueue";
 
 function fillAllExcept(state: SudokuState, skip: { row: number; col: number }): SudokuState {
   let s = state;
@@ -86,7 +94,10 @@ beforeEach(async () => {
   mockStartGame.mockClear();
   mockStartGame.mockReturnValue("game-123");
   mockCompleteGame.mockClear();
-  (sudokuApi.submitScore as jest.Mock).mockReset();
+  (scoreQueue.enqueue as jest.Mock).mockReset();
+  (scoreQueue.enqueue as jest.Mock).mockResolvedValue({ id: "q-1" });
+  (scoreQueue.flush as jest.Mock).mockReset();
+  (scoreQueue.flush as jest.Mock).mockResolvedValue({ attempted: 0, succeeded: 0, failed: 0, remaining: 0 });
 });
 
 describe("SudokuScreen — pre-game (after load)", () => {
@@ -183,12 +194,7 @@ describe("SudokuScreen — win flow", () => {
     return rendered;
   }
 
-  it("POST /sudoku/score succeeds — shows rank after submit", async () => {
-    (sudokuApi.submitScore as jest.Mock).mockResolvedValue({
-      player_name: "Alice",
-      score: 100,
-      rank: 3,
-    });
+  it("enqueues score and shows saved confirmation after submit", async () => {
     const { getByLabelText, findByText } = await renderIntoWinModal();
 
     act(() => {
@@ -197,14 +203,17 @@ describe("SudokuScreen — win flow", () => {
     await act(async () => {
       fireEvent.press(getByLabelText(/submit score/i));
     });
-    await findByText(/#3/);
-    expect(sudokuApi.submitScore).toHaveBeenCalledWith("Alice", 100, "easy");
+    await findByText(/saved/i);
+    expect(scoreQueue.enqueue).toHaveBeenCalledWith(
+      "sudoku",
+      expect.objectContaining({ player_name: "Alice", difficulty: "easy" })
+    );
   });
 
-  it("POST failure shows a retry control; second attempt succeeds", async () => {
-    (sudokuApi.submitScore as jest.Mock)
-      .mockRejectedValueOnce(new Error("network"))
-      .mockResolvedValueOnce({ player_name: "Bob", score: 100, rank: 5 });
+  it("enqueue failure shows retry control; second attempt succeeds", async () => {
+    (scoreQueue.enqueue as jest.Mock)
+      .mockRejectedValueOnce(new Error("storage full"))
+      .mockResolvedValueOnce({ id: "q-2" });
 
     const { getByLabelText, findByLabelText, findByText } = await renderIntoWinModal();
     act(() => fireEvent.changeText(getByLabelText(/your name/i), "Bob"));
@@ -216,7 +225,7 @@ describe("SudokuScreen — win flow", () => {
     await act(async () => {
       fireEvent.press(retry);
     });
-    await findByText(/#5/);
-    expect(sudokuApi.submitScore).toHaveBeenCalledTimes(2);
+    await findByText(/saved/i);
+    expect(scoreQueue.enqueue).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- **#659** — Games played offline now record real play timestamps instead of sync time. `started_at` is captured at game creation; `completed_at` is captured when `completeGame()` is called. Both travel as ISO-8601 strings in the POST `/games` and PATCH `/games/:id/complete` bodies. Backend validates within ±24h / −1yr window and falls back to server-now on bad values.
- **#661** — Sudoku `POST /games` was sending empty `metadata: {}`, causing a 422 and dead-lettering the game record. `useGameSync.start()` now accepts an optional `metadata` arg; `SudokuScreen` passes `{ difficulty }` so the game row is created correctly.
- **#662** — Sudoku leaderboard submit is now queue-backed. A new `scoreSync.ts` registers a handler; the WinModal enqueues to `scoreQueue` (durable AsyncStorage write) and kicks off a background flush instead of a fire-and-forget fetch. Offline submissions retry automatically on reconnect. Rate limit on `/sudoku/score` changed from 5/min global → 30/min session-keyed.

## Test plan

- [x] Frontend: 1349 tests pass (86 suites)
- [x] Backend: 593 tests pass (85% coverage)
- [x] 5 new `_validate_client_timestamp` unit tests
- [x] syncWorker: `started_at` in step-1 body, `completed_at` in step-3 body
- [x] useGameSync: metadata arg threads through to `startGame`
- [x] SudokuScreen: WinModal tests updated for queue-based submit
- [ ] Manual: play Sudoku offline → sync → verify `started_at` ≠ `completed_at` ≠ reconnect time
- [ ] Manual: submit Sudoku score offline → reconnect → score appears on leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)