### PR TITLE
fix(#704): dim disabled Hearts cards via overlay so overlapping cards don't bleed through

### DIFF
--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -64,6 +64,15 @@ describe("PlayingCard", () => {
     fireEvent.press(getByRole("button"));
     expect(onPress).not.toHaveBeenCalled();
   });
+
+  it("disabled card wrapper is fully opaque (no opacity < 1)", () => {
+    // Regression guard for #704: wrapper opacity makes the SVG translucent
+    // and overlapping cards bleed through. Dimming must use an overlay.
+    const { getByRole } = wrap(<PlayingCard card={c("clubs", 7)} onPress={() => {}} disabled />);
+    const style = getByRole("button").props.style;
+    const flat = Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : style;
+    expect(flat.opacity).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/shared/PlayingCard.tsx
+++ b/frontend/src/components/shared/PlayingCard.tsx
@@ -62,7 +62,25 @@ export default function PlayingCard({
     />
   );
 
-  const wrapperStyle = [{ width, height, opacity: disabled ? 0.4 : 1 }, rotateStyle];
+  // Disabled dimming is rendered as a dark overlay on top of the card rather
+  // than by lowering the wrapper's opacity. In overlapping hand layouts (e.g.
+  // Hearts) translucent cards let the card underneath bleed through — the
+  // overlay keeps the card itself opaque. Radius matches CardFace.
+  const wrapperStyle = [{ width, height }, rotateStyle];
+  const disabledOverlay = disabled ? (
+    <View
+      pointerEvents="none"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width,
+        height,
+        borderRadius: 8,
+        backgroundColor: "rgba(0,0,0,0.5)",
+      }}
+    />
+  ) : null;
 
   if (onPress) {
     return (
@@ -75,6 +93,7 @@ export default function PlayingCard({
         accessibilityState={{ disabled }}
       >
         {cardFace}
+        {disabledOverlay}
       </Pressable>
     );
   }
@@ -82,6 +101,7 @@ export default function PlayingCard({
   return (
     <View style={wrapperStyle} accessibilityRole="image" accessibilityLabel={accessibilityLabel}>
       {cardFace}
+      {disabledOverlay}
     </View>
   );
 }


### PR DESCRIPTION
Closes #704.

## Summary
- Lowering the shared `PlayingCard` wrapper opacity to `0.4` made the card SVG itself translucent. In the Hearts hand — where cards are positioned with negative offset so they overlap — this let the rank/suit of the card *underneath* bleed through a disabled card's face, making the hand hard to read.
- Fix: keep the card wrapper fully opaque and render a `rgba(0,0,0,0.5)` overlay `View` on top of the card face (absolutely positioned, `pointerEvents="none"`, `borderRadius: 8` to match all deck faces). The card stays opaque, so no more ghost ranks/suits.
- Scope check: only Hearts passes `disabled={true}` to `PlayingCard` today (grepped). Blackjack and Solitaire are unaffected.

## Test plan
- [x] `npx jest src/components/hearts/__tests__/components.test.tsx` — 25/25 pass, including existing "does not call onPress when disabled" and a new regression guard asserting the disabled wrapper carries no `opacity` style.
- [x] Full frontend Jest suite — 1387/1388 pass (the one failure is a pre-existing `Twenty48Screen.test.tsx` flake unrelated to card rendering).
- [x] `npx tsc --noEmit` — no new type errors in the changed files.
- [ ] Browser verification of the Hearts trick view: disabled cards look dimmed, underlying card no longer visible through the face, selected/highlighted states still visually distinct from disabled. *(I did not run this myself — please confirm visually before merging.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)