### PR TITLE
chore: document available agents in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,13 @@ The visual design system is **BC Arcade** (never "Neon Arcade"). See [`docs/BRAN
   `three_of_a_kind` `four_of_a_kind` `full_house` `small_straight`
   `large_straight` `yacht` `chance`
 - `EXPO_PUBLIC_API_URL` env var overrides `BASE_URL` in `frontend/src/api/client.ts`.
+
+## Available Agents
+
+These project subagents live in `.claude/agents/` and are invoked via the `Agent` tool (not Skill). Always prefer them over a general-purpose agent for their domain.
+
+| Agent | `subagent_type` | When to use |
+|---|---|---|
+| lint-review | `lint-review` | Auto-fix lint issues after a lint-gate hook failure |
+| plan-issues | `plan-issues` | Break a feature/bug/initiative into scoped GitHub issues — investigates code first, drafts for confirmation, then calls `gh issue create` |
+| policy-compliance | `policy-compliance` | Check and fix policy violations after a policy-gate hook failure |


### PR DESCRIPTION
## Summary
- Adds an **Available Agents** table to CLAUDE.md listing the three project subagents (`lint-review`, `plan-issues`, `policy-compliance`) with their `subagent_type` values and when to use each
- Without this, Claude looks for subagents in the skills list (system-reminder), doesn't find them, and falls back to a generic agent

## Test plan
- [ ] Verify Claude correctly invokes `plan-issues` via the `Agent` tool when asked to break work into issues