### PR TITLE
fix(migrations): shorten 0003 revision ID to fit alembic_version VARCHAR(32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ env/
 *.egg-info/
 dist/
 .pytest_cache/
+.hypothesis/
 
 # Node / Expo
 node_modules/

--- a/backend/alembic/versions/0003_relax_games_outcome_ck.py
+++ b/backend/alembic/versions/0003_relax_games_outcome_ck.py
@@ -1,6 +1,6 @@
 """relax games.outcome check constraint to accept lifecycle vocabulary (#514)
 
-Revision ID: 0003_relax_games_outcome_constraint
+Revision ID: 0003_relax_games_outcome_ck
 Revises: 0002_games_events_lookups
 Create Date: 2026-04-15
 
@@ -37,7 +37,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "0003_relax_games_outcome_constraint"
+revision: str = "0003_relax_games_outcome_ck"
 down_revision: Union[str, None] = "0002_games_events_lookups"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/alembic/versions/0004_add_pachisi_game_type.py
+++ b/backend/alembic/versions/0004_add_pachisi_game_type.py
@@ -1,7 +1,7 @@
 """add pachisi to game_types lookup table (#538)
 
 Revision ID: 0004_add_pachisi_game_type
-Revises: 0003_relax_games_outcome_constraint
+Revises: 0003_relax_games_outcome_ck
 Create Date: 2026-04-15
 
 Pachisi was shipping as a frontend game type and had its own backend module
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0004_add_pachisi_game_type"
-down_revision: Union[str, None] = "0003_relax_games_outcome_constraint"
+down_revision: Union[str, None] = "0003_relax_games_outcome_ck"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- Renames `0003_relax_games_outcome_constraint.py` → `0003_relax_games_outcome_ck.py` and shortens its revision ID to fit the `alembic_version` `VARCHAR(32)` column
- Updates `0004`'s `down_revision` pointer accordingly
- Adds `.hypothesis/` to `.gitignore`

Closes #781

## Test plan
- [ ] `cd backend && source .venv/bin/activate && alembic upgrade head` runs clean on a fresh DB
- [ ] `python -m pytest tests/ -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)