### PR TITLE
feat(blackjack): split UI side-by-side hands + per-hand result banners (#713)

### DIFF
--- a/frontend/src/components/blackjack/BlackjackTable.tsx
+++ b/frontend/src/components/blackjack/BlackjackTable.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import { HandResponse } from "../../game/blackjack/types";
 import HandDisplay from "./HandDisplay";
+import ResultBanner from "./ResultBanner";
 
 interface Props {
   playerHand: HandResponse;
@@ -17,6 +18,8 @@ interface Props {
   handBets?: number[];
   /** Per-hand outcomes (when split, in result phase). */
   handOutcomes?: (string | null)[];
+  /** Per-hand payouts (when split, in result phase). */
+  handPayouts?: number[];
   /** Shrink card sizes and table padding on short-height viewports. */
   compact?: boolean;
 }
@@ -29,6 +32,7 @@ export default function BlackjackTable({
   activeHandIndex = 0,
   handBets,
   handOutcomes,
+  handPayouts,
   compact = false,
 }: Props) {
   const { t } = useTranslation("blackjack");
@@ -74,25 +78,11 @@ export default function BlackjackTable({
                 ]}
               >
                 <HandDisplay hand={hand} label={label} variant="player" compact maxPerRow={3} />
-                {bet != null && (
+                {bet != null && phase !== "result" && (
                   <Text style={[styles.handBet, { color: colors.textMuted }]}>{bet}</Text>
                 )}
-                {outcome && phase === "result" && (
-                  <Text
-                    style={[
-                      styles.handOutcome,
-                      {
-                        color:
-                          outcome === "win"
-                            ? colors.bonus
-                            : outcome === "lose"
-                              ? colors.error
-                              : colors.textMuted,
-                      },
-                    ]}
-                  >
-                    {t(`outcome.${outcome}` as Parameters<typeof t>[0])}
-                  </Text>
+                {outcome != null && phase === "result" && (
+                  <ResultBanner outcome={outcome} payout={handPayouts?.[i] ?? 0} compact />
                 )}
                 {isActive && (
                   <Text style={[styles.activeLabel, { color: colors.accent }]}>
@@ -161,10 +151,6 @@ const styles = StyleSheet.create({
   handBet: {
     fontSize: 12,
     fontWeight: "600",
-  },
-  handOutcome: {
-    fontSize: 13,
-    fontWeight: "700",
   },
   activeLabel: {
     fontSize: 11,

--- a/frontend/src/components/blackjack/ResultBanner.tsx
+++ b/frontend/src/components/blackjack/ResultBanner.tsx
@@ -6,9 +6,10 @@ import { useTheme } from "../../theme/ThemeContext";
 interface Props {
   outcome: string;
   payout: number;
+  compact?: boolean;
 }
 
-export default function ResultBanner({ outcome, payout }: Props) {
+export default function ResultBanner({ outcome, payout, compact = false }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
 
@@ -49,6 +50,7 @@ export default function ResultBanner({ outcome, payout }: Props) {
     <View
       style={[
         styles.container,
+        compact && styles.containerCompact,
         {
           backgroundColor: colors.surfaceHigh,
           borderColor: colors.border,
@@ -56,9 +58,11 @@ export default function ResultBanner({ outcome, payout }: Props) {
         },
       ]}
     >
-      <Text style={[styles.outcome, { color: accentColor }]}>{outcomeText}</Text>
+      <Text style={[styles.outcome, compact && styles.outcomeCompact, { color: accentColor }]}>
+        {outcomeText}
+      </Text>
       <Text
-        style={[styles.payout, { color: payoutColor }]}
+        style={[styles.payout, compact && styles.payoutCompact, { color: payoutColor }]}
         accessibilityLabel={t("payout.accessibilityLabel", { amount: payout })}
       >
         {payoutText}
@@ -79,15 +83,26 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     gap: 6,
   },
+  containerCompact: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    gap: 4,
+  },
   outcome: {
-    fontSize: 30,
-    fontWeight: "800",
+    fontSize: 26,
+    fontWeight: "700",
     textAlign: "center",
     letterSpacing: -0.5,
   },
+  outcomeCompact: {
+    fontSize: 18,
+  },
   payout: {
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: "700",
     textAlign: "center",
+  },
+  payoutCompact: {
+    fontSize: 13,
   },
 });

--- a/frontend/src/i18n/locales/ar/blackjack.json
+++ b/frontend/src/i18n/locales/ar/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "يدك",
   "hand.dealer": "يد الموزع",
   "hand.playerHand": "اليد {{number}}",
-  "hand.activeIndicator": "(نشطة)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "القيمة: {{value}}",
   "hand.softValue": "ناعم {{value}}",
   "hand.valueHidden": "القيمة: ؟",

--- a/frontend/src/i18n/locales/de/blackjack.json
+++ b/frontend/src/i18n/locales/de/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Deine Hand",
   "hand.dealer": "Geber Hand",
   "hand.playerHand": "Hand {{number}}",
-  "hand.activeIndicator": "(Aktiv)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Wert: {{value}}",
   "hand.softValue": "Soft {{value}}",
   "hand.valueHidden": "Wert: ?",

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -2,15 +2,12 @@
   "game.title": "Blackjack",
   "game.description": "Beat the dealer. Don't bust.",
   "game.playLabel": "Play Blackjack",
-
   "chips.display": "{{chips}} chips",
   "chips.accessibilityLabel": "You have {{chips}} chips",
-
   "bet.label": "Bet",
   "bet.decreaseLabel": "Decrease bet by 10",
   "bet.increaseLabel": "Increase bet by 10",
   "bet.accessibilityLabel": "Current bet: {{amount}} chips",
-
   "actions.deal": "Deal",
   "actions.dealLabel": "Deal cards with {{amount}}-chip bet",
   "actions.hit": "Hit",
@@ -27,47 +24,39 @@
   "actions.nextHandLabel": "Start the next hand",
   "actions.quit": "Quit",
   "actions.quitLabel": "Quit and return to home screen",
-
   "hand.player": "Your Hand",
   "hand.dealer": "Dealer's Hand",
   "hand.playerHand": "Hand {{number}}",
-  "hand.activeIndicator": "(Active)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Value: {{value}}",
   "hand.softValue": "Soft {{value}}",
   "hand.valueHidden": "Value: ?",
-
   "card.accessibilityLabel": "{{rank}} of {{suit}}",
   "card.faceDown": "Face-down card",
   "card.suit.spades": "Spades",
   "card.suit.hearts": "Hearts",
   "card.suit.diamonds": "Diamonds",
   "card.suit.clubs": "Clubs",
-
   "outcome.blackjack": "Blackjack!",
   "outcome.win": "You Win!",
   "outcome.push": "Push",
   "outcome.lose": "You Lose",
-
   "payout.positive": "+{{amount}} chips",
   "payout.negative": "{{amount}} chips",
   "payout.zero": "No change",
   "payout.accessibilityLabel": "Payout: {{amount}} chips",
-
   "phase.betting": "Place your bet",
   "phase.player": "Your turn",
   "phase.result": "Round over",
-
   "gameOver.title": "Out of Chips",
   "gameOver.body": "You've run out of chips. Better luck next time!",
   "gameOver.playAgain": "Play Again",
   "gameOver.playAgainLabel": "Start a new session with 1000 chips",
   "gameOver.home": "Home",
   "gameOver.homeLabel": "Return to home screen",
-
   "header.brandName": "BC Arcade",
   "header.bankrollLabel": "Bankroll",
   "header.bankrollAccessibilityLabel": "Bankroll: {{chips}} chips",
-
   "hud.currentPot": "Pot",
   "hud.currentPotAccessibilityLabel": "Current pot: {{amount}} chips",
   "hud.lastWin": "Last",
@@ -76,17 +65,14 @@
   "hud.lastWinZero": "Push",
   "hud.lastWinNull": "—",
   "hud.lastWinAccessibilityLabel": "Last win: {{result}}",
-
   "betting.clearBet": "Clear",
   "betting.clearBetLabel": "Clear bet — reset to zero",
   "betting.tableLimits": "Table Limits",
   "betting.tableLimitsRange": "{{min}}–{{max}} chips",
   "betting.tapToAdd": "Tap chips to bet",
-
   "chip.addLabel": "Add {{amount}} to bet",
   "chip.disabledLabel": "{{amount}}-chip not available",
   "chip.vipCredits": "VIP",
-
   "rules.title": "Table Rules",
   "rules.toggleLabel": "Toggle table rules",
   "rules.dealerSoft17": "Dealer soft 17",

--- a/frontend/src/i18n/locales/es/blackjack.json
+++ b/frontend/src/i18n/locales/es/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Tu mano",
   "hand.dealer": "Mano del crupier",
   "hand.playerHand": "Mano {{number}}",
-  "hand.activeIndicator": "(Activa)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Valor: {{value}}",
   "hand.softValue": "Suave {{value}}",
   "hand.valueHidden": "Valor: ?",

--- a/frontend/src/i18n/locales/fr-CA/blackjack.json
+++ b/frontend/src/i18n/locales/fr-CA/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Votre main",
   "hand.dealer": "Main du croupier",
   "hand.playerHand": "Main {{number}}",
-  "hand.activeIndicator": "(Active)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Valeur : {{value}}",
   "hand.softValue": "Souple {{value}}",
   "hand.valueHidden": "Valeur : ?",

--- a/frontend/src/i18n/locales/he/blackjack.json
+++ b/frontend/src/i18n/locales/he/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "היד שלך",
   "hand.dealer": "היד של הדילר",
   "hand.playerHand": "יד {{number}}",
-  "hand.activeIndicator": "(פעילה)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "ערך: {{value}}",
   "hand.softValue": "רך {{value}}",
   "hand.valueHidden": "ערך: ?",

--- a/frontend/src/i18n/locales/hi/blackjack.json
+++ b/frontend/src/i18n/locales/hi/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "आपके पत्ते",
   "hand.dealer": "डीलर के पत्ते",
   "hand.playerHand": "हाथ {{number}}",
-  "hand.activeIndicator": "(सक्रिय)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "मूल्य: {{value}}",
   "hand.softValue": "सॉफ्ट {{value}}",
   "hand.valueHidden": "मूल्य: ?",

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "あなたの手札",
   "hand.dealer": "ディーラーの手札",
   "hand.playerHand": "ハンド {{number}}",
-  "hand.activeIndicator": "(アクティブ)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "合計: {{value}}",
   "hand.softValue": "ソフト {{value}}",
   "hand.valueHidden": "合計: ?",

--- a/frontend/src/i18n/locales/ko/blackjack.json
+++ b/frontend/src/i18n/locales/ko/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "내 패",
   "hand.dealer": "딜러 패",
   "hand.playerHand": "핸드 {{number}}",
-  "hand.activeIndicator": "(활성)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "점수: {{value}}",
   "hand.softValue": "소프트 {{value}}",
   "hand.valueHidden": "점수: ?",

--- a/frontend/src/i18n/locales/nl/blackjack.json
+++ b/frontend/src/i18n/locales/nl/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Jouw Hand",
   "hand.dealer": "Hand Dealer",
   "hand.playerHand": "Hand {{number}}",
-  "hand.activeIndicator": "(Actief)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Waarde: {{value}}",
   "hand.softValue": "Zacht {{value}}",
   "hand.valueHidden": "Waarde: ?",

--- a/frontend/src/i18n/locales/pt/blackjack.json
+++ b/frontend/src/i18n/locales/pt/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Sua Mão",
   "hand.dealer": "Mão do Dealer",
   "hand.playerHand": "Mão {{number}}",
-  "hand.activeIndicator": "(Ativa)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Valor: {{value}}",
   "hand.softValue": "Suave {{value}}",
   "hand.valueHidden": "Valor: ?",

--- a/frontend/src/i18n/locales/ru/blackjack.json
+++ b/frontend/src/i18n/locales/ru/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "Ваши карты",
   "hand.dealer": "Карты дилера",
   "hand.playerHand": "Рука {{number}}",
-  "hand.activeIndicator": "(Активная)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "Сумма: {{value}}",
   "hand.softValue": "Мягкий {{value}}",
   "hand.valueHidden": "Сумма: ?",

--- a/frontend/src/i18n/locales/zh/blackjack.json
+++ b/frontend/src/i18n/locales/zh/blackjack.json
@@ -27,7 +27,7 @@
   "hand.player": "你的牌",
   "hand.dealer": "庄家的牌",
   "hand.playerHand": "手牌 {{number}}",
-  "hand.activeIndicator": "(当前)",
+  "hand.activeIndicator": "● Playing",
   "hand.value": "点数: {{value}}",
   "hand.softValue": "软 {{value}}",
   "hand.valueHidden": "点数: ?",

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -144,6 +144,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
               activeHandIndex={state.active_hand_index}
               handBets={state.hand_bets}
               handOutcomes={state.hand_outcomes}
+              handPayouts={state.hand_payouts}
               compact={isCompact}
             />
           </View>
@@ -157,7 +158,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
       <View style={[styles.controls, isCompact && styles.controlsCompact]}>
         {state?.phase === "result" && (
           <>
-            <ResultBanner outcome={state.outcome!} payout={state.payout} />
+            {!isSplit && <ResultBanner outcome={state.outcome!} payout={state.payout} />}
 
             <View style={styles.resultActions}>
               <Pressable


### PR DESCRIPTION
## Summary
- Side-by-side split hand panels now show a compact `ResultBanner` per hand (outcome + payout, accent-coloured top border) instead of a plain text label — covers all 4 outcomes × both hands
- Single-hand result still shows the full-width `ResultBanner` beneath the table; aggregate banner is hidden in split mode since per-hand banners replace it
- Active hand badge updated from locale-specific "(Active)" variants to `"● Playing"` across all 13 locales (per spec)
- `ResultBanner` gains a `compact` prop (18px/13px vs 26px/18px) so split panels stay legible without crowding the card area

## Test plan
- [ ] Deal a pair, split, hit each hand, stand through both — two correct result banners appear side by side
- [ ] Single-hand outcomes (BJ / Win / Push / Lose) each render the appropriate full-width banner with correct colour and payout
- [ ] All four outcome × two hand combinations work in split (win/win, win/lose, push/push, etc.)
- [ ] Active hand shows `● Playing` glow badge during player phase; badge disappears on result
- [ ] All 247 blackjack Jest tests pass (`npx jest --testPathPattern="blackjack"`)
- [ ] Compact viewport (< 780dp height) renders without overlap

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)