### PR TITLE
fix(#705): pipe console.error into Sentry to surface React warnings

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -26,6 +26,7 @@ import { NetworkProvider } from "./src/game/_shared/NetworkContext";
 import { CardDeckProvider } from "./src/game/_shared/decks/CardDeckContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
+import { installSentryConsoleErrorCapture } from "./src/utils/sentryConsoleError";
 
 const CascadeScreen = React.lazy(() => import("./src/screens/CascadeScreen"));
 const BlackjackBettingScreen = React.lazy(() => import("./src/screens/BlackjackBettingScreen"));
@@ -51,6 +52,7 @@ if (!dsn) {
       dsn,
       sendDefaultPii: true,
     });
+    installSentryConsoleErrorCapture();
   } catch (e) {
     console.error("[Sentry] init failed:", e);
   }

--- a/frontend/src/utils/__tests__/sentryConsoleError.test.ts
+++ b/frontend/src/utils/__tests__/sentryConsoleError.test.ts
@@ -1,0 +1,87 @@
+import * as Sentry from "@sentry/react-native";
+import {
+  installSentryConsoleErrorCapture,
+  _resetSentryConsoleErrorCaptureForTests,
+} from "../sentryConsoleError";
+
+jest.mock("@sentry/react-native", () => ({
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+}));
+
+describe("installSentryConsoleErrorCapture", () => {
+  const originalError = console.error;
+
+  afterEach(() => {
+    _resetSentryConsoleErrorCaptureForTests();
+    console.error = originalError;
+    jest.clearAllMocks();
+  });
+
+  it("forwards plain-string console.error calls to Sentry.captureMessage", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    installSentryConsoleErrorCapture();
+
+    console.error("duplicate key", "warning");
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "duplicate key warning",
+      expect.objectContaining({
+        level: "error",
+        tags: expect.objectContaining({ source: "console.error" }),
+      })
+    );
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("forwards Error instances via Sentry.captureException", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    installSentryConsoleErrorCapture();
+
+    const err = new Error("boom");
+    console.error("prefix:", err);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      err,
+      expect.objectContaining({
+        tags: expect.objectContaining({ source: "console.error" }),
+      })
+    );
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("still calls the original console.error so output is preserved", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    installSentryConsoleErrorCapture();
+
+    console.error("hello");
+
+    expect(spy).toHaveBeenCalledWith("hello");
+    spy.mockRestore();
+  });
+
+  it("is idempotent — calling install twice does not double-wrap", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    installSentryConsoleErrorCapture();
+    installSentryConsoleErrorCapture();
+
+    console.error("once");
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
+
+  it("does not swallow the original log when Sentry.captureMessage throws", () => {
+    (Sentry.captureMessage as jest.Mock).mockImplementation(() => {
+      throw new Error("sentry down");
+    });
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    installSentryConsoleErrorCapture();
+
+    expect(() => console.error("still logs")).not.toThrow();
+    expect(spy).toHaveBeenCalledWith("still logs");
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/utils/sentryConsoleError.ts
+++ b/frontend/src/utils/sentryConsoleError.ts
@@ -1,0 +1,65 @@
+/**
+ * Forwards `console.error` calls to Sentry as `captureMessage` events.
+ *
+ * @sentry/react-native v7 does not re-export `captureConsoleIntegration`
+ * from the bundled core, so we install a small manual wrapper instead.
+ * This captures React warnings (duplicate keys, invalid prop types, etc.)
+ * that go through `console.error` and would otherwise never reach Sentry.
+ *
+ * Call AFTER `Sentry.init(...)` and after `SessionLogger.init()`. Composes
+ * with SessionLogger: our wrapper sits above SessionLogger's, so calls flow
+ *   patched console.error → Sentry forwarder → SessionLogger's wrapper → real console.error
+ * `Sentry.captureException` does not route through `console.error`, so
+ * errors captured explicitly are not double-reported here.
+ */
+
+import * as Sentry from "@sentry/react-native";
+
+let installed = false;
+let originalError: typeof console.error | null = null;
+
+function formatArg(a: unknown): string {
+  if (typeof a === "string") return a;
+  if (a instanceof Error) return `${a.name}: ${a.message}`;
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
+export function installSentryConsoleErrorCapture(): void {
+  if (installed) return;
+  installed = true;
+  originalError = console.error.bind(console);
+
+  console.error = (...args: unknown[]) => {
+    try {
+      const message = args.map(formatArg).join(" ");
+      const firstError = args.find((a): a is Error => a instanceof Error);
+      if (firstError) {
+        Sentry.captureException(firstError, {
+          tags: { source: "console.error" },
+          extra: { message },
+        });
+      } else {
+        Sentry.captureMessage(message, {
+          level: "error",
+          tags: { source: "console.error" },
+        });
+      }
+    } catch {
+      // Never let capture failures swallow the original log.
+    }
+    originalError!(...args);
+  };
+}
+
+/** Test-only: restore the original console.error and reset install flag. */
+export function _resetSentryConsoleErrorCaptureForTests(): void {
+  if (installed && originalError) {
+    console.error = originalError;
+  }
+  installed = false;
+  originalError = null;
+}


### PR DESCRIPTION
## Summary
- Adds a small manual wrapper around `console.error` (installed after `Sentry.init()`) that forwards React warnings and other console errors into Sentry as `captureMessage` / `captureException`, tagged `source: "console.error"`.
- `@sentry/react-native` v7 does not re-export `captureConsoleIntegration`, so the issue's alternative (manual patch) is used.
- Composes with the existing `SessionLogger` console patch — both wrappers run, real `console.error` is preserved, capture failures never swallow the log.
- Unit tests cover: string forwarding, Error forwarding, original-log preservation, idempotency, and Sentry-throws safety.

Closes #705 for the observability half. The actual duplicate-key offender in Solitaire/Hearts is deliberately **not** fixed here — static audit found no clear static offender, and the issue itself calls out that step 2 needs a real Sentry event with a component stack to pinpoint. Follow-up once a warning lands.

Does not touch #698 (Twenty48 tile id collision), which has its own diagnosed fix path.

## Test plan
- [x] `npx jest src/utils/__tests__/sentryConsoleError.test.ts` passes (5/5).
- [x] `npx eslint` clean on changed files.
- [x] Full suite: pre-existing parallel-load flakes in HeartsScreen/SolitaireScreen/SudokuScreen/Twenty48Screen — all pass when run in isolation, unrelated to this change.
- [ ] Smoke on device: trigger a React warning, confirm it appears in Sentry tagged `source: "console.error"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)