### PR TITLE
feat(#760): persist best tile, games played, games won in 2048 scoreboard

### DIFF
--- a/frontend/src/components/scoreboard/Twenty48Scoreboard.tsx
+++ b/frontend/src/components/scoreboard/Twenty48Scoreboard.tsx
@@ -22,9 +22,21 @@ export default function Twenty48Scoreboard({ snapshot }: Props) {
       value: snapshot.bestScore > 0 ? snapshot.bestScore.toLocaleString("en-US") : "—",
       accent: true,
     },
-    { key: "bestTile", label: t("scoreboard.bestTile"), value: "—" },
-    { key: "gamesPlayed", label: t("scoreboard.gamesPlayed"), value: "—" },
-    { key: "gamesWon", label: t("scoreboard.gamesWon"), value: "—" },
+    {
+      key: "bestTile",
+      label: t("scoreboard.bestTile"),
+      value: snapshot.allTimeBestTile > 0 ? snapshot.allTimeBestTile.toLocaleString("en-US") : "—",
+    },
+    {
+      key: "gamesPlayed",
+      label: t("scoreboard.gamesPlayed"),
+      value: snapshot.gamesPlayed > 0 ? snapshot.gamesPlayed.toLocaleString("en-US") : "—",
+    },
+    {
+      key: "gamesWon",
+      label: t("scoreboard.gamesWon"),
+      value: snapshot.gamesWon > 0 ? snapshot.gamesWon.toLocaleString("en-US") : "—",
+    },
   ] as const;
 
   return (

--- a/frontend/src/game/twenty48/Twenty48ScoreboardContext.tsx
+++ b/frontend/src/game/twenty48/Twenty48ScoreboardContext.tsx
@@ -6,6 +6,9 @@ export interface Twenty48ScoreboardSnapshot {
   moveCount: number;
   bestScore: number;
   hasGame: boolean;
+  allTimeBestTile: number;
+  gamesPlayed: number;
+  gamesWon: number;
 }
 
 const initial: Twenty48ScoreboardSnapshot = {
@@ -14,6 +17,9 @@ const initial: Twenty48ScoreboardSnapshot = {
   moveCount: 0,
   bestScore: 0,
   hasGame: false,
+  allTimeBestTile: 0,
+  gamesPlayed: 0,
+  gamesWon: 0,
 };
 
 interface ContextValue {

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -1,6 +1,14 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import { saveGame, loadGame, clearGame, saveBestScore, loadBestScore, loadStats, saveStats } from "../storage";
+import {
+  saveGame,
+  loadGame,
+  clearGame,
+  saveBestScore,
+  loadBestScore,
+  loadStats,
+  saveStats,
+} from "../storage";
 import { _resetTileIds, move, setRng, createSeededRng } from "../engine";
 import { Twenty48State } from "../types";
 

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import { saveGame, loadGame, clearGame, saveBestScore, loadBestScore } from "../storage";
+import { saveGame, loadGame, clearGame, saveBestScore, loadBestScore, loadStats, saveStats } from "../storage";
 import { _resetTileIds, move, setRng, createSeededRng } from "../engine";
 import { Twenty48State } from "../types";
 
@@ -98,6 +98,26 @@ describe("twenty48 storage", () => {
 
   it("loadBestScore returns 0 when nothing is saved", async () => {
     expect(await loadBestScore()).toBe(0);
+  });
+
+  it("saves and loads stats", async () => {
+    await saveStats({ bestTile: 2048, gamesPlayed: 7, gamesWon: 2 });
+    expect(await loadStats()).toEqual({ bestTile: 2048, gamesPlayed: 7, gamesWon: 2 });
+  });
+
+  it("loadStats returns zeros when nothing is saved", async () => {
+    expect(await loadStats()).toEqual({ bestTile: 0, gamesPlayed: 0, gamesWon: 0 });
+  });
+
+  it("loadStats tolerates partial payloads by defaulting missing fields to 0", async () => {
+    await AsyncStorage.setItem("twenty48_stats_v1", JSON.stringify({ bestTile: 512 }));
+    expect(await loadStats()).toEqual({ bestTile: 512, gamesPlayed: 0, gamesWon: 0 });
+  });
+
+  it("loadStats returns zeros for corrupt stats payload", async () => {
+    await AsyncStorage.setItem("twenty48_stats_v1", "not json");
+    expect(await loadStats()).toEqual({ bestTile: 0, gamesPlayed: 0, gamesWon: 0 });
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
   });
 
   // #698: on app reload, the engine's module-level tile-ID counter restarts

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -15,6 +15,13 @@ import { seedNextTileId } from "./engine";
 
 const GAME_KEY = "twenty48_game_v2";
 const BEST_SCORE_KEY = "twenty48_best_score_v1";
+const STATS_KEY = "twenty48_stats_v1";
+
+export interface Twenty48Stats {
+  bestTile: number;
+  gamesPlayed: number;
+  gamesWon: number;
+}
 
 export async function saveGame(state: Twenty48State): Promise<void> {
   try {
@@ -118,5 +125,29 @@ export async function loadBestScore(): Promise<number> {
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "loadBest" } });
     return 0;
+  }
+}
+
+export async function loadStats(): Promise<Twenty48Stats> {
+  try {
+    const raw = await AsyncStorage.getItem(STATS_KEY);
+    if (!raw) return { bestTile: 0, gamesPlayed: 0, gamesWon: 0 };
+    const parsed = JSON.parse(raw);
+    return {
+      bestTile: typeof parsed.bestTile === "number" ? parsed.bestTile : 0,
+      gamesPlayed: typeof parsed.gamesPlayed === "number" ? parsed.gamesPlayed : 0,
+      gamesWon: typeof parsed.gamesWon === "number" ? parsed.gamesWon : 0,
+    };
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "loadStats" } });
+    return { bestTile: 0, gamesPlayed: 0, gamesWon: 0 };
+  }
+}
+
+export async function saveStats(stats: Twenty48Stats): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "twenty48.storage", op: "saveStats" } });
   }
 }

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -15,6 +15,9 @@ import {
   clearGame,
   saveBestScore,
   loadBestScore,
+  loadStats,
+  saveStats,
+  type Twenty48Stats,
 } from "../game/twenty48/storage";
 import Grid from "../components/twenty48/Grid";
 import ScoreBoard from "../components/twenty48/ScoreBoard";
@@ -53,12 +56,15 @@ export default function Twenty48Screen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [winDismissed, setWinDismissed] = useState(false);
   const [bestScore, setBestScore] = useState(0);
+  const [stats, setStats] = useState<Twenty48Stats>({ bestTile: 0, gamesPlayed: 0, gamesWon: 0 });
   const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
 
   /** Blocks new moves while the slide animation plays. */
   const movingRef = useRef(false);
   /** One queued move — fires immediately after the current animation ends. */
   const pendingMove = useRef<Direction | null>(null);
+  /** Guards against double-counting a win within a single game session. */
+  const winRecordedRef = useRef(false);
 
   // Game event instrumentation (#369 / #549). One session per game from load /
   // reset until game_over OR keep-playing. After a keep-playing end, further
@@ -92,10 +98,10 @@ export default function Twenty48Screen({ navigation }: Props) {
     navigation.setOptions({ gestureEnabled: false });
   }, [navigation]);
 
-  // Load saved game and best score on mount.
+  // Load saved game, best score, and stats on mount.
   useEffect(() => {
     let active = true;
-    Promise.all([loadGame(), loadBestScore()]).then(([saved, best]) => {
+    Promise.all([loadGame(), loadBestScore(), loadStats()]).then(([saved, best, savedStats]) => {
       if (!active) return;
       let next = saved ?? newGame();
       // Resume timer when reloading a mid-game state.
@@ -112,6 +118,23 @@ export default function Twenty48Screen({ navigation }: Props) {
         // Resuming a saved mid-game means the player already started — mark it.
         if (saved) syncMarkStarted();
       }
+      // Count a fresh start; also catch any best-tile improvement from the
+      // loaded board (e.g. user had a 1024 before stats were tracked).
+      const currentBestTile = highestTile(next.board);
+      const initialStats: Twenty48Stats = {
+        bestTile: Math.max(savedStats.bestTile, currentBestTile),
+        gamesPlayed: saved ? savedStats.gamesPlayed : savedStats.gamesPlayed + 1,
+        gamesWon: savedStats.gamesWon,
+      };
+      if (
+        initialStats.bestTile !== savedStats.bestTile ||
+        initialStats.gamesPlayed !== savedStats.gamesPlayed
+      ) {
+        saveStats(initialStats);
+      }
+      setStats(initialStats);
+      // Suppress re-counting a win when resuming an already-won game.
+      if (next.has_won) winRecordedRef.current = true;
     });
     return () => {
       active = false;
@@ -139,8 +162,11 @@ export default function Twenty48Screen({ navigation }: Props) {
       moveCount: moveCountRef.current,
       bestScore,
       hasGame: true,
+      allTimeBestTile: stats.bestTile,
+      gamesPlayed: stats.gamesPlayed,
+      gamesWon: stats.gamesWon,
     });
-  }, [state, bestScore, setScoreboardSnapshot]);
+  }, [state, bestScore, stats, setScoreboardSnapshot]);
 
   const executeMove = useCallback(
     (direction: Direction, currentState: Twenty48State) => {
@@ -158,6 +184,19 @@ export default function Twenty48Screen({ navigation }: Props) {
       saveGame(next);
       moveCountRef.current += 1;
       syncMarkStarted();
+      // Track all-time best tile and first win per session.
+      const tile = highestTile(next.board);
+      const justWon = next.has_won && !winRecordedRef.current;
+      if (justWon) winRecordedRef.current = true;
+      if (tile > 0 || justWon) {
+        setStats((prev) => {
+          let updated = prev;
+          if (tile > prev.bestTile) updated = { ...updated, bestTile: tile };
+          if (justWon) updated = { ...updated, gamesWon: updated.gamesWon + 1 };
+          if (updated !== prev) saveStats(updated);
+          return updated;
+        });
+      }
       syncEnqueue({
         type: "move",
         data: {
@@ -206,6 +245,7 @@ export default function Twenty48Screen({ navigation }: Props) {
   const resetGame = useCallback(() => {
     movingRef.current = false;
     pendingMove.current = null;
+    winRecordedRef.current = false;
     setWinDismissed(false);
     // Close out the previous session with proper payload (if still open).
     const prev = stateRef.current;
@@ -221,6 +261,11 @@ export default function Twenty48Screen({ navigation }: Props) {
     saveGame(next);
     moveCountRef.current = 0;
     syncStart({ initial_board: flattenBoard(next.board) });
+    setStats((prev) => {
+      const updated = { ...prev, gamesPlayed: prev.gamesPlayed + 1 };
+      saveStats(updated);
+      return updated;
+    });
   }, [endedPayload, syncComplete, syncStart]);
 
   const handleNewGamePress = useCallback(() => {

--- a/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
+++ b/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
@@ -25,6 +25,8 @@ jest.mock("../../game/twenty48/storage", () => ({
   loadGame: jest.fn().mockResolvedValue(null),
   saveBestScore: jest.fn(),
   loadBestScore: jest.fn().mockResolvedValue(0),
+  loadStats: jest.fn().mockResolvedValue({ bestTile: 0, gamesPlayed: 0, gamesWon: 0 }),
+  saveStats: jest.fn(),
 }));
 
 // Mock the engine so individual tests can force a game_over transition.


### PR DESCRIPTION
## Summary
- Adds `twenty48_stats_v1` AsyncStorage key bundling `bestTile`, `gamesPlayed`, and `gamesWon`
- Exposes new fields via `loadStats()` / `saveStats()` helpers in `storage.ts`
- Wires all three into `Twenty48ScoreboardSnapshot` and `Twenty48Scoreboard` stat cards so they no longer show `—`
- Increments `gamesPlayed` on fresh starts (mount with no saved game) and on each `resetGame()` call; increments `gamesWon` once per session on first `has_won` transition; tracks all-time `bestTile` on every move

## Test plan
- [ ] Open 2048 scoreboard — Best Tile, Games Played, Games Won cards now show real values after playing
- [ ] Win a game (reach 2048) — Games Won increments by 1; does not double-count on Keep Playing
- [ ] Start a new game from the overlay/button — Games Played increments
- [ ] Force-close and relaunch — counts persist across sessions
- [ ] 4 new storage unit tests pass (`loadStats`/`saveStats` round-trip, empty, partial, corrupt)

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)