### PR TITLE
feat(settings): deck picker (#687)

### DIFF
--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "تم مسح السجلات المحلية",
   "capacityWarning.title": "بيانات اللعبة المؤقتة ممتلئة",
   "capacityWarning.body": "قم بمسحها من الإعدادات للحفاظ على أداء التطبيق.",
-  "capacityWarning.dismiss": "تجاهل"
+  "capacityWarning.dismiss": "تجاهل",
+  "deck.label": "مجموعة البطاقات",
+  "deck.select": "اختيار مجموعة {{name}}",
+  "deck.selected": "تم اختيار {{name}}"
 }

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Lokale Logs gelöscht",
   "capacityWarning.title": "Wartende Spieldaten füllen den Speicher",
   "capacityWarning.body": "Lösche sie in den Einstellungen, um die App reibungslos laufen zu lassen.",
-  "capacityWarning.dismiss": "Schließen"
+  "capacityWarning.dismiss": "Schließen",
+  "deck.label": "Kartenspiel",
+  "deck.select": "{{name}}-Kartenspiel auswählen",
+  "deck.selected": "{{name}} ausgewählt"
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Local logs cleared",
   "capacityWarning.title": "Queued game data is filling up",
   "capacityWarning.body": "Clear it in Settings to keep the app running smoothly.",
-  "capacityWarning.dismiss": "Dismiss"
+  "capacityWarning.dismiss": "Dismiss",
+  "deck.label": "Card deck",
+  "deck.select": "Select {{name}} card deck",
+  "deck.selected": "{{name}} selected"
 }

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Registros locales borrados",
   "capacityWarning.title": "Los datos en cola están casi llenos",
   "capacityWarning.body": "Bórralos en Configuración para que la app funcione sin problemas.",
-  "capacityWarning.dismiss": "Cerrar"
+  "capacityWarning.dismiss": "Cerrar",
+  "deck.label": "Baraja de cartas",
+  "deck.select": "Seleccionar baraja {{name}}",
+  "deck.selected": "{{name}} seleccionado"
 }

--- a/frontend/src/i18n/locales/fr-CA/common.json
+++ b/frontend/src/i18n/locales/fr-CA/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Journaux locaux effacés",
   "capacityWarning.title": "Les données de jeu en attente s'accumulent",
   "capacityWarning.body": "Effacez-les dans les paramètres pour que l'application fonctionne bien.",
-  "capacityWarning.dismiss": "Ignorer"
+  "capacityWarning.dismiss": "Ignorer",
+  "deck.label": "Jeu de cartes",
+  "deck.select": "Sélectionner le jeu {{name}}",
+  "deck.selected": "{{name}} sélectionné"
 }

--- a/frontend/src/i18n/locales/he/common.json
+++ b/frontend/src/i18n/locales/he/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "הלוגים המקומיים נוקו",
   "capacityWarning.title": "נתוני המשחק בתור מתמלאים",
   "capacityWarning.body": "נקה אותם בהגדרות כדי לשמור על פעילות תקינה של האפליקציה.",
-  "capacityWarning.dismiss": "סגור"
+  "capacityWarning.dismiss": "סגור",
+  "deck.label": "חפיסת קלפים",
+  "deck.select": "בחר חפיסת קלפים {{name}}",
+  "deck.selected": "{{name}} נבחר"
 }

--- a/frontend/src/i18n/locales/hi/common.json
+++ b/frontend/src/i18n/locales/hi/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "स्थानीय लॉग्स साफ़ हो गए",
   "capacityWarning.title": "कतारबद्ध गेम डेटा भर रहा है",
   "capacityWarning.body": "ऐप को सुचारू रूप से चलाने के लिए इसे सेटिंग्स में साफ़ करें।",
-  "capacityWarning.dismiss": "बंद करें"
+  "capacityWarning.dismiss": "बंद करें",
+  "deck.label": "कार्ड डेक",
+  "deck.select": "{{name}} कार्ड डेक चुनें",
+  "deck.selected": "{{name}} चुना गया"
 }

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "ローカルログを削除しました",
   "capacityWarning.title": "未同期データがいっぱいです",
   "capacityWarning.body": "設定から削除してアプリを快適に使いましょう。",
-  "capacityWarning.dismiss": "閉じる"
+  "capacityWarning.dismiss": "閉じる",
+  "deck.label": "カードデッキ",
+  "deck.select": "{{name}}カードデッキを選択",
+  "deck.selected": "{{name}}が選択されました"
 }

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "로컬 로그가 삭제되었습니다",
   "capacityWarning.title": "대기 중인 게임 데이터가 가득 찼습니다",
   "capacityWarning.body": "앱이 원활히 작동하도록 설정에서 삭제하세요.",
-  "capacityWarning.dismiss": "닫기"
+  "capacityWarning.dismiss": "닫기",
+  "deck.label": "카드 덱",
+  "deck.select": "{{name}} 카드 덱 선택",
+  "deck.selected": "{{name}} 선택됨"
 }

--- a/frontend/src/i18n/locales/nl/common.json
+++ b/frontend/src/i18n/locales/nl/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Lokaal logboek gewist",
   "capacityWarning.title": "Wachtrij met spelgegevens raakt vol",
   "capacityWarning.body": "Wis het in Instellingen om de app soepel te laten werken.",
-  "capacityWarning.dismiss": "Sluiten"
+  "capacityWarning.dismiss": "Sluiten",
+  "deck.label": "Kaartenspel",
+  "deck.select": "{{name}}-kaartenspel selecteren",
+  "deck.selected": "{{name}} geselecteerd"
 }

--- a/frontend/src/i18n/locales/pt/common.json
+++ b/frontend/src/i18n/locales/pt/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Registros locais limpos",
   "capacityWarning.title": "Dados de jogo pendentes estão quase cheios",
   "capacityWarning.body": "Limpe em Configurações para manter o app funcionando sem problemas.",
-  "capacityWarning.dismiss": "Fechar"
+  "capacityWarning.dismiss": "Fechar",
+  "deck.label": "Baralho de cartas",
+  "deck.select": "Selecionar baralho {{name}}",
+  "deck.selected": "{{name}} selecionado"
 }

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "Логи очищены",
   "capacityWarning.title": "Данные игры заполняют память",
   "capacityWarning.body": "Очистите их в настройках, чтобы приложение работало без сбоев.",
-  "capacityWarning.dismiss": "Закрыть"
+  "capacityWarning.dismiss": "Закрыть",
+  "deck.label": "Колода карт",
+  "deck.select": "Выбрать колоду {{name}}",
+  "deck.selected": "{{name}} выбрана"
 }

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -30,5 +30,8 @@
   "clearLogs.success": "本地记录已清除",
   "capacityWarning.title": "游戏数据队列快满了",
   "capacityWarning.body": "请在设置中清除以确保应用顺畅运行。",
-  "capacityWarning.dismiss": "知道了"
+  "capacityWarning.dismiss": "知道了",
+  "deck.label": "牌组",
+  "deck.select": "选择{{name}}牌组",
+  "deck.selected": "已选择{{name}}"
 }

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -8,9 +8,11 @@ import { MODAL_SCRIM } from "../theme/theme.constants";
 import LanguageSwitcher from "../components/LanguageSwitcher";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import { gameEventClient } from "../game/_shared/gameEventClient";
+import { useDeck } from "../game/_shared/decks/CardDeckContext";
 
 export default function SettingsScreen() {
   const { colors, theme, toggle } = useTheme();
+  const { activeDeck, setDeck, availableDecks } = useDeck();
   const insets = useSafeAreaInsets();
   const { t } = useTranslation("common");
 
@@ -54,6 +56,37 @@ export default function SettingsScreen() {
             {theme === "dark" ? t("theme.light", "Light") : t("theme.dark", "Dark")}
           </Text>
         </Pressable>
+      </View>
+
+      <View style={[styles.row, { borderColor: colors.border }]}>
+        <Text style={[styles.label, { color: colors.text }]}>{t("deck.label")}</Text>
+        <View style={styles.pillGroup}>
+          {availableDecks.map((id) => {
+            const active = id === activeDeck.id;
+            return (
+              <Pressable
+                key={id}
+                onPress={() => setDeck(id)}
+                style={[
+                  styles.pill,
+                  { backgroundColor: active ? colors.accent : colors.surfaceAlt },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  active ? t("deck.selected", { name: id }) : t("deck.select", { name: id })
+                }
+                accessibilityState={{ selected: active }}
+                testID={`deck-pill-${id}`}
+              >
+                <Text
+                  style={[styles.pillText, { color: active ? colors.textOnAccent : colors.text }]}
+                >
+                  {id.charAt(0).toUpperCase() + id.slice(1)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
       </View>
 
       <View style={[styles.row, { borderColor: colors.border }]}>
@@ -152,6 +185,9 @@ const styles = StyleSheet.create({
   description: { fontSize: 13, marginTop: 4 },
   toggle: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 8 },
   destructive: { paddingHorizontal: 16, paddingVertical: 8, borderRadius: 8 },
+  pillGroup: { flexDirection: "row", gap: 8 },
+  pill: { paddingHorizontal: 14, paddingVertical: 7, borderRadius: 20 },
+  pillText: { fontSize: 14, fontWeight: "500" },
   modalBackdrop: {
     flex: 1,
     justifyContent: "center",


### PR DESCRIPTION
## Summary

- Adds **Card deck** row to Settings between Theme and Language
- Three pill buttons: Minimal / Classic / Neon — active deck highlighted in `colors.accent`
- Tapping a pill calls `setDeck()` from `CardDeckContext` → persists to AsyncStorage immediately
- i18n keys (`deck.label`, `deck.select`, `deck.selected`) added to all 13 locales

## Test plan

- [ ] Open Settings → three deck pills appear between Theme and Language rows
- [ ] Tap **Classic** → pill highlights; go to a card game and confirm Classic SVG cards render
- [ ] Tap **Minimal** → pill highlights; card games show text/emoji cards
- [ ] Tap **Neon** → pill highlights (renders same as Classic until #686 lands)
- [ ] Kill and relaunch app → selected deck persists
- [ ] Verify in dark mode and light mode — pill text colour flips correctly
- [ ] CI green

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)