### PR TITLE
feat(scoreboard): 2048 + Solitaire + Sudoku scoreboards + HeroStatScoreboard (#719)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -27,6 +27,9 @@ import { CardDeckProvider } from "./src/game/_shared/decks/CardDeckContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
 import { HeartsRoundsProvider } from "./src/game/hearts/RoundsContext";
 import { YachtScorecardProvider } from "./src/game/yacht/ScorecardContext";
+import { Twenty48ScoreboardProvider } from "./src/game/twenty48/Twenty48ScoreboardContext";
+import { SolitaireScoreboardProvider } from "./src/game/solitaire/SolitaireScoreboardContext";
+import { SudokuScoreboardProvider } from "./src/game/sudoku/SudokuScoreboardContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
 import { installSentryConsoleErrorCapture } from "./src/utils/sentryConsoleError";
 import { LazyScreens } from "./src/utils/lazyScreens";
@@ -64,7 +67,7 @@ export type HomeStackParamList = {
   Solitaire: undefined;
   Hearts: undefined;
   Sudoku: undefined;
-  Scoreboard: { gameKey: "hearts" | "yacht" | "blackjack" };
+  Scoreboard: { gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" };
 };
 
 export type ProfileStackParamList = {
@@ -204,11 +207,17 @@ function AppInner() {
           <BlackjackGameProvider>
             <HeartsRoundsProvider>
               <YachtScorecardProvider>
-                <NavigationContainer>
-                  <Stack.Navigator screenOptions={{ headerShown: false }}>
-                    <Stack.Screen name="MainTabs" component={MainTabs} />
-                  </Stack.Navigator>
-                </NavigationContainer>
+                <Twenty48ScoreboardProvider>
+                  <SolitaireScoreboardProvider>
+                    <SudokuScoreboardProvider>
+                      <NavigationContainer>
+                        <Stack.Navigator screenOptions={{ headerShown: false }}>
+                          <Stack.Screen name="MainTabs" component={MainTabs} />
+                        </Stack.Navigator>
+                      </NavigationContainer>
+                    </SudokuScoreboardProvider>
+                  </SolitaireScoreboardProvider>
+                </Twenty48ScoreboardProvider>
               </YachtScorecardProvider>
             </HeartsRoundsProvider>
           </BlackjackGameProvider>

--- a/frontend/src/components/scoreboard/HeroStatScoreboard.tsx
+++ b/frontend/src/components/scoreboard/HeroStatScoreboard.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+import { useTheme } from "../../theme/ThemeContext";
+
+export interface StatCard {
+  key: string;
+  label: string;
+  value: string;
+  accent?: boolean;
+}
+
+interface Props {
+  heroLabel: string;
+  heroValue: string;
+  heroValueColor?: string;
+  heroSub: string;
+  cards: readonly StatCard[];
+}
+
+export default function HeroStatScoreboard({
+  heroLabel,
+  heroValue,
+  heroValueColor,
+  heroSub,
+  cards,
+}: Props) {
+  const { colors } = useTheme();
+  const valueColor = heroValueColor ?? colors.text;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.hero}>
+        <Text style={[styles.heroLabel, { color: colors.textMuted }]}>{heroLabel}</Text>
+        <Text style={[styles.heroValue, { color: valueColor }]}>{heroValue}</Text>
+        <Text style={[styles.heroSub, { color: colors.textMuted }]}>{heroSub}</Text>
+      </View>
+      <View style={styles.grid}>
+        {cards.map((card) => (
+          <View
+            key={card.key}
+            style={[
+              styles.card,
+              {
+                borderColor: card.accent ? colors.accent : colors.border,
+                backgroundColor: card.accent ? colors.surfaceAlt : "transparent",
+              },
+            ]}
+            accessibilityLabel={`${card.label}: ${card.value}`}
+            accessibilityRole="none"
+          >
+            <Text style={[styles.cardValue, { color: colors.text }]}>{card.value}</Text>
+            <Text style={[styles.cardLabel, { color: colors.textMuted }]}>{card.label}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: "100%",
+    gap: 16,
+  },
+  hero: {
+    alignItems: "center",
+    gap: 4,
+  },
+  heroLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+  },
+  heroValue: {
+    fontSize: 30,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  heroSub: {
+    fontSize: 13,
+    fontWeight: "500",
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  card: {
+    flexBasis: "46%",
+    flexGrow: 1,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    alignItems: "center",
+    gap: 4,
+    minWidth: 90,
+  },
+  cardValue: {
+    fontSize: 24,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  cardLabel: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    textAlign: "center",
+  },
+});

--- a/frontend/src/components/scoreboard/SolitaireScoreboard.tsx
+++ b/frontend/src/components/scoreboard/SolitaireScoreboard.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import HeroStatScoreboard from "./HeroStatScoreboard";
+import type { SolitaireScoreboardSnapshot } from "../../game/solitaire/SolitaireScoreboardContext";
+
+interface Props {
+  snapshot: SolitaireScoreboardSnapshot;
+}
+
+export default function SolitaireScoreboard({ snapshot }: Props) {
+  const { t } = useTranslation("solitaire");
+
+  const heroValue = snapshot.hasGame ? String(snapshot.moves) : "—";
+  const heroSub = snapshot.hasGame
+    ? t("scoreboard.heroSub", {
+        moves: snapshot.moves,
+        foundations: snapshot.foundationsComplete,
+      })
+    : t("scoreboard.heroSubEmpty");
+
+  const cards = [
+    { key: "bestTime", label: t("scoreboard.bestTime"), value: "—", accent: true },
+    { key: "bestMoves", label: t("scoreboard.bestMoves"), value: "—" },
+    { key: "gamesPlayed", label: t("scoreboard.gamesPlayed"), value: "—" },
+    { key: "gamesWon", label: t("scoreboard.gamesWon"), value: "—" },
+  ] as const;
+
+  return (
+    <HeroStatScoreboard
+      heroLabel={t("scoreboard.heroLabel")}
+      heroValue={heroValue}
+      heroSub={heroSub}
+      cards={cards}
+    />
+  );
+}

--- a/frontend/src/components/scoreboard/SudokuScoreboard.tsx
+++ b/frontend/src/components/scoreboard/SudokuScoreboard.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import HeroStatScoreboard from "./HeroStatScoreboard";
+import type { SudokuScoreboardSnapshot } from "../../game/sudoku/SudokuScoreboardContext";
+
+interface Props {
+  snapshot: SudokuScoreboardSnapshot;
+}
+
+function formatElapsed(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m.toString().padStart(2, "0")}:${sec.toString().padStart(2, "0")}`;
+}
+
+export default function SudokuScoreboard({ snapshot }: Props) {
+  const { t } = useTranslation("sudoku");
+
+  const heroValue = snapshot.hasGame ? formatElapsed(snapshot.elapsed) : "—";
+  const heroSub = snapshot.hasGame
+    ? t("scoreboard.heroSub", {
+        difficulty: t(`difficulty.${snapshot.difficulty}`),
+        errors: snapshot.errorCount,
+      })
+    : t("scoreboard.heroSubEmpty");
+
+  const cards = [
+    { key: "easyBestTime", label: t("scoreboard.easyBestTime"), value: "—", accent: true },
+    { key: "mediumBestTime", label: t("scoreboard.mediumBestTime"), value: "—" },
+    { key: "hardBestTime", label: t("scoreboard.hardBestTime"), value: "—" },
+    { key: "gamesSolved", label: t("scoreboard.gamesSolved"), value: "—" },
+  ] as const;
+
+  return (
+    <HeroStatScoreboard
+      heroLabel={t("scoreboard.heroLabel")}
+      heroValue={heroValue}
+      heroSub={heroSub}
+      cards={cards}
+    />
+  );
+}

--- a/frontend/src/components/scoreboard/Twenty48Scoreboard.tsx
+++ b/frontend/src/components/scoreboard/Twenty48Scoreboard.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import HeroStatScoreboard from "./HeroStatScoreboard";
+import type { Twenty48ScoreboardSnapshot } from "../../game/twenty48/Twenty48ScoreboardContext";
+
+interface Props {
+  snapshot: Twenty48ScoreboardSnapshot;
+}
+
+export default function Twenty48Scoreboard({ snapshot }: Props) {
+  const { t } = useTranslation("twenty48");
+
+  const heroValue = snapshot.hasGame ? snapshot.score.toLocaleString("en-US") : "—";
+  const heroSub = snapshot.hasGame
+    ? t("scoreboard.heroSub", { bestTile: snapshot.bestTile, moves: snapshot.moveCount })
+    : t("scoreboard.heroSubEmpty");
+
+  const cards = [
+    {
+      key: "bestScore",
+      label: t("scoreboard.bestScore"),
+      value: snapshot.bestScore > 0 ? snapshot.bestScore.toLocaleString("en-US") : "—",
+      accent: true,
+    },
+    { key: "bestTile", label: t("scoreboard.bestTile"), value: "—" },
+    { key: "gamesPlayed", label: t("scoreboard.gamesPlayed"), value: "—" },
+    { key: "gamesWon", label: t("scoreboard.gamesWon"), value: "—" },
+  ] as const;
+
+  return (
+    <HeroStatScoreboard
+      heroLabel={t("scoreboard.heroLabel")}
+      heroValue={heroValue}
+      heroSub={heroSub}
+      cards={cards}
+    />
+  );
+}

--- a/frontend/src/game/solitaire/SolitaireScoreboardContext.tsx
+++ b/frontend/src/game/solitaire/SolitaireScoreboardContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface SolitaireScoreboardSnapshot {
+  moves: number;
+  foundationsComplete: number;
+  hasGame: boolean;
+}
+
+const initial: SolitaireScoreboardSnapshot = {
+  moves: 0,
+  foundationsComplete: 0,
+  hasGame: false,
+};
+
+interface ContextValue {
+  snapshot: SolitaireScoreboardSnapshot;
+  setSnapshot: (s: SolitaireScoreboardSnapshot) => void;
+}
+
+const SolitaireScoreboardContext = createContext<ContextValue | null>(null);
+
+export function SolitaireScoreboardProvider({ children }: { children: React.ReactNode }) {
+  const [snapshot, setSnapshot] = useState(initial);
+  return (
+    <SolitaireScoreboardContext.Provider value={{ snapshot, setSnapshot }}>
+      {children}
+    </SolitaireScoreboardContext.Provider>
+  );
+}
+
+export function useSolitaireScoreboard() {
+  const ctx = useContext(SolitaireScoreboardContext);
+  if (!ctx) throw new Error("useSolitaireScoreboard must be inside SolitaireScoreboardProvider");
+  return ctx;
+}

--- a/frontend/src/game/sudoku/SudokuScoreboardContext.tsx
+++ b/frontend/src/game/sudoku/SudokuScoreboardContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState } from "react";
+import type { Difficulty } from "./types";
+
+export interface SudokuScoreboardSnapshot {
+  elapsed: number;
+  difficulty: Difficulty;
+  errorCount: number;
+  hasGame: boolean;
+}
+
+const initial: SudokuScoreboardSnapshot = {
+  elapsed: 0,
+  difficulty: "easy",
+  errorCount: 0,
+  hasGame: false,
+};
+
+interface ContextValue {
+  snapshot: SudokuScoreboardSnapshot;
+  setSnapshot: (s: SudokuScoreboardSnapshot) => void;
+}
+
+const SudokuScoreboardContext = createContext<ContextValue | null>(null);
+
+export function SudokuScoreboardProvider({ children }: { children: React.ReactNode }) {
+  const [snapshot, setSnapshot] = useState(initial);
+  return (
+    <SudokuScoreboardContext.Provider value={{ snapshot, setSnapshot }}>
+      {children}
+    </SudokuScoreboardContext.Provider>
+  );
+}
+
+export function useSudokuScoreboard() {
+  const ctx = useContext(SudokuScoreboardContext);
+  if (!ctx) throw new Error("useSudokuScoreboard must be inside SudokuScoreboardProvider");
+  return ctx;
+}

--- a/frontend/src/game/twenty48/Twenty48ScoreboardContext.tsx
+++ b/frontend/src/game/twenty48/Twenty48ScoreboardContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface Twenty48ScoreboardSnapshot {
+  score: number;
+  bestTile: number;
+  moveCount: number;
+  bestScore: number;
+  hasGame: boolean;
+}
+
+const initial: Twenty48ScoreboardSnapshot = {
+  score: 0,
+  bestTile: 0,
+  moveCount: 0,
+  bestScore: 0,
+  hasGame: false,
+};
+
+interface ContextValue {
+  snapshot: Twenty48ScoreboardSnapshot;
+  setSnapshot: (s: Twenty48ScoreboardSnapshot) => void;
+}
+
+const Twenty48ScoreboardContext = createContext<ContextValue | null>(null);
+
+export function Twenty48ScoreboardProvider({ children }: { children: React.ReactNode }) {
+  const [snapshot, setSnapshot] = useState(initial);
+  return (
+    <Twenty48ScoreboardContext.Provider value={{ snapshot, setSnapshot }}>
+      {children}
+    </Twenty48ScoreboardContext.Provider>
+  );
+}
+
+export function useTwenty48Scoreboard() {
+  const ctx = useContext(Twenty48ScoreboardContext);
+  if (!ctx) throw new Error("useTwenty48Scoreboard must be inside Twenty48ScoreboardProvider");
+  return ctx;
+}

--- a/frontend/src/i18n/locales/ar/solitaire.json
+++ b/frontend/src/i18n/locales/ar/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "تعذر حفظ لعبتك.",
   "error.loadFailed": "تعذر استئناف اللعبة المحفوظة.",
   "error.submitFailed": "تعذر حفظ النتيجة. تحقق من الاتصال.",
-  "error.submitRetry": "أعد المحاولة"
+  "error.submitRetry": "أعد المحاولة",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ar/sudoku.json
+++ b/frontend/src/i18n/locales/ar/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "أحسنت! لقد حللتها!",
   "win.score": "النقاط: {{score}}",
   "win.errors": "الأخطاء: {{count}}",
-  "win.elapsed": "الوقت: {{time}}"
+  "win.elapsed": "الوقت: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/ar/twenty48.json
+++ b/frontend/src/i18n/locales/ar/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "وصلت إلى 2048! يمكنك الاستمرار للحصول على نتيجة أعلى.",
   "controls.keyboardHint": "أو استخدم مفاتيح الأسهم",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/de/solitaire.json
+++ b/frontend/src/i18n/locales/de/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Spiel konnte nicht gespeichert werden.",
   "error.loadFailed": "Gespeichertes Spiel konnte nicht geladen werden.",
   "error.submitFailed": "Punkte konnten nicht gespeichert werden. Verbindung prüfen.",
-  "error.submitRetry": "Erneut"
+  "error.submitRetry": "Erneut",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/de/sudoku.json
+++ b/frontend/src/i18n/locales/de/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "Geschafft!",
   "win.score": "Punkte: {{score}}",
   "win.errors": "Fehler: {{count}}",
-  "win.elapsed": "Zeit: {{time}}"
+  "win.elapsed": "Zeit: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/de/twenty48.json
+++ b/frontend/src/i18n/locales/de/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "Du hast 2048 erreicht! Du kannst weiterspielen für einen höheren Punktestand.",
   "controls.keyboardHint": "Oder nutze die Pfeiltasten",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/en/solitaire.json
+++ b/frontend/src/i18n/locales/en/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Could not save your game.",
   "error.loadFailed": "Could not resume the saved game.",
   "error.submitFailed": "Could not save score. Check your connection.",
-  "error.submitRetry": "Retry"
+  "error.submitRetry": "Retry",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/en/sudoku.json
+++ b/frontend/src/i18n/locales/en/sudoku.json
@@ -33,5 +33,12 @@
   "win.title": "You Solved It!",
   "win.score": "Score: {{score}}",
   "win.errors": "Errors: {{count}}",
-  "win.elapsed": "Time: {{time}}"
+  "win.elapsed": "Time: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/en/twenty48.json
+++ b/frontend/src/i18n/locales/en/twenty48.json
@@ -21,5 +21,12 @@
   "win.title": "You Win!",
   "win.body": "You reached 2048! You can keep playing for a higher score.",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/es/solitaire.json
+++ b/frontend/src/i18n/locales/es/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "No se pudo guardar tu partida.",
   "error.loadFailed": "No se pudo reanudar la partida guardada.",
   "error.submitFailed": "No se pudo guardar la puntuación. Revisa tu conexión.",
-  "error.submitRetry": "Reintentar"
+  "error.submitRetry": "Reintentar",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/es/sudoku.json
+++ b/frontend/src/i18n/locales/es/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "¡Lo lograste!",
   "win.score": "Puntuación: {{score}}",
   "win.errors": "Errores: {{count}}",
-  "win.elapsed": "Tiempo: {{time}}"
+  "win.elapsed": "Tiempo: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/es/twenty48.json
+++ b/frontend/src/i18n/locales/es/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "¡Llegaste a 2048! Puedes seguir jugando para una puntuación más alta.",
   "controls.keyboardHint": "O usa las flechas del teclado",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/fr-CA/solitaire.json
+++ b/frontend/src/i18n/locales/fr-CA/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Impossible de sauvegarder votre partie.",
   "error.loadFailed": "Impossible de reprendre la partie sauvegardée.",
   "error.submitFailed": "Impossible d'enregistrer le score. Vérifiez votre connexion.",
-  "error.submitRetry": "Réessayer"
+  "error.submitRetry": "Réessayer",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/fr-CA/sudoku.json
+++ b/frontend/src/i18n/locales/fr-CA/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "Bravo, c'est réussi!",
   "win.score": "Score : {{score}}",
   "win.errors": "Erreurs : {{count}}",
-  "win.elapsed": "Temps : {{time}}"
+  "win.elapsed": "Temps : {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/fr-CA/twenty48.json
+++ b/frontend/src/i18n/locales/fr-CA/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "Vous avez atteint 2048 ! Vous pouvez continuer pour un meilleur score.",
   "controls.keyboardHint": "Ou utilise les touches fléchées",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/he/solitaire.json
+++ b/frontend/src/i18n/locales/he/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "לא ניתן לשמור את המשחק.",
   "error.loadFailed": "לא ניתן לטעון את המשחק השמור.",
   "error.submitFailed": "לא ניתן לשמור את הניקוד. בדוק את החיבור.",
-  "error.submitRetry": "נסה שוב"
+  "error.submitRetry": "נסה שוב",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/he/sudoku.json
+++ b/frontend/src/i18n/locales/he/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "פתרתם את זה!",
   "win.score": "נקודות: {{score}}",
   "win.errors": "טעויות: {{count}}",
-  "win.elapsed": "זמן: {{time}}"
+  "win.elapsed": "זמן: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/he/twenty48.json
+++ b/frontend/src/i18n/locales/he/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "הגעת ל-2048! אתה יכול להמשיך לשחק לניקוד גבוה יותר.",
   "controls.keyboardHint": "או השתמש במקשי החיצים",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/hi/solitaire.json
+++ b/frontend/src/i18n/locales/hi/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "आपका गेम सेव नहीं हो सका।",
   "error.loadFailed": "सेव किया हुआ गेम लोड नहीं हो सका।",
   "error.submitFailed": "स्कोर सेव नहीं हो सका। कनेक्शन जांचें।",
-  "error.submitRetry": "पुनः प्रयास"
+  "error.submitRetry": "पुनः प्रयास",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/hi/sudoku.json
+++ b/frontend/src/i18n/locales/hi/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "आपने हल कर लिया!",
   "win.score": "स्कोर: {{score}}",
   "win.errors": "गलतियाँ: {{count}}",
-  "win.elapsed": "समय: {{time}}"
+  "win.elapsed": "समय: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/hi/twenty48.json
+++ b/frontend/src/i18n/locales/hi/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "आप 2048 तक पहुँच गए! उच्च स्कोर के लिए खेलना जारी रख सकते हैं।",
   "controls.keyboardHint": "या तीर कुंजियों का उपयोग करें",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ja/solitaire.json
+++ b/frontend/src/i18n/locales/ja/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "ゲームの保存に失敗しました。",
   "error.loadFailed": "保存したゲームを再開できませんでした。",
   "error.submitFailed": "スコアの送信に失敗しました。接続を確認してください。",
-  "error.submitRetry": "再試行"
+  "error.submitRetry": "再試行",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ja/sudoku.json
+++ b/frontend/src/i18n/locales/ja/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "クリアおめでとう！",
   "win.score": "スコア: {{score}}",
   "win.errors": "ミス: {{count}} 回",
-  "win.elapsed": "時間: {{time}}"
+  "win.elapsed": "時間: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/ja/twenty48.json
+++ b/frontend/src/i18n/locales/ja/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "2048に到達しました！さらに高いスコアを目指して続けられます。",
   "controls.keyboardHint": "または矢印キーを使用",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ko/solitaire.json
+++ b/frontend/src/i18n/locales/ko/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "게임을 저장할 수 없습니다.",
   "error.loadFailed": "저장된 게임을 불러올 수 없습니다.",
   "error.submitFailed": "점수를 저장할 수 없습니다. 연결을 확인하세요.",
-  "error.submitRetry": "다시 시도"
+  "error.submitRetry": "다시 시도",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ko/sudoku.json
+++ b/frontend/src/i18n/locales/ko/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "성공했어요!",
   "win.score": "점수: {{score}}",
   "win.errors": "오류: {{count}}개",
-  "win.elapsed": "시간: {{time}}"
+  "win.elapsed": "시간: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/ko/twenty48.json
+++ b/frontend/src/i18n/locales/ko/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "2048에 도달했습니다! 더 높은 점수를 위해 계속 플레이할 수 있습니다.",
   "controls.keyboardHint": "또는 방향키 사용",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/nl/solitaire.json
+++ b/frontend/src/i18n/locales/nl/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Opslaan van je spel is mislukt.",
   "error.loadFailed": "Het opgeslagen spel kon niet worden hervat.",
   "error.submitFailed": "Score opslaan mislukt. Controleer je verbinding.",
-  "error.submitRetry": "Opnieuw"
+  "error.submitRetry": "Opnieuw",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/nl/sudoku.json
+++ b/frontend/src/i18n/locales/nl/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "Je hebt het opgelost!",
   "win.score": "Score: {{score}}",
   "win.errors": "Fouten: {{count}}",
-  "win.elapsed": "Tijd: {{time}}"
+  "win.elapsed": "Tijd: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/nl/twenty48.json
+++ b/frontend/src/i18n/locales/nl/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "Je hebt 2048 bereikt! Je kunt doorspelen voor een hogere score.",
   "controls.keyboardHint": "Of gebruik de pijltoetsen",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/pt/solitaire.json
+++ b/frontend/src/i18n/locales/pt/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Não foi possível salvar o jogo.",
   "error.loadFailed": "Não foi possível retomar o jogo salvo.",
   "error.submitFailed": "Não foi possível salvar a pontuação. Verifique sua conexão.",
-  "error.submitRetry": "Tentar"
+  "error.submitRetry": "Tentar",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/pt/sudoku.json
+++ b/frontend/src/i18n/locales/pt/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "Você Conseguiu!",
   "win.score": "Pontuação: {{score}}",
   "win.errors": "Erros: {{count}}",
-  "win.elapsed": "Tempo: {{time}}"
+  "win.elapsed": "Tempo: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/pt/twenty48.json
+++ b/frontend/src/i18n/locales/pt/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "Você alcançou 2048! Você pode continuar jogando para uma pontuação maior.",
   "controls.keyboardHint": "Ou use as setas do teclado",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ru/solitaire.json
+++ b/frontend/src/i18n/locales/ru/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "Не удалось сохранить игру.",
   "error.loadFailed": "Не удалось загрузить сохранение.",
   "error.submitFailed": "Не удалось сохранить счет. Проверьте соединение.",
-  "error.submitRetry": "Повторить"
+  "error.submitRetry": "Повторить",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/ru/sudoku.json
+++ b/frontend/src/i18n/locales/ru/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "Вы справились!",
   "win.score": "Очки: {{score}}",
   "win.errors": "Ошибки: {{count}}",
-  "win.elapsed": "Время: {{time}}"
+  "win.elapsed": "Время: {{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/ru/twenty48.json
+++ b/frontend/src/i18n/locales/ru/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "Вы достигли 2048! Можете продолжить игру для более высокого счёта.",
   "controls.keyboardHint": "Или используйте клавиши со стрелками",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/zh/solitaire.json
+++ b/frontend/src/i18n/locales/zh/solitaire.json
@@ -39,5 +39,12 @@
   "error.saveFailed": "无法保存游戏进度。",
   "error.loadFailed": "无法恢复存档。",
   "error.submitFailed": "无法提交分数，请检查网络连接。",
-  "error.submitRetry": "重试"
+  "error.submitRetry": "重试",
+  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestTime": "Best Time",
+  "scoreboard.bestMoves": "Best Moves",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/i18n/locales/zh/sudoku.json
+++ b/frontend/src/i18n/locales/zh/sudoku.json
@@ -26,5 +26,12 @@
   "win.title": "你赢了！",
   "win.score": "得分：{{score}}",
   "win.errors": "错误：{{count}}",
-  "win.elapsed": "时间：{{time}}"
+  "win.elapsed": "时间：{{time}}",
+  "scoreboard.heroLabel": "ELAPSED",
+  "scoreboard.heroSub": "{{difficulty}} · {{errors}} errors",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.easyBestTime": "Easy Best",
+  "scoreboard.mediumBestTime": "Medium Best",
+  "scoreboard.hardBestTime": "Hard Best",
+  "scoreboard.gamesSolved": "Games Solved"
 }

--- a/frontend/src/i18n/locales/zh/twenty48.json
+++ b/frontend/src/i18n/locales/zh/twenty48.json
@@ -21,5 +21,12 @@
   "win.body": "你达到了2048！你可以继续游戏以获得更高分数。",
   "controls.keyboardHint": "或使用方向键",
   "stats.highestTile": "Highest Tile",
-  "stats.timePlayed": "Time Played"
+  "stats.timePlayed": "Time Played",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best tile: {{bestTile}} · {{moves}} moves",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "Best Score",
+  "scoreboard.bestTile": "Best Tile",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.gamesWon": "Games Won"
 }

--- a/frontend/src/screens/ScoreboardScreen.tsx
+++ b/frontend/src/screens/ScoreboardScreen.tsx
@@ -8,9 +8,15 @@ import { useTheme } from "../theme/ThemeContext";
 import HeartsScoreboard from "../components/scoreboard/HeartsScoreboard";
 import YachtScoreboard from "../components/scoreboard/YachtScoreboard";
 import BlackjackScoreboard from "../components/scoreboard/BlackjackScoreboard";
+import Twenty48Scoreboard from "../components/scoreboard/Twenty48Scoreboard";
+import SolitaireScoreboard from "../components/scoreboard/SolitaireScoreboard";
+import SudokuScoreboard from "../components/scoreboard/SudokuScoreboard";
 import { useHeartsRounds } from "../game/hearts/RoundsContext";
 import { useYachtScorecard } from "../game/yacht/ScorecardContext";
 import { useBlackjackSessionStats } from "../game/blackjack/BlackjackGameContext";
+import { useTwenty48Scoreboard } from "../game/twenty48/Twenty48ScoreboardContext";
+import { useSolitaireScoreboard } from "../game/solitaire/SolitaireScoreboardContext";
+import { useSudokuScoreboard } from "../game/sudoku/SudokuScoreboardContext";
 import type { HomeStackParamList } from "../../App";
 
 type GameKey = HomeStackParamList["Scoreboard"]["gameKey"];
@@ -36,6 +42,21 @@ function YachtScoreboardSection() {
 function BlackjackScoreboardSection() {
   const stats = useBlackjackSessionStats();
   return <BlackjackScoreboard stats={stats} />;
+}
+
+function Twenty48ScoreboardSection() {
+  const { snapshot } = useTwenty48Scoreboard();
+  return <Twenty48Scoreboard snapshot={snapshot} />;
+}
+
+function SolitaireScoreboardSection() {
+  const { snapshot } = useSolitaireScoreboard();
+  return <SolitaireScoreboard snapshot={snapshot} />;
+}
+
+function SudokuScoreboardSection() {
+  const { snapshot } = useSudokuScoreboard();
+  return <SudokuScoreboard snapshot={snapshot} />;
 }
 
 function UnknownScoreboardFallback({ gameKey }: { gameKey: string }) {
@@ -65,6 +86,15 @@ export default function ScoreboardScreen() {
       break;
     case "blackjack":
       body = <BlackjackScoreboardSection />;
+      break;
+    case "twenty48":
+      body = <Twenty48ScoreboardSection />;
+      break;
+    case "solitaire":
+      body = <SolitaireScoreboardSection />;
+      break;
+    case "sudoku":
+      body = <SudokuScoreboardSection />;
       break;
     default:
       body = <UnknownScoreboardFallback gameKey={gameKey} />;

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -55,6 +55,7 @@ import {
 import type { DrawMode, Move, SolitaireState, Suit } from "../game/solitaire/types";
 import { SUITS } from "../game/solitaire/types";
 import { clearGame, loadGame, saveGame } from "../game/solitaire/storage";
+import { useSolitaireScoreboard } from "../game/solitaire/SolitaireScoreboardContext";
 import { solitaireApi, type ScoreEntry } from "../game/solitaire/api";
 import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
@@ -110,11 +111,21 @@ export default function SolitaireScreen() {
     getGameId: syncGetGameId,
   } = useGameSync("solitaire");
 
+  const { setSnapshot: setScoreboardSnapshot } = useSolitaireScoreboard();
+
   useEffect(() => {
     return () => {
       if (autoStepTimeoutRef.current !== null) clearTimeout(autoStepTimeoutRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!state) return;
+    const foundationsComplete = Object.values(state.foundations).filter(
+      (cards) => cards.length === 13
+    ).length;
+    setScoreboardSnapshot({ moves, foundationsComplete, hasGame: true });
+  }, [state, moves, setScoreboardSnapshot]);
 
   // #597 — mount load. Restores a saved game silently; on a clean slot the
   // pre-game draw-mode modal is shown so the player picks their mode.
@@ -442,6 +453,7 @@ export default function SolitaireScreen() {
         paddingRight: Math.max(insets.right, 12),
       }}
       onNewGame={resetToPreGame}
+      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "solitaire" })}
       rightSlot={
         <Pressable
           onPress={handleUndo}

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -53,6 +53,7 @@ import {
 } from "../game/sudoku/engine";
 import type { CellValue, Difficulty, SudokuState } from "../game/sudoku/types";
 import { clearGame, loadGame, saveGame } from "../game/sudoku/storage";
+import { useSudokuScoreboard } from "../game/sudoku/SudokuScoreboardContext";
 import { scoreQueue } from "../game/_shared/scoreQueue";
 import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
@@ -113,6 +114,18 @@ export default function SudokuScreen() {
     complete: syncComplete,
     getGameId: syncGetGameId,
   } = useGameSync("sudoku");
+
+  const { setSnapshot: setScoreboardSnapshot } = useSudokuScoreboard();
+
+  useEffect(() => {
+    if (!state) return;
+    setScoreboardSnapshot({
+      elapsed,
+      difficulty: state.difficulty,
+      errorCount: state.errorCount,
+      hasGame: true,
+    });
+  }, [state, elapsed, setScoreboardSnapshot]);
 
   // Mount load — restores a saved game silently; on a clean slot the
   // pre-game picker shows.
@@ -386,6 +399,7 @@ export default function SudokuScreen() {
       loading={loading}
       onBack={() => navigation.popToTop()}
       onNewGame={handleStart}
+      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "sudoku" })}
       rightSlot={headerRight}
       style={{
         paddingBottom: Math.max(insets.bottom, 16),

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -22,6 +22,7 @@ import GameOverlay from "../components/twenty48/GameOverlay";
 import StatsBento from "../components/twenty48/StatsBento";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { useGameSync } from "../game/_shared/useGameSync";
+import { useTwenty48Scoreboard } from "../game/twenty48/Twenty48ScoreboardContext";
 
 function flattenBoard(board: number[][]): number[] {
   return board.flat();
@@ -70,6 +71,7 @@ export default function Twenty48Screen({ navigation }: Props) {
   } = useGameSync("twenty48");
   const moveCountRef = useRef(0);
   const stateRef = useRef<Twenty48State | null>(null);
+  const { setSnapshot: setScoreboardSnapshot } = useTwenty48Scoreboard();
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
@@ -128,6 +130,17 @@ export default function Twenty48Screen({ navigation }: Props) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state?.score]); // intentional: only re-run when score changes, not on every state update
+
+  useEffect(() => {
+    if (!state) return;
+    setScoreboardSnapshot({
+      score: state.score,
+      bestTile: highestTile(state.board),
+      moveCount: moveCountRef.current,
+      bestScore,
+      hasGame: true,
+    });
+  }, [state, bestScore, setScoreboardSnapshot]);
 
   const executeMove = useCallback(
     (direction: Direction, currentState: Twenty48State) => {
@@ -291,6 +304,7 @@ export default function Twenty48Screen({ navigation }: Props) {
       requireBack
       onBack={() => navigation.popToTop()}
       onNewGame={resetGame}
+      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "twenty48" })}
       loading={!state && loading}
       style={{
         paddingBottom: Math.max(insets.bottom, 16),

--- a/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
@@ -12,6 +12,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import SolitaireScreen from "../SolitaireScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+import { SolitaireScoreboardProvider } from "../../game/solitaire/SolitaireScoreboardContext";
 import { createSeededRng, dealGame, setRng } from "../../game/solitaire/engine";
 import { solitaireApi } from "../../game/solitaire/api";
 
@@ -79,7 +80,9 @@ jest.mock("../../game/solitaire/api", () => ({
 function renderScreen() {
   return render(
     <ThemeProvider>
-      <SolitaireScreen />
+      <SolitaireScoreboardProvider>
+        <SolitaireScreen />
+      </SolitaireScoreboardProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/screens/__tests__/SudokuScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SudokuScreen.test.tsx
@@ -12,6 +12,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import SudokuScreen from "../SudokuScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+import { SudokuScoreboardProvider } from "../../game/sudoku/SudokuScoreboardContext";
 import { enterDigit, loadPuzzle, selectCell } from "../../game/sudoku/engine";
 import { saveGame } from "../../game/sudoku/storage";
 import type { CellValue, SudokuState } from "../../game/sudoku/types";
@@ -76,7 +77,9 @@ function fillAllExcept(state: SudokuState, skip: { row: number; col: number }): 
 function renderScreen() {
   return render(
     <ThemeProvider>
-      <SudokuScreen />
+      <SudokuScoreboardProvider>
+        <SudokuScreen />
+      </SudokuScoreboardProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
+++ b/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { render, act, waitFor, fireEvent } from "@testing-library/react-native";
 import Twenty48Screen from "../Twenty48Screen";
 import { ThemeProvider } from "../../theme/ThemeContext";
+import { Twenty48ScoreboardProvider } from "../../game/twenty48/Twenty48ScoreboardContext";
 import { saveGame, clearGame, loadGame } from "../../game/twenty48/storage";
 import { Twenty48State } from "../../game/twenty48/types";
 
@@ -74,7 +75,9 @@ function mockNav() {
 function renderScreen(nav = mockNav()) {
   return render(
     <ThemeProvider>
-      <Twenty48Screen navigation={nav} />
+      <Twenty48ScoreboardProvider>
+        <Twenty48Screen navigation={nav} />
+      </Twenty48ScoreboardProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts shared `<HeroStatScoreboard>` subcomponent (hero + 4-card stat grid layout) used by all three new scoreboards
- Adds `Twenty48ScoreboardContext`, `SolitaireScoreboardContext`, `SudokuScoreboardContext` — thin snapshot providers mounted at the app root, following the Hearts/Yacht pattern
- Adds `Twenty48Scoreboard`, `SolitaireScoreboard`, `SudokuScoreboard` components wired into `ScoreboardScreen`
- Wires `⋯ → Scoreboard` in `Twenty48Screen`, `SolitaireScreen`, and `SudokuScreen`
- Extends `HomeStackParamList.Scoreboard.gameKey` union and adds 3 switch cases in `ScoreboardScreen`
- Placeholder `—` cards for stats not yet persisted; filed follow-up issues #760 (2048), #761 (Solitaire), #762 (Sudoku)

## What's displayed

| Game | Hero | Live cards | Placeholder cards |
|---|---|---|---|
| 2048 | Current score | Best Score (from AsyncStorage) | Best Tile, Games Played, Games Won |
| Solitaire | Moves | — | Best Time, Best Moves, Games Played, Games Won |
| Sudoku | Elapsed time | — | Easy Best, Medium Best, Hard Best, Games Solved |

## Test plan

- [ ] Open 2048 → tap ⋯ → Scoreboard — hero shows current score; Best Score card shows AsyncStorage value or `—`
- [ ] Open Solitaire → tap ⋯ → Scoreboard — hero shows move count and foundation state
- [ ] Open Sudoku → tap ⋯ → Scoreboard — hero shows elapsed + difficulty + errors
- [ ] Each game: scoreboard before first game started → "No games played yet"
- [ ] Scoreboard renders in both dark and cream-light themes without layout issues

## Related

- Closes #719
- Follow-ups: #760, #761, #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)