### PR TITLE
fix(#746): park unknown_event_type 400s for retry instead of dead-lettering

### DIFF
--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -261,6 +261,92 @@ describe("SyncWorker", () => {
   });
 
   // -------------------------------------------------------------------------
+  // 400 unknown_event_type → park for retry (#746)
+  // -------------------------------------------------------------------------
+
+  it("unknown_event_type 400 parks rows for retry, does not dead-letter", async () => {
+    api.onNext((p) => p === "/games", ok());
+    api.onNext((p) => p.endsWith("/events"), {
+      status: 400,
+      ok: false,
+      retryAfterMs: null,
+      body: { detail: { error: "unknown_event_type", rejected: ["game_ended"] } },
+    });
+
+    const gid = client.startGame("hearts");
+    client.enqueueEvent(gid, { type: "game_ended" });
+    await flushMicro();
+    const result = await worker.flush();
+
+    // Rows must NOT be dead-lettered.
+    const rows = await store.peek(100, { includeDeadLettered: true });
+    const dead = rows.filter((r) => r.dead_lettered && r.log_type === "game_event");
+    expect(dead.length).toBe(0);
+
+    // They must be parked (next_retry_at in the future, not visible in live peek).
+    const live = (await store.peek(100)).filter((r) => r.log_type === "game_event");
+    expect(live.length).toBe(0);
+
+    expect(result.parked).toBeGreaterThan(0);
+    expect(result.deadLettered).toBe(0);
+  });
+
+  it("unknown_event_type 400 logs Sentry at warning, not error", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/react-native");
+    Sentry.captureMessage.mockClear();
+
+    api.onNext((p) => p === "/games", ok());
+    api.onNext((p) => p.endsWith("/events"), {
+      status: 400,
+      ok: false,
+      retryAfterMs: null,
+      body: { detail: { error: "unknown_event_type", rejected: ["game_ended"] } },
+    });
+
+    const gid = client.startGame("hearts");
+    client.enqueueEvent(gid, { type: "game_ended" });
+    await flushMicro();
+    await worker.flush();
+
+    const calls = (Sentry.captureMessage as jest.Mock).mock.calls;
+    const eventCall = calls.find((c: unknown[]) =>
+      typeof c[0] === "string" && c[0].includes("unknown_event_type")
+    );
+    expect(eventCall).toBeDefined();
+    expect(eventCall[1]).toMatchObject({ level: "warning" });
+    // Must NOT fire at "error" level for this specific error.
+    const errorCall = calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === "string" &&
+        c[0].includes("event batch") &&
+        (c[1] as { level?: string })?.level === "error"
+    );
+    expect(errorCall).toBeUndefined();
+  });
+
+  it("plain 400 (non-unknown-event-type) still dead-letters immediately", async () => {
+    api.onNext((p) => p === "/games", ok());
+    api.onNext((p) => p.endsWith("/events"), {
+      status: 400,
+      ok: false,
+      retryAfterMs: null,
+      body: { detail: { error: "malformed_payload" } },
+    });
+
+    const gid = client.startGame("yacht");
+    client.enqueueEvent(gid, { type: "roll" });
+    await flushMicro();
+    const result = await worker.flush();
+
+    const rows = await store.peek(100, { includeDeadLettered: true });
+    const dead = rows.filter((r) => r.dead_lettered && r.log_type === "game_event");
+    expect(dead.length).toBeGreaterThan(0);
+    expect(result.deadLettered).toBeGreaterThan(0);
+    expect(result.parked).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
   // 400 / 403 → dead-letter
   // -------------------------------------------------------------------------
 

--- a/frontend/src/game/_shared/__tests__/syncWorker.test.ts
+++ b/frontend/src/game/_shared/__tests__/syncWorker.test.ts
@@ -310,8 +310,8 @@ describe("SyncWorker", () => {
     await worker.flush();
 
     const calls = (Sentry.captureMessage as jest.Mock).mock.calls;
-    const eventCall = calls.find((c: unknown[]) =>
-      typeof c[0] === "string" && c[0].includes("unknown_event_type")
+    const eventCall = calls.find(
+      (c: unknown[]) => typeof c[0] === "string" && c[0].includes("unknown_event_type")
     );
     expect(eventCall).toBeDefined();
     expect(eventCall[1]).toMatchObject({ level: "warning" });

--- a/frontend/src/game/_shared/eventQueueConfig.ts
+++ b/frontend/src/game/_shared/eventQueueConfig.ts
@@ -62,6 +62,13 @@ export interface LogConfig {
   /** Rows exceeding this retry count are dead-lettered. */
   MAX_RETRY_COUNT: number;
 
+  /**
+   * Fixed retry delay applied when the backend returns 400 unknown_event_type.
+   * This is a server-side schema gap (missing event_types row), not a bad
+   * client payload — the row should be retried after the migration lands.
+   */
+  UNKNOWN_EVENT_TYPE_BACKOFF_MS: number;
+
   /** Per-row payload caps — oversized payloads are truncated on enqueue. */
   MAX_EVENT_PAYLOAD_BYTES: number;
   MAX_BUG_CONTEXT_BYTES: number;
@@ -89,6 +96,7 @@ export const logConfig: LogConfig = {
   BACKOFF_BASE_MS: 1000,
   BACKOFF_MAX_MS: 30 * 60 * 1000, // 30 min
   MAX_RETRY_COUNT: 10,
+  UNKNOWN_EVENT_TYPE_BACKOFF_MS: 24 * 60 * 60 * 1000, // 24 h
   MAX_EVENT_PAYLOAD_BYTES: 8 * 1024, // 8 KB
   MAX_BUG_CONTEXT_BYTES: 16 * 1024, // 16 KB
   REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,
@@ -117,6 +125,7 @@ export function resetLogConfig(): void {
     BACKOFF_BASE_MS: 1000,
     BACKOFF_MAX_MS: 30 * 60 * 1000,
     MAX_RETRY_COUNT: 10,
+    UNKNOWN_EVENT_TYPE_BACKOFF_MS: 24 * 60 * 60 * 1000,
     MAX_EVENT_PAYLOAD_BYTES: 8 * 1024,
     MAX_BUG_CONTEXT_BYTES: 16 * 1024,
     REPORT_BUG_MAX_PER_MINUTE_PER_SOURCE: 10,

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -55,6 +55,8 @@ export interface FlushResult {
   accepted: number;
   duplicates: number;
   deadLettered: number;
+  /** Rows parked for long-backoff retry (e.g. unknown_event_type). */
+  parked: number;
   backoffMs: number;
 }
 
@@ -63,6 +65,7 @@ const EMPTY: FlushResult = {
   accepted: 0,
   duplicates: 0,
   deadLettered: 0,
+  parked: 0,
   backoffMs: 0,
 };
 
@@ -283,11 +286,27 @@ export class SyncWorker {
       if (g) g.startedSynced = false;
       return true;
     }
-    // 400, 403, or other 4xx terminal — dead-letter the chunk.
-    // 400 is always "error" level: it means the client sent an unrecognised
-    // event_type (e.g. a new game type whose DB event_types rows are missing).
-    // The response body contains {"error":"unknown_event_type","rejected":[...]}
-    // which is actionable — include it as extra so Sentry surfaces the names.
+    // 400 unknown_event_type — server-side schema gap (missing event_types row),
+    // not a bad client payload. Park with a long backoff so the rows survive
+    // until the migration lands rather than being silently dropped.
+    if (
+      res.status === 400 &&
+      (res.body as { detail?: { error?: string } } | null)?.detail?.error ===
+        "unknown_event_type"
+    ) {
+      Sentry.captureMessage(`syncWorker: unknown_event_type on ${gameId} event batch`, {
+        level: "warning",
+        extra: {
+          gameId,
+          eventTypes: chunk.map((r) => r.event_type),
+          body: res.body,
+        },
+      });
+      await this.applyPerRowBackoff(chunk, logConfig.UNKNOWN_EVENT_TYPE_BACKOFF_MS, now);
+      result.parked += chunk.length;
+      return true;
+    }
+    // 400 (other), 403, or other 4xx terminal — dead-letter the chunk.
     Sentry.captureMessage(`syncWorker: ${res.status} on ${gameId} event batch`, {
       level: "error",
       extra: {

--- a/frontend/src/game/_shared/syncWorker.ts
+++ b/frontend/src/game/_shared/syncWorker.ts
@@ -291,8 +291,7 @@ export class SyncWorker {
     // until the migration lands rather than being silently dropped.
     if (
       res.status === 400 &&
-      (res.body as { detail?: { error?: string } } | null)?.detail?.error ===
-        "unknown_event_type"
+      (res.body as { detail?: { error?: string } } | null)?.detail?.error === "unknown_event_type"
     ) {
       Sentry.captureMessage(`syncWorker: unknown_event_type on ${gameId} event batch`, {
         level: "warning",


### PR DESCRIPTION
## Summary

- When `POST /games/:id/events` returns `400` with `body.detail.error === "unknown_event_type"`, the batch is now **parked with a 24h fixed backoff** instead of dead-lettered. The events survive until the migration lands and the next retry window opens.
- All other 400s (malformed payload, auth mismatch, etc.) remain terminal and dead-letter immediately as before.
- `FlushResult` gains a `parked` counter distinct from `deadLettered` so callers and tests can distinguish the two outcomes.
- Sentry severity drops from `"error"` → `"warning"` for this specific code path — it's a server-side gap, not a client bug.

## Why this matters

The #746 outage silently lost 31 events across 2 users because `unknown_event_type` 400s were treated as unrecoverable. They aren't — the backend's `event_types` rows were simply missing. Once migration `0010` landed, any events that had been dead-lettered were gone forever. With this fix, events park for up to 24h × `MAX_RETRY_COUNT` (10) = ~10 days before escalating to dead-letter, giving ops time to apply a migration fix.

## Test plan

- [x] 3 new `syncWorker` tests: park path, warning severity, plain-400 still dead-letters
- [x] All 25 syncWorker tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)