### PR TITLE
feat(scoreboard): Cascade scoreboard (#720)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -68,7 +68,9 @@ export type HomeStackParamList = {
   Solitaire: undefined;
   Hearts: undefined;
   Sudoku: undefined;
-  Scoreboard: { gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" | "cascade" };
+  Scoreboard: {
+    gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" | "cascade";
+  };
 };
 
 export type ProfileStackParamList = {
@@ -212,11 +214,11 @@ function AppInner() {
                   <SolitaireScoreboardProvider>
                     <SudokuScoreboardProvider>
                       <CascadeScoreboardProvider>
-                      <NavigationContainer>
-                        <Stack.Navigator screenOptions={{ headerShown: false }}>
-                          <Stack.Screen name="MainTabs" component={MainTabs} />
-                        </Stack.Navigator>
-                      </NavigationContainer>
+                        <NavigationContainer>
+                          <Stack.Navigator screenOptions={{ headerShown: false }}>
+                            <Stack.Screen name="MainTabs" component={MainTabs} />
+                          </Stack.Navigator>
+                        </NavigationContainer>
                       </CascadeScoreboardProvider>
                     </SudokuScoreboardProvider>
                   </SolitaireScoreboardProvider>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -30,6 +30,7 @@ import { YachtScorecardProvider } from "./src/game/yacht/ScorecardContext";
 import { Twenty48ScoreboardProvider } from "./src/game/twenty48/Twenty48ScoreboardContext";
 import { SolitaireScoreboardProvider } from "./src/game/solitaire/SolitaireScoreboardContext";
 import { SudokuScoreboardProvider } from "./src/game/sudoku/SudokuScoreboardContext";
+import { CascadeScoreboardProvider } from "./src/game/cascade/CascadeScoreboardContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
 import { installSentryConsoleErrorCapture } from "./src/utils/sentryConsoleError";
 import { LazyScreens } from "./src/utils/lazyScreens";
@@ -67,7 +68,7 @@ export type HomeStackParamList = {
   Solitaire: undefined;
   Hearts: undefined;
   Sudoku: undefined;
-  Scoreboard: { gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" };
+  Scoreboard: { gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" | "cascade" };
 };
 
 export type ProfileStackParamList = {
@@ -210,11 +211,13 @@ function AppInner() {
                 <Twenty48ScoreboardProvider>
                   <SolitaireScoreboardProvider>
                     <SudokuScoreboardProvider>
+                      <CascadeScoreboardProvider>
                       <NavigationContainer>
                         <Stack.Navigator screenOptions={{ headerShown: false }}>
                           <Stack.Screen name="MainTabs" component={MainTabs} />
                         </Stack.Navigator>
                       </NavigationContainer>
+                      </CascadeScoreboardProvider>
                     </SudokuScoreboardProvider>
                   </SolitaireScoreboardProvider>
                 </Twenty48ScoreboardProvider>

--- a/frontend/src/components/scoreboard/CascadeScoreboard.tsx
+++ b/frontend/src/components/scoreboard/CascadeScoreboard.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import HeroStatScoreboard from "./HeroStatScoreboard";
+import type { CascadeScoreboardSnapshot } from "../../game/cascade/CascadeScoreboardContext";
+
+interface Props {
+  snapshot: CascadeScoreboardSnapshot;
+}
+
+export default function CascadeScoreboard({ snapshot }: Props) {
+  const { t } = useTranslation("cascade");
+
+  const heroValue = snapshot.hasGame ? snapshot.score.toLocaleString("en-US") : "—";
+  const heroSub = snapshot.hasGame
+    ? t("scoreboard.heroSub", { bestFruit: snapshot.bestFruitName, merges: snapshot.mergeCount })
+    : t("scoreboard.heroSubEmpty");
+
+  const cards = [
+    {
+      key: "bestScore",
+      label: t("scoreboard.bestScore"),
+      value: snapshot.bestScore > 0 ? snapshot.bestScore.toLocaleString("en-US") : "—",
+      accent: true,
+    },
+    {
+      key: "bestFruit",
+      label: t("scoreboard.bestFruit"),
+      value: snapshot.hasGame ? snapshot.bestFruitName : "—",
+    },
+    {
+      key: "gamesPlayed",
+      label: t("scoreboard.gamesPlayed"),
+      value: snapshot.gamesPlayed > 0 ? String(snapshot.gamesPlayed) : "—",
+    },
+    {
+      key: "totalMerges",
+      label: t("scoreboard.totalMerges"),
+      value: snapshot.mergeCount > 0 ? String(snapshot.mergeCount) : "—",
+    },
+  ] as const;
+
+  return (
+    <HeroStatScoreboard
+      heroLabel={t("scoreboard.heroLabel")}
+      heroValue={heroValue}
+      heroSub={heroSub}
+      cards={cards}
+    />
+  );
+}

--- a/frontend/src/game/cascade/CascadeScoreboardContext.tsx
+++ b/frontend/src/game/cascade/CascadeScoreboardContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface CascadeScoreboardSnapshot {
+  score: number;
+  bestScore: number;
+  bestFruitName: string;
+  mergeCount: number;
+  gamesPlayed: number;
+  hasGame: boolean;
+}
+
+const initial: CascadeScoreboardSnapshot = {
+  score: 0,
+  bestScore: 0,
+  bestFruitName: "—",
+  mergeCount: 0,
+  gamesPlayed: 0,
+  hasGame: false,
+};
+
+interface ContextValue {
+  snapshot: CascadeScoreboardSnapshot;
+  setSnapshot: (s: CascadeScoreboardSnapshot) => void;
+}
+
+const CascadeScoreboardContext = createContext<ContextValue | null>(null);
+
+export function CascadeScoreboardProvider({ children }: { children: React.ReactNode }) {
+  const [snapshot, setSnapshot] = useState(initial);
+  return (
+    <CascadeScoreboardContext.Provider value={{ snapshot, setSnapshot }}>
+      {children}
+    </CascadeScoreboardContext.Provider>
+  );
+}
+
+export function useCascadeScoreboard() {
+  const ctx = useContext(CascadeScoreboardContext);
+  if (!ctx) throw new Error("useCascadeScoreboard must be inside CascadeScoreboardProvider");
+  return ctx;
+}

--- a/frontend/src/i18n/locales/_meta/cascade.meta.json
+++ b/frontend/src/i18n/locales/_meta/cascade.meta.json
@@ -223,5 +223,68 @@
     "placeholders": [],
     "doNotTranslate": [],
     "notes": null
+  },
+  "scoreboard.heroLabel": {
+    "component": "CascadeScoreboard",
+    "description": "Short uppercase label above the hero score value.",
+    "tone": "functional",
+    "characterLimit": 8,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "scoreboard.heroSub": {
+    "component": "CascadeScoreboard",
+    "description": "Sub-line below the hero score — shows best fruit and merge count.",
+    "tone": "neutral",
+    "characterLimit": 50,
+    "placeholders": ["{{bestFruit}}", "{{merges}}"],
+    "doNotTranslate": [],
+    "notes": "{{bestFruit}} is a fruit name like Cherry — do not translate fruit names."
+  },
+  "scoreboard.heroSubEmpty": {
+    "component": "CascadeScoreboard",
+    "description": "Sub-line shown when no game has been played yet.",
+    "tone": "neutral",
+    "characterLimit": 30,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "scoreboard.bestScore": {
+    "component": "CascadeScoreboard",
+    "description": "Stat card label for the all-time best score this session.",
+    "tone": "functional",
+    "characterLimit": 15,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "scoreboard.bestFruit": {
+    "component": "CascadeScoreboard",
+    "description": "Stat card label for the highest-tier fruit merged this session.",
+    "tone": "functional",
+    "characterLimit": 12,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "scoreboard.gamesPlayed": {
+    "component": "CascadeScoreboard",
+    "description": "Stat card label for the number of games completed this session.",
+    "tone": "functional",
+    "characterLimit": 14,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "scoreboard.totalMerges": {
+    "component": "CascadeScoreboard",
+    "description": "Stat card label for the total merges in the current game.",
+    "tone": "functional",
+    "characterLimit": 14,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
   }
 }

--- a/frontend/src/i18n/locales/ar/cascade.json
+++ b/frontend/src/i18n/locales/ar/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "تم الحفظ! #{{rank}}",
   "gameOver.playAgain": "العب مجددًا",
   "gameOver.playAgainButton": "العب مرة أخرى",
-  "gameOver.savedLocally": "تم الحفظ محليًا — سيتم الإرسال عند الاتصال"
+  "gameOver.savedLocally": "تم الحفظ محليًا — سيتم الإرسال عند الاتصال",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/de/cascade.json
+++ b/frontend/src/i18n/locales/de/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Gespeichert! #{{rank}}",
   "gameOver.playAgain": "Nochmal spielen",
   "gameOver.playAgainButton": "Nochmal!",
-  "gameOver.savedLocally": "Lokal gespeichert — wird online übermittelt"
+  "gameOver.savedLocally": "Lokal gespeichert — wird online übermittelt",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/en/cascade.json
+++ b/frontend/src/i18n/locales/en/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Saved! #{{rank}}",
   "gameOver.savedLocally": "Saved locally — will submit when online",
   "gameOver.playAgain": "Play again",
-  "gameOver.playAgainButton": "Play Again"
+  "gameOver.playAgainButton": "Play Again",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/es/cascade.json
+++ b/frontend/src/i18n/locales/es/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "¡Guardado! #{{rank}}",
   "gameOver.playAgain": "Jugar de nuevo",
   "gameOver.playAgainButton": "Jugar otra vez",
-  "gameOver.savedLocally": "Guardado localmente — se enviará al estar en línea"
+  "gameOver.savedLocally": "Guardado localmente — se enviará al estar en línea",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/fr-CA/cascade.json
+++ b/frontend/src/i18n/locales/fr-CA/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Enregistré! #{{rank}}",
   "gameOver.playAgain": "Rejouer",
   "gameOver.playAgainButton": "Rejouer",
-  "gameOver.savedLocally": "Enregistré localement — sera envoyé une fois en ligne"
+  "gameOver.savedLocally": "Enregistré localement — sera envoyé une fois en ligne",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/he/cascade.json
+++ b/frontend/src/i18n/locales/he/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "נשמר! #{{rank}}",
   "gameOver.playAgain": "שחק שוב",
   "gameOver.playAgainButton": "שחק שוב",
-  "gameOver.savedLocally": "נשמר מקומית — יישלח כשמחובר"
+  "gameOver.savedLocally": "נשמר מקומית — יישלח כשמחובר",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/hi/cascade.json
+++ b/frontend/src/i18n/locales/hi/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "सेव्ड! #{{rank}}",
   "gameOver.playAgain": "फिर से खेलें",
   "gameOver.playAgainButton": "फिर से खेलें",
-  "gameOver.savedLocally": "स्थानीय रूप से सहेजा गया — ऑनलाइन होने पर भेजा जाएगा"
+  "gameOver.savedLocally": "स्थानीय रूप से सहेजा गया — ऑनलाइन होने पर भेजा जाएगा",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/ja/cascade.json
+++ b/frontend/src/i18n/locales/ja/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "保存完了！#{{rank}}",
   "gameOver.playAgain": "もう一度プレイ",
   "gameOver.playAgainButton": "再挑戦",
-  "gameOver.savedLocally": "ローカルに保存しました — オンライン時に送信されます"
+  "gameOver.savedLocally": "ローカルに保存しました — オンライン時に送信されます",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/ko/cascade.json
+++ b/frontend/src/i18n/locales/ko/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "저장 완료! #{{rank}}",
   "gameOver.playAgain": "다시 하기",
   "gameOver.playAgainButton": "다시 플레이",
-  "gameOver.savedLocally": "로컬에 저장됨 — 온라인 시 전송됩니다"
+  "gameOver.savedLocally": "로컬에 저장됨 — 온라인 시 전송됩니다",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/nl/cascade.json
+++ b/frontend/src/i18n/locales/nl/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Opgeslagen! #{{rank}}",
   "gameOver.playAgain": "Opnieuw spelen",
   "gameOver.playAgainButton": "Nog een keer",
-  "gameOver.savedLocally": "Lokaal opgeslagen — wordt online verzonden"
+  "gameOver.savedLocally": "Lokaal opgeslagen — wordt online verzonden",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/pt/cascade.json
+++ b/frontend/src/i18n/locales/pt/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Salvo! #{{rank}}",
   "gameOver.playAgain": "Jogar de novo",
   "gameOver.playAgainButton": "Jogar Novamente",
-  "gameOver.savedLocally": "Salvo localmente — será enviado quando online"
+  "gameOver.savedLocally": "Salvo localmente — será enviado quando online",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/ru/cascade.json
+++ b/frontend/src/i18n/locales/ru/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "Сохранено! №{{rank}}",
   "gameOver.playAgain": "Играть снова",
   "gameOver.playAgainButton": "Играть ещё",
-  "gameOver.savedLocally": "Сохранено локально — будет отправлено онлайн"
+  "gameOver.savedLocally": "Сохранено локально — будет отправлено онлайн",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/i18n/locales/zh/cascade.json
+++ b/frontend/src/i18n/locales/zh/cascade.json
@@ -24,5 +24,12 @@
   "gameOver.savedConfirmation": "已保存！第{{rank}}名",
   "gameOver.playAgain": "再玩一次",
   "gameOver.playAgainButton": "再来一局",
-  "gameOver.savedLocally": "已在本地保存 — 联网后将提交"
+  "gameOver.savedLocally": "已在本地保存 — 联网后将提交",
+  "scoreboard.heroLabel": "SCORE",
+  "scoreboard.heroSub": "Best fruit: {{bestFruit}} · {{merges}} merges",
+  "scoreboard.heroSubEmpty": "No games played yet",
+  "scoreboard.bestScore": "All-Time Best",
+  "scoreboard.bestFruit": "Best Fruit",
+  "scoreboard.gamesPlayed": "Games Played",
+  "scoreboard.totalMerges": "Total Merges"
 }

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -25,6 +25,7 @@ import {
   clearGame as clearCascadeGame,
   CascadeGameSnapshot,
 } from "../game/cascade/storage";
+import { useCascadeScoreboard } from "../game/cascade/CascadeScoreboardContext";
 
 /** Throttle for save-during-play — saves at most this often. */
 const SAVE_THROTTLE_MS = 2000;
@@ -63,6 +64,12 @@ function CascadeGame() {
     complete: syncComplete,
     getGameId,
   } = useGameSync("cascade");
+  const { setSnapshot: setScoreboardSnapshot } = useCascadeScoreboard();
+  const bestScoreRef = useRef(0);
+  const bestFruitTierRef = useRef(-1);
+  const bestFruitNameRef = useRef("—");
+  const gamesPlayedRef = useRef(0);
+
   // Holds the game ID captured at game-over so GameOverOverlay can PATCH /cascade/score/{id}.
   const completedGameIdRef = useRef<string | null>(null);
   const gameStartTimeRef = useRef<number>(Date.now());
@@ -103,6 +110,17 @@ function CascadeGame() {
     },
     [syncComplete]
   );
+
+  const pushScoreboardSnapshot = useCallback(() => {
+    setScoreboardSnapshot({
+      score: scoreRef.current,
+      bestScore: bestScoreRef.current,
+      bestFruitName: bestFruitNameRef.current,
+      mergeCount: mergeCountRef.current,
+      gamesPlayed: gamesPlayedRef.current,
+      hasGame: true,
+    });
+  }, [setScoreboardSnapshot]);
 
   // Start session on mount. Unmount cleanup is handled by useGameSync.
   useEffect(() => {
@@ -237,13 +255,18 @@ function CascadeGame() {
       const merged = activeFruitSet.fruits[event.tier];
       if (merged) {
         canvasRef.current?.announceEvent(t("cascade:event.merged", { fruit: merged.name }));
+        if (event.tier > bestFruitTierRef.current) {
+          bestFruitTierRef.current = event.tier;
+          bestFruitNameRef.current = merged.name;
+        }
       }
+      pushScoreboardSnapshot();
       // #216 — merges are the highest-value save trigger. A player who
       // just merged up a tier definitely wants that progress preserved
       // across an accidental reload.
       saveGameThrottled();
     },
-    [activeFruitSet, t, saveGameThrottled, syncEnqueue]
+    [activeFruitSet, t, saveGameThrottled, syncEnqueue, pushScoreboardSnapshot]
   );
 
   const handleGameOver = useCallback(() => {
@@ -256,7 +279,12 @@ function CascadeGame() {
     // #216 — game over: clear the saved snapshot so the next mount
     // starts with a fresh board instead of resuming a lost game.
     clearCascadeGame().catch(() => {});
-  }, [t, endInstrumentedSession, getGameId]);
+    gamesPlayedRef.current += 1;
+    if (scoreRef.current > bestScoreRef.current) {
+      bestScoreRef.current = scoreRef.current;
+    }
+    pushScoreboardSnapshot();
+  }, [t, endInstrumentedSession, getGameId, pushScoreboardSnapshot]);
 
   const handleTap = useCallback(
     (x: number) => {
@@ -377,6 +405,7 @@ function CascadeGame() {
     hasLoadedRef.current = true; // prevent onReady from re-applying any stale pending load
     pendingLoadRef.current = null;
     startInstrumentedSession(activeFruitSetRef.current.id);
+    pushScoreboardSnapshot();
   }
 
   const queue = queueRef.current;
@@ -396,6 +425,7 @@ function CascadeGame() {
       requireBack
       onBack={() => navigation.popToTop()}
       onNewGame={handleRestart}
+      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "cascade" })}
       style={{
         paddingBottom: Math.max(insets.bottom, 16),
         paddingLeft: Math.max(insets.left, 16),

--- a/frontend/src/screens/ScoreboardScreen.tsx
+++ b/frontend/src/screens/ScoreboardScreen.tsx
@@ -11,12 +11,14 @@ import BlackjackScoreboard from "../components/scoreboard/BlackjackScoreboard";
 import Twenty48Scoreboard from "../components/scoreboard/Twenty48Scoreboard";
 import SolitaireScoreboard from "../components/scoreboard/SolitaireScoreboard";
 import SudokuScoreboard from "../components/scoreboard/SudokuScoreboard";
+import CascadeScoreboard from "../components/scoreboard/CascadeScoreboard";
 import { useHeartsRounds } from "../game/hearts/RoundsContext";
 import { useYachtScorecard } from "../game/yacht/ScorecardContext";
 import { useBlackjackSessionStats } from "../game/blackjack/BlackjackGameContext";
 import { useTwenty48Scoreboard } from "../game/twenty48/Twenty48ScoreboardContext";
 import { useSolitaireScoreboard } from "../game/solitaire/SolitaireScoreboardContext";
 import { useSudokuScoreboard } from "../game/sudoku/SudokuScoreboardContext";
+import { useCascadeScoreboard } from "../game/cascade/CascadeScoreboardContext";
 import type { HomeStackParamList } from "../../App";
 
 type GameKey = HomeStackParamList["Scoreboard"]["gameKey"];
@@ -59,6 +61,11 @@ function SudokuScoreboardSection() {
   return <SudokuScoreboard snapshot={snapshot} />;
 }
 
+function CascadeScoreboardSection() {
+  const { snapshot } = useCascadeScoreboard();
+  return <CascadeScoreboard snapshot={snapshot} />;
+}
+
 function UnknownScoreboardFallback({ gameKey }: { gameKey: string }) {
   const { colors } = useTheme();
   return (
@@ -95,6 +102,9 @@ export default function ScoreboardScreen() {
       break;
     case "sudoku":
       body = <SudokuScoreboardSection />;
+      break;
+    case "cascade":
+      body = <CascadeScoreboardSection />;
       break;
     default:
       body = <UnknownScoreboardFallback gameKey={gameKey} />;

--- a/frontend/src/screens/__tests__/CascadeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/CascadeScreen.test.tsx
@@ -12,6 +12,7 @@
 import React from "react";
 import { act, create } from "react-test-renderer";
 import CascadeScreen from "../CascadeScreen";
+import { CascadeScoreboardProvider } from "../../game/cascade/CascadeScoreboardContext";
 
 jest.mock("expo-blur", () => ({
   BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -103,7 +104,11 @@ const mockNavigation = { goBack: jest.fn() } as unknown as Parameters<
 function renderScreen() {
   let renderer!: ReturnType<typeof create>;
   act(() => {
-    renderer = create(<CascadeScreen navigation={mockNavigation} />);
+    renderer = create(
+      <CascadeScoreboardProvider>
+        <CascadeScreen navigation={mockNavigation} />
+      </CascadeScoreboardProvider>
+    );
   });
 
   // Trigger onLayout so the canvas renders (containerWidth/canvasHeight default to 0)


### PR DESCRIPTION
## Summary
- Adds `CascadeScoreboardContext` with session-tracked snapshot (score, best score, best fruit, merge count, games played)
- Adds `CascadeScoreboard` component using the shared `<HeroStatScoreboard>` pattern
- Wires scoreboard into `CascadeScreen` via `onOpenScoreboard` on `<GameShell>` + stat tracking in `handleMerge` / `handleGameOver` / `handleRestart`
- Adds `"cascade"` to `HomeStackParamList` and registers `CascadeScoreboardProvider` in `App.tsx`
- Adds 7 scoreboard i18n keys to all 13 locale `cascade.json` files + `_meta`

## Test plan
- [x] All 1494 existing tests pass
- [ ] Open Cascade → tap `⋯` menu → Scoreboard item appears and navigates correctly
- [ ] Play a game, merge some fruits → scoreboard shows current score, best fruit name, merge count
- [ ] After game over → Games Played increments, All-Time Best updates if score is higher
- [ ] New game via menu → score/merges reset; session bests persist
- [ ] Both light and dark themes render correctly

Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)