### PR TITLE
feat(hearts): trick-take animation (#714)

### DIFF
--- a/frontend/src/components/hearts/TrickArea.tsx
+++ b/frontend/src/components/hearts/TrickArea.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet, Animated, Easing } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import PlayingCard from "./PlayingCard";
@@ -10,19 +10,85 @@ interface Props {
   playerIndex: number;
   playerLabels?: string[];
   winnerIndex?: number | null;
+  onAnimationComplete?: () => void;
 }
 
 const POSITIONS = ["bottom", "left", "top", "right"] as const;
+const ANIMATION_DURATION_MS = 600;
 
-export default function TrickArea({ trick, playerIndex, playerLabels, winnerIndex }: Props) {
+// Direction vector per winner screen-position (relative to human). Cards slide
+// from the trick area toward the winning seat, matching the design spec.
+const DIRECTION_OFFSET: Record<(typeof POSITIONS)[number], { x: number; y: number }> = {
+  bottom: { x: 0, y: 120 },
+  left: { x: -140, y: 0 },
+  top: { x: 0, y: -120 },
+  right: { x: 140, y: 0 },
+};
+
+export default function TrickArea({
+  trick,
+  playerIndex,
+  playerLabels,
+  winnerIndex,
+  onAnimationComplete,
+}: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
+  const progress = useRef(new Animated.Value(0)).current;
+  const onCompleteRef = useRef(onAnimationComplete);
+  onCompleteRef.current = onAnimationComplete;
 
   // Map seat index (0-3) to compass position relative to human player
   function positionForSeat(seat: number): (typeof POSITIONS)[number] {
     const offset = (seat - playerIndex + 4) % 4;
     return POSITIONS[offset] ?? "bottom";
   }
+
+  const hasWinner = winnerIndex !== null && winnerIndex !== undefined;
+  const shouldAnimate = hasWinner && trick.length === 4;
+  const winnerDirection = shouldAnimate
+    ? DIRECTION_OFFSET[positionForSeat(winnerIndex as number)]
+    : null;
+
+  useEffect(() => {
+    if (!shouldAnimate) {
+      progress.setValue(0);
+      return;
+    }
+    progress.setValue(0);
+    const anim = Animated.timing(progress, {
+      toValue: 1,
+      duration: ANIMATION_DURATION_MS,
+      easing: Easing.in(Easing.ease),
+      useNativeDriver: false,
+    });
+    anim.start(({ finished }) => {
+      if (finished) onCompleteRef.current?.();
+    });
+    return () => {
+      anim.stop();
+    };
+  }, [shouldAnimate, winnerIndex, progress]);
+
+  const animatedStyle = winnerDirection
+    ? {
+        transform: [
+          {
+            translateX: progress.interpolate({
+              inputRange: [0, 1],
+              outputRange: [0, winnerDirection.x],
+            }),
+          },
+          {
+            translateY: progress.interpolate({
+              inputRange: [0, 1],
+              outputRange: [0, winnerDirection.y],
+            }),
+          },
+        ],
+        opacity: progress.interpolate({ inputRange: [0, 1], outputRange: [1, 0] }),
+      }
+    : null;
 
   const slots: Record<string, TrickCard | undefined> = {};
   for (const tc of trick) {
@@ -32,12 +98,12 @@ export default function TrickArea({ trick, playerIndex, playerLabels, winnerInde
   function renderSlot(pos: (typeof POSITIONS)[number], seatIndex: number) {
     const tc = slots[pos];
     const label = playerLabels?.[seatIndex] ?? String(seatIndex);
-    const isWinner = winnerIndex !== null && winnerIndex !== undefined && winnerIndex === seatIndex;
+    const isWinner = hasWinner && winnerIndex === seatIndex;
 
     return (
-      <View
+      <Animated.View
         key={pos}
-        style={[styles.slot, styles[pos]]}
+        style={[styles.slot, styles[pos], animatedStyle]}
         accessibilityLabel={
           tc
             ? isWinner
@@ -56,7 +122,7 @@ export default function TrickArea({ trick, playerIndex, playerLabels, winnerInde
             ]}
           />
         )}
-      </View>
+      </Animated.View>
     );
   }
 

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, fireEvent } from "@testing-library/react-native";
+import { render, fireEvent, act } from "@testing-library/react-native";
 import { ThemeProvider } from "../../../theme/ThemeContext";
 import PlayingCard from "../PlayingCard";
 import PlayerHand from "../PlayerHand";
@@ -173,6 +173,97 @@ describe("TrickArea", () => {
     );
     expect(getByText("10")).toBeTruthy();
     expect(getByText("3")).toBeTruthy();
+  });
+
+  describe("animation", () => {
+    const fullTrick: TrickCard[] = [
+      { card: c("spades", 10), playerIndex: 0 },
+      { card: c("hearts", 3), playerIndex: 1 },
+      { card: c("clubs", 8), playerIndex: 2 },
+      { card: c("diamonds", 5), playerIndex: 3 },
+    ];
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("does not fire onAnimationComplete when winnerIndex is null", () => {
+      const onComplete = jest.fn();
+      wrap(
+        <TrickArea
+          trick={fullTrick}
+          playerIndex={0}
+          winnerIndex={null}
+          onAnimationComplete={onComplete}
+        />
+      );
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it("does not fire onAnimationComplete for an incomplete trick", () => {
+      const onComplete = jest.fn();
+      const partial: TrickCard[] = [
+        { card: c("spades", 10), playerIndex: 0 },
+        { card: c("hearts", 3), playerIndex: 1 },
+      ];
+      wrap(
+        <TrickArea
+          trick={partial}
+          playerIndex={0}
+          winnerIndex={1}
+          onAnimationComplete={onComplete}
+        />
+      );
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
+    it("fires onAnimationComplete when a complete trick has a winner", () => {
+      const onComplete = jest.fn();
+      wrap(
+        <TrickArea
+          trick={fullTrick}
+          playerIndex={0}
+          winnerIndex={2}
+          onAnimationComplete={onComplete}
+        />
+      );
+      act(() => {
+        jest.advanceTimersByTime(700);
+      });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onAnimationComplete within the 600ms budget plus a small margin", () => {
+      const onComplete = jest.fn();
+      wrap(
+        <TrickArea
+          trick={fullTrick}
+          playerIndex={0}
+          winnerIndex={0}
+          onAnimationComplete={onComplete}
+        />
+      );
+      // Not yet complete at mid-animation.
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+      // Finishes after the full duration.
+      act(() => {
+        jest.advanceTimersByTime(400);
+      });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -107,6 +107,7 @@ export default function HeartsScreen() {
   const loopActiveRef = useRef(false);
   const gameStateRef = useRef<HeartsState>(gameState);
   const lastRecordedHandRef = useRef<number>(0);
+  const trickAnimResolverRef = useRef<(() => void) | null>(null);
 
   const {
     start: syncStart,
@@ -123,6 +124,9 @@ export default function HeartsScreen() {
   useEffect(
     () => () => {
       unmountedRef.current = true;
+      const resolve = trickAnimResolverRef.current;
+      trickAnimResolverRef.current = null;
+      if (resolve) resolve();
     },
     []
   );
@@ -200,7 +204,9 @@ export default function HeartsScreen() {
         setGameState(s);
 
         if (completedTrick && s.phase === "playing") {
-          await delay(1500);
+          await new Promise<void>((resolve) => {
+            trickAnimResolverRef.current = resolve;
+          });
           if (unmountedRef.current) return;
           setLastTrick(null);
         }
@@ -244,14 +250,25 @@ export default function HeartsScreen() {
       if (newState.phase === "playing") {
         setLastTrick({ trick: completedTrick, winnerIndex: newState.currentLeaderIndex });
         setGameState(newState);
-        setTimeout(() => {
-          if (!unmountedRef.current) setLastTrick(null);
-        }, 1500);
         return;
       }
     }
     setLastTrick(null);
     setGameState(newState);
+  }
+
+  // Called by TrickArea when the trick-take animation completes. Resolves the
+  // AI loop's pending await; for human-led tricks (no pending resolver),
+  // clears lastTrick directly.
+  function handleTrickAnimationComplete() {
+    if (unmountedRef.current) return;
+    const resolve = trickAnimResolverRef.current;
+    if (resolve) {
+      trickAnimResolverRef.current = null;
+      resolve();
+    } else if (lastTrick !== null) {
+      setLastTrick(null);
+    }
   }
 
   // ─── Passing ──────────────────────────────────────────────────────────────
@@ -376,6 +393,7 @@ export default function HeartsScreen() {
             playerIndex={HUMAN}
             playerLabels={playerLabels}
             winnerIndex={trickWinnerIndex}
+            onAnimationComplete={handleTrickAnimationComplete}
           />
           <View style={styles.sideColumn}>
             <CompactHand


### PR DESCRIPTION
## Summary
- Replaces the abrupt "cards vanish after 1500ms" behaviour with a 600ms ease-in slide + fade toward the winning seat — the visible direction of travel tells the player who took the trick.
- `TrickArea` now owns the animation: new `onAnimationComplete` prop drives the `lastTrick` clear.
- `HeartsScreen` waits on that callback (via a promise resolver) instead of a fixed `await delay(1500)` / `setTimeout`, so the AI loop and the hand-end transition stay in sync with what the player sees.

## Design fidelity
- 600ms `Easing.in(Easing.ease)` — matches the spec in #714.
- Direction vector keyed to the winner's on-screen position (bottom +120 / left −140 / top −120 / right +140); opacity fades 1 → 0 over the same window.
- Animation only runs when all 4 cards are present **and** a winner is set — mid-trick renders stay still.
- Cleanup path: unmount resolves any pending AI-loop await so a `navigate away` during the animation can't strand the loop.

## Test plan
- [x] `npx jest src/components/hearts src/screens/__tests__/HeartsScreen src/game/hearts` — 131/131 pass
- [x] `npx prettier --check` clean on all three changed files
- [x] `npx eslint` clean on all three changed files
- [x] `npx tsc --noEmit` adds 0 new errors (pre-existing errors are all in cascade/fruit/sentry files — unrelated)
- [x] New tests: `onAnimationComplete` fires within 600ms budget; no-op when `winnerIndex` is null or trick is incomplete
- [ ] **Visual check in Expo web** — play a few tricks; watch that cards slide toward the winner's seat (not flagged as blocking; I can't run Expo from here)

## Related
- Parent umbrella: #702
- Capture-pile endpoint (where cards "land"): #715 (merged via #752)

🤖 Generated with [Claude Code](https://claude.com/claude-code)