### PR TITLE
feat(blackjack): fan overlap layout for split hands (#672)

### DIFF
--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, useWindowDimensions } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import { HandResponse } from "../../game/blackjack/types";
@@ -33,8 +33,13 @@ export default function BlackjackTable({
 }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
+  const { width: screenWidth } = useWindowDimensions();
   const isPlayerPhase = phase === "player";
   const isSplit = playerHands && playerHands.length > 1;
+
+  // Available inner width per split hand: screen minus HUD sidebar (88), the
+  // gap between hands (8), and splitHand padding (6×2 each side = 24 total).
+  const splitHandMaxWidth = Math.max(80, (screenWidth - 88 - 8) / 2 - 24);
 
   return (
     <View style={[styles.container, compact && styles.containerCompact]}>
@@ -70,7 +75,13 @@ export default function BlackjackTable({
                   },
                 ]}
               >
-                <HandDisplay hand={hand} label={label} variant="player" compact />
+                <HandDisplay
+                  hand={hand}
+                  label={label}
+                  variant="player"
+                  compact
+                  fanMaxWidth={splitHandMaxWidth}
+                />
                 {bet != null && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
                 )}

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -16,10 +16,24 @@ interface Props {
    *  rendering and by the whole table on short-height viewports. Shrinks
    *  both the "player" and "dealer" variants when set. */
   compact?: boolean;
+  /**
+   * When set, cards with count > 2 switch from wrap to a fan/overlap layout
+   * that constrains the row to this pixel width. Each card after the first
+   * shifts left so the rank+suit pip of earlier cards peeks out on the left.
+   * Pass the available inner width of the containing column.
+   */
+  fanMaxWidth?: number;
 }
 
 // First two player cards get a gentle fan tilt
 const PLAYER_ROTATIONS: Record<number, number> = { 0: -3, 1: 2 };
+
+function computeOverlap(cardCount: number, cardWidth: number, maxWidth: number): number {
+  if (cardCount <= 2 || cardWidth * cardCount <= maxWidth) return 0;
+  // total = cardWidth + (n-1) × (cardWidth - overlap) ≤ maxWidth
+  // → overlap = cardWidth - (maxWidth - cardWidth) / (n - 1)
+  return Math.max(0, Math.ceil(cardWidth - (maxWidth - cardWidth) / (cardCount - 1)));
+}
 
 export default function HandDisplay({
   hand,
@@ -27,9 +41,15 @@ export default function HandDisplay({
   concealed = false,
   variant = "dealer",
   compact = false,
+  fanMaxWidth,
 }: Props) {
   const { colors } = useTheme();
   const showScore = hand.cards.length > 0;
+
+  // Card width matches blackjack PlayingCard cardSize() values.
+  const cardWidth = variant === "player" ? (compact ? 48 : 68) : compact ? 40 : 52;
+  const isFan = fanMaxWidth !== undefined && hand.cards.length > 2;
+  const overlapPx = isFan ? computeOverlap(hand.cards.length, cardWidth, fanMaxWidth!) : 0;
 
   return (
     <View style={[styles.container, compact && styles.containerCompact]}>
@@ -37,15 +57,19 @@ export default function HandDisplay({
         {label}
       </Text>
 
-      <View style={styles.cards}>
+      <View style={isFan ? styles.cardsFan : styles.cards}>
         {hand.cards.map((card, i) => (
-          <PlayingCard
+          <View
             key={i}
-            card={card}
-            variant={variant}
-            compact={compact}
-            rotation={variant === "player" ? (PLAYER_ROTATIONS[i] ?? 0) : 0}
-          />
+            style={isFan ? { marginLeft: i > 0 ? -overlapPx : 0, zIndex: i } : undefined}
+          >
+            <PlayingCard
+              card={card}
+              variant={variant}
+              compact={compact}
+              rotation={variant === "player" ? (PLAYER_ROTATIONS[i] ?? 0) : 0}
+            />
+          </View>
         ))}
       </View>
 
@@ -76,6 +100,11 @@ const styles = StyleSheet.create({
   cards: {
     flexDirection: "row",
     flexWrap: "wrap",
+    justifyContent: "center",
+  },
+  cardsFan: {
+    flexDirection: "row",
+    flexWrap: "nowrap",
     justifyContent: "center",
   },
 });


### PR DESCRIPTION
## Summary

Fixes the unreadable split-hand layout at phone width. When a split hand has more than 2 cards, `HandDisplay` now switches from a wrapping row to a fan/overlap layout that keeps all cards visible within the available column width.

**How it works:**
- `HandDisplay` accepts a new `fanMaxWidth` prop (optional — existing callers unchanged)
- When `fanMaxWidth` is set and card count > 2, computes `overlapPx` so all cards fit: `overlap = cardWidth − (maxWidth − cardWidth) / (n − 1)`
- Cards at index ≥ 1 get `marginLeft: −overlapPx`; `zIndex: i` ensures later cards sit on top
- `BlackjackTable` computes `splitHandMaxWidth` from screen width at runtime (adapts to any device)

**iPhone SE portrait (375px) — 5-card split hand:**
- Available per hand ≈ 115px
- Compact player card = 48px wide
- Computed overlap = ceil(48 − (115−48)/4) = ceil(48−16.75) = 32px
- Fan width = 48 + 4×(48−32) = 48 + 64 = 112px ✓ fits with margin to spare

## Test plan

- [ ] Deal until you can split; split the hand; hit each hand to 4–5 cards — both hands visible simultaneously without scrolling
- [ ] Active hand shows accent border + glow + "YOUR TURN" label
- [ ] Completed hand (stood/busted) shows faded without highlight
- [ ] Bet chip and outcome text still render under each hand
- [ ] iPhone SE portrait: entire table + action bar fits on one screen
- [ ] Wider phone (e.g. 390px+): overlap is proportionally less — cards show more of themselves
- [ ] Non-split single hand: unchanged (wrap layout, fan not triggered)
- [ ] CI green

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)