### PR TITLE
feat(hearts): captured penalty piles per seat (#715)

### DIFF
--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -1,0 +1,270 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import type { Card } from "../../game/hearts/types";
+
+const SUIT_SYMBOL: Record<Card["suit"], string> = {
+  clubs: "♣",
+  diamonds: "♦",
+  hearts: "♥",
+  spades: "♠",
+};
+
+const RANK_TEXT: Record<number, string> = {
+  1: "A",
+  11: "J",
+  12: "Q",
+  13: "K",
+};
+
+function rankText(rank: number): string {
+  return RANK_TEXT[rank] ?? String(rank);
+}
+
+function isRedSuit(suit: Card["suit"]): boolean {
+  return suit === "hearts" || suit === "diamonds";
+}
+
+/**
+ * Hearts penalty points: each heart is +1; Q♠ is +13.
+ * Exported for tests and reuse.
+ */
+export function penaltyPoints(cards: readonly Card[]): number {
+  return cards.reduce((sum, c) => {
+    if (c.suit === "hearts") return sum + 1;
+    if (c.suit === "spades" && c.rank === 12) return sum + 13;
+    return sum;
+  }, 0);
+}
+
+const OPP_CARD_W = 24;
+const OPP_CARD_H = 28;
+const OPP_OFFSET = 8;
+const OPP_MAX_VISIBLE = 4;
+
+const SELF_CARD_W = 28;
+const SELF_CARD_H = 40;
+const SELF_OFFSET = 18;
+
+// Append alpha ~0.4 (hex 66) to a 6-digit hex color.
+function alpha40(hex: string): string {
+  return hex.length === 7 ? `${hex}66` : hex;
+}
+
+interface OpponentProps {
+  cards: readonly Card[];
+  seatLabel: string;
+}
+
+export function OpponentCapturedPile({ cards, seatLabel }: OpponentProps) {
+  const { t } = useTranslation("hearts");
+  const { colors } = useTheme();
+  const count = cards.length;
+  const points = penaltyPoints(cards);
+  const visible = Math.min(count, OPP_MAX_VISIBLE);
+  const fanWidth = visible > 0 ? (visible - 1) * OPP_OFFSET + OPP_CARD_W : 0;
+
+  return (
+    <View
+      style={styles.oppContainer}
+      accessibilityLabel={t("captured.opponentLabel", { label: seatLabel, count, points })}
+      accessibilityRole="none"
+    >
+      <View style={[styles.oppFan, { width: fanWidth, height: OPP_CARD_H }]}>
+        {Array.from({ length: visible }).map((_, i) => (
+          <LinearGradient
+            key={i}
+            colors={[alpha40(colors.accent), alpha40(colors.secondary)]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[
+              styles.oppCard,
+              {
+                left: i * OPP_OFFSET,
+                borderColor: colors.border,
+              },
+            ]}
+          />
+        ))}
+      </View>
+      {count > 0 && (
+        <View
+          style={[
+            styles.summaryPill,
+            { backgroundColor: colors.surfaceAlt, borderColor: colors.border },
+          ]}
+        >
+          <Text style={[styles.summaryCount, { color: colors.text }]}>{count}</Text>
+          <Text style={[styles.summaryDivider, { color: colors.textMuted }]}>·</Text>
+          <Text style={[styles.summaryPoints, { color: colors.error }]}>{`+${points}`}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+interface SelfProps {
+  cards: readonly Card[];
+}
+
+export function SelfCapturedPile({ cards }: SelfProps) {
+  const { t } = useTranslation("hearts");
+  const { colors } = useTheme();
+  const count = cards.length;
+  const points = penaltyPoints(cards);
+  const rowWidth = count > 0 ? (count - 1) * SELF_OFFSET + SELF_CARD_W : 0;
+
+  return (
+    <View
+      style={[styles.selfRow, { borderColor: colors.border }]}
+      accessibilityLabel={t("captured.selfLabel", { count, points })}
+      accessibilityRole="none"
+    >
+      <Text style={[styles.selfLabel, { color: colors.textMuted }]}>{t("captured.taken")}</Text>
+      <View style={styles.selfCards}>
+        {count === 0 ? (
+          <Text style={[styles.selfEmpty, { color: colors.textMuted }]}>{t("captured.empty")}</Text>
+        ) : (
+          <View style={{ width: rowWidth, height: SELF_CARD_H }}>
+            {cards.map((card, i) => (
+              <View
+                key={`${card.suit}-${card.rank}-${i}`}
+                style={[
+                  styles.selfCard,
+                  {
+                    left: i * SELF_OFFSET,
+                    backgroundColor: colors.surface,
+                    borderColor: colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.selfRank,
+                    { color: isRedSuit(card.suit) ? colors.error : colors.text },
+                  ]}
+                >
+                  {rankText(card.rank)}
+                </Text>
+                <Text
+                  style={[
+                    styles.selfSuit,
+                    { color: isRedSuit(card.suit) ? colors.error : colors.text },
+                  ]}
+                >
+                  {SUIT_SYMBOL[card.suit]}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </View>
+      {count > 0 && (
+        <View
+          style={[
+            styles.selfPointsPill,
+            {
+              backgroundColor: alpha40(colors.error),
+            },
+          ]}
+        >
+          <Text style={[styles.selfPointsText, { color: colors.error }]}>{`+${points}`}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // ── Opponent ───────────────────────────────────────────────────────────────
+  oppContainer: {
+    alignItems: "center",
+    gap: 4,
+  },
+  oppFan: {
+    position: "relative",
+  },
+  oppCard: {
+    position: "absolute",
+    top: 0,
+    width: OPP_CARD_W,
+    height: OPP_CARD_H,
+    borderRadius: 4,
+    borderWidth: 1,
+  },
+  summaryPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 3,
+    paddingHorizontal: 10,
+    gap: 4,
+  },
+  summaryCount: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  summaryDivider: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  summaryPoints: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+
+  // ── Self ───────────────────────────────────────────────────────────────────
+  selfRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: 64,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    gap: 10,
+  },
+  selfLabel: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+  selfCards: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  selfEmpty: {
+    fontSize: 12,
+    fontStyle: "italic",
+  },
+  selfCard: {
+    position: "absolute",
+    top: 0,
+    width: SELF_CARD_W,
+    height: SELF_CARD_H,
+    borderRadius: 4,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  selfRank: {
+    fontSize: 12,
+    fontWeight: "700",
+    lineHeight: 14,
+  },
+  selfSuit: {
+    fontSize: 12,
+    lineHeight: 14,
+  },
+  selfPointsPill: {
+    borderRadius: 999,
+    paddingVertical: 3,
+    paddingHorizontal: 10,
+  },
+  selfPointsText: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+});

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -7,6 +7,7 @@ import OpponentHand from "../OpponentHand";
 import TrickArea from "../TrickArea";
 import ScoreBoard from "../ScoreBoard";
 import PassBanner from "../PassBanner";
+import { OpponentCapturedPile, SelfCapturedPile, penaltyPoints } from "../CapturedPile";
 import type { Card, TrickCard } from "../../../game/hearts/types";
 
 jest.mock("expo-linear-gradient", () => ({
@@ -261,5 +262,85 @@ describe("PassBanner", () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Modal } = require("react-native");
     expect(UNSAFE_queryAllByType(Modal)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CapturedPile — penalty points helper
+// ---------------------------------------------------------------------------
+
+describe("penaltyPoints", () => {
+  it("returns 0 for empty and non-penalty cards", () => {
+    expect(penaltyPoints([])).toBe(0);
+    expect(penaltyPoints([c("clubs", 7), c("diamonds", 3), c("spades", 1)])).toBe(0);
+  });
+
+  it("counts hearts as +1 each", () => {
+    expect(penaltyPoints([c("hearts", 2), c("hearts", 8), c("hearts", 13)])).toBe(3);
+  });
+
+  it("counts Q♠ as +13", () => {
+    expect(penaltyPoints([c("spades", 12)])).toBe(13);
+  });
+
+  it("combines hearts + Q♠: 3 hearts + Q♠ = 16", () => {
+    expect(penaltyPoints([c("hearts", 4), c("hearts", 10), c("hearts", 11), c("spades", 12)])).toBe(
+      16
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpponentCapturedPile (face-down)
+// ---------------------------------------------------------------------------
+
+describe("OpponentCapturedPile", () => {
+  it("renders no summary pill when pile is empty", () => {
+    const { queryByText } = wrap(<OpponentCapturedPile cards={[]} seatLabel="Left" />);
+    expect(queryByText("+0")).toBeNull();
+  });
+
+  it("renders count and penalty points for a mixed pile (4 cards, +16)", () => {
+    const cards: Card[] = [c("hearts", 4), c("hearts", 10), c("hearts", 11), c("spades", 12)];
+    const { getByText } = wrap(<OpponentCapturedPile cards={cards} seatLabel="Top" />);
+    expect(getByText("4")).toBeTruthy();
+    expect(getByText("+16")).toBeTruthy();
+  });
+
+  it("exposes count and points in its accessibility label", () => {
+    const cards: Card[] = [c("hearts", 2), c("spades", 12)];
+    const { getByLabelText } = wrap(<OpponentCapturedPile cards={cards} seatLabel="Right" />);
+    expect(getByLabelText(/Right.*2.*14/)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SelfCapturedPile (face-up)
+// ---------------------------------------------------------------------------
+
+describe("SelfCapturedPile", () => {
+  it("shows the empty-state placeholder when no cards captured", () => {
+    const { getByText } = wrap(<SelfCapturedPile cards={[]} />);
+    expect(getByText(/nothing yet/i)).toBeTruthy();
+  });
+
+  it("does not render a points pill when empty", () => {
+    const { queryByText } = wrap(<SelfCapturedPile cards={[]} />);
+    expect(queryByText("+0")).toBeNull();
+  });
+
+  it("renders face-up rank + suit for each captured card", () => {
+    const cards: Card[] = [c("hearts", 13), c("spades", 12)];
+    const { getAllByText, getByText } = wrap(<SelfCapturedPile cards={cards} />);
+    expect(getByText("K")).toBeTruthy();
+    expect(getByText("Q")).toBeTruthy();
+    expect(getAllByText("♥").length).toBeGreaterThan(0);
+    expect(getAllByText("♠").length).toBeGreaterThan(0);
+  });
+
+  it("renders running points pill matching the penalty calculation", () => {
+    const cards: Card[] = [c("hearts", 2), c("hearts", 5), c("hearts", 9), c("spades", 12)];
+    const { getByText } = wrap(<SelfCapturedPile cards={cards} />);
+    expect(getByText("+16")).toBeTruthy();
   });
 });

--- a/frontend/src/i18n/locales/_meta/hearts.meta.json
+++ b/frontend/src/i18n/locales/_meta/hearts.meta.json
@@ -143,6 +143,42 @@
     "doNotTranslate": [],
     "notes": null
   },
+  "captured.taken": {
+    "component": "SelfCapturedPile label",
+    "description": "Label above the row showing penalty cards the human has taken this hand. Styled uppercase.",
+    "tone": "functional, label",
+    "characterLimit": 12,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Rendered as uppercase tracking label. If the locale doesn't support uppercase styling, a short all-caps equivalent is fine."
+  },
+  "captured.empty": {
+    "component": "SelfCapturedPile placeholder",
+    "description": "Italic placeholder shown in the 'Taken' row when the human has not yet captured any penalty cards this hand.",
+    "tone": "casual, understated",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "captured.opponentLabel": {
+    "component": "OpponentCapturedPile (accessibility)",
+    "description": "Screen-reader label describing how many penalty cards and points an AI opponent has captured this hand.",
+    "tone": "functional",
+    "characterLimit": 80,
+    "placeholders": ["{{label}}", "{{count}}", "{{points}}"],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "captured.selfLabel": {
+    "component": "SelfCapturedPile (accessibility)",
+    "description": "Screen-reader label describing how many penalty cards and points the human has captured this hand.",
+    "tone": "functional",
+    "characterLimit": 80,
+    "placeholders": ["{{count}}", "{{points}}"],
+    "doNotTranslate": [],
+    "notes": null
+  },
   "trick.area": {
     "component": "TrickArea (accessibility)",
     "description": "Accessibility label for the trick-play area.",

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -18,6 +18,11 @@
   "hand.player": "Your hand, {{count}} cards",
   "hand.opponent": "{{label}}'s hand, {{count}} cards",
 
+  "captured.taken": "TAKEN",
+  "captured.empty": "Nothing yet",
+  "captured.opponentLabel": "{{label}} has taken {{count}} cards, {{points}} penalty points",
+  "captured.selfLabel": "You have taken {{count}} cards, {{points}} penalty points",
+
   "trick.area": "Current trick",
   "trick.slot.empty": "Empty slot — {{label}}",
   "trick.winner": "{{label}} won the trick",

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
 import type { Colors } from "../theme/ThemeContext";
 import { GameShell } from "../components/shared/GameShell";
+import { OpponentCapturedPile, SelfCapturedPile } from "../components/hearts/CapturedPile";
 import OpponentHand from "../components/hearts/OpponentHand";
 import PassBanner from "../components/hearts/PassBanner";
 import PlayerHand from "../components/hearts/PlayerHand";
@@ -350,28 +351,44 @@ export default function HeartsScreen() {
             label={playerLabels[2] ?? ""}
             score={gameState.cumulativeScores[2] ?? 0}
           />
+          <OpponentCapturedPile
+            cards={gameState.wonCards[2] ?? []}
+            seatLabel={playerLabels[2] ?? ""}
+          />
         </View>
 
         {/* Middle: Left AI | TrickArea | Right AI */}
         <View style={styles.middleRow}>
-          <CompactHand
-            cardCount={gameState.playerHands[1]?.length ?? 0}
-            label={playerLabels[1] ?? ""}
-            score={gameState.cumulativeScores[1] ?? 0}
-            colors={colors}
-          />
+          <View style={styles.sideColumn}>
+            <CompactHand
+              cardCount={gameState.playerHands[1]?.length ?? 0}
+              label={playerLabels[1] ?? ""}
+              score={gameState.cumulativeScores[1] ?? 0}
+              colors={colors}
+            />
+            <OpponentCapturedPile
+              cards={gameState.wonCards[1] ?? []}
+              seatLabel={playerLabels[1] ?? ""}
+            />
+          </View>
           <TrickArea
             trick={[...displayTrick]}
             playerIndex={HUMAN}
             playerLabels={playerLabels}
             winnerIndex={trickWinnerIndex}
           />
-          <CompactHand
-            cardCount={gameState.playerHands[3]?.length ?? 0}
-            label={playerLabels[3] ?? ""}
-            score={gameState.cumulativeScores[3] ?? 0}
-            colors={colors}
-          />
+          <View style={styles.sideColumn}>
+            <CompactHand
+              cardCount={gameState.playerHands[3]?.length ?? 0}
+              label={playerLabels[3] ?? ""}
+              score={gameState.cumulativeScores[3] ?? 0}
+              colors={colors}
+            />
+            <OpponentCapturedPile
+              cards={gameState.wonCards[3] ?? []}
+              seatLabel={playerLabels[3] ?? ""}
+            />
+          </View>
         </View>
 
         {/* Human hand */}
@@ -391,6 +408,7 @@ export default function HeartsScreen() {
               onConfirm={handlePassConfirm}
             />
           )}
+          <SelfCapturedPile cards={gameState.wonCards[HUMAN] ?? []} />
           <PlayerHand
             hand={humanHand}
             selectedCards={isPassing ? humanPassSelections : undefined}
@@ -676,6 +694,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     paddingHorizontal: 8,
+  },
+  sideColumn: {
+    alignItems: "center",
+    gap: 6,
   },
   bottomArea: {
     paddingBottom: 8,


### PR DESCRIPTION
## Summary
- New `CapturedPile.tsx` exports `OpponentCapturedPile` (face-down mini fan + `{count} · +{pts}` pill) and `SelfCapturedPile` ("TAKEN" row with face-up mini cards + red `+{pts}` pill, italic "Nothing yet" empty state), plus a shared `penaltyPoints` helper (hearts = +1 each, Q♠ = +13)
- Wired into `HeartsScreen.tsx`: opponent piles mount adjacent to each seat's hand (top seat below `OpponentHand`, side seats in a new `sideColumn` under `CompactHand`); self pile sits between the human header and `PlayerHand`
- Reads directly from existing `gameState.wonCards` — engine already resets at hand boundaries, so no state plumbing needed
- i18n keys added to `en/hearts.json` + `hearts.meta.json` (other locales fall back to en until translated)

## Test plan
- [x] `npx jest` — **1414/1414** passing, including 11 new tests covering penalty calc (hearts + Q♠), opponent empty/filled/a11y label, self empty placeholder, face-up rank+suit rendering, running points pill
- [x] Lint clean on touched files
- [x] `tsc --noEmit` — 0 new errors (64 baseline errors in unrelated `useFruitImages.ts` + `sentry.web.ts` unchanged)
- [ ] Visual verification in Expo web: each seat shows correct pile + pill; both themes read correctly; piles reset on hand boundary; moon-shoot case still visible on hand-end overlay

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)