### PR TITLE
feat(#772): animation infrastructure — GameEvent bus + AnimationOverlay

### DIFF
--- a/frontend/src/components/shared/AnimationOverlay.tsx
+++ b/frontend/src/components/shared/AnimationOverlay.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+import { AccessibilityInfo, Pressable, StyleSheet, View } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
+
+interface AnimationOverlayProps {
+  visible: boolean;
+  onDismiss: () => void;
+  children?: React.ReactNode;
+}
+
+export function AnimationOverlay({ visible, onDismiss, children }: AnimationOverlayProps) {
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  useEffect(() => {
+    const target = visible ? 1 : 0;
+    if (reduceMotion) {
+      opacity.value = target;
+    } else {
+      opacity.value = withTiming(target, { duration: visible ? 300 : 200 });
+    }
+  }, [visible, reduceMotion, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  // Reduced-motion: instant static tint, no animated motion.
+  if (reduceMotion) {
+    return (
+      <View
+        style={[styles.overlay, { opacity: visible ? 1 : 0 }]}
+        pointerEvents={visible ? "auto" : "none"}
+        testID="animation-overlay-static"
+      >
+        <Pressable style={StyleSheet.absoluteFillObject} onPress={onDismiss} />
+        {children}
+      </View>
+    );
+  }
+
+  return (
+    <Animated.View
+      style={[styles.overlay, animatedStyle]}
+      pointerEvents={visible ? "auto" : "none"}
+      testID="animation-overlay"
+    >
+      <Pressable style={StyleSheet.absoluteFillObject} onPress={onDismiss} />
+      {children}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 999,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/frontend/src/components/shared/__tests__/AnimationOverlay.test.tsx
+++ b/frontend/src/components/shared/__tests__/AnimationOverlay.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { AccessibilityInfo } from "react-native";
+import { render, act, fireEvent } from "@testing-library/react-native";
+import { AnimationOverlay } from "../AnimationOverlay";
+
+beforeEach(() => {
+  jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(false);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("AnimationOverlay — pointer events", () => {
+  it("is pointer-transparent when visible=false", () => {
+    const { getByTestId } = render(<AnimationOverlay visible={false} onDismiss={jest.fn()} />);
+    const overlay = getByTestId("animation-overlay");
+    expect(overlay.props.pointerEvents).toBe("none");
+  });
+
+  it("is interactive when visible=true", () => {
+    const { getByTestId } = render(<AnimationOverlay visible={true} onDismiss={jest.fn()} />);
+    const overlay = getByTestId("animation-overlay");
+    expect(overlay.props.pointerEvents).toBe("auto");
+  });
+});
+
+describe("AnimationOverlay — children", () => {
+  it("renders children without crashing", () => {
+    const { getByTestId } = render(
+      <AnimationOverlay visible={true} onDismiss={jest.fn()}>
+        <></>
+      </AnimationOverlay>
+    );
+    expect(getByTestId("animation-overlay")).toBeTruthy();
+  });
+
+  it("calls onDismiss when backdrop is pressed", () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(<AnimationOverlay visible={true} onDismiss={onDismiss} />);
+    // The Pressable backdrop is the first child of the overlay
+    const overlay = getByTestId("animation-overlay");
+    // Fire press on the first child (backdrop Pressable)
+    fireEvent.press(overlay.children[0]);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AnimationOverlay — reduced motion", () => {
+  it("renders the static fallback when isReduceMotionEnabled returns true", async () => {
+    jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(true);
+
+    const { getByTestId } = render(<AnimationOverlay visible={true} onDismiss={jest.fn()} />);
+
+    // Flush the AccessibilityInfo.isReduceMotionEnabled promise.
+    await act(async () => {});
+
+    expect(getByTestId("animation-overlay-static")).toBeTruthy();
+  });
+
+  it("static fallback is pointer-transparent when visible=false", async () => {
+    jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(true);
+
+    const { getByTestId } = render(<AnimationOverlay visible={false} onDismiss={jest.fn()} />);
+    await act(async () => {});
+
+    const overlay = getByTestId("animation-overlay-static");
+    expect(overlay.props.pointerEvents).toBe("none");
+  });
+});

--- a/frontend/src/game/_shared/__tests__/useGameEvents.test.ts
+++ b/frontend/src/game/_shared/__tests__/useGameEvents.test.ts
@@ -1,0 +1,99 @@
+import { renderHook } from "@testing-library/react-native";
+import { useGameEvents } from "../useGameEvents";
+import type { GameEvent } from "../../hearts/types";
+
+describe("useGameEvents", () => {
+  it("fires the correct callback for each event type in the array", () => {
+    const onMoonShot = jest.fn();
+    const onHeartsBroken = jest.fn();
+    const onQueenOfSpades = jest.fn();
+    const onClear = jest.fn();
+
+    const events: GameEvent[] = [
+      { type: "moonShot", shooter: 0 },
+      { type: "heartsBroken" },
+      { type: "queenOfSpades", takerSeat: 2 },
+    ];
+
+    renderHook(() =>
+      useGameEvents(
+        events,
+        { moonShot: onMoonShot, heartsBroken: onHeartsBroken, queenOfSpades: onQueenOfSpades },
+        onClear
+      )
+    );
+
+    expect(onMoonShot).toHaveBeenCalledWith({ type: "moonShot", shooter: 0 });
+    expect(onHeartsBroken).toHaveBeenCalledWith({ type: "heartsBroken" });
+    expect(onQueenOfSpades).toHaveBeenCalledWith({ type: "queenOfSpades", takerSeat: 2 });
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-fire events that have already been processed", () => {
+    const onMoonShot = jest.fn();
+    const onClear = jest.fn();
+    const events: GameEvent[] = [{ type: "moonShot", shooter: 1 }];
+
+    const { rerender } = renderHook(
+      ({ evts }: { evts: readonly GameEvent[] }) =>
+        useGameEvents(evts, { moonShot: onMoonShot }, onClear),
+      { initialProps: { evts: events } }
+    );
+
+    // Same array reference — must not re-fire.
+    rerender({ evts: events });
+
+    expect(onMoonShot).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("processes a new events array after the previous one was cleared", () => {
+    const onMoonShot = jest.fn();
+    const onClear = jest.fn();
+    const first: GameEvent[] = [{ type: "moonShot", shooter: 0 }];
+    const second: GameEvent[] = [{ type: "moonShot", shooter: 3 }];
+
+    const { rerender } = renderHook(
+      ({ evts }: { evts: readonly GameEvent[] }) =>
+        useGameEvents(evts, { moonShot: onMoonShot }, onClear),
+      { initialProps: { evts: first } }
+    );
+
+    rerender({ evts: second });
+
+    expect(onMoonShot).toHaveBeenCalledTimes(2);
+    expect(onClear).toHaveBeenCalledTimes(2);
+  });
+
+  it("is a no-op when events is undefined", () => {
+    const onMoonShot = jest.fn();
+    const onClear = jest.fn();
+
+    renderHook(() => useGameEvents(undefined, { moonShot: onMoonShot }, onClear));
+
+    expect(onMoonShot).not.toHaveBeenCalled();
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when events is empty", () => {
+    const onMoonShot = jest.fn();
+    const onClear = jest.fn();
+
+    renderHook(() => useGameEvents([], { moonShot: onMoonShot }, onClear));
+
+    expect(onMoonShot).not.toHaveBeenCalled();
+    expect(onClear).not.toHaveBeenCalled();
+  });
+
+  it("silently skips events with no registered handler", () => {
+    const onClear = jest.fn();
+    const events: GameEvent[] = [{ type: "moonShot", shooter: 0 }];
+
+    // No moonShot handler registered — should not throw.
+    expect(() =>
+      renderHook(() => useGameEvents(events, { heartsBroken: jest.fn() }, onClear))
+    ).not.toThrow();
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/game/_shared/useGameEvents.ts
+++ b/frontend/src/game/_shared/useGameEvents.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react";
+import type { GameEvent } from "../hearts/types";
+
+type GameEventHandlers = {
+  [K in GameEvent["type"]]?: (event: Extract<GameEvent, { type: K }>) => void;
+};
+
+/**
+ * Fires registered callbacks for each unprocessed event in `events`, then
+ * calls `onClear` so the caller can clear the array from game state.
+ *
+ * Identity-based deduplication: the same array reference is never processed
+ * twice, so re-renders between the effect firing and the state update are safe.
+ */
+export function useGameEvents(
+  events: readonly GameEvent[] | undefined,
+  handlers: GameEventHandlers,
+  onClear: () => void
+): void {
+  const handlersRef = useRef(handlers);
+  const onClearRef = useRef(onClear);
+  const lastProcessedRef = useRef<readonly GameEvent[] | undefined>(undefined);
+
+  // Keep refs current without adding them to the effect dep array.
+  useEffect(() => {
+    handlersRef.current = handlers;
+    onClearRef.current = onClear;
+  });
+
+  useEffect(() => {
+    if (!events || events.length === 0 || events === lastProcessedRef.current) return;
+    lastProcessedRef.current = events;
+    for (const event of events) {
+      const handler = handlersRef.current[event.type] as ((e: GameEvent) => void) | undefined;
+      handler?.(event);
+    }
+    onClearRef.current();
+  }, [events]);
+}

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -5,6 +5,12 @@
  * engine, AI, UI components, and persistence layer alike.
  */
 
+/** UI events emitted by the engine and consumed by the animation layer. */
+export type GameEvent =
+  | { readonly type: "moonShot"; readonly shooter: number }
+  | { readonly type: "heartsBroken" }
+  | { readonly type: "queenOfSpades"; readonly takerSeat: number };
+
 export type Suit = "spades" | "hearts" | "diamonds" | "clubs";
 export type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
 
@@ -72,4 +78,9 @@ export interface HeartsState {
   readonly tricksPlayedInHand: number;
   readonly isComplete: boolean;
   readonly winnerIndex: number | null;
+  /**
+   * One-shot UI events set by the engine and cleared by the animation layer.
+   * Optional so legacy serialized states (no `events` field) deserialize cleanly.
+   */
+  readonly events?: readonly GameEvent[];
 }


### PR DESCRIPTION
## Summary

- **`GameEvent` union type** (`moonShot | heartsBroken | queenOfSpades`) in `hearts/types.ts`
- **`HeartsState.events?`** — optional field so legacy serialized states without it deserialize cleanly
- **`useGameEvents` hook** — fires per-event-type callbacks then calls `onClear`; identity-based deduplication prevents re-firing on re-renders before the caller's state update lands
- **`AnimationOverlay` component** — full-screen `react-native-reanimated` overlay driven by `visible`/`onDismiss`; passes pointer events through when not visible; instant static fallback when `AccessibilityInfo.isReduceMotionEnabled()` is `true`
- **12 unit tests** covering all acceptance criteria

## Test plan

- [x] `useGameEvents` fires correct callback for each event type
- [x] `useGameEvents` does not re-fire already-processed events
- [x] `useGameEvents` processes a fresh array after clear
- [x] `useGameEvents` no-ops on empty/undefined events
- [x] `useGameEvents` silently skips events with no registered handler
- [x] `AnimationOverlay` pointer-transparent when `visible=false`
- [x] `AnimationOverlay` interactive when `visible=true`
- [x] `AnimationOverlay` calls `onDismiss` on backdrop press
- [x] `AnimationOverlay` renders static fallback when reduce-motion enabled
- [x] Static fallback is pointer-transparent when `visible=false`
- [x] All 99 existing Hearts engine tests still pass
- [x] ESLint + Prettier clean

Closes #772
Part of #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)