### PR TITLE
fix(#703): tighten neon deck glow and make diamonds red

### DIFF
--- a/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
+++ b/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
@@ -140,12 +140,7 @@ export default function NeonCardFace({
       >
         {rl}
       </SvgText>
-      <SvgText
-        x={5}
-        y={cornerFontSize + smallSuitSize + 4}
-        fontSize={smallSuitSize}
-        fill={color}
-      >
+      <SvgText x={5} y={cornerFontSize + smallSuitSize + 4} fontSize={smallSuitSize} fill={color}>
         {suitEmoji(suit)}
       </SvgText>
 
@@ -191,12 +186,7 @@ export default function NeonCardFace({
         >
           {rl}
         </SvgText>
-        <SvgText
-          x={5}
-          y={cornerFontSize + smallSuitSize + 4}
-          fontSize={smallSuitSize}
-          fill={color}
-        >
+        <SvgText x={5} y={cornerFontSize + smallSuitSize + 4} fontSize={smallSuitSize} fill={color}>
           {suitEmoji(suit)}
         </SvgText>
       </G>

--- a/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
+++ b/frontend/src/game/_shared/decks/neon/NeonCardFace.tsx
@@ -21,7 +21,7 @@ const BG_BACK = "#070d1a";
 const BORDER = "#334155";
 const SPADES_CLUBS = "#e2e8f0";
 const HEARTS = "#f43f5e";
-const DIAMONDS = "#06b6d4";
+const DIAMONDS = HEARTS;
 const RANK_TEXT = "#f1f5f9";
 const BACK_GRID = "#06b6d4";
 
@@ -45,7 +45,7 @@ function GlowDefs() {
   return (
     <Defs>
       <Filter id="neon-glow" x="-30%" y="-30%" width="160%" height="160%">
-        <FeGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+        <FeGaussianBlur in="SourceGraphic" stdDeviation="1.5" result="blur" />
         <FeMerge>
           <FeMergeNode in="blur" />
           <FeMergeNode in="SourceGraphic" />
@@ -145,7 +145,6 @@ export default function NeonCardFace({
         y={cornerFontSize + smallSuitSize + 4}
         fontSize={smallSuitSize}
         fill={color}
-        filter="url(#neon-glow)"
       >
         {suitEmoji(suit)}
       </SvgText>
@@ -197,7 +196,6 @@ export default function NeonCardFace({
           y={cornerFontSize + smallSuitSize + 4}
           fontSize={smallSuitSize}
           fill={color}
-          filter="url(#neon-glow)"
         >
           {suitEmoji(suit)}
         </SvgText>


### PR DESCRIPTION
## Summary
- Lower neon glow `stdDeviation` from `3` → `1.5` so the halo reads as a tight rim light instead of a blurry wash.
- Drop the glow filter from the small corner pips (it's what made them look fuzzy at in-game size); keep it on the centre suit art and face letters, where the neon effect is actually doing work.
- Switch `DIAMONDS` from cyan (`#06b6d4`) to `HEARTS` red (`#f43f5e`) so the deck follows the standard red/black suit convention. Cyan stays as the deck accent on the back-grid (`BACK_GRID`).

Closes #703.

## Test plan
- [ ] `npx expo start --web`, open Solitaire with Neon deck selected
- [ ] Diamonds render red, same shade as hearts
- [ ] Centre suit art + face letters have a subtle rim halo (not blurry)
- [ ] Small corner pips are crisp
- [ ] Card back still has cyan diamond-grid pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)