### PR TITLE
fix(#697): seed missing event_types for solitaire/hearts/sudoku; promote 400 batch alert to error

### DIFF
--- a/backend/alembic/versions/0010_add_event_types_solitaire_hearts_sudoku.py
+++ b/backend/alembic/versions/0010_add_event_types_solitaire_hearts_sudoku.py
@@ -1,0 +1,52 @@
+"""seed event_types for solitaire, hearts, and sudoku (#697)
+
+Revision ID: 0010_add_event_types_solitaire_hearts_sudoku
+Revises: 0009_add_sudoku_game_type
+Create Date: 2026-04-21
+
+Migrations 0007-0009 registered the game_type rows for solitaire (id=6),
+hearts (id=7), and sudoku (id=8) but never seeded their event_types. Every
+POST /games/:id/events from those games returned 400 (unknown_event_type)
+and the SyncWorker dead-lettered the batch — silently dropping all events.
+
+All three screens only emit the two lifecycle events injected automatically
+by gameEventClient.startGame / completeGame: game_started and game_ended.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0010_add_event_types_solitaire_hearts_sudoku"
+down_revision: Union[str, None] = "0009_add_sudoku_game_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    event_types = sa.table(
+        "event_types",
+        sa.column("game_type_id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("description", sa.Text),
+    )
+    op.bulk_insert(
+        event_types,
+        [
+            # solitaire (id=6)
+            {"game_type_id": 6, "name": "game_started", "display_name": "Game Started", "description": None},
+            {"game_type_id": 6, "name": "game_ended", "display_name": "Game Ended", "description": None},
+            # hearts (id=7)
+            {"game_type_id": 7, "name": "game_started", "display_name": "Game Started", "description": None},
+            {"game_type_id": 7, "name": "game_ended", "display_name": "Game Ended", "description": None},
+            # sudoku (id=8)
+            {"game_type_id": 8, "name": "game_started", "display_name": "Game Started", "description": None},
+            {"game_type_id": 8, "name": "game_ended", "display_name": "Game Ended", "description": None},
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM event_types WHERE game_type_id IN (6, 7, 8)")

--- a/backend/alembic/versions/0010_add_event_types_solitaire_hearts_sudoku.py
+++ b/backend/alembic/versions/0010_add_event_types_solitaire_hearts_sudoku.py
@@ -36,14 +36,44 @@ def upgrade() -> None:
         event_types,
         [
             # solitaire (id=6)
-            {"game_type_id": 6, "name": "game_started", "display_name": "Game Started", "description": None},
-            {"game_type_id": 6, "name": "game_ended", "display_name": "Game Ended", "description": None},
+            {
+                "game_type_id": 6,
+                "name": "game_started",
+                "display_name": "Game Started",
+                "description": None,
+            },
+            {
+                "game_type_id": 6,
+                "name": "game_ended",
+                "display_name": "Game Ended",
+                "description": None,
+            },
             # hearts (id=7)
-            {"game_type_id": 7, "name": "game_started", "display_name": "Game Started", "description": None},
-            {"game_type_id": 7, "name": "game_ended", "display_name": "Game Ended", "description": None},
+            {
+                "game_type_id": 7,
+                "name": "game_started",
+                "display_name": "Game Started",
+                "description": None,
+            },
+            {
+                "game_type_id": 7,
+                "name": "game_ended",
+                "display_name": "Game Ended",
+                "description": None,
+            },
             # sudoku (id=8)
-            {"game_type_id": 8, "name": "game_started", "display_name": "Game Started", "description": None},
-            {"game_type_id": 8, "name": "game_ended", "display_name": "Game Ended", "description": None},
+            {
+                "game_type_id": 8,
+                "name": "game_started",
+                "display_name": "Game Started",
+                "description": None,
+            },
+            {
+                "game_type_id": 8,
+                "name": "game_ended",
+                "display_name": "Game Ended",
+                "description": None,
+            },
         ],
     )
 

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0009_add_sudoku_game_type"
+        assert version == "0010_add_event_types_solitaire_hearts_sudoku"

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -284,8 +284,18 @@ export class SyncWorker {
       return true;
     }
     // 400, 403, or other 4xx terminal — dead-letter the chunk.
+    // 400 is always "error" level: it means the client sent an unrecognised
+    // event_type (e.g. a new game type whose DB event_types rows are missing).
+    // The response body contains {"error":"unknown_event_type","rejected":[...]}
+    // which is actionable — include it as extra so Sentry surfaces the names.
     Sentry.captureMessage(`syncWorker: ${res.status} on ${gameId} event batch`, {
-      level: res.status === 403 ? "error" : "warning",
+      level: "error",
+      extra: {
+        status: res.status,
+        body: res.body,
+        gameId,
+        eventTypes: chunk.map((r) => r.event_type),
+      },
     });
     await this.markDeadLettered(chunk.map((r) => r.id));
     result.deadLettered += chunk.length;


### PR DESCRIPTION
## Root cause

Migrations 0007–0009 registered the `solitaire`, `hearts`, and `sudoku` game types but never seeded their `event_types` rows. `append_events()` in the service layer looks up every incoming `event_type` against the DB map — if any name is absent, it raises `GameServiceError(400, {"error": "unknown_event_type", ...})` and rejects the whole batch. SyncWorker then silently dead-lettered it at `warning` level.

Since all three screens only emit `game_started` and `game_ended` (auto-injected by `gameEventClient.startGame` / `completeGame`), the fix is to seed exactly those two event types for each missing game.

## Changes

| File | Change |
|---|---|
| `backend/alembic/versions/0010_add_event_types_solitaire_hearts_sudoku.py` | New migration: seeds `game_started` + `game_ended` for game_type_ids 6 (solitaire), 7 (hearts), 8 (sudoku) |
| `backend/tests/test_db_connection.py` | Bumps expected alembic head to `0010_…` |
| `frontend/src/game/_shared/syncWorker.ts` | Promotes 400 event-batch Sentry captures from `warning` → `error`; adds `extra` with response body and event_type list so rejected names are visible in the alert |

## Test plan
- [ ] `python -m pytest tests/ -v` — all 632 pass (already verified)
- [ ] Run a Solitaire session in dev; confirm POST `/games/:id/events` returns 2xx after running `alembic upgrade head`
- [ ] Confirm Hearts and Sudoku event batches also succeed
- [ ] Check Sentry: future 400 event-batch alerts appear at `error` level with `body` + `eventTypes` extra

Closes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)