### PR TITLE
feat(audit): timestamp TZ audit + formatTimestamp utility (#660)

### DIFF
--- a/frontend/src/screens/GameDetailScreen.tsx
+++ b/frontend/src/screens/GameDetailScreen.tsx
@@ -9,6 +9,7 @@ import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import { statsApi } from "../api/stats";
 import type { GameDetailResponse } from "../api/types";
 import type { ProfileStackParamList } from "../../App";
+import { formatTimestamp } from "../utils/formatTimestamp";
 
 type Props = {
   navigation: NativeStackNavigationProp<ProfileStackParamList, "GameDetail">;
@@ -37,13 +38,6 @@ function formatDuration(ms: number | null): string {
   const m = Math.floor(s / 60);
   const rs = s % 60;
   return `${m}m ${rs}s`;
-}
-
-function formatTimestamp(iso: string | null): string {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleString();
 }
 
 export default function GameDetailScreen({ navigation, route }: Props) {

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -17,6 +17,7 @@ import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import { statsApi } from "../api/stats";
 import type { StatsResponse, GameRow } from "../api/types";
 import type { ProfileStackParamList } from "../../App";
+import { formatDate } from "../utils/formatTimestamp";
 
 type ProfileNav = NativeStackNavigationProp<ProfileStackParamList, "ProfileHome">;
 
@@ -77,13 +78,6 @@ function formatGameType(raw: string): string {
     default:
       return raw;
   }
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
 }
 
 function outcomeGlyph(outcome: string | null): string {

--- a/frontend/src/utils/__tests__/formatTimestamp.test.ts
+++ b/frontend/src/utils/__tests__/formatTimestamp.test.ts
@@ -1,0 +1,77 @@
+import { formatTimestamp, formatDate } from "../formatTimestamp";
+
+// A fixed UTC instant: 2024-06-15 20:00:00 UTC.
+// In America/New_York (EDT = UTC−4) this is 4:00 PM.
+// In Asia/Tokyo (JST = UTC+9) this is 05:00 next day.
+// The key invariant: the output must come from the runtime's TZ-aware
+// formatter, not from toISOString() or manual offset arithmetic.
+const UTC_ISO = "2024-06-15T20:00:00.000Z";
+
+describe("formatTimestamp", () => {
+  it("returns — for null", () => {
+    expect(formatTimestamp(null)).toBe("—");
+  });
+
+  it("returns — for an unparseable string", () => {
+    expect(formatTimestamp("not-a-date")).toBe("—");
+  });
+
+  it("returns — for empty string", () => {
+    expect(formatTimestamp("")).toBe("—");
+  });
+
+  it("does not return the raw ISO string (proves toLocaleString, not toISOString)", () => {
+    const result = formatTimestamp(UTC_ISO);
+    expect(result).not.toBe(UTC_ISO);
+    // ISO-8601 markers that should never appear in a locale-formatted date
+    expect(result).not.toContain("T");
+    expect(result).not.toContain(".000Z");
+  });
+
+  it("delegates to Date.prototype.toLocaleString (no manual offset math)", () => {
+    const spy = jest.spyOn(Date.prototype, "toLocaleString");
+    formatTimestamp(UTC_ISO);
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Called with no arguments — lets the runtime pick the device locale & TZ.
+    expect(spy).toHaveBeenCalledWith();
+    spy.mockRestore();
+  });
+
+  it("returns a non-empty string for a valid UTC timestamp", () => {
+    expect(formatTimestamp(UTC_ISO).length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatDate", () => {
+  it("returns empty string for null", () => {
+    expect(formatDate(null)).toBe("");
+  });
+
+  it("returns empty string for an unparseable string", () => {
+    expect(formatDate("bad")).toBe("");
+  });
+
+  it("does not return the raw ISO string", () => {
+    const result = formatDate(UTC_ISO);
+    expect(result).not.toContain("T");
+    expect(result).not.toContain("Z");
+    expect(result).not.toMatch(/^\d{4}-\d{2}-\d{2}/); // ISO date fragment
+  });
+
+  it("delegates to toLocaleDateString with the canonical options", () => {
+    const spy = jest.spyOn(Date.prototype, "toLocaleDateString");
+    formatDate(UTC_ISO);
+    expect(spy).toHaveBeenCalledWith(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    spy.mockRestore();
+  });
+
+  it("includes the year in the output", () => {
+    // toLocaleDateString with year:'numeric' must include the year.
+    // This would fail if someone switched to toISOString() or dropped the options.
+    expect(formatDate(UTC_ISO)).toContain("2024");
+  });
+});

--- a/frontend/src/utils/formatTimestamp.ts
+++ b/frontend/src/utils/formatTimestamp.ts
@@ -1,0 +1,32 @@
+/**
+ * Timestamp display utilities — always use these, never toISOString() or
+ * manual offset arithmetic. The device's local timezone is applied
+ * automatically by the JS runtime when you pass a Date to toLocaleString /
+ * toLocaleDateString.
+ *
+ * Pattern:
+ *   const d = new Date(isoUtcString);   // parses ISO-8601 → local TZ
+ *   return d.toLocaleString();           // renders in device local TZ
+ */
+
+/**
+ * Full date + time in the device's local timezone.
+ * Returns "—" for null or an unparseable string.
+ */
+export function formatTimestamp(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+/**
+ * Short date (e.g. "Jun 15, 2024") in the device's local timezone.
+ * Returns "" for null or an unparseable string.
+ */
+export function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}


### PR DESCRIPTION
## Summary

Closes the #660 audit. Finding: **no regressions** — both existing timestamp sites were already correct.

**Inventory:**

| File | Call site | Status |
|---|---|---|
| `GameDetailScreen.tsx:42` | `new Date(iso).toLocaleString()` | ✅ TZ-aware |
| `ProfileScreen.tsx:82` | `new Date(iso).toLocaleDateString(undefined, opts)` | ✅ TZ-aware |
| `cascade/GameCanvas.tsx` | RAF `timestamp` param (frame timing, not display) | ✅ not a display call |
| `twenty48/StatsBento.tsx:12` | `formatTime(ms)` (elapsed duration, not a wall-clock timestamp) | ✅ not a display call |
| All `toLocaleString()` in betting/chips | Number formatting, not timestamps | ✅ unrelated |

No ⚠️ sites found.

**Changes:**
- Extracted both functions into `src/utils/formatTimestamp.ts` — single canonical location with a JSDoc pattern note so future code follows it
- Removed the inlined copies from `GameDetailScreen` and `ProfileScreen` (import from util)
- 11 Jest tests guard against regression to raw ISO output or manual UTC math

## Test plan

- [ ] Profile screen: recent games list shows dates in device local timezone (e.g. not "2024-06-15T20:00:00Z")
- [ ] Game detail screen: started_at / completed_at show local datetime
- [ ] `npm test -- --testPathPattern=formatTimestamp` → 11 tests pass
- [ ] CI green

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)