### PR TITLE
feat(#761): persist Solitaire best time, best moves, games played, games won

### DIFF
--- a/frontend/src/components/scoreboard/SolitaireScoreboard.tsx
+++ b/frontend/src/components/scoreboard/SolitaireScoreboard.tsx
@@ -7,10 +7,19 @@ interface Props {
   snapshot: SolitaireScoreboardSnapshot;
 }
 
+function formatMs(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 export default function SolitaireScoreboard({ snapshot }: Props) {
   const { t } = useTranslation("solitaire");
 
-  const heroValue = snapshot.hasGame ? String(snapshot.moves) : "—";
+  const heroValue = snapshot.hasGame ? formatMs(snapshot.elapsedMs) : "—";
   const heroSub = snapshot.hasGame
     ? t("scoreboard.heroSub", {
         moves: snapshot.moves,
@@ -19,10 +28,27 @@ export default function SolitaireScoreboard({ snapshot }: Props) {
     : t("scoreboard.heroSubEmpty");
 
   const cards = [
-    { key: "bestTime", label: t("scoreboard.bestTime"), value: "—", accent: true },
-    { key: "bestMoves", label: t("scoreboard.bestMoves"), value: "—" },
-    { key: "gamesPlayed", label: t("scoreboard.gamesPlayed"), value: "—" },
-    { key: "gamesWon", label: t("scoreboard.gamesWon"), value: "—" },
+    {
+      key: "bestTime",
+      label: t("scoreboard.bestTime"),
+      value: snapshot.bestTimeMs > 0 ? formatMs(snapshot.bestTimeMs) : "—",
+      accent: true,
+    },
+    {
+      key: "bestMoves",
+      label: t("scoreboard.bestMoves"),
+      value: snapshot.bestMoves > 0 ? snapshot.bestMoves.toLocaleString("en-US") : "—",
+    },
+    {
+      key: "gamesPlayed",
+      label: t("scoreboard.gamesPlayed"),
+      value: snapshot.gamesPlayed > 0 ? snapshot.gamesPlayed.toLocaleString("en-US") : "—",
+    },
+    {
+      key: "gamesWon",
+      label: t("scoreboard.gamesWon"),
+      value: snapshot.gamesWon > 0 ? snapshot.gamesWon.toLocaleString("en-US") : "—",
+    },
   ] as const;
 
   return (

--- a/frontend/src/game/solitaire/SolitaireScoreboardContext.tsx
+++ b/frontend/src/game/solitaire/SolitaireScoreboardContext.tsx
@@ -2,14 +2,24 @@ import React, { createContext, useContext, useState } from "react";
 
 export interface SolitaireScoreboardSnapshot {
   moves: number;
+  elapsedMs: number;
   foundationsComplete: number;
   hasGame: boolean;
+  bestTimeMs: number;
+  bestMoves: number;
+  gamesPlayed: number;
+  gamesWon: number;
 }
 
 const initial: SolitaireScoreboardSnapshot = {
   moves: 0,
+  elapsedMs: 0,
   foundationsComplete: 0,
   hasGame: false,
+  bestTimeMs: 0,
+  bestMoves: 0,
+  gamesPlayed: 0,
+  gamesWon: 0,
 };
 
 interface ContextValue {

--- a/frontend/src/game/solitaire/__tests__/storage.test.ts
+++ b/frontend/src/game/solitaire/__tests__/storage.test.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 
-import { clearGame, loadGame, saveGame } from "../storage";
+import { clearGame, loadGame, saveGame, loadStats, saveStats } from "../storage";
 import { dealGame, applyMove } from "../engine";
 import type { SolitaireState } from "../types";
 
@@ -88,5 +88,46 @@ describe("solitaire storage", () => {
     await saveGame(seedState());
     await clearGame();
     expect(await loadGame()).toBeNull();
+  });
+
+  it("normalizes missing timer fields for saves created before timer was added", async () => {
+    const stateWithoutTimer = { ...seedState() } as Partial<SolitaireState>;
+    delete (stateWithoutTimer as Record<string, unknown>).startedAt;
+    delete (stateWithoutTimer as Record<string, unknown>).accumulatedMs;
+    await AsyncStorage.setItem(GAME_KEY, JSON.stringify(stateWithoutTimer));
+    const loaded = await loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.startedAt).toBeNull();
+    expect(loaded!.accumulatedMs).toBe(0);
+  });
+});
+
+describe("solitaire stats storage", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+  });
+
+  it("returns zero defaults when no stats saved", async () => {
+    const stats = await loadStats();
+    expect(stats).toEqual({ bestTimeMs: 0, bestMoves: 0, gamesPlayed: 0, gamesWon: 0 });
+  });
+
+  it("saves and loads stats round-trip", async () => {
+    await saveStats({ bestTimeMs: 95000, bestMoves: 42, gamesPlayed: 7, gamesWon: 3 });
+    const loaded = await loadStats();
+    expect(loaded).toEqual({ bestTimeMs: 95000, bestMoves: 42, gamesPlayed: 7, gamesWon: 3 });
+  });
+
+  it("returns zero defaults on corrupt stats payload", async () => {
+    await AsyncStorage.setItem("solitaire_stats_v1", "not-json{");
+    const stats = await loadStats();
+    expect(stats).toEqual({ bestTimeMs: 0, bestMoves: 0, gamesPlayed: 0, gamesWon: 0 });
+  });
+
+  it("coerces missing numeric fields to 0 on partial payload", async () => {
+    await AsyncStorage.setItem("solitaire_stats_v1", JSON.stringify({ gamesPlayed: 5 }));
+    const stats = await loadStats();
+    expect(stats).toEqual({ bestTimeMs: 0, bestMoves: 0, gamesPlayed: 5, gamesWon: 0 });
   });
 });

--- a/frontend/src/game/solitaire/engine.ts
+++ b/frontend/src/game/solitaire/engine.ts
@@ -167,6 +167,8 @@ export function dealGame(drawMode: DrawMode, explicitSeed?: number): SolitaireSt
     recycleCount: 0,
     undoStack: [],
     isComplete: false,
+    startedAt: null,
+    accumulatedMs: 0,
   };
 }
 
@@ -276,11 +278,24 @@ function clampScore(score: number): number {
 
 /** Take a snapshot of `prev` (with its own undoStack cleared to []), append
  * it to `prev.undoStack`, cap at UNDO_CAP, and attach to `next`. */
-function withUndo(prev: SolitaireState, next: Omit<SolitaireState, "undoStack">): SolitaireState {
+function withUndo(
+  prev: SolitaireState,
+  next: Omit<SolitaireState, "undoStack" | "startedAt" | "accumulatedMs">
+): SolitaireState {
   const snapshot: SolitaireState = { ...prev, undoStack: [] };
   const stack = [...prev.undoStack, snapshot];
   const capped = stack.length > UNDO_CAP ? stack.slice(stack.length - UNDO_CAP) : stack;
-  return { ...next, undoStack: capped };
+  return { ...next, undoStack: capped, startedAt: prev.startedAt, accumulatedMs: prev.accumulatedMs };
+}
+
+/** Start, advance, or freeze the timer. Called after every state mutation. */
+function applyTimer(prev: SolitaireState, next: SolitaireState): SolitaireState {
+  const now = Date.now();
+  if (next.isComplete && !prev.isComplete) {
+    const activeStart = prev.startedAt ?? now;
+    return { ...next, accumulatedMs: prev.accumulatedMs + (now - activeStart), startedAt: null };
+  }
+  return { ...next, startedAt: prev.startedAt ?? now, accumulatedMs: prev.accumulatedMs };
 }
 
 /** If the top card of `col` exists and is face-down, flip it and return
@@ -308,17 +323,13 @@ function isWin(foundations: Foundations): boolean {
 
 function finalizeAfterMove(
   prev: SolitaireState,
-  next: Omit<SolitaireState, "undoStack" | "isComplete">
+  next: Omit<SolitaireState, "undoStack" | "isComplete" | "startedAt" | "accumulatedMs">
 ): SolitaireState {
   const wasComplete = prev.isComplete;
   const nowComplete = isWin(next.foundations);
   const bonus = !wasComplete && nowComplete ? SCORE_WIN_BONUS : 0;
   const finalScore = clampScore(next.score + bonus);
-  return withUndo(prev, {
-    ...next,
-    score: finalScore,
-    isComplete: nowComplete,
-  });
+  return applyTimer(prev, withUndo(prev, { ...next, score: finalScore, isComplete: nowComplete }));
 }
 
 // ---------------------------------------------------------------------------
@@ -463,17 +474,20 @@ export function drawFromStock(state: SolitaireState): SolitaireState {
   }
   const newStock = state.stock.slice(0, state.stock.length - n);
   const newWaste = [...state.waste, ...drawn];
-  return withUndo(state, {
-    _v: 1,
-    drawMode: state.drawMode,
-    tableau: state.tableau,
-    foundations: state.foundations,
-    stock: newStock,
-    waste: newWaste,
-    score: state.score,
-    recycleCount: state.recycleCount,
-    isComplete: state.isComplete,
-  });
+  return applyTimer(
+    state,
+    withUndo(state, {
+      _v: 1,
+      drawMode: state.drawMode,
+      tableau: state.tableau,
+      foundations: state.foundations,
+      stock: newStock,
+      waste: newWaste,
+      score: state.score,
+      recycleCount: state.recycleCount,
+      isComplete: state.isComplete,
+    })
+  );
 }
 
 /**
@@ -489,17 +503,20 @@ export function recycleWaste(state: SolitaireState): SolitaireState {
     newStock.push({ ...card, faceUp: false });
   }
   const penalty = state.recycleCount >= 1 ? SCORE_RECYCLE_PENALTY : 0;
-  return withUndo(state, {
-    _v: 1,
-    drawMode: state.drawMode,
-    tableau: state.tableau,
-    foundations: state.foundations,
-    stock: newStock,
-    waste: [],
-    score: clampScore(state.score + penalty),
-    recycleCount: state.recycleCount + 1,
-    isComplete: state.isComplete,
-  });
+  return applyTimer(
+    state,
+    withUndo(state, {
+      _v: 1,
+      drawMode: state.drawMode,
+      tableau: state.tableau,
+      foundations: state.foundations,
+      stock: newStock,
+      waste: [],
+      score: clampScore(state.score + penalty),
+      recycleCount: state.recycleCount + 1,
+      isComplete: state.isComplete,
+    })
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -516,7 +533,8 @@ export function undo(state: SolitaireState): SolitaireState {
   const last = state.undoStack[state.undoStack.length - 1];
   if (last === undefined) return state;
   const remaining = state.undoStack.slice(0, -1);
-  return { ...last, undoStack: remaining };
+  // Preserve the live timer — don't restore the older timer snapshot from the undo entry.
+  return { ...last, undoStack: remaining, startedAt: state.startedAt, accumulatedMs: state.accumulatedMs };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/solitaire/engine.ts
+++ b/frontend/src/game/solitaire/engine.ts
@@ -285,7 +285,12 @@ function withUndo(
   const snapshot: SolitaireState = { ...prev, undoStack: [] };
   const stack = [...prev.undoStack, snapshot];
   const capped = stack.length > UNDO_CAP ? stack.slice(stack.length - UNDO_CAP) : stack;
-  return { ...next, undoStack: capped, startedAt: prev.startedAt, accumulatedMs: prev.accumulatedMs };
+  return {
+    ...next,
+    undoStack: capped,
+    startedAt: prev.startedAt,
+    accumulatedMs: prev.accumulatedMs,
+  };
 }
 
 /** Start, advance, or freeze the timer. Called after every state mutation. */
@@ -534,7 +539,12 @@ export function undo(state: SolitaireState): SolitaireState {
   if (last === undefined) return state;
   const remaining = state.undoStack.slice(0, -1);
   // Preserve the live timer — don't restore the older timer snapshot from the undo entry.
-  return { ...last, undoStack: remaining, startedAt: state.startedAt, accumulatedMs: state.accumulatedMs };
+  return {
+    ...last,
+    undoStack: remaining,
+    startedAt: state.startedAt,
+    accumulatedMs: state.accumulatedMs,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/solitaire/storage.ts
+++ b/frontend/src/game/solitaire/storage.ts
@@ -21,6 +21,14 @@ import * as Sentry from "@sentry/react-native";
 import type { SolitaireState } from "./types";
 
 const GAME_KEY = "solitaire_game";
+const STATS_KEY = "solitaire_stats_v1";
+
+export interface SolitaireStats {
+  bestTimeMs: number;
+  bestMoves: number;
+  gamesPlayed: number;
+  gamesWon: number;
+}
 
 function stripNestedUndo(state: SolitaireState): SolitaireState {
   return {
@@ -59,6 +67,9 @@ export async function loadGame(): Promise<SolitaireState | null> {
       await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
       return null;
     }
+    // Normalize timer fields — absent in saves created before timer tracking was added.
+    parsed.startedAt = parsed.startedAt ?? null;
+    parsed.accumulatedMs = parsed.accumulatedMs ?? 0;
     return parsed as SolitaireState;
   } catch (e) {
     Sentry.captureMessage("solitaire.storage: corrupt game payload, discarding", {
@@ -76,5 +87,32 @@ export async function clearGame(): Promise<void> {
     await AsyncStorage.removeItem(GAME_KEY);
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "solitaire.storage", op: "clear" } });
+  }
+}
+
+const EMPTY_STATS: SolitaireStats = { bestTimeMs: 0, bestMoves: 0, gamesPlayed: 0, gamesWon: 0 };
+
+export async function loadStats(): Promise<SolitaireStats> {
+  try {
+    const raw = await AsyncStorage.getItem(STATS_KEY);
+    if (!raw) return { ...EMPTY_STATS };
+    const parsed = JSON.parse(raw);
+    return {
+      bestTimeMs: typeof parsed.bestTimeMs === "number" ? parsed.bestTimeMs : 0,
+      bestMoves: typeof parsed.bestMoves === "number" ? parsed.bestMoves : 0,
+      gamesPlayed: typeof parsed.gamesPlayed === "number" ? parsed.gamesPlayed : 0,
+      gamesWon: typeof parsed.gamesWon === "number" ? parsed.gamesWon : 0,
+    };
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "solitaire.storage", op: "loadStats" } });
+    return { ...EMPTY_STATS };
+  }
+}
+
+export async function saveStats(stats: SolitaireStats): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "solitaire.storage", op: "saveStats" } });
   }
 }

--- a/frontend/src/game/solitaire/types.ts
+++ b/frontend/src/game/solitaire/types.ts
@@ -46,6 +46,10 @@ export interface SolitaireState {
    * Nested `undoStack` is always `[]` to prevent exponential nesting. */
   readonly undoStack: readonly SolitaireState[];
   readonly isComplete: boolean;
+  /** Timestamp (Date.now()) when the current play session started; null if not yet started or game is over. */
+  readonly startedAt: number | null;
+  /** Total elapsed milliseconds accumulated across all sessions before the current one. */
+  readonly accumulatedMs: number;
 }
 
 /** Card moves are the 5 player actions that shuffle cards between piles.

--- a/frontend/src/i18n/locales/ar/solitaire.json
+++ b/frontend/src/i18n/locales/ar/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "تعذر استئناف اللعبة المحفوظة.",
   "error.submitFailed": "تعذر حفظ النتيجة. تحقق من الاتصال.",
   "error.submitRetry": "أعد المحاولة",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/de/solitaire.json
+++ b/frontend/src/i18n/locales/de/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Gespeichertes Spiel konnte nicht geladen werden.",
   "error.submitFailed": "Punkte konnten nicht gespeichert werden. Verbindung prüfen.",
   "error.submitRetry": "Erneut",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/en/solitaire.json
+++ b/frontend/src/i18n/locales/en/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Could not resume the saved game.",
   "error.submitFailed": "Could not save score. Check your connection.",
   "error.submitRetry": "Retry",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/es/solitaire.json
+++ b/frontend/src/i18n/locales/es/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "No se pudo reanudar la partida guardada.",
   "error.submitFailed": "No se pudo guardar la puntuación. Revisa tu conexión.",
   "error.submitRetry": "Reintentar",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/fr-CA/solitaire.json
+++ b/frontend/src/i18n/locales/fr-CA/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Impossible de reprendre la partie sauvegardée.",
   "error.submitFailed": "Impossible d'enregistrer le score. Vérifiez votre connexion.",
   "error.submitRetry": "Réessayer",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/he/solitaire.json
+++ b/frontend/src/i18n/locales/he/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "לא ניתן לטעון את המשחק השמור.",
   "error.submitFailed": "לא ניתן לשמור את הניקוד. בדוק את החיבור.",
   "error.submitRetry": "נסה שוב",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/hi/solitaire.json
+++ b/frontend/src/i18n/locales/hi/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "सेव किया हुआ गेम लोड नहीं हो सका।",
   "error.submitFailed": "स्कोर सेव नहीं हो सका। कनेक्शन जांचें।",
   "error.submitRetry": "पुनः प्रयास",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/ja/solitaire.json
+++ b/frontend/src/i18n/locales/ja/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "保存したゲームを再開できませんでした。",
   "error.submitFailed": "スコアの送信に失敗しました。接続を確認してください。",
   "error.submitRetry": "再試行",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/ko/solitaire.json
+++ b/frontend/src/i18n/locales/ko/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "저장된 게임을 불러올 수 없습니다.",
   "error.submitFailed": "점수를 저장할 수 없습니다. 연결을 확인하세요.",
   "error.submitRetry": "다시 시도",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/nl/solitaire.json
+++ b/frontend/src/i18n/locales/nl/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Het opgeslagen spel kon niet worden hervat.",
   "error.submitFailed": "Score opslaan mislukt. Controleer je verbinding.",
   "error.submitRetry": "Opnieuw",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/pt/solitaire.json
+++ b/frontend/src/i18n/locales/pt/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Não foi possível retomar o jogo salvo.",
   "error.submitFailed": "Não foi possível salvar a pontuação. Verifique sua conexão.",
   "error.submitRetry": "Tentar",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/ru/solitaire.json
+++ b/frontend/src/i18n/locales/ru/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "Не удалось загрузить сохранение.",
   "error.submitFailed": "Не удалось сохранить счет. Проверьте соединение.",
   "error.submitRetry": "Повторить",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/i18n/locales/zh/solitaire.json
+++ b/frontend/src/i18n/locales/zh/solitaire.json
@@ -40,7 +40,7 @@
   "error.loadFailed": "无法恢复存档。",
   "error.submitFailed": "无法提交分数，请检查网络连接。",
   "error.submitRetry": "重试",
-  "scoreboard.heroLabel": "MOVES",
+  "scoreboard.heroLabel": "TIME",
   "scoreboard.heroSub": "{{moves}} moves · {{foundations}} of 4 complete",
   "scoreboard.heroSubEmpty": "No games played yet",
   "scoreboard.bestTime": "Best Time",

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -54,7 +54,14 @@ import {
 } from "../game/solitaire/engine";
 import type { DrawMode, Move, SolitaireState, Suit } from "../game/solitaire/types";
 import { SUITS } from "../game/solitaire/types";
-import { clearGame, loadGame, saveGame } from "../game/solitaire/storage";
+import {
+  clearGame,
+  loadGame,
+  loadStats,
+  saveGame,
+  saveStats,
+  type SolitaireStats,
+} from "../game/solitaire/storage";
 import { useSolitaireScoreboard } from "../game/solitaire/SolitaireScoreboardContext";
 import { solitaireApi, type ScoreEntry } from "../game/solitaire/api";
 import { useGameSync } from "../game/_shared/useGameSync";
@@ -91,6 +98,12 @@ export default function SolitaireScreen() {
   const [autoCompleting, setAutoCompleting] = useState(false);
   const [outerWidth, setOuterWidth] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [stats, setStats] = useState<SolitaireStats>({
+    bestTimeMs: 0,
+    bestMoves: 0,
+    gamesPlayed: 0,
+    gamesWon: 0,
+  });
 
   // Invalid-move flash — red overlay pulse instead of positional shake so we
   // don't fight React Navigation / safe-area layout math.
@@ -103,6 +116,8 @@ export default function SolitaireScreen() {
   const stateRef = useRef<SolitaireState | null>(null);
   const movesRef = useRef(0);
   const prevCompleteRef = useRef(false);
+  /** Guards against double-counting a win within a single game session. */
+  const winRecordedRef = useRef(false);
 
   const {
     start: syncStart,
@@ -124,22 +139,35 @@ export default function SolitaireScreen() {
     const foundationsComplete = Object.values(state.foundations).filter(
       (cards) => cards.length === 13
     ).length;
-    setScoreboardSnapshot({ moves, foundationsComplete, hasGame: true });
-  }, [state, moves, setScoreboardSnapshot]);
+    const elapsedMs =
+      state.accumulatedMs + (state.startedAt !== null ? Date.now() - state.startedAt : 0);
+    setScoreboardSnapshot({
+      moves,
+      elapsedMs,
+      foundationsComplete,
+      hasGame: true,
+      bestTimeMs: stats.bestTimeMs,
+      bestMoves: stats.bestMoves,
+      gamesPlayed: stats.gamesPlayed,
+      gamesWon: stats.gamesWon,
+    });
+  }, [state, moves, stats, setScoreboardSnapshot]);
 
   // #597 — mount load. Restores a saved game silently; on a clean slot the
   // pre-game draw-mode modal is shown so the player picks their mode.
   useEffect(() => {
     let alive = true;
-    loadGame()
-      .then((saved) => {
-        if (!alive) return;
-        hasLoadedRef.current = true;
-        if (saved !== null) setState(saved);
-      })
-      .finally(() => {
-        if (alive) setLoading(false);
-      });
+    Promise.all([loadGame(), loadStats()]).then(([saved, savedStats]) => {
+      if (!alive) return;
+      hasLoadedRef.current = true;
+      if (saved !== null) {
+        setState(saved);
+        // Suppress re-counting a win when resuming an already-won game.
+        if (saved.isComplete) winRecordedRef.current = true;
+      }
+      setStats(savedStats);
+      setLoading(false);
+    });
     return () => {
       alive = false;
     };
@@ -170,10 +198,27 @@ export default function SolitaireScreen() {
     }
     if (state.isComplete && !prevCompleteRef.current) {
       syncComplete(
-        { finalScore: state.score, outcome: "completed", durationMs: 0 },
+        { finalScore: state.score, outcome: "completed", durationMs: state.accumulatedMs },
         { final_score: state.score, outcome: "completed", moves: movesRef.current }
       );
       clearGame().catch(() => {});
+      if (!winRecordedRef.current) {
+        winRecordedRef.current = true;
+        const finalMs = state.accumulatedMs;
+        const finalMoves = movesRef.current;
+        setStats((prev) => {
+          const updated: SolitaireStats = {
+            ...prev,
+            gamesWon: prev.gamesWon + 1,
+            bestTimeMs:
+              prev.bestTimeMs === 0 || finalMs < prev.bestTimeMs ? finalMs : prev.bestTimeMs,
+            bestMoves:
+              prev.bestMoves === 0 || finalMoves < prev.bestMoves ? finalMoves : prev.bestMoves,
+          };
+          saveStats(updated);
+          return updated;
+        });
+      }
     }
     prevCompleteRef.current = state.isComplete;
   }, [state, syncComplete]);
@@ -217,6 +262,11 @@ export default function SolitaireScreen() {
     setState(dealGame(drawMode));
     setSelection(null);
     setMoves(0);
+    setStats((prev) => {
+      const updated = { ...prev, gamesPlayed: prev.gamesPlayed + 1 };
+      saveStats(updated);
+      return updated;
+    });
   }, []);
 
   const tryMove = useCallback(
@@ -425,6 +475,7 @@ export default function SolitaireScreen() {
     setState(null);
     setSelection(null);
     setMoves(0);
+    winRecordedRef.current = false;
   }, []);
 
   const undoDisabled = state === null || state.undoStack.length === 0 || autoCompleting;

--- a/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
@@ -14,6 +14,7 @@ import SolitaireScreen from "../SolitaireScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import { SolitaireScoreboardProvider } from "../../game/solitaire/SolitaireScoreboardContext";
 import { createSeededRng, dealGame, setRng } from "../../game/solitaire/engine";
+import { saveStats } from "../../game/solitaire/storage";
 import { solitaireApi } from "../../game/solitaire/api";
 
 jest.mock("expo-blur", () => ({
@@ -403,5 +404,67 @@ describe("SolitaireScreen — win-modal score submission", () => {
     });
     expect(api.getByLabelText("Draw 1")).toBeTruthy();
     expect(await AsyncStorage.getItem("solitaire_game")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #761 — stats tracking
+// ---------------------------------------------------------------------------
+
+describe("SolitaireScreen — stats tracking", () => {
+  it("increments gamesPlayed when the player chooses a draw mode", async () => {
+    const api = await mount();
+    await chooseDraw1(api);
+    await waitFor(async () => {
+      const raw = await AsyncStorage.getItem("solitaire_stats_v1");
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!).gamesPlayed).toBe(1);
+    });
+  });
+
+  it("does not double-count gamesPlayed when resuming a saved game", async () => {
+    const saved = dealGame(1, 12345);
+    await AsyncStorage.setItem("solitaire_game", JSON.stringify(saved));
+    await mount();
+    const raw = await AsyncStorage.getItem("solitaire_stats_v1");
+    // No new deal was started — stats not yet written or gamesPlayed is still 0.
+    const gamesPlayed = raw ? JSON.parse(raw).gamesPlayed : 0;
+    expect(gamesPlayed).toBe(0);
+  });
+
+  it("does not double-count gamesWon when resuming an already-complete game", async () => {
+    // Pre-seed stats as if a win was already counted in a prior session.
+    await saveStats({ bestTimeMs: 95000, bestMoves: 42, gamesPlayed: 1, gamesWon: 1 });
+    // Seed a complete game (edge case: game wasn't cleared before app killed).
+    const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
+    const rankSeq = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const;
+    const full = suits.flatMap((suit) => rankSeq.map((rank) => ({ suit, rank, faceUp: true })));
+    const winState = {
+      _v: 1,
+      drawMode: 1,
+      tableau: [[], [], [], [], [], [], []],
+      foundations: {
+        spades: full.filter((c) => c.suit === "spades"),
+        hearts: full.filter((c) => c.suit === "hearts"),
+        diamonds: full.filter((c) => c.suit === "diamonds"),
+        clubs: full.filter((c) => c.suit === "clubs"),
+      },
+      stock: [],
+      waste: [],
+      score: 820,
+      recycleCount: 0,
+      undoStack: [],
+      isComplete: true,
+      startedAt: null,
+      accumulatedMs: 95000,
+    };
+    await AsyncStorage.setItem("solitaire_game", JSON.stringify(winState));
+    await mount();
+    // gamesWon must remain 1, not 2.
+    await waitFor(async () => {
+      const raw = await AsyncStorage.getItem("solitaire_stats_v1");
+      const stats = raw ? JSON.parse(raw) : { gamesWon: 1 };
+      expect(stats.gamesWon).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `startedAt` / `accumulatedMs` timer fields to `SolitaireState` (matching the 2048 timer pattern) — timer starts on first move, freezes on win, preserved across undo
- Adds `solitaire_stats_v1` AsyncStorage key tracking `bestTimeMs`, `bestMoves`, `gamesPlayed`, `gamesWon`
- Wires all four stats into `SolitaireScoreboardSnapshot` so stat cards no longer show `—`
- Hero on the Solitaire scoreboard now shows elapsed time (`m:ss` / `h:mm:ss`) instead of move count; move count moves to the sub-line (unchanged)

## Test plan

- [ ] All Solitaire storage tests pass (12 tests, including 5 new stats/timer tests)
- [ ] All SolitaireScreen tests pass (24 tests, including 3 new stats lifecycle tests)
- [ ] Engine tests still pass (45 tests — timer fields flow through without breaking existing assertions)
- [ ] `Twenty48Screen` / `useSound` flakiness confirmed pre-existing on `dev` (not introduced here)
- [ ] Deal a game → Scoreboard → Games Played shows 1
- [ ] Win a game → Scoreboard → Games Won shows 1, Best Time shows elapsed, Best Moves shows move count
- [ ] Start a second game → Games Played increments, Best Time/Moves update if improved
- [ ] Kill and relaunch app mid-game → elapsed time resumes correctly from saved state

Closes #761

🤖 Generated with [Claude Code](https://claude.ai/claude-code)