### PR TITLE
feat(#774): hearts — hearts-broken sound + animation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -152,6 +152,22 @@ the Sentry dashboard open and filtered to `subsystem:hearts.integrity`.
 3. Repeat-mount the screen with the same payload. Confirm Sentry receives
    **at most one** event per check per mount (per-mount dedupe).
 
+### Hearts: hearts-broken sound + animation (#774)
+
+Verifies the crack sound and burst animation fire exactly once when hearts break.
+
+1. Start a Hearts game. Pass phase may occur first — complete it.
+2. Play non-heart cards until someone is void in the led suit and must discard a heart.
+   (Alternatively: reach trick 2+ where hearts can be led if broken, then lead a heart.)
+3. The moment the **first** heart is played into any trick:
+   - Confirm the crack sound plays once (audible pop/crack).
+   - Confirm a red ♥ icon springs up at the trick center, cracks radiate outward, and a red tint flashes on the trick area.
+   - Confirm the icon lingers at reduced opacity (~3 s total), then fades out over 0.5 s.
+   - Confirm play is **not blocked** — other cards remain tappable while the animation runs.
+4. Play a second heart into a subsequent trick. Confirm the animation and sound do **not** fire again.
+5. **Reduced-motion fallback:** Enable Reduce Motion in device accessibility settings, repeat steps 2–3.
+   Confirm only an instant red tint flash (~0.3 s) occurs, no spring or crack-line motion.
+
 ---
 
 ## E2E Test Conventions

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -59,6 +59,16 @@ jest.mock("react-native-reanimated", () => {
   };
 });
 
+// expo-audio mock — native audio APIs are unavailable in Jest
+jest.mock("expo-audio", () => ({
+  createAudioPlayer: jest.fn(() => ({
+    play: jest.fn(),
+    seekTo: jest.fn(),
+    remove: jest.fn(),
+  })),
+  AudioPlayer: jest.fn(),
+}));
+
 // Safe area context mock — returns zero insets in tests
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,9 @@
         "lines": 80,
         "statements": 80
       }
+    },
+    "moduleNameMapper": {
+      "\\.mp3$": "<rootDir>/src/__mocks__/fileMock.js"
     }
   },
   "dependencies": {

--- a/frontend/src/__mocks__/fileMock.js
+++ b/frontend/src/__mocks__/fileMock.js
@@ -1,0 +1,3 @@
+// Stub for static audio/binary assets (e.g. .mp3) required by sounds.ts.
+// Metro resolves these to numeric asset IDs at bundle time; Jest returns 1 as a stand-in.
+module.exports = 1;

--- a/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
+++ b/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AccessibilityInfo, StyleSheet, View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  visible: boolean;
+  onAnimationEnd: () => void;
+}
+
+// Six crack lines at 30° intervals radiating outward
+const CRACK_ANGLES = [0, 30, 60, 90, 120, 150] as const;
+
+export function HeartsBrokenAnimation({ visible, onAnimationEnd }: Props) {
+  const { t } = useTranslation("hearts");
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const iconScale = useSharedValue(0);
+  const iconOpacity = useSharedValue(0);
+  // Tint opacity: 0 → 0.3 → 0.08 (hold) → 0 (fade out)
+  const tintOpacity = useSharedValue(0);
+
+  // One shared value per crack line — hooks cannot be called in a loop
+  const crack0 = useSharedValue(0);
+  const crack1 = useSharedValue(0);
+  const crack2 = useSharedValue(0);
+  const crack3 = useSharedValue(0);
+  const crack4 = useSharedValue(0);
+  const crack5 = useSharedValue(0);
+  const cracks = [crack0, crack1, crack2, crack3, crack4, crack5];
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      iconScale.value = 0;
+      iconOpacity.value = 0;
+      tintOpacity.value = 0;
+      cracks.forEach((c) => {
+        c.value = 0;
+      });
+      return;
+    }
+
+    if (reduceMotion) {
+      // Reduced motion: instant red tint flash only, ~0.3 s total
+      tintOpacity.value = withSequence(
+        withTiming(0.3, { duration: 50 }),
+        withDelay(200, withTiming(0, { duration: 50 }))
+      );
+      const t1 = setTimeout(onAnimationEnd, 300);
+      timersRef.current.push(t1);
+      return () => {
+        clearTimeout(t1);
+        timersRef.current = [];
+      };
+    }
+
+    // Phase 1 — burst (0–1000 ms)
+    iconOpacity.value = 1;
+    iconScale.value = withSequence(
+      withTiming(1.3, { duration: 300 }),
+      withSpring(1.0, { damping: 8, stiffness: 180 })
+    );
+    tintOpacity.value = withSequence(
+      withTiming(0.3, { duration: 150 }),
+      withDelay(350, withTiming(0.08, { duration: 500 }))
+    );
+    cracks.forEach((c, i) => {
+      c.value = withDelay(i * 60, withTiming(1, { duration: 300 }));
+    });
+
+    // Phase 2 — linger: icon fades to reduced opacity after burst peak
+    const t1 = setTimeout(() => {
+      iconOpacity.value = withTiming(0.25, { duration: 200 });
+    }, 800);
+
+    // Phase 3 — fade everything out at ~2900 ms (total ~3.4 s)
+    const t2 = setTimeout(() => {
+      iconOpacity.value = withTiming(0, { duration: 500 });
+      tintOpacity.value = withTiming(0, { duration: 500 });
+      iconScale.value = withTiming(0, { duration: 500 });
+      cracks.forEach((c) => {
+        c.value = withTiming(0, { duration: 400 });
+      });
+    }, 2900);
+
+    const t3 = setTimeout(onAnimationEnd, 3400);
+    timersRef.current.push(t1, t2, t3);
+
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+      cancelAnimation(iconScale);
+      cancelAnimation(iconOpacity);
+      cancelAnimation(tintOpacity);
+      cracks.forEach((c) => cancelAnimation(c));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, reduceMotion]);
+
+  // Tint layer uses its own opacity so it does not affect child elements
+  const tintStyle = useAnimatedStyle(() => ({ opacity: tintOpacity.value }));
+  const iconStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: iconScale.value }],
+    opacity: iconOpacity.value,
+  }));
+  const crack0Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[0]}deg` }, { scaleX: crack0.value }],
+    opacity: crack0.value,
+  }));
+  const crack1Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[1]}deg` }, { scaleX: crack1.value }],
+    opacity: crack1.value,
+  }));
+  const crack2Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[2]}deg` }, { scaleX: crack2.value }],
+    opacity: crack2.value,
+  }));
+  const crack3Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[3]}deg` }, { scaleX: crack3.value }],
+    opacity: crack3.value,
+  }));
+  const crack4Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[4]}deg` }, { scaleX: crack4.value }],
+    opacity: crack4.value,
+  }));
+  const crack5Style = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${CRACK_ANGLES[5]}deg` }, { scaleX: crack5.value }],
+    opacity: crack5.value,
+  }));
+  const crackStyles = [crack0Style, crack1Style, crack2Style, crack3Style, crack4Style, crack5Style];
+
+  return (
+    // Non-interactive wrapper — never blocks touches
+    <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
+      {/* Red tint layer — separate from content so its opacity does not bleed into children */}
+      <Animated.View style={[StyleSheet.absoluteFillObject, styles.tintLayer, tintStyle]} />
+      {/* Content: heart icon + radiating crack lines */}
+      <View style={styles.content}>
+        {crackStyles.map((crackStyle, i) => (
+          <Animated.View key={i} style={[styles.crackLine, crackStyle]} />
+        ))}
+        <Animated.Text
+          style={[styles.heartIcon, iconStyle]}
+          accessibilityLabel={t("events.heartsBroken")}
+          accessibilityRole="text"
+          accessibilityLiveRegion="polite"
+        >
+          ♥
+        </Animated.Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tintLayer: {
+    backgroundColor: "#dc2626",
+    zIndex: 100,
+  },
+  content: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 101,
+  },
+  heartIcon: {
+    fontSize: 48,
+    color: "#dc2626",
+    lineHeight: 56,
+  },
+  crackLine: {
+    position: "absolute",
+    width: 80,
+    height: 3,
+    borderRadius: 2,
+    backgroundColor: "#dc2626",
+  },
+});

--- a/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
+++ b/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
@@ -140,7 +140,14 @@ export function HeartsBrokenAnimation({ visible, onAnimationEnd }: Props) {
     transform: [{ rotate: `${CRACK_ANGLES[5]}deg` }, { scaleX: crack5.value }],
     opacity: crack5.value,
   }));
-  const crackStyles = [crack0Style, crack1Style, crack2Style, crack3Style, crack4Style, crack5Style];
+  const crackStyles = [
+    crack0Style,
+    crack1Style,
+    crack2Style,
+    crack3Style,
+    crack4Style,
+    crack5Style,
+  ];
 
   return (
     // Non-interactive wrapper — never blocks touches

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -7,4 +7,6 @@ export type SoundKey = string;
 
 // Metro resolves require() at bundle time so assets must be static literals.
 // Each game-specific issue adds its entries here.
-export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {};
+export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
+  "hearts.heartsBroken": require("../../assets/sounds/hearts-broken.mp3"),
+};

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -9,5 +9,5 @@ export type SoundKey = string;
 // Each game-specific issue adds its entries here.
 export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  "hearts.heartsBroken": require("../../assets/sounds/hearts-broken.mp3"),
+  "hearts.heartsBroken": require("../../../assets/sounds/hearts-broken.mp3"),
 };

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -8,5 +8,6 @@ export type SoundKey = string;
 // Metro resolves require() at bundle time so assets must be static literals.
 // Each game-specific issue adds its entries here.
 export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   "hearts.heartsBroken": require("../../assets/sounds/hearts-broken.mp3"),
 };

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -422,6 +422,49 @@ describe("playCard", () => {
     const next = playCard(state, 0, c("clubs", 2));
     expect(next.heartsBroken).toBe(false);
   });
+
+  it("emits heartsBroken event when first heart is played", () => {
+    const hand = [c("hearts", 5), c("clubs", 3)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 1,
+      heartsBroken: false,
+      currentTrick: [
+        { card: c("hearts", 2), playerIndex: 3 },
+        { card: c("hearts", 3), playerIndex: 1 },
+        { card: c("hearts", 4), playerIndex: 2 },
+      ],
+    });
+    const next = playCard(state, 0, c("hearts", 5));
+    expect(next.events).toContainEqual({ type: "heartsBroken" });
+  });
+
+  it("does not emit heartsBroken when hearts already broken", () => {
+    const hand = [c("hearts", 7), c("clubs", 3)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 2,
+      heartsBroken: true,
+      currentTrick: [
+        { card: c("hearts", 2), playerIndex: 3 },
+        { card: c("hearts", 3), playerIndex: 1 },
+        { card: c("hearts", 4), playerIndex: 2 },
+      ],
+    });
+    const next = playCard(state, 0, c("hearts", 7));
+    expect(next.events ?? []).not.toContainEqual({ type: "heartsBroken" });
+  });
+
+  it("does not emit heartsBroken for non-heart cards", () => {
+    const hand = [c("clubs", 2), c("clubs", 5)];
+    const state = mkState({
+      playerHands: h4(hand),
+      tricksPlayedInHand: 0,
+      heartsBroken: false,
+    });
+    const next = playCard(state, 0, c("clubs", 2));
+    expect(next.events ?? []).not.toContainEqual({ type: "heartsBroken" });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -268,6 +268,12 @@ export function playCard(state: HeartsState, playerIndex: number, card: Card): H
 
   const newTrick: TrickCard[] = [...state.currentTrick, { card, playerIndex }];
   const newHeartsBroken = state.heartsBroken || card.suit === "hearts";
+  const newEvents = [
+    ...(state.events ?? []),
+    ...(!state.heartsBroken && card.suit === "hearts"
+      ? ([{ type: "heartsBroken" }] as const)
+      : []),
+  ];
 
   let next: HeartsState = {
     ...state,
@@ -275,6 +281,7 @@ export function playCard(state: HeartsState, playerIndex: number, card: Card): H
     currentTrick: newTrick,
     heartsBroken: newHeartsBroken,
     currentPlayerIndex: (playerIndex + 1) % 4,
+    events: newEvents,
   };
 
   if (newTrick.length === 4) {

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -270,9 +270,7 @@ export function playCard(state: HeartsState, playerIndex: number, card: Card): H
   const newHeartsBroken = state.heartsBroken || card.suit === "hearts";
   const newEvents = [
     ...(state.events ?? []),
-    ...(!state.heartsBroken && card.suit === "hearts"
-      ? ([{ type: "heartsBroken" }] as const)
-      : []),
+    ...(!state.heartsBroken && card.suit === "hearts" ? ([{ type: "heartsBroken" }] as const) : []),
   ];
 
   let next: HeartsState = {

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "كُسرت القلوب"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Herz gebrochen"
 }

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -68,5 +68,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Hearts broken"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Corazones descubiertos"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Cœurs brisés"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "הלבבות נשברו"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "दिल टूटे"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "ハートが解禁"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "하트 해제"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Harten gebroken"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Copas abertas"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "Черви раскрыты"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -52,5 +52,7 @@
   "settings.rename_title": "Player Names",
   "settings.player_label": "Player {{n}} (default: {{default}})",
   "settings.save": "Save",
-  "settings.cancel": "Cancel"
+  "settings.cancel": "Cancel",
+
+  "events.heartsBroken": "红心已开"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -35,7 +35,10 @@ import { useHeartsRounds } from "../game/hearts/RoundsContext";
 import { createIntegrityReporter } from "../game/hearts/integrity";
 import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
+import { useGameEvents } from "../game/_shared/useGameEvents";
+import { useSound } from "../game/_shared/useSound";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
+import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
 import type { Card, HeartsState, TrickCard } from "../game/hearts/types";
 
 const HUMAN = 0;
@@ -66,6 +69,7 @@ export default function HeartsScreen() {
 
   const [gameState, setGameState] = useState<HeartsState>(() => dealGame());
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
+  const [showHeartsBroken, setShowHeartsBroken] = useState(false);
   const [showRename, setShowRename] = useState(false);
   const [playerName, setPlayerName] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
@@ -156,6 +160,19 @@ export default function HeartsScreen() {
     });
     return unsub;
   }, [navigation, syncComplete, syncGetGameId]);
+
+  const { play: playHeartsBroken } = useSound("hearts.heartsBroken");
+
+  useGameEvents(
+    gameState.events,
+    {
+      heartsBroken: () => {
+        playHeartsBroken();
+        setShowHeartsBroken(true);
+      },
+    },
+    () => setGameState((prev) => ({ ...prev, events: [] }))
+  );
 
   const playerLabels = playerNames;
 
@@ -369,13 +386,19 @@ export default function HeartsScreen() {
               seatLabel={playerLabels[1] ?? ""}
             />
           </View>
-          <TrickArea
-            trick={[...displayTrick]}
-            playerIndex={HUMAN}
-            playerLabels={playerLabels}
-            winnerIndex={trickWinnerIndex}
-            onAnimationComplete={handleTrickAnimationComplete}
-          />
+          <View style={styles.trickWrapper}>
+            <TrickArea
+              trick={[...displayTrick]}
+              playerIndex={HUMAN}
+              playerLabels={playerLabels}
+              winnerIndex={trickWinnerIndex}
+              onAnimationComplete={handleTrickAnimationComplete}
+            />
+            <HeartsBrokenAnimation
+              visible={showHeartsBroken}
+              onAnimationEnd={() => setShowHeartsBroken(false)}
+            />
+          </View>
           <View style={styles.sideColumn}>
             <SideSeatLabel label={playerLabels[3] ?? ""} colors={colors} />
             <OpponentCapturedPile
@@ -648,6 +671,9 @@ const styles = StyleSheet.create({
   sideColumn: {
     alignItems: "center",
     gap: 6,
+  },
+  trickWrapper: {
+    position: "relative",
   },
   bottomArea: {
     paddingBottom: 8,


### PR DESCRIPTION
## Summary
- `playCard()` emits `{ type: 'heartsBroken' }` on the first heart played (engine-side, single-fire)
- Registers `hearts.heartsBroken` in `SOUND_REGISTRY` → `hearts-broken.mp3`; plays via `useSound` + `useGameEvents` in `HeartsScreen`
- New `HeartsBrokenAnimation` component: spring-scale ♥ icon + 6 radiating crack lines + red tint flash at trick center, ~3.4 s total (burst → linger → fade), `pointerEvents="none"` throughout so play is never blocked
- Reduced-motion fallback: instant red tint flash only (~0.3 s)
- `events.heartsBroken` i18n key added to all 13 locales
- 3 new engine unit tests; `expo-audio` mock + `.mp3` asset mapper added to Jest config

## Test plan
- [ ] Play first heart into a trick — crack sound plays, burst animation fires at trick center
- [ ] Animation lingers ~3 s then fades; cards remain tappable throughout
- [ ] Second heart in a subsequent trick — no sound, no animation
- [ ] Enable Reduce Motion → confirm tint-flash only, no spring/crack-line motion
- [ ] CI green (lint, type check, 1540 tests)

Closes #774
Part of #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)