### PR TITLE
docs: add README with venv runbook; trim CLAUDE.md to <50 lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,48 @@
-# BC Games — Claude Guide
+# BC Arcade — Claude Guide
 
-<!-- Global standards: ~/.claude/CLAUDE.md and ~/.claude/standards/ -->
+<!-- User-level standards: ~/.claude/CLAUDE.md and ~/.claude/standards/ -->
 
 ## Stack
 
-- **Backend:** Python 3, FastAPI, uvicorn (in-memory, no DB)
+- **Backend:** Python 3.13, FastAPI, uvicorn (in-memory, no DB)
 - **Frontend:** Expo TypeScript, runs in browser via Expo Web
-- **Docs:** See `docs/` for testing, deployment, and workflow details
+- **Setup & runbook:** [`README.md`](README.md)
+- **Docs:** testing, iOS/Android CI, Render, branding — see [`docs/`](docs/)
 
-## Git Workflow
-
-See [~/.claude/standards/git.md](~/.claude/standards/git.md).
+## Git Workflow — see [~/.claude/standards/git.md](~/.claude/standards/git.md)
 
 - Never push directly to `main` or `dev`
-- Branch: `git checkout dev && git checkout -b feat/<name>`
+- Branch from `dev`: `git checkout dev && git checkout -b feat/<name>`
 - PR: `feat/<name>` → `dev` → `main` (releases only)
 
-## Running Locally
+## Testing — see [~/.claude/standards/testing.md](~/.claude/standards/testing.md) + [`docs/TESTING.md`](docs/TESTING.md)
 
-```bash
-# Backend (Terminal 1)
-cd backend && python -m pip install -r requirements.txt
-python -m uvicorn main:app --reload   # http://localhost:8000
+`cd backend && source .venv/bin/activate && python -m pytest tests/ -v`
 
-# Frontend (Terminal 2)
-cd frontend && npm install
-npx expo start --web                  # http://localhost:8081
-```
+## iOS & Android Builds
 
-## Testing
+- **iOS:** Xcode Cloud (App Store Connect). `frontend/ios/` is committed. See [`docs/IOS.md`](docs/IOS.md). Do **not** suggest `eas build` or treat `ios/` as ephemeral.
+- **Android:** Gradle → Play Console. `frontend/android/` is committed. See [`docs/ANDROID-CI.md`](docs/ANDROID-CI.md) for modification/signing/CI rules. Do **not** suggest `eas build`/`eas submit`.
+- Before modifying `frontend/android/`: verify `cd frontend/android && ./gradlew assembleDebug` passes locally.
+- Never commit `upload-keystore.jks`, `debug.keystore`, or `local.properties` (gitignored).
 
-See [~/.claude/standards/testing.md](~/.claude/standards/testing.md) + [`docs/TESTING.md`](docs/TESTING.md) for project-specific test cases.
+## Deployment & Branding
 
-```bash
-cd backend && python -m pytest tests/ -v
-```
-
-## iOS Builds
-
-**Xcode Cloud (App Store Connect) — EAS Build is NOT used.** `frontend/ios/` is committed to the repo, not generated at build time. `/Volumes/workspace/repository/` in build logs is Apple's Xcode Cloud runner.
-See [`docs/IOS.md`](docs/IOS.md). Do not suggest `eas build`, `prebuildCommand`, or treating `ios/` as ephemeral.
-
-## Android Builds
-
-**Gradle → Google Play Console (internal testing) — EAS Build is NOT used.** `frontend/android/` is committed to the repo (bare workflow), not generated at build time.
-See [`docs/ANDROID-CI.md`](docs/ANDROID-CI.md). Do not suggest `eas build`, `eas submit`, or treating `android/` as ephemeral.
-
-### Android Rules
-
-- Before modifying files under `frontend/android/`: verify the change builds locally with `cd frontend/android && ./gradlew assembleDebug`.
-- Never commit `upload-keystore.jks`, `debug.keystore`, or `local.properties` — these are gitignored for security.
-- Never change the Gradle wrapper version (`gradle-wrapper.properties`) without verifying compatibility with current AGP and React Native Gradle Plugin.
-- Read `docs/ANDROID-CI.md` before modifying `build.gradle`, `settings.gradle`, or `gradle.properties`.
-- After any change to `build.gradle`, `settings.gradle`, or `gradle.properties`, verify `android-bundle-check` and `android-build-check` CI jobs pass before merging.
-- `sentry.properties` must use environment variables for org/project/token — never hardcode Sentry credentials.
-
-## Deployment
-
-See [`docs/RENDER.md`](docs/RENDER.md) for Render hosting setup.
-
-## Branding & Design
-
-The visual design system is **BC Arcade** (never "Neon Arcade"). See [`docs/BRANDING.md`](docs/BRANDING.md) for palette, typography, theming rules, and per-screen Stitch-vs-ours guidance.
+Deployment (Render): [`docs/RENDER.md`](docs/RENDER.md). Design system is **BC Arcade** (never "Neon Arcade") — see [`docs/BRANDING.md`](docs/BRANDING.md).
 
 ## Key Conventions
 
-- All rule enforcement is server-side (`backend/game.py`). Frontend is display only.
+- All rule enforcement is server-side in `backend/<game>/module.py`. Frontend is display only.
 - Frontend replaces state wholesale from each API response.
-- Scoring category keys: `ones` `twos` `threes` `fours` `fives` `sixes`
-  `three_of_a_kind` `four_of_a_kind` `full_house` `small_straight`
-  `large_straight` `yacht` `chance`
+- Yacht scoring keys: `ones` `twos` `threes` `fours` `fives` `sixes` `three_of_a_kind` `four_of_a_kind` `full_house` `small_straight` `large_straight` `yacht` `chance`.
 - `EXPO_PUBLIC_API_URL` env var overrides `BASE_URL` in `frontend/src/api/client.ts`.
 
 ## Available Agents
 
-These project subagents live in `.claude/agents/` and are invoked via the `Agent` tool (not Skill). Always prefer them over a general-purpose agent for their domain.
+Project subagents in `.claude/agents/`, invoked via the `Agent` tool. Prefer these over general-purpose:
 
 | Agent | `subagent_type` | When to use |
 |---|---|---|
 | lint-review | `lint-review` | Auto-fix lint issues after a lint-gate hook failure |
-| plan-issues | `plan-issues` | Break a feature/bug/initiative into scoped GitHub issues — investigates code first, drafts for confirmation, then calls `gh issue create` |
+| plan-issues | `plan-issues` | Break a feature/bug/initiative into scoped GitHub issues — investigates code, drafts for confirmation, then `gh issue create` |
 | policy-compliance | `policy-compliance` | Check and fix policy violations after a policy-gate hook failure |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# BC Arcade
+
+A collection of classic card/dice games (Yacht, Hearts, Solitaire, Blackjack, Sudoku, Cascade) with a FastAPI backend and an Expo/React Native frontend that runs on iOS, Android, and the web.
+
+- **Backend:** Python 3.13, FastAPI, uvicorn
+- **Frontend:** Expo (TypeScript), React Native, Expo Web
+- **Docs:** see [`docs/`](docs/) for testing, deployment, iOS/Android, branding
+- **Claude Code guide:** [`CLAUDE.md`](CLAUDE.md)
+
+## Requirements
+
+- **Python 3.13** (3.14 is not yet supported by `pydantic-core` / PyO3 — the install will fail)
+- **Node.js 20+** and **npm**
+- Xcode (for iOS local builds), Android Studio + JDK 17 (for Android local builds)
+
+## Running Locally
+
+Two terminals from the repo root.
+
+### Terminal 1 — Backend
+
+First time (or when `requirements.txt` changes):
+
+```bash
+cd backend
+python3.13 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Every time:
+
+```bash
+cd backend
+source .venv/bin/activate
+python -m uvicorn main:app --reload   # http://localhost:8000
+```
+
+To leave the venv: `deactivate`.
+
+### Terminal 2 — Frontend (web)
+
+```bash
+cd frontend
+npm install            # first time or when package.json changes
+npx expo start --web   # http://localhost:8081
+```
+
+The frontend points at `http://localhost:8000` by default. Override with `EXPO_PUBLIC_API_URL` if the backend is elsewhere.
+
+## Testing
+
+```bash
+cd backend && source .venv/bin/activate && python -m pytest tests/ -v
+```
+
+Project-specific test cases and E2E guidance live in [`docs/TESTING.md`](docs/TESTING.md).
+
+## Git Workflow
+
+- Branch from `dev`: `git checkout dev && git checkout -b feat/<name>`
+- Open PR: `feat/<name>` → `dev`
+- Releases only: `dev` → `main`
+- Never push directly to `main` or `dev`
+
+## Mobile Builds
+
+- **iOS:** Xcode Cloud (App Store Connect). `frontend/ios/` is committed — see [`docs/IOS.md`](docs/IOS.md).
+- **Android:** Gradle → Google Play Console. `frontend/android/` is committed — see [`docs/ANDROID-CI.md`](docs/ANDROID-CI.md).
+
+EAS Build is **not** used for either platform.
+
+## Deployment
+
+Backend is hosted on Render — see [`docs/RENDER.md`](docs/RENDER.md).
+
+## Troubleshooting
+
+**`pip install -r requirements.txt` fails building `pydantic-core`** — your venv is using Python 3.14. Recreate it with 3.13:
+
+```bash
+deactivate
+rm -rf backend/.venv
+python3.13 -m venv backend/.venv
+source backend/.venv/bin/activate
+pip install --upgrade pip
+pip install -r backend/requirements.txt
+```


### PR DESCRIPTION
## Summary

- Add a root `README.md` with the full local-dev runbook, including the `python3.13 -m venv` flow and a troubleshooting note for the `pydantic-core` build failure on Python 3.14.
- Trim `CLAUDE.md` from 83 → 48 lines by moving the Running Locally block to the README and collapsing the Android Rules list to a pointer at `docs/ANDROID-CI.md` (which already documents them in full) plus the two load-bearing security guardrails.
- Fix a stale reference in CLAUDE.md: rule enforcement lives in `backend/<game>/module.py`, not `backend/game.py`.

## Why

- Onboarding friction: running `pip install -r requirements.txt` with system Python (3.14) fails at `pydantic-core` because PyO3 0.24 caps at 3.13. README now calls out the Python 3.13 requirement up front and gives a copy-paste recovery.
- CLAUDE.md was drifting toward a dumping ground for setup + per-surface rules. Keeping it tight (<50 lines) preserves its role as a high-signal index that Claude loads every turn.

## Test plan

- [ ] `README.md` renders correctly on GitHub (headings, code blocks, relative links resolve).
- [ ] `CLAUDE.md` still resolves all relative links (`docs/*.md`, `README.md`).
- [ ] Follow the README venv flow on a clean `.venv` with `python3.13`:
  - [ ] `pip install -r requirements.txt` succeeds (no Rust build).
  - [ ] `python -m uvicorn main:app --reload` serves on `:8000`.
- [ ] `npx expo start --web` from `frontend/` still serves on `:8081`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)