### PR TITLE
fix(#716): remove in-game numeric score badges from captured piles

### DIFF
--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -90,18 +90,6 @@ export function OpponentCapturedPile({ cards, seatLabel }: OpponentProps) {
           />
         ))}
       </View>
-      {count > 0 && (
-        <View
-          style={[
-            styles.summaryPill,
-            { backgroundColor: colors.surfaceAlt, borderColor: colors.border },
-          ]}
-        >
-          <Text style={[styles.summaryCount, { color: colors.text }]}>{count}</Text>
-          <Text style={[styles.summaryDivider, { color: colors.textMuted }]}>·</Text>
-          <Text style={[styles.summaryPoints, { color: colors.error }]}>{`+${points}`}</Text>
-        </View>
-      )}
     </View>
   );
 }
@@ -163,18 +151,6 @@ export function SelfCapturedPile({ cards }: SelfProps) {
           </View>
         )}
       </View>
-      {count > 0 && (
-        <View
-          style={[
-            styles.selfPointsPill,
-            {
-              backgroundColor: alpha40(colors.error),
-            },
-          ]}
-        >
-          <Text style={[styles.selfPointsText, { color: colors.error }]}>{`+${points}`}</Text>
-        </View>
-      )}
     </View>
   );
 }
@@ -196,28 +172,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     borderWidth: 1,
   },
-  summaryPill: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderWidth: 1,
-    borderRadius: 999,
-    paddingVertical: 3,
-    paddingHorizontal: 10,
-    gap: 4,
-  },
-  summaryCount: {
-    fontSize: 14,
-    fontWeight: "700",
-  },
-  summaryDivider: {
-    fontSize: 14,
-    fontWeight: "700",
-  },
-  summaryPoints: {
-    fontSize: 12,
-    fontWeight: "700",
-  },
-
   // ── Self ───────────────────────────────────────────────────────────────────
   selfRow: {
     flexDirection: "row",
@@ -259,14 +213,5 @@ const styles = StyleSheet.create({
   selfSuit: {
     fontSize: 12,
     lineHeight: 14,
-  },
-  selfPointsPill: {
-    borderRadius: 999,
-    paddingVertical: 3,
-    paddingHorizontal: 10,
-  },
-  selfPointsText: {
-    fontSize: 12,
-    fontWeight: "700",
   },
 });

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -343,11 +343,11 @@ describe("OpponentCapturedPile", () => {
     expect(queryByText("+0")).toBeNull();
   });
 
-  it("renders count and penalty points for a mixed pile (4 cards, +16)", () => {
+  it("renders card fan without numeric badges for a mixed pile (4 cards, +16)", () => {
     const cards: Card[] = [c("hearts", 4), c("hearts", 10), c("hearts", 11), c("spades", 12)];
-    const { getByText } = wrap(<OpponentCapturedPile cards={cards} seatLabel="Top" />);
-    expect(getByText("4")).toBeTruthy();
-    expect(getByText("+16")).toBeTruthy();
+    const { queryByText } = wrap(<OpponentCapturedPile cards={cards} seatLabel="Top" />);
+    expect(queryByText("4")).toBeNull();
+    expect(queryByText("+16")).toBeNull();
   });
 
   it("exposes count and points in its accessibility label", () => {
@@ -381,10 +381,10 @@ describe("SelfCapturedPile", () => {
     expect(getAllByText("♠").length).toBeGreaterThan(0);
   });
 
-  it("renders running points pill matching the penalty calculation", () => {
+  it("does not render a numeric points badge (score badges removed per #716)", () => {
     const cards: Card[] = [c("hearts", 2), c("hearts", 5), c("hearts", 9), c("spades", 12)];
-    const { getByText } = wrap(<SelfCapturedPile cards={cards} />);
-    expect(getByText("+16")).toBeTruthy();
+    const { queryByText } = wrap(<SelfCapturedPile cards={cards} />);
+    expect(queryByText("+16")).toBeNull();
   });
 
   it("sorts captured cards by suit then rank, matching PlayerHand order", () => {


### PR DESCRIPTION
## Summary
- Removes the `summaryPill` (`count · +N pts`) badge from `OpponentCapturedPile`
- Removes the `selfPointsPill` (`+N`) badge from `SelfCapturedPile`
- Drops the now-unused `summaryPill`, `summaryCount`, `summaryDivider`, `summaryPoints`, `selfPointsPill`, and `selfPointsText` styles
- Keeps `penaltyPoints()` (still used for accessibility labels and exported for engine tests)
- Updates two tests that previously asserted badge text rendered — they now assert the badges are absent

## Test plan
- [ ] All 38 Hearts component tests pass (`npx jest src/components/hearts/__tests__/components.test.tsx`)
- [ ] Game table shows captured card fans (gradient tiles for opponents, face-up mini-cards for self) with no numeric overlays
- [ ] Accessibility labels still include count and penalty points for screen readers

Part of #702 umbrella — PR-A of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)