### PR TITLE
feat(#771): sound infrastructure — expo-audio hook + global mute

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -23,6 +23,7 @@ import { GameState } from "./src/game/yacht/types";
 import { ThemeProvider } from "./src/theme/ThemeContext";
 import { useHtmlAttributes } from "./src/i18n/useHtmlAttributes";
 import { NetworkProvider } from "./src/game/_shared/NetworkContext";
+import { SoundProvider } from "./src/game/_shared/SoundContext";
 import { CardDeckProvider } from "./src/game/_shared/decks/CardDeckContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
 import { HeartsRoundsProvider } from "./src/game/hearts/RoundsContext";
@@ -205,6 +206,7 @@ function AppInner() {
   useHtmlAttributes();
   return (
     <NetworkProvider>
+      <SoundProvider>
       <ThemeProvider>
         <CardDeckProvider>
           <BlackjackGameProvider>
@@ -228,6 +230,7 @@ function AppInner() {
           </BlackjackGameProvider>
         </CardDeckProvider>
       </ThemeProvider>
+      </SoundProvider>
     </NetworkProvider>
   );
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -207,29 +207,29 @@ function AppInner() {
   return (
     <NetworkProvider>
       <SoundProvider>
-      <ThemeProvider>
-        <CardDeckProvider>
-          <BlackjackGameProvider>
-            <HeartsRoundsProvider>
-              <YachtScorecardProvider>
-                <Twenty48ScoreboardProvider>
-                  <SolitaireScoreboardProvider>
-                    <SudokuScoreboardProvider>
-                      <CascadeScoreboardProvider>
-                        <NavigationContainer>
-                          <Stack.Navigator screenOptions={{ headerShown: false }}>
-                            <Stack.Screen name="MainTabs" component={MainTabs} />
-                          </Stack.Navigator>
-                        </NavigationContainer>
-                      </CascadeScoreboardProvider>
-                    </SudokuScoreboardProvider>
-                  </SolitaireScoreboardProvider>
-                </Twenty48ScoreboardProvider>
-              </YachtScorecardProvider>
-            </HeartsRoundsProvider>
-          </BlackjackGameProvider>
-        </CardDeckProvider>
-      </ThemeProvider>
+        <ThemeProvider>
+          <CardDeckProvider>
+            <BlackjackGameProvider>
+              <HeartsRoundsProvider>
+                <YachtScorecardProvider>
+                  <Twenty48ScoreboardProvider>
+                    <SolitaireScoreboardProvider>
+                      <SudokuScoreboardProvider>
+                        <CascadeScoreboardProvider>
+                          <NavigationContainer>
+                            <Stack.Navigator screenOptions={{ headerShown: false }}>
+                              <Stack.Screen name="MainTabs" component={MainTabs} />
+                            </Stack.Navigator>
+                          </NavigationContainer>
+                        </CascadeScoreboardProvider>
+                      </SudokuScoreboardProvider>
+                    </SolitaireScoreboardProvider>
+                  </Twenty48ScoreboardProvider>
+                </YachtScorecardProvider>
+              </HeartsRoundsProvider>
+            </BlackjackGameProvider>
+          </CardDeckProvider>
+        </ThemeProvider>
       </SoundProvider>
     </NetworkProvider>
   );

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -19,9 +19,7 @@
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": [
-              "CA92.1"
-            ]
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
           }
         ],
         "NSPrivacyCollectedDataTypes": [],

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -19,7 +19,9 @@
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "CA92.1"
+            ]
           }
         ],
         "NSPrivacyCollectedDataTypes": [],
@@ -47,7 +49,8 @@
           "organization": "buffing-chi"
         }
       ],
-      "expo-localization"
+      "expo-localization",
+      "expo-audio"
     ]
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "@sentry/react-native": "~7.11.0",
         "@shopify/react-native-skia": "2.4.18",
         "expo": "~55.0.17",
+        "expo-audio": "~55.0.14",
         "expo-blur": "~55.0.14",
         "expo-linear-gradient": "~55.0.13",
         "expo-localization": "^55.0.13",
@@ -8704,6 +8705,18 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-55.0.14.tgz",
+      "integrity": "sha512-Biy6ffKXrnKHgcWSVWLKVdWLNhV/pj1JWJeotY6nDR6fVe8mjXQDCvi6EbaSFPdffVHym6UB2siKzWUNSnG+kQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "expo-asset": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "@sentry/react-native": "~7.11.0",
     "@shopify/react-native-skia": "2.4.18",
     "expo": "~55.0.17",
+    "expo-audio": "~55.0.14",
     "expo-blur": "~55.0.14",
     "expo-linear-gradient": "~55.0.13",
     "expo-localization": "^55.0.13",

--- a/frontend/src/game/_shared/SoundContext.tsx
+++ b/frontend/src/game/_shared/SoundContext.tsx
@@ -27,11 +27,7 @@ export function SoundProvider({ children }: { children: React.ReactNode }) {
     AsyncStorage.setItem(STORAGE_KEY, String(value));
   }, []);
 
-  return (
-    <SoundContext.Provider value={{ muted, setMuted }}>
-      {children}
-    </SoundContext.Provider>
-  );
+  return <SoundContext.Provider value={{ muted, setMuted }}>{children}</SoundContext.Provider>;
 }
 
 export function useSoundSettings(): SoundContextValue {

--- a/frontend/src/game/_shared/SoundContext.tsx
+++ b/frontend/src/game/_shared/SoundContext.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "settings.soundMuted";
+
+interface SoundContextValue {
+  muted: boolean;
+  setMuted: (muted: boolean) => void;
+}
+
+const SoundContext = createContext<SoundContextValue>({
+  muted: false,
+  setMuted: () => {},
+});
+
+export function SoundProvider({ children }: { children: React.ReactNode }) {
+  const [muted, setMutedState] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((val) => {
+      if (val !== null) setMutedState(val === "true");
+    });
+  }, []);
+
+  const setMuted = useCallback((value: boolean) => {
+    setMutedState(value);
+    AsyncStorage.setItem(STORAGE_KEY, String(value));
+  }, []);
+
+  return (
+    <SoundContext.Provider value={{ muted, setMuted }}>
+      {children}
+    </SoundContext.Provider>
+  );
+}
+
+export function useSoundSettings(): SoundContextValue {
+  return useContext(SoundContext);
+}

--- a/frontend/src/game/_shared/__tests__/SoundContext.test.tsx
+++ b/frontend/src/game/_shared/__tests__/SoundContext.test.tsx
@@ -47,14 +47,18 @@ describe("SoundContext — setMuted", () => {
   it("updates muted state immediately", async () => {
     const { result } = renderHook(() => useSoundSettings(), { wrapper });
     await act(async () => {});
-    act(() => { result.current.setMuted(true); });
+    act(() => {
+      result.current.setMuted(true);
+    });
     expect(result.current.muted).toBe(true);
   });
 
   it("persists muted=true to AsyncStorage", async () => {
     const { result } = renderHook(() => useSoundSettings(), { wrapper });
     await act(async () => {});
-    act(() => { result.current.setMuted(true); });
+    act(() => {
+      result.current.setMuted(true);
+    });
     expect(mockSetItem).toHaveBeenCalledWith("settings.soundMuted", "true");
   });
 
@@ -62,7 +66,9 @@ describe("SoundContext — setMuted", () => {
     mockGetItem.mockResolvedValueOnce("true");
     const { result } = renderHook(() => useSoundSettings(), { wrapper });
     await act(async () => {});
-    act(() => { result.current.setMuted(false); });
+    act(() => {
+      result.current.setMuted(false);
+    });
     expect(mockSetItem).toHaveBeenCalledWith("settings.soundMuted", "false");
   });
 });

--- a/frontend/src/game/_shared/__tests__/SoundContext.test.tsx
+++ b/frontend/src/game/_shared/__tests__/SoundContext.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { renderHook, act } from "@testing-library/react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { SoundProvider, useSoundSettings } from "../SoundContext";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SoundProvider>{children}</SoundProvider>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetItem.mockResolvedValue(null);
+});
+
+describe("SoundContext — initial state", () => {
+  it("defaults to unmuted when no value in AsyncStorage", async () => {
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    expect(result.current.muted).toBe(false);
+  });
+
+  it("reads saved muted=true from AsyncStorage on mount", async () => {
+    mockGetItem.mockResolvedValueOnce("true");
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    expect(result.current.muted).toBe(true);
+    expect(mockGetItem).toHaveBeenCalledWith("settings.soundMuted");
+  });
+
+  it("reads saved muted=false from AsyncStorage on mount", async () => {
+    mockGetItem.mockResolvedValueOnce("false");
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    expect(result.current.muted).toBe(false);
+  });
+});
+
+describe("SoundContext — setMuted", () => {
+  it("updates muted state immediately", async () => {
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    act(() => { result.current.setMuted(true); });
+    expect(result.current.muted).toBe(true);
+  });
+
+  it("persists muted=true to AsyncStorage", async () => {
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    act(() => { result.current.setMuted(true); });
+    expect(mockSetItem).toHaveBeenCalledWith("settings.soundMuted", "true");
+  });
+
+  it("persists muted=false to AsyncStorage", async () => {
+    mockGetItem.mockResolvedValueOnce("true");
+    const { result } = renderHook(() => useSoundSettings(), { wrapper });
+    await act(async () => {});
+    act(() => { result.current.setMuted(false); });
+    expect(mockSetItem).toHaveBeenCalledWith("settings.soundMuted", "false");
+  });
+});

--- a/frontend/src/game/_shared/__tests__/useSound.test.ts
+++ b/frontend/src/game/_shared/__tests__/useSound.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react-native";
 import React from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { SoundProvider } from "../SoundContext";
 import { useSound } from "../useSound";
 import { SOUND_REGISTRY } from "../sounds";
@@ -34,7 +35,9 @@ beforeEach(() => {
 describe("useSound — unregistered key", () => {
   it("play() is a no-op when key has no entry in SOUND_REGISTRY", () => {
     const { result } = renderHook(() => useSound("unknown.key"), { wrapper });
-    act(() => { result.current.play(); });
+    act(() => {
+      result.current.play();
+    });
     expect(mockPlay).not.toHaveBeenCalled();
   });
 });
@@ -47,19 +50,22 @@ describe("useSound — registered key", () => {
 
   it("play() calls seekTo(0) then play() on the audio player", () => {
     const { result } = renderHook(() => useSound("test.beep"), { wrapper });
-    act(() => { result.current.play(); });
+    act(() => {
+      result.current.play();
+    });
     expect(mockSeekTo).toHaveBeenCalledWith(0);
     expect(mockPlay).toHaveBeenCalledTimes(1);
   });
 
   it("play() is a no-op when muted", async () => {
-    const AsyncStorage = require("@react-native-async-storage/async-storage");
-    AsyncStorage.getItem.mockResolvedValueOnce("true");
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce("true");
 
     const { result } = renderHook(() => useSound("test.beep"), { wrapper });
     // Wait for AsyncStorage to resolve
     await act(async () => {});
-    act(() => { result.current.play(); });
+    act(() => {
+      result.current.play();
+    });
     expect(mockPlay).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/game/_shared/__tests__/useSound.test.ts
+++ b/frontend/src/game/_shared/__tests__/useSound.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act } from "@testing-library/react-native";
+import React from "react";
+import { SoundProvider } from "../SoundContext";
+import { useSound } from "../useSound";
+import { SOUND_REGISTRY } from "../sounds";
+
+const mockPlay = jest.fn();
+const mockSeekTo = jest.fn();
+const mockRemove = jest.fn();
+
+jest.mock("expo-audio", () => ({
+  createAudioPlayer: jest.fn(() => ({
+    play: mockPlay,
+    seekTo: mockSeekTo,
+    remove: mockRemove,
+  })),
+}));
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(SoundProvider, null, children);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Clear registry between tests
+  Object.keys(SOUND_REGISTRY).forEach((k) => delete SOUND_REGISTRY[k]);
+});
+
+describe("useSound — unregistered key", () => {
+  it("play() is a no-op when key has no entry in SOUND_REGISTRY", () => {
+    const { result } = renderHook(() => useSound("unknown.key"), { wrapper });
+    act(() => { result.current.play(); });
+    expect(mockPlay).not.toHaveBeenCalled();
+  });
+});
+
+describe("useSound — registered key", () => {
+  beforeEach(() => {
+    // Simulate a registered asset (Metro require returns a number)
+    SOUND_REGISTRY["test.beep"] = 1 as unknown as number;
+  });
+
+  it("play() calls seekTo(0) then play() on the audio player", () => {
+    const { result } = renderHook(() => useSound("test.beep"), { wrapper });
+    act(() => { result.current.play(); });
+    expect(mockSeekTo).toHaveBeenCalledWith(0);
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("play() is a no-op when muted", async () => {
+    const AsyncStorage = require("@react-native-async-storage/async-storage");
+    AsyncStorage.getItem.mockResolvedValueOnce("true");
+
+    const { result } = renderHook(() => useSound("test.beep"), { wrapper });
+    // Wait for AsyncStorage to resolve
+    await act(async () => {});
+    act(() => { result.current.play(); });
+    expect(mockPlay).not.toHaveBeenCalled();
+  });
+
+  it("returns a stable play reference across re-renders", () => {
+    const { result, rerender } = renderHook(() => useSound("test.beep"), { wrapper });
+    const first = result.current.play;
+    rerender({});
+    expect(result.current.play).toBe(first);
+  });
+
+  it("calls remove() on the player when unmounted", () => {
+    const { unmount } = renderHook(() => useSound("test.beep"), { wrapper });
+    unmount();
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -1,0 +1,10 @@
+// Sound asset registry.
+//
+// SoundKey is a string union — add new keys here when wiring a game's sounds.
+// The corresponding require() goes in SOUND_REGISTRY.
+// Hearts keys (moonShot, heartsBroken, queenOfSpades) are added in #773–#775.
+export type SoundKey = string;
+
+// Metro resolves require() at bundle time so assets must be static literals.
+// Each game-specific issue adds its entries here.
+export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {};

--- a/frontend/src/game/_shared/useSound.ts
+++ b/frontend/src/game/_shared/useSound.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef } from "react";
+import { createAudioPlayer, AudioPlayer } from "expo-audio";
+import { useSoundSettings } from "./SoundContext";
+import { SOUND_REGISTRY, SoundKey } from "./sounds";
+
+export function useSound(key: SoundKey): { play: () => void } {
+  const { muted } = useSoundSettings();
+  const playerRef = useRef<AudioPlayer | null>(null);
+  const mutedRef = useRef(muted);
+
+  // Keep ref in sync so the stable `play` callback sees the latest muted value.
+  useEffect(() => {
+    mutedRef.current = muted;
+  }, [muted]);
+
+  useEffect(() => {
+    const source = SOUND_REGISTRY[key];
+    if (source == null) return;
+    const player = createAudioPlayer(source);
+    playerRef.current = player;
+    return () => {
+      player.remove();
+      playerRef.current = null;
+    };
+  }, [key]);
+
+  const play = useCallback(() => {
+    if (mutedRef.current) return;
+    const player = playerRef.current;
+    if (!player) return;
+    try {
+      player.seekTo(0);
+      player.play();
+    } catch {
+      // expo-audio may throw on web if audio context is suspended; fail silently.
+    }
+  }, []);
+
+  return { play };
+}

--- a/frontend/src/i18n/locales/_meta/common.meta.json
+++ b/frontend/src/i18n/locales/_meta/common.meta.json
@@ -5,9 +5,7 @@
     "tone": "neutral",
     "characterLimit": 20,
     "placeholders": [],
-    "doNotTranslate": [
-      "Gaming App"
-    ],
+    "doNotTranslate": ["Gaming App"],
     "notes": "Do not translate the app name."
   },
   "app.subtitle": {
@@ -78,9 +76,7 @@
     "description": "Accessibility label for the theme toggle. {{mode}} is 'light' or 'dark'.",
     "tone": "functional",
     "characterLimit": 40,
-    "placeholders": [
-      "{{mode}}"
-    ],
+    "placeholders": ["{{mode}}"],
     "doNotTranslate": [],
     "notes": "{{mode}} will already be translated by the time it is interpolated."
   },

--- a/frontend/src/i18n/locales/_meta/common.meta.json
+++ b/frontend/src/i18n/locales/_meta/common.meta.json
@@ -5,7 +5,9 @@
     "tone": "neutral",
     "characterLimit": 20,
     "placeholders": [],
-    "doNotTranslate": ["Gaming App"],
+    "doNotTranslate": [
+      "Gaming App"
+    ],
     "notes": "Do not translate the app name."
   },
   "app.subtitle": {
@@ -76,7 +78,9 @@
     "description": "Accessibility label for the theme toggle. {{mode}} is 'light' or 'dark'.",
     "tone": "functional",
     "characterLimit": 40,
-    "placeholders": ["{{mode}}"],
+    "placeholders": [
+      "{{mode}}"
+    ],
     "doNotTranslate": [],
     "notes": "{{mode}} will already be translated by the time it is interpolated."
   },
@@ -103,6 +107,15 @@
     "description": "Accessibility label for the language selector control.",
     "tone": "functional",
     "characterLimit": 25,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "settings.soundEffects": {
+    "component": "SettingsScreen",
+    "description": "Label for the global sound effects toggle in Settings.",
+    "tone": "functional",
+    "characterLimit": 20,
     "placeholders": [],
     "doNotTranslate": [],
     "notes": null

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "ستفقد اللعبة الحالية. سيتم إعادة تعيين النقاط والجولة.",
   "newGame.confirm.confirm": "ابدأ لعبة جديدة",
   "newGame.confirm.cancel": "إلغاء",
+  "settings.soundEffects": "المؤثرات الصوتية",
   "clearLogs.label": "مسح السجلات المحلية",
   "clearLogs.description": "حذف جميع الأحداث والتقارير التي لم تتم مزامنتها بعد.",
   "clearLogs.button": "مسح",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Dein aktuelles Spiel geht verloren. Punkte und Runde werden zurückgesetzt.",
   "newGame.confirm.confirm": "Spiel starten",
   "newGame.confirm.cancel": "Abbrechen",
+  "settings.soundEffects": "Soundeffekte",
   "clearLogs.label": "Lokale Logs löschen",
   "clearLogs.description": "Alle wartenden Ereignisse und Fehlerprotokolle löschen, die noch nicht synchronisiert wurden.",
   "clearLogs.button": "Löschen",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Your current game will be lost. Score and round will reset.",
   "newGame.confirm.confirm": "Start new game",
   "newGame.confirm.cancel": "Cancel",
+  "settings.soundEffects": "Sound effects",
   "clearLogs.label": "Clear local logs",
   "clearLogs.description": "Delete all queued events and bug logs that haven't synced yet.",
   "clearLogs.button": "Clear",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Perderás tu partida actual. La puntuación y la ronda se reiniciarán.",
   "newGame.confirm.confirm": "Empezar nuevo juego",
   "newGame.confirm.cancel": "Cancelar",
+  "settings.soundEffects": "Efectos de sonido",
   "clearLogs.label": "Borrar registros locales",
   "clearLogs.description": "Elimina todos los eventos en cola y registros de errores que no se hayan sincronizado aún.",
   "clearLogs.button": "Borrar",

--- a/frontend/src/i18n/locales/fr-CA/common.json
+++ b/frontend/src/i18n/locales/fr-CA/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Votre partie actuelle sera perdue. Le score et le tour seront réinitialisés.",
   "newGame.confirm.confirm": "Commencer",
   "newGame.confirm.cancel": "Annuler",
+  "settings.soundEffects": "Effets sonores",
   "clearLogs.label": "Effacer les journaux locaux",
   "clearLogs.description": "Supprime tous les événements en attente et les journaux d'erreurs non synchronisés.",
   "clearLogs.button": "Effacer",

--- a/frontend/src/i18n/locales/he/common.json
+++ b/frontend/src/i18n/locales/he/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "המשחק הנוכחי יאבד. הניקוד והסיבוב יאופסו.",
   "newGame.confirm.confirm": "התחל משחק חדש",
   "newGame.confirm.cancel": "ביטול",
+  "settings.soundEffects": "אפקטים קוליים",
   "clearLogs.label": "ניקוי לוגים מקומיים",
   "clearLogs.description": "מוחק את כל האירועים והלוגים שלא סונכרנו עדיין.",
   "clearLogs.button": "נקה",

--- a/frontend/src/i18n/locales/hi/common.json
+++ b/frontend/src/i18n/locales/hi/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "आपका वर्तमान गेम खो जाएगा। स्कोर और राउंड रीसेट हो जाएगा।",
   "newGame.confirm.confirm": "नया गेम शुरू करें",
   "newGame.confirm.cancel": "रद्द करें",
+  "settings.soundEffects": "ध्वनि प्रभाव",
   "clearLogs.label": "स्थानीय लॉग्स साफ़ करें",
   "clearLogs.description": "सभी कतारबद्ध इवेंट्स और बग लॉग्स हटाएं जो अभी तक सिंक नहीं हुए हैं।",
   "clearLogs.button": "साफ़ करें",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "現在のゲームは失われます。スコアとラウンドがリセットされます。",
   "newGame.confirm.confirm": "新しいゲームを開始",
   "newGame.confirm.cancel": "キャンセル",
+  "settings.soundEffects": "サウンドエフェクト",
   "clearLogs.label": "ローカルログを削除",
   "clearLogs.description": "未同期のイベントやバグログをすべて削除します。",
   "clearLogs.button": "削除",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "현재 게임이 사라집니다. 점수와 라운드가 초기화됩니다.",
   "newGame.confirm.confirm": "새 게임 시작",
   "newGame.confirm.cancel": "취소",
+  "settings.soundEffects": "음향 효과",
   "clearLogs.label": "로컬 로그 삭제",
   "clearLogs.description": "동기화되지 않은 대기 중인 이벤트와 버그 로그를 삭제합니다.",
   "clearLogs.button": "삭제",

--- a/frontend/src/i18n/locales/nl/common.json
+++ b/frontend/src/i18n/locales/nl/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Je huidige spel gaat verloren. Score en ronde worden gereset.",
   "newGame.confirm.confirm": "Start nieuw spel",
   "newGame.confirm.cancel": "Annuleren",
+  "settings.soundEffects": "Geluidseffecten",
   "clearLogs.label": "Lokaal logboek wissen",
   "clearLogs.description": "Verwijder alle wachtrij-evenementen en foutlogs die nog niet zijn gesynchroniseerd.",
   "clearLogs.button": "Wissen",

--- a/frontend/src/i18n/locales/pt/common.json
+++ b/frontend/src/i18n/locales/pt/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Seu jogo atual será perdido. Pontuação e rodada serão reiniciadas.",
   "newGame.confirm.confirm": "Iniciar novo jogo",
   "newGame.confirm.cancel": "Cancelar",
+  "settings.soundEffects": "Efeitos sonoros",
   "clearLogs.label": "Limpar registros locais",
   "clearLogs.description": "Apagar todos os eventos e registros de erros pendentes que ainda não foram sincronizados.",
   "clearLogs.button": "Limpar",

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "Текущая игра будет потеряна. Очки и раунд сбросятся.",
   "newGame.confirm.confirm": "Начать игру",
   "newGame.confirm.cancel": "Отмена",
+  "settings.soundEffects": "Звуковые эффекты",
   "clearLogs.label": "Очистить логи",
   "clearLogs.description": "Удалить все несинхронизированные события и отчёты об ошибках.",
   "clearLogs.button": "Очистить",

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -22,6 +22,7 @@
   "newGame.confirm.body": "当前游戏将丢失。分数和回合将重置。",
   "newGame.confirm.confirm": "开始新游戏",
   "newGame.confirm.cancel": "取消",
+  "settings.soundEffects": "音效",
   "clearLogs.label": "清除本地记录",
   "clearLogs.description": "删除所有未同步的事件和错误记录。",
   "clearLogs.button": "清除",

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { View, Text, Pressable, StyleSheet, Modal } from "react-native";
+import { View, Text, Pressable, StyleSheet, Modal, Switch } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
@@ -9,12 +9,14 @@ import LanguageSwitcher from "../components/LanguageSwitcher";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import { gameEventClient } from "../game/_shared/gameEventClient";
 import { useDeck } from "../game/_shared/decks/CardDeckContext";
+import { useSoundSettings } from "../game/_shared/SoundContext";
 
 const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
 
 export default function SettingsScreen() {
   const { colors, themeMode, setThemeMode } = useTheme();
   const { activeDeck, setDeck, availableDecks } = useDeck();
+  const { muted, setMuted } = useSoundSettings();
   const insets = useSafeAreaInsets();
   const { t } = useTranslation("common");
 
@@ -125,6 +127,22 @@ export default function SettingsScreen() {
           {t("settings.language", "Language")}
         </Text>
         <LanguageSwitcher />
+      </View>
+
+      <View style={[styles.row, { borderColor: colors.border }]}>
+        <Text style={[styles.label, { color: colors.text }]}>
+          {t("settings.soundEffects", "Sound effects")}
+        </Text>
+        <Switch
+          value={!muted}
+          onValueChange={(enabled) => setMuted(!enabled)}
+          trackColor={{ false: colors.surfaceAlt, true: colors.accent }}
+          thumbColor={colors.textOnAccent}
+          accessibilityRole="switch"
+          accessibilityLabel={t("settings.soundEffects", "Sound effects")}
+          accessibilityState={{ checked: !muted }}
+          testID="sound-effects-toggle"
+        />
       </View>
 
       <View style={[styles.rowStacked, { borderColor: colors.border }]}>


### PR DESCRIPTION
## Summary
- `expo-audio ~55.0.14` installed; Expo config plugin registered in `app.json`
- `sounds.ts` — `SoundKey` type + `SOUND_REGISTRY` map (empty here; Hearts keys added in #773–#775)
- `SoundContext.tsx` — `{ muted, setMuted }` context; reads/persists `settings.soundMuted` via AsyncStorage; follows `NetworkContext` pattern
- `useSound.ts` — `useSound(key)` returns stable `play()`; creates/removes `AudioPlayer` per key; no-op when muted or key unregistered; fail-silent on web
- `SettingsScreen` — Sound effects `Switch` row added after Language row; i18n key `common:settings.soundEffects`
- `App.tsx` — `SoundProvider` added to provider tree
- 13 locale files + `common.meta.json` updated with `settings.soundEffects` translations

Closes #771. Blocks #773, #774, #775.

## Test plan
- [ ] Settings screen shows "Sound effects" toggle
- [ ] Toggle off → subsequent `play()` calls are silent
- [ ] Toggle off, close app, reopen → still muted
- [ ] Toggle on → sounds resume
- [ ] All 1524 existing tests still pass (`npx jest --no-coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)