### PR TITLE
feat(#709): port BC Arcade canonical color tokens to ThemeContext

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5080,9 +5080,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12775,9 +12775,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12797,9 +12794,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12821,9 +12815,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12843,9 +12834,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/frontend/src/theme/ThemeContext.tsx
+++ b/frontend/src/theme/ThemeContext.tsx
@@ -28,38 +28,44 @@ export interface Colors {
   totalBg: string;
   modalBg: string;
   overlay: string;
+  /** Translucent panel colour for blurred header + tabbar chrome. */
+  chromeBg: string;
+  /** CSS-shorthand shadow spec for the header/tabbar glow (`offsetX offsetY blur rgba`). */
+  chromeShadow: string;
   error: string;
   bonus: string;
   fruitContainer: string;
   fruitBackground: string;
 }
 
-// --- BC Arcade design tokens (see docs/BRANDING.md) ---
+// --- BC Arcade design tokens (see docs/BRANDING.md, issue #709) ---
+// Dark values mirror colors_and_type.css; light values mirror the cream
+// SharedComponents.jsx palette (cream supersedes the gray light variant).
 const TOKENS = {
   // Dark backgrounds
   darkBg: "#0e0e13",
   darkSurface: "#19191f",
   darkSurfaceAlt: "#1f1f26",
   darkSurfaceHigh: "#25252c",
-  // Light backgrounds
-  lightBg: "#f5f5fa",
-  lightSurface: "#ffffff",
-  lightSurfaceAlt: "#ededf5",
-  lightSurfaceHigh: "#e0e0ec",
-  // Accents
+  // Light backgrounds (cream)
+  lightBg: "#f5ecd7",
+  lightSurface: "#fbf4e2",
+  lightSurfaceAlt: "#eddfbf",
+  lightSurfaceHigh: "#fff8e8",
+  // Accents — light variants desaturated so they don't vibrate on cream
   accentDark: "#8ff5ff",
-  accentLight: "#0099aa",
+  accentLight: "#1bc5d4",
   accentBrightDark: "#00eefc",
-  accentBrightLight: "#00b8cc",
+  accentBrightLight: "#00a8b8",
   secondaryDark: "#d674ff",
-  secondaryLight: "#9900cf",
+  secondaryLight: "#a34fc4",
   tertiaryDark: "#cafd00",
-  tertiaryLight: "#5c7a00",
+  tertiaryLight: "#8fa800",
   // Semantic
   errorDark: "#ff716c",
-  errorLight: "#c0392b",
+  errorLight: "#d94a42",
   bonusDark: "#4ade80",
-  bonusLight: "#16a34a",
+  bonusLight: "#2da557",
   white: "#ffffff",
 } as const;
 
@@ -89,6 +95,8 @@ const dark: Colors = {
   totalBg: TOKENS.darkBg,
   modalBg: TOKENS.darkSurfaceHigh,
   overlay: "rgba(0,0,0,0.75)",
+  chromeBg: "rgba(14,14,19,0.7)",
+  chromeShadow: "0 4px 20px rgba(143,245,255,0.08)",
   error: TOKENS.errorDark,
   bonus: TOKENS.bonusDark,
   fruitContainer: TOKENS.darkSurface,
@@ -100,26 +108,28 @@ const light: Colors = {
   surface: TOKENS.lightSurface,
   surfaceAlt: TOKENS.lightSurfaceAlt,
   surfaceHigh: TOKENS.lightSurfaceHigh,
-  border: "#d4d4e0",
-  text: "#1a1a24",
-  textMuted: "#6e6e7a",
-  textFilled: "#9a9aa6",
-  textOnAccent: TOKENS.white,
+  border: "#d8c9a6",
+  text: "#1a1412",
+  textMuted: "#6b5e4a",
+  textFilled: "#b5a684",
+  textOnAccent: "#0e0e13", // dark text on teal accent (readable on cream variant)
   accent: TOKENS.accentLight,
   accentBright: TOKENS.accentBrightLight,
   secondary: TOKENS.secondaryLight,
   tertiary: TOKENS.tertiaryLight,
-  potential: TOKENS.accentLight, // teal on white — 4.6:1 AA
-  heldBg: "#d6f5f8",
+  potential: TOKENS.accentLight, // desaturated teal on cream
+  heldBg: "#d7eff2", // cream-compatible light teal tint for highlighted dice
   heldBorder: TOKENS.accentLight,
   dieBg: TOKENS.lightSurface,
-  dieBorder: "#c8c8d4",
-  headerBg: "#1a1a24",
+  dieBorder: "#d8c9a6",
+  headerBg: "#1a1412", // dark header over cream body — existing screen contract
   sectionHeaderBg: "#25252c",
   bonusBg: TOKENS.lightSurfaceAlt,
   totalBg: "#25252c",
   modalBg: TOKENS.lightSurface,
   overlay: "rgba(0,0,0,0.75)",
+  chromeBg: "rgba(245,236,215,0.82)",
+  chromeShadow: "0 4px 20px rgba(0,0,0,0.06)",
   error: TOKENS.errorLight,
   bonus: TOKENS.bonusLight,
   fruitContainer: TOKENS.lightSurfaceAlt,


### PR DESCRIPTION
## Summary
- Aligns the dark palette in `frontend/src/theme/ThemeContext.tsx` with the canonical spec from `bc-arcade-design-system/project/colors_and_type.css` (values already matched; added a design-source comment for traceability).
- Replaces the gray-based light palette with the **cream** variant from `SharedComponents.jsx` — per #709 and the design-handoff memo, cream is the canonical light theme and supersedes the gray values in `colors_and_type.css`.
- Adds two new tokens to the `Colors` interface used by the design's blurred app shell: `chromeBg` (translucent panel colour for header/tabbar) and `chromeShadow` (CSS-shorthand shadow spec for the glow).

**Light palette changes (cream)**
- Backgrounds: `#f5ecd7` / `#fbf4e2` / `#eddfbf` / `#fff8e8`
- Accents desaturated so they don't vibrate on cream: accent `#1bc5d4`, accentBright `#00a8b8`, secondary `#a34fc4`, tertiary `#8fa800`, error `#d94a42`, bonus `#2da557`
- Text: text `#1a1412`, textMuted `#6b5e4a`, textFilled `#b5a684`, textOnAccent `#0e0e13` (dark text on teal accent)
- Borders and dice frames re-tuned to the cream palette

**Deferred (out of scope for this PR, per discussion)**
- Spacing / radii / shadow scales — #709 lists these in the inventory but acceptance criteria only require color parity; these scales would touch many screens and are better as follow-up PRs.
- Typography — #709 notes it is "already mostly aligned"; `typography.ts` unchanged.
- Wiring the new `chromeBg` / `chromeShadow` into the app header + tabbar (blur chrome) — tokens exist now; the consumer change belongs to its own PR.
- `docs/BRANDING.md` — not part of the acceptance criteria; will refresh alongside the shell-blur consumer PR.

## Test plan
- [x] `npx jest src/theme/` — 17/17 passing
- [x] Full `npx jest` — 1378 tests across 89 suites passing (one prior run had 3 `SudokuScreen` timeout flakes unrelated to tokens; reran cleanly)
- [x] `npx tsc --noEmit` — no new type errors introduced (pre-existing `.webp` / `sentry.web` errors unchanged)
- [ ] Manual smoke: load the app in light theme, step through Home / Yacht / Hearts / Sudoku / Solitaire / Blackjack to confirm cream renders readably and no orphaned old-light colors remain
- [ ] Manual smoke: dark theme unchanged (zero perceptible drift — per acceptance criteria)

🤖 Generated with [Claude Code](https://claude.com/claude-code)