### PR TITLE
fix(#741): Solitaire WinModal New Game crash

### DIFF
--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -556,9 +556,7 @@ export default function SolitaireScreen() {
         </View>
       )}
 
-      {state?.isComplete === true && (
-        <WinModal score={state.score} onNewGame={resetToPreGame} />
-      )}
+      {state?.isComplete === true && <WinModal score={state.score} onNewGame={resetToPreGame} />}
     </GameShell>
   );
 }

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -416,11 +416,6 @@ export default function SolitaireScreen() {
     setMoves(0);
   }, []);
 
-  const handleConfirmNewGame = useCallback(() => {
-    setShowNewGameConfirm(false);
-    resetToPreGame();
-  }, [resetToPreGame]);
-
   const undoDisabled = state === null || state.undoStack.length === 0 || autoCompleting;
   const showAutoComplete = state !== null && !state.isComplete && canAutoComplete(state);
   const scale = outerWidth > 0 ? Math.min(1, outerWidth / BOARD_WIDTH) : 1;
@@ -562,7 +557,7 @@ export default function SolitaireScreen() {
       )}
 
       {state?.isComplete === true && (
-        <WinModal score={state.score} onNewGame={handleConfirmNewGame} />
+        <WinModal score={state.score} onNewGame={resetToPreGame} />
       )}
     </GameShell>
   );

--- a/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
@@ -389,4 +389,16 @@ describe("SolitaireScreen — win-modal score submission", () => {
       expect(api.getByLabelText("Retry")).toBeTruthy();
     });
   });
+
+  // Regression #741: tapping "New Game" in the WinModal used to throw
+  // `Property 'setShowNewGameConfirm' doesn't exist` because a stray setter
+  // call survived the #711 overflow-menu cleanup.
+  it("returns to the pre-game modal when New Game is tapped in the WinModal", async () => {
+    const api = await mountAtWinState();
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("New Game"));
+    });
+    expect(api.getByLabelText("Draw 1")).toBeTruthy();
+    expect(await AsyncStorage.getItem("solitaire_game")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Removes the stray `setShowNewGameConfirm(false)` call that survived the #711 overflow-menu cleanup and was causing `Property 'setShowNewGameConfirm' doesn't exist` whenever a user tapped **New Game** in the Solitaire WinModal.
- Drops the now-empty `handleConfirmNewGame` wrapper and passes `resetToPreGame` to `WinModal.onNewGame` directly — matches the header callsite at `SolitaireScreen.tsx:449`.
- Adds a regression test in the win-modal suite that exercises the WinModal New Game button (the #711 cleanup missed this callsite because no test walked the win path).

Fixes #741.

## Test plan

- [x] `npx jest src/screens/__tests__/SolitaireScreen.test.tsx` — 21/21 pass, including the new regression test.
- [ ] Manual: deal a Solitaire game into a win state, tap **New Game** in the WinModal → pre-game modal reappears, no redbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)