### PR TITLE
fix(#695): wrap Blackjack cards into rows so score pill clears action bar

### DIFF
--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, StyleSheet, useWindowDimensions } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import { HandResponse } from "../../game/blackjack/types";
@@ -33,23 +33,21 @@ export default function BlackjackTable({
 }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
-  const { width: screenWidth } = useWindowDimensions();
   const isPlayerPhase = phase === "player";
   const isSplit = playerHands && playerHands.length > 1;
 
-  // Available inner width per split hand: screen minus HUD sidebar (88), the
-  // gap between hands (8), and splitHand padding (6×2 each side = 24 total).
-  const splitHandMaxWidth = Math.max(80, (screenWidth - 88 - 8) / 2 - 24);
-
   return (
     <View style={[styles.container, compact && styles.containerCompact]}>
-      <HandDisplay
-        hand={dealerHand}
-        label={t("hand.dealer")}
-        concealed={isPlayerPhase}
-        variant="dealer"
-        compact={compact}
-      />
+      <View style={styles.dealerArea}>
+        <HandDisplay
+          hand={dealerHand}
+          label={t("hand.dealer")}
+          concealed={isPlayerPhase}
+          variant="dealer"
+          compact={compact}
+          maxPerRow={5}
+        />
+      </View>
       <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
       {isSplit ? (
@@ -80,7 +78,7 @@ export default function BlackjackTable({
                   label={label}
                   variant="player"
                   compact
-                  fanMaxWidth={splitHandMaxWidth}
+                  maxPerRow={3}
                 />
                 {bet != null && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
@@ -112,12 +110,15 @@ export default function BlackjackTable({
           })}
         </View>
       ) : (
-        <HandDisplay
-          hand={playerHand}
-          label={t("hand.player")}
-          variant="player"
-          compact={compact}
-        />
+        <View style={styles.playerArea}>
+          <HandDisplay
+            hand={playerHand}
+            label={t("hand.player")}
+            variant="player"
+            compact={compact}
+            maxPerRow={5}
+          />
+        </View>
       )}
     </View>
   );
@@ -125,12 +126,22 @@ export default function BlackjackTable({
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     alignItems: "center",
-    gap: 20,
+    justifyContent: "space-between",
+    gap: 8,
     width: "100%",
+    paddingVertical: 8,
   },
   containerCompact: {
-    gap: 8,
+    gap: 4,
+    paddingVertical: 4,
+  },
+  dealerArea: {
+    alignItems: "center",
+  },
+  playerArea: {
+    alignItems: "center",
   },
   divider: {
     width: "60%",

--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -73,13 +73,7 @@ export default function BlackjackTable({
                   },
                 ]}
               >
-                <HandDisplay
-                  hand={hand}
-                  label={label}
-                  variant="player"
-                  compact
-                  maxPerRow={3}
-                />
+                <HandDisplay hand={hand} label={label} variant="player" compact maxPerRow={3} />
                 {bet != null && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
                 )}

--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -17,23 +17,15 @@ interface Props {
    *  both the "player" and "dealer" variants when set. */
   compact?: boolean;
   /**
-   * When set, cards with count > 2 switch from wrap to a fan/overlap layout
-   * that constrains the row to this pixel width. Each card after the first
-   * shifts left so the rank+suit pip of earlier cards peeks out on the left.
-   * Pass the available inner width of the containing column.
+   * Maximum cards per row. Additional cards wrap to a new row so the hand
+   * grows downward into reserved table space rather than overflowing into
+   * the action bar. Defaults to 5 (single-hand). Split hands pass 3.
    */
-  fanMaxWidth?: number;
+  maxPerRow?: number;
 }
 
 // First two player cards get a gentle fan tilt
 const PLAYER_ROTATIONS: Record<number, number> = { 0: -3, 1: 2 };
-
-function computeOverlap(cardCount: number, cardWidth: number, maxWidth: number): number {
-  if (cardCount <= 2 || cardWidth * cardCount <= maxWidth) return 0;
-  // total = cardWidth + (n-1) × (cardWidth - overlap) ≤ maxWidth
-  // → overlap = cardWidth - (maxWidth - cardWidth) / (n - 1)
-  return Math.max(0, Math.ceil(cardWidth - (maxWidth - cardWidth) / (cardCount - 1)));
-}
 
 export default function HandDisplay({
   hand,
@@ -41,15 +33,15 @@ export default function HandDisplay({
   concealed = false,
   variant = "dealer",
   compact = false,
-  fanMaxWidth,
+  maxPerRow = 5,
 }: Props) {
   const { colors } = useTheme();
   const showScore = hand.cards.length > 0;
 
-  // Card width matches blackjack PlayingCard cardSize() values.
-  const cardWidth = variant === "player" ? (compact ? 48 : 68) : compact ? 40 : 52;
-  const isFan = fanMaxWidth !== undefined && hand.cards.length > 2;
-  const overlapPx = isFan ? computeOverlap(hand.cards.length, cardWidth, fanMaxWidth!) : 0;
+  const rows: (typeof hand.cards)[] = [];
+  for (let i = 0; i < hand.cards.length; i += maxPerRow) {
+    rows.push(hand.cards.slice(i, i + maxPerRow));
+  }
 
   return (
     <View style={[styles.container, compact && styles.containerCompact]}>
@@ -57,18 +49,21 @@ export default function HandDisplay({
         {label}
       </Text>
 
-      <View style={isFan ? styles.cardsFan : styles.cards}>
-        {hand.cards.map((card, i) => (
-          <View
-            key={i}
-            style={isFan ? { marginLeft: i > 0 ? -overlapPx : 0, zIndex: i } : undefined}
-          >
-            <PlayingCard
-              card={card}
-              variant={variant}
-              compact={compact}
-              rotation={variant === "player" ? (PLAYER_ROTATIONS[i] ?? 0) : 0}
-            />
+      <View style={styles.rows}>
+        {rows.map((rowCards, rowIndex) => (
+          <View key={rowIndex} style={styles.row}>
+            {rowCards.map((card, cardIndex) => {
+              const absoluteIndex = rowIndex * maxPerRow + cardIndex;
+              return (
+                <PlayingCard
+                  key={absoluteIndex}
+                  card={card}
+                  variant={variant}
+                  compact={compact}
+                  rotation={variant === "player" ? (PLAYER_ROTATIONS[absoluteIndex] ?? 0) : 0}
+                />
+              );
+            })}
           </View>
         ))}
       </View>
@@ -97,14 +92,12 @@ const styles = StyleSheet.create({
   labelCompact: {
     fontSize: 11,
   },
-  cards: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    justifyContent: "center",
+  rows: {
+    alignItems: "center",
+    gap: 4,
   },
-  cardsFan: {
+  row: {
     flexDirection: "row",
-    flexWrap: "nowrap",
     justifyContent: "center",
   },
 });


### PR DESCRIPTION
## Summary
- Fix iOS bug where the player's hand-total chip rendered behind the HIT/STAND/DOUBLE DOWN action bar (#695).
- Switch `HandDisplay` from width-less `flexWrap: wrap` to explicit rows driven by a new `maxPerRow` prop (5 single-hand, 3 split-hand), matching the design-system spec in the issue.
- Restructure `BlackjackTable` to `flex: 1` + `justifyContent: space-between` so dealer anchors to the top and the player score pill stays above the action cluster on any hand size.

## Test plan
- [x] `npx jest` — all 1388 tests pass (including existing `BlackjackTableScreen` and blackjack component suites)
- [x] Blackjack-specific TypeScript check clean (`npx tsc --noEmit` — remaining errors are pre-existing in unrelated files: `useFruitImages.ts`, `sentry.web.ts`)
- [ ] Manual verification on iOS simulator: hit to bust (6+ cards) and confirm the score pill remains fully visible above HIT/STAND
- [ ] Manual verification on split: 8-card bust lays out as 3+3+2 rows without obscuring the total

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)