### PR TITLE
fix(#706): prefetch lobby chunks + screen_mount_ms metric

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,6 @@
 import "./src/utils/appTiming"; // must be first — captures JS-side cold-start timestamp
 import "./src/i18n/i18n";
-import React, { Suspense } from "react";
+import React, { Suspense, useEffect, useRef } from "react";
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from "react-native";
 import { useFonts } from "expo-font";
 import { SpaceGrotesk_400Regular, SpaceGrotesk_700Bold } from "@expo-google-fonts/space-grotesk";
@@ -27,17 +27,7 @@ import { CardDeckProvider } from "./src/game/_shared/decks/CardDeckContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
 import { installSentryConsoleErrorCapture } from "./src/utils/sentryConsoleError";
-
-const CascadeScreen = React.lazy(() => import("./src/screens/CascadeScreen"));
-const BlackjackBettingScreen = React.lazy(() => import("./src/screens/BlackjackBettingScreen"));
-const BlackjackTableScreen = React.lazy(() => import("./src/screens/BlackjackTableScreen"));
-const Twenty48Screen = React.lazy(() => import("./src/screens/Twenty48Screen"));
-const SolitaireScreen = React.lazy(() => import("./src/screens/SolitaireScreen"));
-const HeartsScreen = React.lazy(() => import("./src/screens/HeartsScreen"));
-const SudokuScreen = React.lazy(() => import("./src/screens/SudokuScreen"));
-const LeaderboardScreen = React.lazy(() => import("./src/screens/LeaderboardScreen"));
-const GameDetailScreen = React.lazy(() => import("./src/screens/GameDetailScreen"));
-const SettingsScreen = React.lazy(() => import("./src/screens/SettingsScreen"));
+import { LazyScreens } from "./src/utils/lazyScreens";
 
 // Start capturing console.warn / console.error for feedback submissions
 SessionLogger.init();
@@ -79,32 +69,71 @@ export type ProfileStackParamList = {
   GameDetail: { gameId: string };
 };
 
-function withSuspense<P extends object>(Component: React.ComponentType<P>): React.FC<P> {
-  const Wrapped = (props: P) => (
-    <Suspense
-      fallback={
-        <View style={{ flex: 1 }}>
-          <ActivityIndicator style={{ flex: 1 }} />
-        </View>
-      }
-    >
-      <Component {...props} />
-    </Suspense>
-  );
-  Wrapped.displayName = `WithSuspense(${Component.displayName ?? Component.name ?? "Component"})`;
+// Must live inside the Suspense boundary. The outer Wrapped commits immediately
+// (Suspense never suspends its own parent), so only an inner child mounts after
+// the lazy chunk resolves — that's where we stop the timer.
+function SuspenseMountTimer({
+  startMs,
+  screenName,
+  children,
+}: {
+  startMs: number;
+  screenName: string;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    const elapsedMs = performance.now() - startMs;
+    try {
+      Sentry.metrics.distribution("screen_mount_ms", elapsedMs, {
+        unit: "millisecond",
+        attributes: { screen: screenName },
+      });
+    } catch {
+      // Instrumentation must never break the screen it's measuring.
+    }
+    // startMs/screenName are stable for this component instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <>{children}</>;
+}
+
+function withSuspense<P extends object>(
+  Component: React.ComponentType<P>,
+  screenName: string
+): React.FC<P> {
+  const Wrapped = (props: P) => {
+    // Captured at parent render — close enough to "user tapped Play".
+    // Stopped by SuspenseMountTimer's useEffect, which only fires after the
+    // lazy chunk resolves and the screen commits.
+    const startRef = useRef(performance.now());
+    return (
+      <Suspense
+        fallback={
+          <View style={{ flex: 1 }}>
+            <ActivityIndicator style={{ flex: 1 }} />
+          </View>
+        }
+      >
+        <SuspenseMountTimer startMs={startRef.current} screenName={screenName}>
+          <Component {...props} />
+        </SuspenseMountTimer>
+      </Suspense>
+    );
+  };
+  Wrapped.displayName = `WithSuspense(${screenName})`;
   return Wrapped;
 }
 
-const LazyCascadeScreen = withSuspense(CascadeScreen);
-const LazyBlackjackBettingScreen = withSuspense(BlackjackBettingScreen);
-const LazyBlackjackTableScreen = withSuspense(BlackjackTableScreen);
-const LazyTwenty48Screen = withSuspense(Twenty48Screen);
-const LazySolitaireScreen = withSuspense(SolitaireScreen);
-const LazyHeartsScreen = withSuspense(HeartsScreen);
-const LazySudokuScreen = withSuspense(SudokuScreen);
-const LazyLeaderboardScreen = withSuspense(LeaderboardScreen);
-const LazyGameDetailScreen = withSuspense(GameDetailScreen);
-const LazySettingsScreen = withSuspense(SettingsScreen);
+const LazyCascadeScreen = withSuspense(LazyScreens.Cascade, "cascade");
+const LazyBlackjackBettingScreen = withSuspense(LazyScreens.BlackjackBetting, "blackjack_betting");
+const LazyBlackjackTableScreen = withSuspense(LazyScreens.BlackjackTable, "blackjack_table");
+const LazyTwenty48Screen = withSuspense(LazyScreens.Twenty48, "twenty48");
+const LazySolitaireScreen = withSuspense(LazyScreens.Solitaire, "solitaire");
+const LazyHeartsScreen = withSuspense(LazyScreens.Hearts, "hearts");
+const LazySudokuScreen = withSuspense(LazyScreens.Sudoku, "sudoku");
+const LazyLeaderboardScreen = withSuspense(LazyScreens.Leaderboard, "leaderboard");
+const LazyGameDetailScreen = withSuspense(LazyScreens.GameDetail, "game_detail");
+const LazySettingsScreen = withSuspense(LazyScreens.Settings, "settings");
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const HomeStack = createNativeStackNavigator<HomeStackParamList>();

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -14,6 +14,7 @@ import { typography } from "../theme/typography";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import OfflineBanner from "../components/OfflineBanner";
 import { APP_START_MS } from "../utils/appTiming";
+import { prefetchLobbyGameScreens } from "../utils/lazyScreens";
 
 /** Below this viewport width the grid collapses to a single column. */
 const SINGLE_COL_BREAKPOINT = 360;
@@ -50,6 +51,14 @@ export default function HomeScreen() {
       const coldStartMs = performance.now() - APP_START_MS;
       Sentry.metrics.distribution("cold_start_ms", coldStartMs, { unit: "millisecond" });
     }
+  }, []);
+
+  // Warm lobby game chunks once Home has painted so nav doesn't show a
+  // Suspense fallback on tap (issue #706). setTimeout(0) defers past the
+  // current frame without the InteractionManager deprecation in RN 0.83.
+  useEffect(() => {
+    const id = setTimeout(prefetchLobbyGameScreens, 0);
+    return () => clearTimeout(id);
   }, []);
 
   async function startYacht() {

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -13,6 +13,11 @@ jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockPrefetch = jest.fn();
+jest.mock("../../utils/lazyScreens", () => ({
+  prefetchLobbyGameScreens: () => mockPrefetch(),
+}));
+
 // ---------------------------------------------------------------------------
 // Mock yacht storage — no saved game by default
 // ---------------------------------------------------------------------------
@@ -135,6 +140,13 @@ describe("HomeScreen — AppHeader", () => {
   it("renders AppHeader with app title", () => {
     const { getByRole } = renderScreen();
     expect(getByRole("header")).toBeTruthy();
+  });
+});
+
+describe("HomeScreen — lobby prefetch (issue #706)", () => {
+  it("warms lobby game chunks after interactions settle", async () => {
+    renderScreen();
+    await waitFor(() => expect(mockPrefetch).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/frontend/src/utils/__tests__/lazyScreens.test.tsx
+++ b/frontend/src/utils/__tests__/lazyScreens.test.tsx
@@ -1,0 +1,114 @@
+import React, { Suspense } from "react";
+import { Text } from "react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
+import * as Sentry from "@sentry/react-native";
+
+// The HomeScreen wiring around prefetch is covered by HomeScreen.test.tsx.
+// This file exercises lazyScreens.ts in isolation and the mount-timer path
+// in App.tsx's withSuspense helper (issue #706).
+
+// Replace the real screen factories with tiny stubs so we don't pull a whole
+// game screen (and its dependencies) into this test.
+jest.mock("../../screens/CascadeScreen", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("../../screens/BlackjackBettingScreen", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("../../screens/BlackjackTableScreen", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock("../../screens/Twenty48Screen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/SolitaireScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/HeartsScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/SudokuScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/LeaderboardScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/GameDetailScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/SettingsScreen", () => ({ __esModule: true, default: () => null }));
+
+describe("prefetchLobbyGameScreens", () => {
+  it("resolves without throwing when called repeatedly", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { prefetchLobbyGameScreens } = require("../lazyScreens");
+    expect(() => {
+      prefetchLobbyGameScreens();
+      prefetchLobbyGameScreens();
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// screen_mount_ms — verifies the timer pattern used by withSuspense in App.tsx.
+// We replicate the shape inline so this test doesn't require booting App.tsx
+// (which transitively requires navigation, i18n, fonts, etc.).
+// ---------------------------------------------------------------------------
+
+function SuspenseMountTimer({
+  startMs,
+  screenName,
+  children,
+}: {
+  startMs: number;
+  screenName: string;
+  children: React.ReactNode;
+}) {
+  React.useEffect(() => {
+    const elapsedMs = performance.now() - startMs;
+    Sentry.metrics.distribution("screen_mount_ms", elapsedMs, {
+      unit: "millisecond",
+      attributes: { screen: screenName },
+    });
+    // startMs/screenName are stable per instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <>{children}</>;
+}
+
+describe("screen_mount_ms timer (withSuspense pattern)", () => {
+  beforeEach(() => {
+    (Sentry.metrics.distribution as jest.Mock).mockClear();
+  });
+
+  it("emits once after the lazy child resolves, tagged with the screen name", async () => {
+    let resolveFactory: (mod: { default: React.ComponentType }) => void = () => undefined;
+    const LazyChild = React.lazy(
+      () =>
+        new Promise<{ default: React.ComponentType }>((resolve) => {
+          resolveFactory = resolve;
+        })
+    );
+
+    const startMs = performance.now();
+
+    render(
+      <Suspense fallback={<Text>loading</Text>}>
+        <SuspenseMountTimer startMs={startMs} screenName="hearts">
+          <LazyChild />
+        </SuspenseMountTimer>
+      </Suspense>
+    );
+
+    // Nothing emitted while the chunk is still pending.
+    expect(Sentry.metrics.distribution).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveFactory({ default: () => <Text>hearts-mounted</Text> });
+    });
+
+    await waitFor(() => {
+      expect(Sentry.metrics.distribution).toHaveBeenCalledTimes(1);
+    });
+
+    const [metricName, value, options] = (Sentry.metrics.distribution as jest.Mock).mock.calls[0];
+    expect(metricName).toBe("screen_mount_ms");
+    expect(typeof value).toBe("number");
+    expect(value).toBeGreaterThanOrEqual(0);
+    expect(options).toEqual({
+      unit: "millisecond",
+      attributes: { screen: "hearts" },
+    });
+  });
+});

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -1,0 +1,45 @@
+import React from "react";
+
+// Factories are held separately so prefetch callers can invoke the same
+// import() as React.lazy — the module loader dedupes, so once prefetched the
+// React.lazy promise resolves synchronously on navigation.
+const factories = {
+  Cascade: () => import("../screens/CascadeScreen"),
+  BlackjackBetting: () => import("../screens/BlackjackBettingScreen"),
+  BlackjackTable: () => import("../screens/BlackjackTableScreen"),
+  Twenty48: () => import("../screens/Twenty48Screen"),
+  Solitaire: () => import("../screens/SolitaireScreen"),
+  Hearts: () => import("../screens/HeartsScreen"),
+  Sudoku: () => import("../screens/SudokuScreen"),
+  Leaderboard: () => import("../screens/LeaderboardScreen"),
+  GameDetail: () => import("../screens/GameDetailScreen"),
+  Settings: () => import("../screens/SettingsScreen"),
+} as const;
+
+export const LazyScreens = {
+  Cascade: React.lazy(factories.Cascade),
+  BlackjackBetting: React.lazy(factories.BlackjackBetting),
+  BlackjackTable: React.lazy(factories.BlackjackTable),
+  Twenty48: React.lazy(factories.Twenty48),
+  Solitaire: React.lazy(factories.Solitaire),
+  Hearts: React.lazy(factories.Hearts),
+  Sudoku: React.lazy(factories.Sudoku),
+  Leaderboard: React.lazy(factories.Leaderboard),
+  GameDetail: React.lazy(factories.GameDetail),
+  Settings: React.lazy(factories.Settings),
+} as const;
+
+/**
+ * Fire-and-forget prefetch of lobby game chunks. Called from HomeScreen after
+ * interactions settle so the Suspense fallback doesn't flash when the user
+ * taps into a game (issue #706). Safe to call multiple times — the module
+ * loader dedupes.
+ */
+export function prefetchLobbyGameScreens(): void {
+  factories.Cascade().catch(() => undefined);
+  factories.BlackjackBetting().catch(() => undefined);
+  factories.Twenty48().catch(() => undefined);
+  factories.Solitaire().catch(() => undefined);
+  factories.Hearts().catch(() => undefined);
+  factories.Sudoku().catch(() => undefined);
+}


### PR DESCRIPTION
## Summary
- Prefetch lobby game chunks from HomeScreen so tapping into a game no longer flashes the Suspense fallback (issue #706). Factories live in `src/utils/lazyScreens.ts` and feed both `React.lazy` and the prefetch call — the module loader dedupes so `React.lazy` resolves synchronously once warmed.
- `withSuspense` now emits a `screen_mount_ms` distribution to Sentry, tagged via `attributes.screen`. The timer stops inside the Suspense boundary (via an inner `SuspenseMountTimer`) so `useEffect` only fires once the chunk resolves and the screen commits — capturing the true felt latency instead of zero.
- HomeScreen schedules the prefetch via `setTimeout(0)` (deferred past the current frame, no `InteractionManager` deprecation in RN 0.83).

## Test plan
- [x] `npx jest` — 1382/1382 pass (90 suites)
- [x] `npx tsc --noEmit` — 64 errors, matches baseline dev (no new ones)
- [x] `npx eslint` — clean on touched files
- [x] New `src/utils/__tests__/lazyScreens.test.tsx` — asserts `prefetchLobbyGameScreens` is safe to call repeatedly, and the timer pattern emits `screen_mount_ms` exactly once with the right `attributes.screen` tag after lazy resolve
- [x] `HomeScreen.test.tsx` — new case asserts prefetch is scheduled after mount
- [ ] Manual web verify: open /web, navigate Home → each game, confirm no Suspense spinner on warm nav
- [ ] Manual device verify (Xcode Cloud / Google Play internal): same as web
- [ ] After release: confirm `screen_mount_ms` distribution appears in Sentry, grouped by `screen`, and wire the p95 metric alert per the issue acceptance criteria

## Out of scope (covered by existing infra / followups)
- Sentry metric alert config is a dashboard action (no code change).
- Bundle budget enforcement is already in `android-bundle-check` CI at 5.5 MB; tightening it back to 5.0 MB is a followup once this lands and regresses.

Fixes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)