### PR TITLE
feat(decks): Neon deck (#686)

### DIFF
--- a/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
+++ b/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import {
+  Defs,
+  FeGaussianBlur,
+  FeMerge,
+  FeMergeNode,
+  Filter,
+  G,
+  Path,
+  Rect,
+  Svg,
+  Text as SvgText,
+} from "react-native-svg";
+import { rankLabel } from "../cardId";
+import { SUIT_PATHS } from "../classic/suitPaths";
+import type { CardFaceProps } from "../types";
+
+// Neon palette — always dark, ignores ThemeContext light/dark mode.
+const BG = "#0f172a";
+const BG_BACK = "#070d1a";
+const BORDER = "#334155";
+const SPADES_CLUBS = "#e2e8f0";
+const HEARTS = "#f43f5e";
+const DIAMONDS = "#06b6d4";
+const RANK_TEXT = "#f1f5f9";
+const BACK_GRID = "#06b6d4";
+
+const FACE_LETTERS: Record<number, string> = { 11: "J", 12: "Q", 13: "K" };
+
+function suitColor(suit: string): string {
+  if (suit === "hearts") return HEARTS;
+  if (suit === "diamonds") return DIAMONDS;
+  return SPADES_CLUBS;
+}
+
+function suitEmoji(suit: string): string {
+  if (suit === "spades") return "♠";
+  if (suit === "hearts") return "♥";
+  if (suit === "diamonds") return "♦";
+  return "♣";
+}
+
+// Shared neon glow — blur halo under the sharp source graphic.
+function GlowDefs() {
+  return (
+    <Defs>
+      <Filter id="neon-glow" x="-30%" y="-30%" width="160%" height="160%">
+        <FeGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+        <FeMerge>
+          <FeMergeNode in="blur" />
+          <FeMergeNode in="SourceGraphic" />
+        </FeMerge>
+      </Filter>
+    </Defs>
+  );
+}
+
+export default function NeonCardFace({
+  suit,
+  rank,
+  width,
+  height,
+  faceDown,
+  borderHighlight,
+}: CardFaceProps) {
+  const r = 8;
+
+  if (faceDown) {
+    return (
+      <Svg width={width} height={height}>
+        <Rect x={0} y={0} width={width} height={height} rx={r} fill={BG_BACK} />
+        <Rect
+          x={1}
+          y={1}
+          width={width - 2}
+          height={height - 2}
+          rx={r - 1}
+          stroke={BORDER}
+          strokeWidth={1}
+          fill="none"
+        />
+        {/* Neon diamond-grid back */}
+        <G opacity={0.35}>
+          {Array.from({ length: 8 }, (_, i) => (
+            <Path
+              key={i}
+              d={`M ${(i - 2) * 14} 0 L ${(i + 2) * 14} ${height}`}
+              stroke={BACK_GRID}
+              strokeWidth={1}
+            />
+          ))}
+          {Array.from({ length: 8 }, (_, i) => (
+            <Path
+              key={`h${i}`}
+              d={`M 0 ${(i - 2) * 14} L ${width} ${(i + 2) * 14}`}
+              stroke={BACK_GRID}
+              strokeWidth={1}
+            />
+          ))}
+        </G>
+      </Svg>
+    );
+  }
+
+  const color = suitColor(suit);
+  const rl = rankLabel(rank);
+  const faceLabel = FACE_LETTERS[rank];
+  const cornerFontSize = Math.max(10, Math.round(width * 0.24));
+  const smallSuitSize = Math.max(8, Math.round(width * 0.18));
+  const cx = width / 2;
+  const cy = height / 2;
+  const suitViewSize = Math.round(Math.min(width, height) * 0.52);
+  const suitX = cx - suitViewSize / 2;
+  const suitY = cy - suitViewSize / 2;
+
+  return (
+    <Svg width={width} height={height}>
+      <GlowDefs />
+
+      {/* Card face — always dark */}
+      <Rect x={0} y={0} width={width} height={height} rx={r} fill={BG} />
+      <Rect
+        x={1}
+        y={1}
+        width={width - 2}
+        height={height - 2}
+        rx={r - 1}
+        stroke={borderHighlight ?? BORDER}
+        strokeWidth={1}
+        fill="none"
+      />
+
+      {/* Top-left corner */}
+      <SvgText
+        x={5}
+        y={cornerFontSize + 2}
+        fontSize={cornerFontSize}
+        fontWeight="700"
+        fill={RANK_TEXT}
+      >
+        {rl}
+      </SvgText>
+      <SvgText
+        x={5}
+        y={cornerFontSize + smallSuitSize + 4}
+        fontSize={smallSuitSize}
+        fill={color}
+        filter="url(#neon-glow)"
+      >
+        {suitEmoji(suit)}
+      </SvgText>
+
+      {/* Centre: suit path with glow or face letter */}
+      {faceLabel ? (
+        <>
+          <Rect
+            x={6}
+            y={height * 0.22}
+            width={width - 12}
+            height={height * 0.56}
+            rx={4}
+            stroke={BORDER}
+            strokeWidth={0.75}
+            fill="none"
+          />
+          <SvgText
+            x={cx}
+            y={cy + suitViewSize * 0.28}
+            fontSize={suitViewSize * 0.72}
+            fontWeight="700"
+            fill={color}
+            textAnchor="middle"
+            filter="url(#neon-glow)"
+          >
+            {faceLabel}
+          </SvgText>
+        </>
+      ) : (
+        <Svg x={suitX} y={suitY} width={suitViewSize} height={suitViewSize} viewBox="0 0 500 500">
+          <Path d={SUIT_PATHS[suit]} fill={color} filter="url(#neon-glow)" />
+        </Svg>
+      )}
+
+      {/* Bottom-right corner (rotated 180°) */}
+      <G rotation={180} origin={`${cx}, ${cy}`}>
+        <SvgText
+          x={5}
+          y={cornerFontSize + 2}
+          fontSize={cornerFontSize}
+          fontWeight="700"
+          fill={RANK_TEXT}
+        >
+          {rl}
+        </SvgText>
+        <SvgText
+          x={5}
+          y={cornerFontSize + smallSuitSize + 4}
+          fontSize={smallSuitSize}
+          fill={color}
+          filter="url(#neon-glow)"
+        >
+          {suitEmoji(suit)}
+        </SvgText>
+      </G>
+    </Svg>
+  );
+}

--- a/frontend/src/game/_shared/decks/neon/index.ts
+++ b/frontend/src/game/_shared/decks/neon/index.ts
@@ -1,3 +1,10 @@
-// Neon deck — implemented in issue #686.
-// Stub re-exports Classic until the real implementation lands.
-export { default } from "../classic";
+import NeonCardFace from "./NeonCardFace";
+import type { DeckTheme } from "../types";
+
+const NeonDeck: DeckTheme = {
+  id: "neon",
+  name: "Neon",
+  CardFace: NeonCardFace,
+};
+
+export default NeonDeck;


### PR DESCRIPTION
## Summary

- Implements the real Neon deck, replacing the Classic stub
- **Always-dark palette** — `#0f172a` card face regardless of app light/dark mode toggle (deliberate design choice)
- Suit colours: Hearts → `#f43f5e` (rose), Diamonds → `#06b6d4` (cyan), Spades/Clubs → `#e2e8f0` (off-white)
- SVG `feGaussianBlur` glow filter applied to suit glyphs, corner pips, and face card letters
- Card back: cyan diamond-grid on near-black `#070d1a` — no raster images
- Selected/highlighted state uses `borderHighlight` from props (accent colour from ThemeContext)
- Reuses suit path data from Classic — no duplication
- Only loads when user selects Neon in Settings (lazy via DECK_REGISTRY)

## Test plan

- [ ] Open Settings → select **Neon** deck
- [ ] Open a card game — cards show deep navy background with neon-coloured suits
- [ ] Hearts and Diamonds render rose/cyan; Spades/Clubs render off-white
- [ ] Glow effect visible on suit glyphs and face letters (J/Q/K)
- [ ] Face-down cards show cyan diamond-grid on near-black
- [ ] Flip app to **Light mode** — Neon cards remain dark (palette doesn't change)
- [ ] Select a card (highlighted state) — border changes to accent colour
- [ ] Switch back to Classic/Minimal — correct deck renders immediately
- [ ] CI green

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)