### PR TITLE
fix(#698): re-seed tile-ID counter on loadGame to prevent duplicate React keys

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5080,9 +5080,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12775,9 +12775,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12797,9 +12794,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12821,9 +12815,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12843,9 +12834,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame, saveBestScore, loadBestScore } from "../storage";
+import { _resetTileIds, move, setRng, createSeededRng } from "../engine";
 import { Twenty48State } from "../types";
 
 const GAME_KEY = "twenty48_game_v2";
@@ -97,5 +98,50 @@ describe("twenty48 storage", () => {
 
   it("loadBestScore returns 0 when nothing is saved", async () => {
     expect(await loadBestScore()).toBe(0);
+  });
+
+  // #698: on app reload, the engine's module-level tile-ID counter restarts
+  // at 1. Without re-seeding on load, subsequent spawns/merges issue IDs
+  // that collide with surviving tiles and React warns about duplicate keys
+  // in Grid.
+  it("re-seeds the engine tile-ID counter above max(tile.id) on load (#698)", async () => {
+    const highIdState: Twenty48State = {
+      board: [
+        [2, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ],
+      tiles: [
+        { id: 100, value: 2, row: 0, col: 0, prevRow: 0, prevCol: 0, isNew: false, isMerge: false },
+      ],
+      score: 0,
+      scoreDelta: 0,
+      game_over: false,
+      has_won: false,
+      startedAt: null,
+      accumulatedMs: 0,
+    };
+    await saveGame(highIdState);
+
+    // Simulate a JS reload: the module counter snaps back to 1.
+    _resetTileIds();
+    setRng(createSeededRng(42));
+
+    const loaded = await loadGame();
+    expect(loaded).not.toBeNull();
+
+    // A successful move spawns a new tile. Without the re-seed fix the
+    // spawned tile would get id=1, but the surviving slid tile's id is
+    // 100 — no collision here, yet subsequent spawns would march up to
+    // 100 and collide. Assert the spawned id is already above max.
+    const afterMove = move(loaded!, "right");
+    const spawned = afterMove.tiles.find((t) => t.isNew);
+    expect(spawned).toBeDefined();
+    expect(spawned!.id).toBeGreaterThan(100);
+
+    // And the surviving tile keeps its original id.
+    const survivor = afterMove.tiles.find((t) => !t.isNew && t.value === 2);
+    expect(survivor?.id).toBe(100);
   });
 });

--- a/frontend/src/game/twenty48/engine.ts
+++ b/frontend/src/game/twenty48/engine.ts
@@ -26,6 +26,18 @@ function nextId(): number {
   return _nextTileId++;
 }
 
+/**
+ * Re-seed the tile ID counter so the next assigned ID is `fromId`.
+ *
+ * Must be called after restoring a persisted game whose tiles already hold
+ * IDs produced by an earlier session — otherwise the counter (reset to 1 on
+ * every JS reload) will re-issue IDs that collide with surviving tiles and
+ * React will warn about duplicate keys in the Grid (#698).
+ */
+export function seedNextTileId(fromId: number): void {
+  _nextTileId = Math.max(1, fromId);
+}
+
 /** Reset the ID counter — for testing only. */
 export function _resetTileIds(): void {
   _nextTileId = 1;
@@ -336,6 +348,9 @@ function applyDown(
 // ---------------------------------------------------------------------------
 
 export function newGame(): Twenty48State {
+  // Fresh game: restart IDs from 1 so a new game doesn't reuse stale IDs
+  // carried over from a previous in-session game.
+  _resetTileIds();
   const board: number[][] = Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
   const idBoard: number[][] = Array.from({ length: SIZE }, () => Array(SIZE).fill(0));
   spawnTile(board, idBoard);

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -11,6 +11,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import { Twenty48State } from "./types";
+import { seedNextTileId } from "./engine";
 
 const GAME_KEY = "twenty48_game_v2";
 const BEST_SCORE_KEY = "twenty48_best_score_v1";
@@ -38,7 +39,8 @@ export async function loadGame(): Promise<Twenty48State | null> {
     }
     // Backfill tiles array for saves created before v2 tile animation data (#570).
     if (!Array.isArray(parsed.tiles)) {
-      let nextId = 0;
+      // Start at 1: id 0 is the engine's "empty cell" sentinel in idBoard.
+      let nextId = 1;
       parsed.tiles = parsed.board.flatMap((row, r) =>
         row
           .map((val, c) =>
@@ -70,6 +72,10 @@ export async function loadGame(): Promise<Twenty48State | null> {
     // Normalize timer fields — absent in states saved before timer was added.
     parsed.startedAt = parsed.startedAt ?? null;
     parsed.accumulatedMs = parsed.accumulatedMs ?? 0;
+    // Re-seed the engine's tile-ID counter above every restored ID so
+    // subsequent spawns/merges don't collide with surviving tiles (#698).
+    const maxId = parsed.tiles.reduce((m, t) => (t.id > m ? t.id : m), 0);
+    seedNextTileId(maxId + 1);
     return parsed;
   } catch (e) {
     // Corrupt payload: recovery is complete (we remove the bad entry and


### PR DESCRIPTION
## Summary
- **Root cause of the duplicate `key='1'` warning in Twenty48 Grid:** `_nextTileId` in `frontend/src/game/twenty48/engine.ts` is module-level and re-initializes to `1` on every JS reload. When `loadGame()` restored a saved state whose tiles already carried IDs from the previous session, the engine would re-issue those low IDs on subsequent spawns/merges — producing React's "Encountered two children with the same key" warning and breaking reconciliation (tiles could visually duplicate or disappear mid-merge).
- **Fix:** export `seedNextTileId(fromId)` from the engine and call it from `loadGame()` with `max(tile.id) + 1`. Fresh games now also reset to 1 via `newGame()` for deterministic IDs.
- **Drive-by:** the v1-payload backfill in `storage.ts` was seeding `let nextId = 0` and issuing `id=0` to the first tile, which collides with the engine's "empty cell" sentinel in idBoard. Changed to start at 1.

The existing test helper `engine.test.ts:28` already worked around this bug with a comment *"use high IDs to avoid collisions with engine-generated IDs"* — that confirms the collision risk was known and tolerated in tests. Production `loadGame()` didn't have the same luxury.

## Why the Grid `key` can't just be changed
`AnimatedTile` relies on a stable `key={tile.id}` across renders to animate slides (from `prevRow/prevCol` to `row/col`) and merges. Switching to a composite like `${id}-${row}-${col}` would change the key every frame and break animations. The right fix is to make the IDs genuinely unique.

## Scope note re: #705
Issue #705 flagged six "duplicate-key offenders" but five of them use index keys (`key={i}`) over arrays — indices are always unique 0..N-1, so they **cannot** produce duplicate-key warnings. They're stability/hardening concerns for a separate sweep. The actual duplicate-key warning was the Twenty48 case tracked in #698, which this PR closes.

## Test plan
- [x] `npx jest src/game/twenty48 src/components/twenty48` — 119/119 passing, including new regression test in `storage.test.ts` that saves a state with `id: 100`, simulates module reload via `_resetTileIds()`, loads + moves, and asserts the spawned tile's id > 100 while the survivor keeps its original id.
- [x] `npx tsc --noEmit` — no new type errors in touched files.
- [x] `npx eslint src/game/twenty48 src/components/twenty48` — clean.
- [ ] Manual: play Twenty48 past first merge, kill+reload app, resume saved game, play through another merge. No duplicate-key warning appears.

Closes #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)