### PR TITLE
chore(#722): bump expo to 55.0.17

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@react-navigation/native-stack": "^7.14.6",
         "@sentry/react-native": "~7.11.0",
         "@shopify/react-native-skia": "2.4.18",
-        "expo": "~55.0.16",
+        "expo": "~55.0.17",
         "expo-blur": "~55.0.14",
         "expo-linear-gradient": "~55.0.13",
         "expo-localization": "^55.0.13",
@@ -1650,9 +1650,9 @@
       "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
-      "version": "55.0.25",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.25.tgz",
-      "integrity": "sha512-a2NWHAVF2iRR3zzHhc8FI5CQIIg1IiX8cEs6v6md73DPtVdzlM0KFi+GtcqXt7eCYWz49ArRBqaCbrNcSrwiPg==",
+      "version": "55.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.26.tgz",
+      "integrity": "sha512-Ud9gpeGMF5RIL42LXvCw3k3mWK8rf/P2wu+Yrzz9Do1kcFKZeT9Vy2D/xukjdr/Xw+ELba87ThOot17GsPiWjw==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "^0.0.6",
@@ -8640,13 +8640,13 @@
       }
     },
     "node_modules/expo": {
-      "version": "55.0.16",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.16.tgz",
-      "integrity": "sha512-UFZevOJCCB833D3banyIxDnOWNj/q+VZOxPdMvpmcowyZO0sFsnfd57LOh3pb7gLMxdAtXX4F8ZX7A8P0Ne3Ng==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.17.tgz",
+      "integrity": "sha512-yVF2phiPw5XgOCedC/oQaL3j0XbwzsBLst3JiAF8bi9aFlxLOVvuDEM8BDg3E09XGSLaGCAclY4q5L+sFerXlQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "55.0.25",
+        "@expo/cli": "55.0.26",
         "@expo/config": "~55.0.15",
         "@expo/config-plugins": "~55.0.8",
         "@expo/devtools": "55.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,7 @@
     "@react-navigation/native-stack": "^7.14.6",
     "@sentry/react-native": "~7.11.0",
     "@shopify/react-native-skia": "2.4.18",
-    "expo": "~55.0.16",
+    "expo": "~55.0.17",
     "expo-blur": "~55.0.14",
     "expo-linear-gradient": "~55.0.13",
     "expo-localization": "^55.0.13",


### PR DESCRIPTION
## Summary
- Bumps `expo` from `~55.0.16` to `~55.0.17` so `npx expo install --check` exits 0. Unblocks the `expo-compat` CI gate on every open PR.
- Cascading bump of `@expo/cli` from 55.0.25 → 55.0.26 in the lockfile (no direct dep).
- No behavior changes, no source code touched.

Closes #722. Once merged, rebase #721 onto dev and `expo-compat` there will pass.

## Test plan
- [x] `cd frontend && npx expo install --check` exits 0 locally.
- [x] `cd frontend && npx expo install --fix` reports "Dependencies are up to date" on the resulting tree.
- [ ] CI `expo-compat` check passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)