### PR TITLE
feat(hearts): fan hand, round scoreboard, player renaming (#664 #665 #666)

### DIFF
--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -8,11 +8,12 @@ import type { Card, Rank, Suit } from "../../game/hearts/types";
 interface Props {
   cardCount: number;
   label: string;
+  score?: number;
 }
 
 const PLACEHOLDER_CARD: Card = { suit: "spades" as Suit, rank: 2 as Rank };
 
-export default function OpponentHand({ cardCount, label }: Props) {
+export default function OpponentHand({ cardCount, label, score }: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
 
@@ -23,6 +24,7 @@ export default function OpponentHand({ cardCount, label }: Props) {
       accessibilityRole="none"
     >
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
+      {score !== undefined && <Text style={[styles.score, { color: colors.text }]}>{score}</Text>}
       <View style={styles.cards}>
         {Array.from({ length: cardCount }).map((_, i) => (
           <PlayingCard key={i} card={PLACEHOLDER_CARD} faceDown />
@@ -40,6 +42,10 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 12,
     fontWeight: "600",
+  },
+  score: {
+    fontSize: 13,
+    fontWeight: "700",
   },
   cards: {
     flexDirection: "row",

--- a/frontend/src/components/hearts/PlayerHand.tsx
+++ b/frontend/src/components/hearts/PlayerHand.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ScrollView, StyleSheet } from "react-native";
+import { View, StyleSheet, useWindowDimensions } from "react-native";
 import { useTranslation } from "react-i18next";
 import PlayingCard from "./PlayingCard";
 import type { Card } from "../../game/hearts/types";
@@ -11,8 +11,20 @@ interface Props {
   onCardPress?: (card: Card) => void;
 }
 
-function cardKey(c: Card): string {
-  return `${c.suit}-${c.rank}`;
+// Canonical suit order: ♣ ♦ ♠ ♥ (clubs first, hearts last)
+const SUIT_ORDER: Record<string, number> = { clubs: 0, diamonds: 1, spades: 2, hearts: 3 };
+
+// Ace sorts high (as 14)
+function sortRank(rank: number): number {
+  return rank === 1 ? 14 : rank;
+}
+
+function sortHand(cards: Card[]): Card[] {
+  return [...cards].sort((a, b) => {
+    const suitDiff = (SUIT_ORDER[a.suit] ?? 0) - (SUIT_ORDER[b.suit] ?? 0);
+    if (suitDiff !== 0) return suitDiff;
+    return sortRank(a.rank) - sortRank(b.rank);
+  });
 }
 
 function inSet(cards: Card[] | undefined, card: Card): boolean {
@@ -20,38 +32,74 @@ function inSet(cards: Card[] | undefined, card: Card): boolean {
   return cards.some((c) => c.suit === card.suit && c.rank === card.rank);
 }
 
+function cardKey(c: Card): string {
+  return `${c.suit}-${c.rank}`;
+}
+
+const CARD_WIDTH = 52;
+const CARD_HEIGHT = 74;
+const POP_AMOUNT = 16;
+const H_PADDING = 8;
+
 export default function PlayerHand({ hand, selectedCards, validCards, onCardPress }: Props) {
   const { t } = useTranslation("hearts");
+  const { width: screenWidth } = useWindowDimensions();
+
+  const sorted = sortHand(hand);
+  const count = sorted.length;
+  const availableWidth = screenWidth - H_PADDING * 2;
+
+  // Overlap offset so all cards fit without scroll; rightmost card is fully visible.
+  const offset =
+    count > 1 ? Math.min((availableWidth - CARD_WIDTH) / (count - 1), CARD_WIDTH + 4) : 0;
+  const containerWidth = count > 1 ? offset * (count - 1) + CARD_WIDTH : CARD_WIDTH;
 
   return (
-    <ScrollView
-      horizontal
-      contentContainerStyle={styles.container}
-      accessibilityLabel={t("hand.player", { count: hand.length })}
+    <View
+      style={[styles.wrapper, { paddingHorizontal: H_PADDING }]}
+      accessibilityLabel={t("hand.player", { count })}
       accessibilityRole="none"
-      showsHorizontalScrollIndicator={false}
     >
-      {hand.map((card) => {
-        const highlighted = inSet(selectedCards, card);
-        const disabled = validCards !== undefined && !inSet(validCards, card);
-        return (
-          <PlayingCard
-            key={cardKey(card)}
-            card={card}
-            highlighted={highlighted}
-            disabled={disabled}
-            onPress={onCardPress ? () => onCardPress(card) : undefined}
-          />
-        );
-      })}
-    </ScrollView>
+      <View style={[styles.container, { width: containerWidth, height: CARD_HEIGHT + POP_AMOUNT }]}>
+        {sorted.map((card, i) => {
+          const highlighted = inSet(selectedCards, card);
+          const disabled = validCards !== undefined && !inSet(validCards, card);
+          const popped = highlighted;
+          return (
+            <View
+              key={cardKey(card)}
+              style={[
+                styles.cardSlot,
+                { left: i * offset, zIndex: i },
+                popped && styles.poppedSlot,
+              ]}
+            >
+              <PlayingCard
+                card={card}
+                highlighted={highlighted}
+                disabled={disabled}
+                onPress={onCardPress ? () => onCardPress(card) : undefined}
+              />
+            </View>
+          );
+        })}
+      </View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: "row",
+  wrapper: {
     alignItems: "center",
-    paddingHorizontal: 8,
+  },
+  container: {
+    position: "relative",
+  },
+  cardSlot: {
+    position: "absolute",
+    top: POP_AMOUNT,
+  },
+  poppedSlot: {
+    top: 0,
   },
 });

--- a/frontend/src/components/hearts/ScoreBoard.tsx
+++ b/frontend/src/components/hearts/ScoreBoard.tsx
@@ -1,23 +1,41 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 
 interface Props {
   playerLabels: string[];
   cumulativeScores: number[];
-  handScores: number[];
+  /** Per-round history: scoreHistory[roundIndex][playerIndex] = points that round. */
+  scoreHistory: number[][];
   dangerIndex?: number | null;
 }
 
 export default function ScoreBoard({
   playerLabels,
   cumulativeScores,
-  handScores,
+  scoreHistory,
   dangerIndex,
 }: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
+
+  // Leading player = lowest cumulative score (Hearts: low is good)
+  const leadIndex = cumulativeScores.reduce(
+    (minIdx, s, i, arr) => (s < (arr[minIdx] ?? Infinity) ? i : minIdx),
+    0
+  );
+
+  function playerColor(i: number): string {
+    if (dangerIndex !== null && dangerIndex !== undefined && dangerIndex === i) return colors.error;
+    if (i === leadIndex) return colors.accent;
+    return colors.text;
+  }
+
+  // Abbreviate player label to 4 chars to fit 4 columns at phone width
+  function abbrev(label: string): string {
+    return label.length > 5 ? label.slice(0, 4) + "…" : label;
+  }
 
   return (
     <View
@@ -25,30 +43,46 @@ export default function ScoreBoard({
       accessibilityLabel={t("score.board")}
       accessibilityRole="none"
     >
+      {/* Header row */}
       <View style={[styles.row, styles.header, { borderBottomColor: colors.border }]}>
-        <Text style={[styles.cell, styles.headerText, { color: colors.textMuted }]}>
-          {t("score.player")}
+        <Text style={[styles.roundCell, styles.headerText, { color: colors.textMuted }]}>
+          {t("score.round")}
         </Text>
-        <Text style={[styles.cell, styles.headerText, { color: colors.textMuted }]}>
+        {playerLabels.map((label, i) => (
+          <Text key={i} style={[styles.cell, styles.headerText, { color: playerColor(i) }]}>
+            {abbrev(label)}
+          </Text>
+        ))}
+      </View>
+
+      {/* Per-round rows */}
+      <ScrollView style={styles.historyScroll} nestedScrollEnabled>
+        {scoreHistory.map((roundScores, round) => (
+          <View
+            key={round}
+            style={[styles.row, round % 2 === 1 && { backgroundColor: colors.surfaceAlt + "44" }]}
+          >
+            <Text style={[styles.roundCell, { color: colors.textMuted }]}>{round + 1}</Text>
+            {playerLabels.map((_, i) => (
+              <Text key={i} style={[styles.cell, { color: playerColor(i) }]}>
+                {roundScores[i] ?? 0}
+              </Text>
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+
+      {/* Total row */}
+      <View style={[styles.row, styles.totalRow, { borderTopColor: colors.border }]}>
+        <Text style={[styles.roundCell, styles.totalText, { color: colors.textMuted }]}>
           {t("score.total")}
         </Text>
-        <Text style={[styles.cell, styles.headerText, { color: colors.textMuted }]}>
-          {t("score.hand")}
-        </Text>
+        {cumulativeScores.map((score, i) => (
+          <Text key={i} style={[styles.cell, styles.totalText, { color: playerColor(i) }]}>
+            {score}
+          </Text>
+        ))}
       </View>
-      {playerLabels.map((label, i) => {
-        const isDanger = dangerIndex !== null && dangerIndex !== undefined && dangerIndex === i;
-        const scoreColor = isDanger ? colors.error : colors.text;
-        const cumulative = cumulativeScores[i] ?? 0;
-        const hand = handScores[i] ?? 0;
-        return (
-          <View key={i} style={styles.row}>
-            <Text style={[styles.cell, { color: scoreColor }]}>{label}</Text>
-            <Text style={[styles.cell, { color: scoreColor }]}>{cumulative}</Text>
-            <Text style={[styles.cell, { color: scoreColor }]}>{hand > 0 ? `+${hand}` : hand}</Text>
-          </View>
-        );
-      })}
     </View>
   );
 }
@@ -58,23 +92,43 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
+    width: "100%",
   },
   row: {
     flexDirection: "row",
+    alignItems: "center",
   },
   header: {
     borderBottomWidth: 1,
+  },
+  totalRow: {
+    borderTopWidth: 1,
   },
   headerText: {
     fontSize: 11,
     fontWeight: "600",
     textTransform: "uppercase",
   },
+  totalText: {
+    fontWeight: "700",
+    fontSize: 13,
+  },
+  roundCell: {
+    width: 32,
+    paddingVertical: 6,
+    paddingHorizontal: 6,
+    fontSize: 12,
+    textAlign: "center",
+  },
   cell: {
     flex: 1,
     paddingVertical: 6,
-    paddingHorizontal: 8,
+    paddingHorizontal: 4,
     fontSize: 13,
     fontWeight: "500",
+    textAlign: "center",
+  },
+  historyScroll: {
+    maxHeight: 180,
   },
 });

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -87,9 +87,29 @@ describe("PlayerHand", () => {
 
   it("fires onCardPress with the correct card", () => {
     const onPress = jest.fn();
+    // Hand is sorted: clubs 9, spades 2, hearts 5 → suit order clubs→spades→hearts
+    // Sorted: clubs-9, spades-2, hearts-5 → buttons[0]=clubs9, [1]=spades2, [2]=hearts5
     const { getAllByRole } = wrap(<PlayerHand hand={hand} onCardPress={onPress} />);
-    fireEvent.press(getAllByRole("button")[1]!);
-    expect(onPress).toHaveBeenCalledWith(hand[1]);
+    fireEvent.press(getAllByRole("button")[0]!);
+    expect(onPress).toHaveBeenCalledWith(c("clubs", 9));
+  });
+
+  it("sorts by suit then rank ascending (clubs→diamonds→spades→hearts, Ace high)", () => {
+    const unsorted: Card[] = [
+      c("hearts", 1),
+      c("clubs", 3),
+      c("spades", 7),
+      c("diamonds", 2),
+      c("clubs", 1),
+    ];
+    const { getAllByRole } = wrap(<PlayerHand hand={unsorted} onCardPress={jest.fn()} />);
+    const buttons = getAllByRole("button");
+    // Expected sort: clubs-3, clubs-A, diamonds-2, spades-7, hearts-A
+    expect(buttons[0]!.props.accessibilityLabel).toMatch(/3.*clubs/i);
+    expect(buttons[1]!.props.accessibilityLabel).toMatch(/A.*clubs/i);
+    expect(buttons[2]!.props.accessibilityLabel).toMatch(/2.*diamonds/i);
+    expect(buttons[3]!.props.accessibilityLabel).toMatch(/7.*spades/i);
+    expect(buttons[4]!.props.accessibilityLabel).toMatch(/A.*hearts/i);
   });
 });
 
@@ -111,6 +131,11 @@ describe("OpponentHand", () => {
   it("renders zero cards without error", () => {
     const { toJSON } = wrap(<OpponentHand cardCount={0} label="Top" />);
     expect(toJSON()).toBeTruthy();
+  });
+
+  it("renders score when provided", () => {
+    const { getByText } = wrap(<OpponentHand cardCount={3} label="Top" score={12} />);
+    expect(getByText("12")).toBeTruthy();
   });
 });
 
@@ -144,27 +169,38 @@ describe("TrickArea", () => {
 describe("ScoreBoard", () => {
   const labels = ["You", "Left", "Top", "Right"];
   const cumulative = [10, 5, 20, 0];
-  const hand = [3, 2, 8, 0];
+  const history = [
+    [3, 2, 8, 0],
+    [7, 3, 12, 0],
+  ];
 
   it("renders all player labels", () => {
     const { getByText } = wrap(
-      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} handScores={hand} />
+      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} scoreHistory={history} />
     );
-    labels.forEach((l) => expect(getByText(l)).toBeTruthy());
+    labels.forEach((l) => expect(getByText(l.slice(0, 5))).toBeTruthy());
   });
 
-  it("renders cumulative scores", () => {
+  it("renders cumulative totals row", () => {
     const { getByText } = wrap(
-      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} handScores={hand} />
+      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} scoreHistory={history} />
     );
     expect(getByText("20")).toBeTruthy();
   });
 
-  it("renders positive hand delta with + prefix", () => {
-    const { getByText } = wrap(
-      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} handScores={[5, 0, 0, 0]} />
+  it("renders per-round scores", () => {
+    const { getAllByText } = wrap(
+      <ScoreBoard playerLabels={labels} cumulativeScores={cumulative} scoreHistory={history} />
     );
-    expect(getByText("+5")).toBeTruthy();
+    expect(getAllByText("3").length).toBeGreaterThan(0);
+    expect(getAllByText("12").length).toBeGreaterThan(0);
+  });
+
+  it("renders empty history without error", () => {
+    const { toJSON } = wrap(
+      <ScoreBoard playerLabels={labels} cumulativeScores={[0, 0, 0, 0]} scoreHistory={[]} />
+    );
+    expect(toJSON()).toBeTruthy();
   });
 });
 

--- a/frontend/src/game/hearts/playerNames.ts
+++ b/frontend/src/game/hearts/playerNames.ts
@@ -1,0 +1,33 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+
+const STORAGE_KEY = "hearts_player_names";
+const MAX_NAME_LENGTH = 32;
+
+export const DEFAULT_NAMES = ["You", "West", "North", "East"] as const;
+
+export function validateName(raw: string, fallback: string): string {
+  const trimmed = raw.trim().slice(0, MAX_NAME_LENGTH);
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+export async function loadPlayerNames(): Promise<string[]> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return [...DEFAULT_NAMES];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length !== 4) return [...DEFAULT_NAMES];
+    return parsed.map((n, i) => validateName(String(n), DEFAULT_NAMES[i] ?? "Player"));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "hearts.playerNames", op: "load" } });
+    return [...DEFAULT_NAMES];
+  }
+}
+
+export async function savePlayerNames(names: string[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(names));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "hearts.playerNames", op: "save" } });
+  }
+}

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "فشل الإرسال.",
   "game_over.retry": "أعد المحاولة",
   "game_over.again": "العب مرة أخرى",
-  "score.close": "إغلاق"
+  "score.close": "إغلاق",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Senden fehlgeschlagen.",
   "game_over.retry": "Erneut",
   "game_over.again": "Nochmal spielen",
-  "score.close": "Schließen"
+  "score.close": "Schließen",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -24,7 +24,8 @@
 
   "score.board": "Scores",
   "score.player": "Player",
-  "score.total": "Score",
+  "score.round": "Rnd",
+  "score.total": "Total",
   "score.hand": "Hand",
 
   "pass.direction.left": "Pass left",
@@ -55,5 +56,11 @@
   "game_over.retry": "Retry",
   "game_over.again": "Play Again",
 
-  "score.close": "Close"
+  "score.close": "Close",
+
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Error al enviar.",
   "game_over.retry": "Reintentar",
   "game_over.again": "Jugar de nuevo",
-  "score.close": "Cerrar"
+  "score.close": "Cerrar",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Échec de l’envoi.",
   "game_over.retry": "Réessayer",
   "game_over.again": "Rejouer",
-  "score.close": "Fermer"
+  "score.close": "Fermer",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "שליחה נכשלה.",
   "game_over.retry": "נסה שוב",
   "game_over.again": "שחק שוב",
-  "score.close": "סגור"
+  "score.close": "סגור",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "भेजने में विफल।",
   "game_over.retry": "पुनः प्रयास",
   "game_over.again": "फिर से खेलें",
-  "score.close": "बंद करें"
+  "score.close": "बंद करें",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "送信に失敗しました。",
   "game_over.retry": "再試行",
   "game_over.again": "もう一度プレイ",
-  "score.close": "閉じる"
+  "score.close": "閉じる",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "제출 실패",
   "game_over.retry": "재시도",
   "game_over.again": "다시 플레이",
-  "score.close": "닫기"
+  "score.close": "닫기",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Indienen mislukt.",
   "game_over.retry": "Opnieuw",
   "game_over.again": "Nog een keer!",
-  "score.close": "Sluiten"
+  "score.close": "Sluiten",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Erro ao enviar.",
   "game_over.retry": "Tentar",
   "game_over.again": "Jogar Novamente",
-  "score.close": "Fechar"
+  "score.close": "Fechar",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "Ошибка отправки.",
   "game_over.retry": "Повтор",
   "game_over.again": "Играть снова",
-  "score.close": "Закрыть"
+  "score.close": "Закрыть",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -46,5 +46,11 @@
   "game_over.submit_error": "提交失败。",
   "game_over.retry": "重试",
   "game_over.again": "再玩一次",
-  "score.close": "关闭"
+  "score.close": "关闭",
+  "score.round": "Rnd",
+  "settings.rename": "Edit Names",
+  "settings.rename_title": "Player Names",
+  "settings.player_label": "Player {{n}} (default: {{default}})",
+  "settings.save": "Save",
+  "settings.cancel": "Cancel"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Modal, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Modal, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
@@ -21,6 +21,12 @@ import {
 } from "../game/hearts/engine";
 import { selectCardToPlay, selectCardsToPass } from "../game/hearts/ai";
 import { clearGame, loadGame, saveGame } from "../game/hearts/storage";
+import {
+  DEFAULT_NAMES,
+  loadPlayerNames,
+  savePlayerNames,
+  validateName,
+} from "../game/hearts/playerNames";
 import { heartsApi } from "../game/hearts/api";
 import { useGameSync } from "../game/_shared/useGameSync";
 import type { Card, HeartsState, TrickCard } from "../game/hearts/types";
@@ -39,10 +45,12 @@ type SubmitState = "idle" | "submitting" | "done" | "error";
 function CompactHand({
   cardCount,
   label,
+  score,
   colors,
 }: {
   cardCount: number;
   label: string;
+  score: number;
   colors: Colors;
 }) {
   return (
@@ -56,6 +64,7 @@ function CompactHand({
       >
         <Text style={[compactStyles.count, { color: colors.textMuted }]}>{cardCount}</Text>
       </View>
+      <Text style={[compactStyles.score, { color: colors.text }]}>{score}</Text>
     </View>
   );
 }
@@ -72,6 +81,7 @@ const compactStyles = StyleSheet.create({
     justifyContent: "center",
   },
   count: { fontSize: 13, fontWeight: "700" },
+  score: { fontSize: 13, fontWeight: "700" },
 });
 
 export default function HeartsScreen() {
@@ -82,13 +92,18 @@ export default function HeartsScreen() {
   const [gameState, setGameState] = useState<HeartsState>(() => dealGame());
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
   const [showScores, setShowScores] = useState(false);
+  const [showRename, setShowRename] = useState(false);
   const [playerName, setPlayerName] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
+  const [playerNames, setPlayerNames] = useState<string[]>([...DEFAULT_NAMES]);
+  const [draftNames, setDraftNames] = useState<string[]>([...DEFAULT_NAMES]);
+  const [scoreHistory, setScoreHistory] = useState<number[][]>([]);
 
   const unmountedRef = useRef(false);
   const loopActiveRef = useRef(false);
   const syncStartedRef = useRef(false);
   const gameStateRef = useRef<HeartsState>(gameState);
+  const lastRecordedHandRef = useRef<number>(0);
 
   const { start: syncStart, complete: syncComplete } = useGameSync("hearts");
 
@@ -104,12 +119,26 @@ export default function HeartsScreen() {
     []
   );
 
-  // ─── Load saved game on mount ──────────────────────────────────────────────
+  // ─── Load saved game and player names on mount ────────────────────────────
   useEffect(() => {
     loadGame().then((saved) => {
       if (saved && !unmountedRef.current) setGameState(saved);
     });
+    loadPlayerNames().then((names) => {
+      if (!unmountedRef.current) {
+        setPlayerNames(names);
+        setDraftNames(names);
+      }
+    });
   }, []);
+
+  // ─── Track per-round score history ────────────────────────────────────────
+  useEffect(() => {
+    if (gameState.phase !== "dealing" && gameState.phase !== "game_over") return;
+    if (gameState.handNumber <= lastRecordedHandRef.current) return;
+    lastRecordedHandRef.current = gameState.handNumber;
+    setScoreHistory((prev) => [...prev, [...gameState.handScores]]);
+  }, [gameState.phase, gameState.handNumber, gameState.handScores]);
 
   // ─── Abandon on back-navigation ───────────────────────────────────────────
   useEffect(() => {
@@ -125,7 +154,7 @@ export default function HeartsScreen() {
     return unsub;
   }, [navigation, syncComplete]);
 
-  const playerLabels = [t("player.you"), t("player.left"), t("player.top"), t("player.right")];
+  const playerLabels = playerNames;
 
   // ─── Start sync on first card play ────────────────────────────────────────
   function ensureSyncStarted() {
@@ -261,11 +290,27 @@ export default function HeartsScreen() {
     setLastTrick(null);
     setSubmitState("idle");
     setPlayerName("");
+    setScoreHistory([]);
+    lastRecordedHandRef.current = 0;
     loopActiveRef.current = false;
     syncStartedRef.current = false;
     clearGame().catch(() => {});
     const fresh = dealGame();
     setGameState(fresh);
+  }
+
+  function handleOpenRename() {
+    setDraftNames([...playerNames]);
+    setShowRename(true);
+  }
+
+  function handleSaveNames() {
+    const validated = playerNames.map((def, i) =>
+      validateName(draftNames[i] ?? "", DEFAULT_NAMES[i] ?? def)
+    );
+    setPlayerNames(validated);
+    savePlayerNames(validated).catch(() => {});
+    setShowRename(false);
   }
 
   // ─── Derived state ────────────────────────────────────────────────────────
@@ -302,6 +347,7 @@ export default function HeartsScreen() {
           <OpponentHand
             cardCount={gameState.playerHands[2]?.length ?? 0}
             label={playerLabels[2] ?? ""}
+            score={gameState.cumulativeScores[2] ?? 0}
           />
         </View>
 
@@ -310,6 +356,7 @@ export default function HeartsScreen() {
           <CompactHand
             cardCount={gameState.playerHands[1]?.length ?? 0}
             label={playerLabels[1] ?? ""}
+            score={gameState.cumulativeScores[1] ?? 0}
             colors={colors}
           />
           <TrickArea
@@ -321,12 +368,21 @@ export default function HeartsScreen() {
           <CompactHand
             cardCount={gameState.playerHands[3]?.length ?? 0}
             label={playerLabels[3] ?? ""}
+            score={gameState.cumulativeScores[3] ?? 0}
             colors={colors}
           />
         </View>
 
         {/* Human hand */}
         <View style={styles.bottomArea}>
+          <View style={styles.humanHeader}>
+            <Text style={[styles.humanLabel, { color: colors.textMuted }]}>
+              {playerLabels[0] ?? ""}
+            </Text>
+            <Text style={[styles.humanScore, { color: colors.text }]}>
+              {gameState.cumulativeScores[HUMAN] ?? 0}
+            </Text>
+          </View>
           <PlayerHand hand={humanHand} validCards={validCards} onCardPress={handleCardPress} />
         </View>
       </View>
@@ -361,7 +417,7 @@ export default function HeartsScreen() {
               <ScoreBoard
                 playerLabels={playerLabels}
                 cumulativeScores={[...gameState.cumulativeScores]}
-                handScores={[...gameState.handScores]}
+                scoreHistory={scoreHistory}
                 dangerIndex={dangerIndex}
               />
               <Pressable
@@ -398,7 +454,7 @@ export default function HeartsScreen() {
               <ScoreBoard
                 playerLabels={playerLabels}
                 cumulativeScores={[...gameState.cumulativeScores]}
-                handScores={[...gameState.handScores]}
+                scoreHistory={scoreHistory}
                 dangerIndex={dangerIndex}
               />
 
@@ -505,9 +561,17 @@ export default function HeartsScreen() {
             <ScoreBoard
               playerLabels={playerLabels}
               cumulativeScores={[...gameState.cumulativeScores]}
-              handScores={[...gameState.handScores]}
+              scoreHistory={scoreHistory}
               dangerIndex={dangerIndex}
             />
+            <Pressable
+              style={[styles.btn, { backgroundColor: colors.surfaceAlt }]}
+              onPress={handleOpenRename}
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.rename")}
+            >
+              <Text style={[styles.btnText, { color: colors.text }]}>{t("settings.rename")}</Text>
+            </Pressable>
             <Pressable
               style={[styles.btn, { backgroundColor: colors.surfaceAlt }]}
               onPress={() => setShowScores(false)}
@@ -515,6 +579,74 @@ export default function HeartsScreen() {
               accessibilityLabel={t("score.close")}
             >
               <Text style={[styles.btnText, { color: colors.text }]}>{t("score.close")}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+
+      {/* ── Rename players modal ───────────────────────────────────── */}
+      <Modal
+        visible={showRename}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowRename(false)}
+        accessibilityViewIsModal
+      >
+        <View style={[styles.overlay, { backgroundColor: colors.overlay }]}>
+          <View
+            style={[styles.panel, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          >
+            <Text style={[styles.panelTitle, { color: colors.text }]}>
+              {t("settings.rename_title")}
+            </Text>
+            <ScrollView style={styles.renameScroll} contentContainerStyle={styles.renameContent}>
+              {DEFAULT_NAMES.map((def, i) => (
+                <View key={i} style={styles.renameRow}>
+                  <Text style={[styles.renameLabel, { color: colors.textMuted }]}>
+                    {t("settings.player_label", { n: i + 1, default: def })}
+                  </Text>
+                  <TextInput
+                    style={[
+                      styles.renameInput,
+                      {
+                        color: colors.text,
+                        borderColor: colors.border,
+                        backgroundColor: colors.surfaceAlt,
+                      },
+                    ]}
+                    value={draftNames[i] ?? ""}
+                    onChangeText={(v) =>
+                      setDraftNames((prev) => {
+                        const next = [...prev];
+                        next[i] = v;
+                        return next;
+                      })
+                    }
+                    placeholder={def}
+                    placeholderTextColor={colors.textMuted}
+                    maxLength={32}
+                    accessibilityLabel={t("settings.player_label", { n: i + 1, default: def })}
+                  />
+                </View>
+              ))}
+            </ScrollView>
+            <Pressable
+              style={[styles.btn, { backgroundColor: colors.accent }]}
+              onPress={handleSaveNames}
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.save")}
+            >
+              <Text style={[styles.btnText, { color: colors.textOnAccent }]}>
+                {t("settings.save")}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.btn, { backgroundColor: colors.surfaceAlt }]}
+              onPress={() => setShowRename(false)}
+              accessibilityRole="button"
+              accessibilityLabel={t("settings.cancel")}
+            >
+              <Text style={[styles.btnText, { color: colors.text }]}>{t("settings.cancel")}</Text>
             </Pressable>
           </View>
         </View>
@@ -605,5 +737,41 @@ const styles = StyleSheet.create({
   headerBtnText: {
     fontSize: 14,
     fontWeight: "600",
+  },
+  humanHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingBottom: 4,
+  },
+  humanLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  humanScore: {
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  renameScroll: {
+    width: "100%",
+    maxHeight: 260,
+  },
+  renameContent: {
+    gap: 12,
+  },
+  renameRow: {
+    gap: 4,
+  },
+  renameLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  renameInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 15,
   },
 });

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -11,6 +11,13 @@ jest.mock("../../game/hearts/storage", () => ({
   clearGame: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock("../../game/hearts/playerNames", () => ({
+  DEFAULT_NAMES: ["You", "West", "North", "East"],
+  loadPlayerNames: jest.fn().mockResolvedValue(["You", "West", "North", "East"]),
+  savePlayerNames: jest.fn().mockResolvedValue(undefined),
+  validateName: jest.fn((v: string, def: string) => v.trim() || def),
+}));
+
 jest.mock("../../game/hearts/api", () => ({
   heartsApi: {
     submitScore: jest.fn().mockResolvedValue({ player_name: "test", score: 0, rank: 1 }),
@@ -93,7 +100,7 @@ describe("HeartsScreen — playing phase (no modal)", () => {
   it("score panel opens and shows score board", () => {
     const { getByLabelText, getByText } = renderScreen();
     fireEvent.press(getByLabelText("Scores"));
-    expect(getByText("Player")).toBeTruthy(); // ScoreBoard column header
+    expect(getByText("Total")).toBeTruthy(); // ScoreBoard total row header
   });
 
   it("score panel close button dismisses the panel", () => {


### PR DESCRIPTION
## Summary

- **#664 Fan hand layout + sort**: Replaces the horizontal-scrolling hand with an absolute-positioned fan/overlap layout. All 13 cards visible at iPhone SE width without scroll. Sorted clubs→diamonds→spades→hearts, rank ascending (Ace high). Selected card pops up 16px for visibility.
- **#665 Scores on board + round-by-round scoreboard**: All four players' cumulative scores now displayed on the main gameplay board (top opponent via `OpponentHand`, left/right via `CompactHand`, human in a header above the hand). `ScoreBoard` modal redesigned as a round-by-round table with per-hand points, alternating row shading, and highlighted totals. Leading player (lowest score) shown in accent colour.
- **#666 Player renaming**: Custom names persist via `AsyncStorage` (`hearts_player_names` key). Rename modal accessible from the Scores panel → "Edit Names". Names applied consistently to HUD, scoreboard columns, and game-over results.

## Test plan

- [ ] All 1352 frontend tests pass
- [ ] All 632 backend tests pass
- [ ] Fan layout renders 13 cards without horizontal scroll on narrow viewport
- [ ] Cards sort correctly: clubs low→high, diamonds, spades, hearts (Ace last in each suit)
- [ ] Tapping any overlapped card reliably triggers the correct card
- [ ] All four player scores visible on main board during play
- [ ] Scoreboard modal shows round-by-round rows after each hand completes
- [ ] Player names entered in rename modal persist across app restarts
- [ ] Renamed names appear in HUD, scoreboard header, and game-over winner text

🤖 Generated with [Claude Code](https://claude.com/claude-code)