### PR TITLE
fix(#699): clamp cascade fruit to floor in native engine safety net

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5080,9 +5080,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12775,9 +12775,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12797,9 +12794,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12821,9 +12815,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12843,9 +12834,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/frontend/src/game/cascade/__tests__/engine.native.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.native.test.ts
@@ -362,6 +362,27 @@ describe("boundary escape", () => {
     expect(onGameOver).not.toHaveBeenCalled();
     handle.cleanup();
   });
+
+  // #699 — a body that ends a step below the floor but within the escape
+  // margin must be snapped back to innerBottom by the floor safety net,
+  // not left to drift past H + margin on subsequent frames and fire a
+  // Sentry warning.
+  it("clamps a body below the floor (within escape margin) back to innerBottom", async () => {
+    const { handle, onBoundaryEscape } = await buildEscape();
+    const tier0 = fruit(0);
+    const innerBottom = H - 16 - tier0.radius; // WALL_THICKNESS = 16
+    // y = H + radius is below the floor but well inside the escape margin
+    // (margin = radius * 2). The floor rectangle sits at y ∈ [H-16, H], so
+    // the body is clear of it and Matter.js will not push it out — only our
+    // safety net will.
+    handle.drop(tier0, "fruits", W / 2, H + tier0.radius);
+
+    const snapshots = handle.step(1 / 60);
+
+    expect(onBoundaryEscape).not.toHaveBeenCalled();
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.y).toBeLessThanOrEqual(innerBottom + 0.5);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -215,11 +215,12 @@ export async function createEngine(
       processMerges();
 
       // Safety net: hard-clamp any body that drifted slightly outside the
-      // left/right walls and zero inward velocity so it can't re-tunnel next
-      // frame. This catches the rare case where Matter.js corrective impulses
-      // from polygon vertex decomposition push a body through a thin wall.
-      // Only applies within the escape margin — bodies farther outside are
-      // left for the escape-detection pass below to remove.
+      // left/right walls or below the floor and zero outward velocity so it
+      // can't re-tunnel next frame. This catches the rare case where Matter.js
+      // corrective impulses from polygon vertex decomposition push a body
+      // through a thin static collider. Only applies within the escape margin
+      // — bodies farther outside are left for the escape-detection pass below
+      // to remove. See #699 for the floor case (19 events / 5 users).
       {
         const allBodiesAfterMerge = Matter.Composite.allBodies(world);
         fruitMap.forEach((fb, bodyId) => {
@@ -227,9 +228,12 @@ export async function createEngine(
           if (!body) return;
           const innerLeft = WALL_THICKNESS + fb.fruitRadius;
           const innerRight = W - WALL_THICKNESS - fb.fruitRadius;
+          const innerBottom = H - WALL_THICKNESS - fb.fruitRadius;
           const escapeMargin = fb.fruitRadius * 2;
           let px = body.position.x;
+          let py = body.position.y;
           let vx = body.velocity.x;
+          let vy = body.velocity.y;
           let clamped = false;
           if (px < innerLeft && px >= -escapeMargin) {
             px = innerLeft;
@@ -240,9 +244,14 @@ export async function createEngine(
             vx = Math.min(0, vx);
             clamped = true;
           }
+          if (py > innerBottom && py <= H + escapeMargin) {
+            py = innerBottom;
+            vy = Math.min(0, vy);
+            clamped = true;
+          }
           if (clamped) {
-            Matter.Body.setPosition(body, { x: px, y: body.position.y });
-            Matter.Body.setVelocity(body, { x: vx, y: body.velocity.y });
+            Matter.Body.setPosition(body, { x: px, y: py });
+            Matter.Body.setVelocity(body, { x: vx, y: vy });
           }
         });
       }


### PR DESCRIPTION
## Summary
- Extends the per-step safety-net clamp in `frontend/src/game/cascade/engine.native.ts` to cover the floor in addition to the left/right walls. Any body whose `y` ends a step below `innerBottom = H - WALL_THICKNESS - radius` but within the escape margin (`2 * radius`) is snapped back to `innerBottom` with downward velocity zeroed.
- Root cause of #699: the existing clamp only handled horizontal walls, so Matter.js corrective impulses from polygon-vertex decomposition (or high vertical velocity) could let a fruit tunnel past the thin floor collider and keep falling until `onBoundaryEscape` fired (19 events / 5 users in 30d; representative sample: `canvasHeight=700`, `y=745`, `tier=0`).
- Adds a regression test in `engine.native.test.ts` that drops a tier-0 fruit below the floor but inside the escape margin and asserts the safety net clamps it back to `innerBottom` without firing `onBoundaryEscape`.

## Test plan
- [x] `npx jest src/game/cascade/__tests__/engine.native.test.ts` — 25/25 passing (includes new floor-clamp case)
- [x] `npx jest src/game/cascade/` — 228/228 passing
- [ ] Smoke on iOS Simulator (iPhone 17 / iOS 26.4) — drop/merge fruits for several minutes, confirm no `Cascade: fruit escaped boundary` warnings in Sentry dev
- [ ] Smoke on Android 14 emulator (`sdk_gphone64_x86_64`) — same check; this device accounted for 68% of events

🤖 Generated with [Claude Code](https://claude.com/claude-code)