### PR TITLE
fix(#739): treat Ace as high when resolving Hearts tricks

### DIFF
--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -491,6 +491,80 @@ describe("trick resolution", () => {
     // P0 led K♠ and won (K > Q)
     expect(state.handScores[0]).toBe(13);
   });
+
+  // Ace is high in Hearts — guards against rank-1 being treated as lowest (#739).
+  it("Ace of led suit wins when led", () => {
+    // P0 leads A♠; P1 K♠; P2 10♠; P3 5♠ — P0 should win
+    const hands = [
+      [c("spades", 1), c("clubs", 2)],
+      [c("spades", 13), c("clubs", 3)],
+      [c("spades", 10), c("clubs", 4)],
+      [c("spades", 5), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 1));
+    state = playCard(state, 1, c("spades", 13));
+    state = playCard(state, 2, c("spades", 10));
+    state = playCard(state, 3, c("spades", 5));
+
+    expect(state.currentLeaderIndex).toBe(0);
+    expect(state.wonCards[0]).toContainEqual(c("spades", 1));
+  });
+
+  it("Ace of led suit wins when following suit", () => {
+    // P0 leads 5♠; P1 follows A♠; P2 K♠; P3 3♠ — P1 should win
+    const hands = [
+      [c("spades", 5), c("clubs", 2)],
+      [c("spades", 1), c("clubs", 3)],
+      [c("spades", 13), c("clubs", 4)],
+      [c("spades", 3), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 5));
+    state = playCard(state, 1, c("spades", 1));
+    state = playCard(state, 2, c("spades", 13));
+    state = playCard(state, 3, c("spades", 3));
+
+    expect(state.currentLeaderIndex).toBe(1);
+    expect(state.wonCards[1]).toContainEqual(c("spades", 1));
+  });
+
+  it("Ace of led suit collects Q♠ penalty points", () => {
+    // P0 leads 3♠; P1 A♠; P2 Q♠; P3 5♠ — P1 wins A♠ and the 13-point Q♠
+    const hands = [
+      [c("spades", 3), c("clubs", 2)],
+      [c("spades", 1), c("clubs", 3)],
+      [c("spades", 12), c("clubs", 4)],
+      [c("spades", 5), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 3));
+    state = playCard(state, 1, c("spades", 1));
+    state = playCard(state, 2, c("spades", 12));
+    state = playCard(state, 3, c("spades", 5));
+
+    expect(state.currentLeaderIndex).toBe(1);
+    expect(state.handScores[1]).toBe(13);
+    expect(state.handScores[2]).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -284,6 +284,9 @@ export function playCard(state: HeartsState, playerIndex: number, card: Card): H
 }
 
 function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsState {
+  // Ace is high in Hearts; Rank stores it as 1, so treat 1 as 14 when comparing.
+  const aceHigh = (r: Rank): number => (r === 1 ? 14 : r);
+
   const first = trick[0]!;
   const ledSuit = first.card.suit;
 
@@ -292,7 +295,7 @@ function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsSt
 
   for (let i = 1; i < trick.length; i++) {
     const tc = trick[i]!;
-    if (tc.card.suit === ledSuit && tc.card.rank > winnerRank) {
+    if (tc.card.suit === ledSuit && aceHigh(tc.card.rank) > aceHigh(winnerRank)) {
       winnerRank = tc.card.rank;
       winnerPlayerIndex = tc.playerIndex;
     }


### PR DESCRIPTION
## Summary
- Fixes #739 — Ace of the led suit now wins the trick instead of losing to every other in-suit card.
- Root cause: `Rank` is `1..13` with Ace=1, and `resolveTrick()` compared ranks with raw `>`. Mapped Ace to 14 inside the comparison only; no type changes.
- Audit: every other `.rank` reference in `engine.ts` is equality (2♣ lead, Q♠ detection, card identity), so the fix stays local.

## Test plan
- [x] 3 new tests in `engine.test.ts` — Ace leads, Ace follows, Ace collects Q♠ penalty. All fail pre-fix, pass post-fix.
- [x] Existing off-suit-Ace-loses test still passes (regression guard).
- [x] Full hearts suite: 80/80 green.
- [ ] Manual playthrough: deal an Ace, play it in-suit, confirm the trick is taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)