### PR TITLE
fix(#696): center Sudoku number pad and add grid/pad divider

### DIFF
--- a/frontend/src/components/sudoku/NumberPad.tsx
+++ b/frontend/src/components/sudoku/NumberPad.tsx
@@ -14,6 +14,11 @@ interface Props {
 }
 
 const DIGITS: readonly CellValue[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const DIGIT_ROWS: readonly (readonly CellValue[])[] = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+];
 
 function countValue(grid: Grid, digit: CellValue): number {
   let n = 0;
@@ -37,32 +42,36 @@ export default function NumberPad({ grid, notesMode, onDigit, onErase, onToggleN
   return (
     <View style={styles.pad}>
       <View style={styles.digitGrid}>
-        {DIGITS.map((d) => {
-          const disabled = completed.has(d);
-          return (
-            <Pressable
-              key={d}
-              onPress={() => onDigit(d)}
-              disabled={disabled}
-              accessibilityRole="button"
-              accessibilityLabel={t("numberPad.digit", {
-                digit: d,
-                defaultValue: `Enter digit ${d}`,
-              })}
-              accessibilityState={{ disabled }}
-              style={[
-                styles.digitBtn,
-                {
-                  backgroundColor: colors.surface,
-                  borderColor: colors.border,
-                  opacity: disabled ? 0.35 : 1,
-                },
-              ]}
-            >
-              <Text style={[styles.digitText, { color: colors.text }]}>{d}</Text>
-            </Pressable>
-          );
-        })}
+        {DIGIT_ROWS.map((row, ri) => (
+          <View key={ri} style={styles.digitRow}>
+            {row.map((d) => {
+              const disabled = completed.has(d);
+              return (
+                <Pressable
+                  key={d}
+                  onPress={() => onDigit(d)}
+                  disabled={disabled}
+                  accessibilityRole="button"
+                  accessibilityLabel={t("numberPad.digit", {
+                    digit: d,
+                    defaultValue: `Enter digit ${d}`,
+                  })}
+                  accessibilityState={{ disabled }}
+                  style={[
+                    styles.digitBtn,
+                    {
+                      backgroundColor: colors.surface,
+                      borderColor: colors.border,
+                      opacity: disabled ? 0.35 : 1,
+                    },
+                  ]}
+                >
+                  <Text style={[styles.digitText, { color: colors.text }]}>{d}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        ))}
       </View>
       <View style={styles.actionRow}>
         <Pressable
@@ -108,18 +117,20 @@ export default function NumberPad({ grid, notesMode, onDigit, onErase, onToggleN
 
 const styles = StyleSheet.create({
   pad: {
-    width: "100%",
-    gap: 8,
+    alignItems: "center",
+    gap: 12,
   },
   digitGrid: {
+    gap: 8,
+  },
+  digitRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
-    justifyContent: "space-between",
+    justifyContent: "center",
     gap: 8,
   },
   digitBtn: {
-    width: "31%",
-    aspectRatio: 2,
+    width: 64,
+    height: 56,
     borderRadius: 8,
     borderWidth: 1,
     alignItems: "center",
@@ -135,6 +146,8 @@ const styles = StyleSheet.create({
   actionRow: {
     flexDirection: "row",
     gap: 8,
+    alignSelf: "stretch",
+    maxWidth: 280,
   },
   actionBtn: {
     flex: 1,

--- a/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
+++ b/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
@@ -211,648 +211,677 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
 <View
   style={
     {
-      "gap": 8,
-      "width": "100%",
+      "alignItems": "center",
+      "gap": 12,
     }
   }
 >
   <View
     style={
       {
-        "flexDirection": "row",
-        "flexWrap": "wrap",
         "gap": 8,
-        "justifyContent": "space-between",
       }
     }
   >
     <View
-      accessibilityLabel="Enter digit 1"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
+        {
+          "flexDirection": "row",
+          "gap": 8,
+          "justifyContent": "center",
+        }
       }
     >
-      <Text
+      <View
+        accessibilityLabel="Enter digit 1"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           [
             {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
             },
             {
-              "color": "#e8e8f0",
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
             },
           ]
         }
       >
-        1
-      </Text>
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          1
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 2"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          2
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 3"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          3
+        </Text>
+      </View>
     </View>
     <View
-      accessibilityLabel="Enter digit 2"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
+        {
+          "flexDirection": "row",
+          "gap": 8,
+          "justifyContent": "center",
+        }
       }
     >
-      <Text
+      <View
+        accessibilityLabel="Enter digit 4"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           [
             {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
             },
             {
-              "color": "#e8e8f0",
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
             },
           ]
         }
       >
-        2
-      </Text>
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          4
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 5"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          5
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 6"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          [
+            {
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
+            },
+            {
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          6
+        </Text>
+      </View>
     </View>
     <View
-      accessibilityLabel="Enter digit 3"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
       style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
+        {
+          "flexDirection": "row",
+          "gap": 8,
+          "justifyContent": "center",
+        }
       }
     >
-      <Text
+      <View
+        accessibilityLabel="Enter digit 7"
+        accessibilityRole="button"
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           [
             {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
             },
             {
-              "color": "#e8e8f0",
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
             },
           ]
         }
       >
-        3
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 4"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          7
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 8"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
           {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           [
             {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
             },
             {
-              "color": "#e8e8f0",
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
             },
           ]
         }
       >
-        4
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 5"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          8
+        </Text>
+      </View>
+      <View
+        accessibilityLabel="Enter digit 9"
+        accessibilityRole="button"
+        accessibilityState={
           {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": false,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
           {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           [
             {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
+              "alignItems": "center",
+              "borderRadius": 8,
+              "borderWidth": 1,
+              "height": 56,
+              "justifyContent": "center",
+              "width": 64,
             },
             {
-              "color": "#e8e8f0",
+              "backgroundColor": "#19191f",
+              "borderColor": "#2e2e38",
+              "opacity": 1,
             },
           ]
         }
       >
-        5
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 6"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
-            },
-            {
-              "color": "#e8e8f0",
-            },
-          ]
-        }
-      >
-        6
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 7"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
-            },
-            {
-              "color": "#e8e8f0",
-            },
-          ]
-        }
-      >
-        7
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 8"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
-            },
-            {
-              "color": "#e8e8f0",
-            },
-          ]
-        }
-      >
-        8
-      </Text>
-    </View>
-    <View
-      accessibilityLabel="Enter digit 9"
-      accessibilityRole="button"
-      accessibilityState={
-        {
-          "busy": undefined,
-          "checked": undefined,
-          "disabled": false,
-          "expanded": undefined,
-          "selected": undefined,
-        }
-      }
-      accessibilityValue={
-        {
-          "max": undefined,
-          "min": undefined,
-          "now": undefined,
-          "text": undefined,
-        }
-      }
-      accessible={true}
-      collapsable={false}
-      focusable={true}
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onResponderGrant={[Function]}
-      onResponderMove={[Function]}
-      onResponderRelease={[Function]}
-      onResponderTerminate={[Function]}
-      onResponderTerminationRequest={[Function]}
-      onStartShouldSetResponder={[Function]}
-      style={
-        [
-          {
-            "alignItems": "center",
-            "aspectRatio": 2,
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "justifyContent": "center",
-            "width": "31%",
-          },
-          {
-            "backgroundColor": "#19191f",
-            "borderColor": "#2e2e38",
-            "opacity": 1,
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "fontSize": 22,
-              "fontWeight": "600",
-              "lineHeight": 22,
-              "textAlign": "center",
-              "textAlignVertical": "center",
-            },
-            {
-              "color": "#e8e8f0",
-            },
-          ]
-        }
-      >
-        9
-      </Text>
+        <Text
+          style={
+            [
+              {
+                "fontSize": 22,
+                "fontWeight": "600",
+                "lineHeight": 22,
+                "textAlign": "center",
+                "textAlignVertical": "center",
+              },
+              {
+                "color": "#e8e8f0",
+              },
+            ]
+          }
+        >
+          9
+        </Text>
+      </View>
     </View>
   </View>
   <View
     style={
       {
+        "alignSelf": "stretch",
         "flexDirection": "row",
         "gap": 8,
+        "maxWidth": 280,
       }
     }
   >

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -424,6 +424,12 @@ export default function SudokuScreen() {
             />
           </View>
 
+          <View
+            style={[styles.gridPadDivider, { backgroundColor: colors.border }]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          />
+
           <View style={styles.padWrap}>
             <NumberPad
               grid={state.grid}
@@ -728,9 +734,16 @@ const styles = StyleSheet.create({
   gridWrap: {
     alignSelf: "stretch",
   },
-  padWrap: {
+  gridPadDivider: {
     alignSelf: "stretch",
-    marginTop: "auto",
+    height: StyleSheet.hairlineWidth,
+    marginHorizontal: 4,
+  },
+  padWrap: {
+    flex: 1,
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
   },
   preGameWrap: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Center the Sudoku 3×3 number pad horizontally and vertically in the space between the grid and the bottom action row (was left-aligned and flush against the grid).
- Add a hairline divider (themed `border` color) between the grid and the pad so the two regions read as distinct.
- Restructure `NumberPad` into three explicit rows of three buttons with fixed 64×56 sizing, replacing the `flexWrap + space-between` layout that caused the ragged left-alignment.

Closes #696

## Test plan
- [x] `jest src/components/sudoku/__tests__/components.test.tsx` — 18/18 pass (snapshot regenerated for the new row grouping)
- [x] `jest src/screens/__tests__/SudokuScreen.test.tsx` — 8/8 pass
- [ ] Visual check in Expo Go / `expo start --web` on iPhone 17 sim: pad is centered in the lower area, divider is visible but subtle, grid unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)