### PR TITLE
feat(#762): Sudoku scoreboard — per-difficulty best time and games solved

### DIFF
--- a/frontend/src/components/scoreboard/SudokuScoreboard.tsx
+++ b/frontend/src/components/scoreboard/SudokuScoreboard.tsx
@@ -25,11 +25,31 @@ export default function SudokuScoreboard({ snapshot }: Props) {
       })
     : t("scoreboard.heroSubEmpty");
 
+  const { easy, medium, hard } = snapshot.stats;
+  const totalSolved = easy.gamesSolved + medium.gamesSolved + hard.gamesSolved;
+
   const cards = [
-    { key: "easyBestTime", label: t("scoreboard.easyBestTime"), value: "—", accent: true },
-    { key: "mediumBestTime", label: t("scoreboard.mediumBestTime"), value: "—" },
-    { key: "hardBestTime", label: t("scoreboard.hardBestTime"), value: "—" },
-    { key: "gamesSolved", label: t("scoreboard.gamesSolved"), value: "—" },
+    {
+      key: "easyBestTime",
+      label: t("scoreboard.easyBestTime"),
+      value: easy.bestTimeS > 0 ? formatElapsed(easy.bestTimeS) : "—",
+      accent: true,
+    },
+    {
+      key: "mediumBestTime",
+      label: t("scoreboard.mediumBestTime"),
+      value: medium.bestTimeS > 0 ? formatElapsed(medium.bestTimeS) : "—",
+    },
+    {
+      key: "hardBestTime",
+      label: t("scoreboard.hardBestTime"),
+      value: hard.bestTimeS > 0 ? formatElapsed(hard.bestTimeS) : "—",
+    },
+    {
+      key: "gamesSolved",
+      label: t("scoreboard.gamesSolved"),
+      value: totalSolved > 0 ? totalSolved.toLocaleString("en-US") : "—",
+    },
   ] as const;
 
   return (

--- a/frontend/src/game/sudoku/SudokuScoreboardContext.tsx
+++ b/frontend/src/game/sudoku/SudokuScoreboardContext.tsx
@@ -1,11 +1,14 @@
 import React, { createContext, useContext, useState } from "react";
 import type { Difficulty } from "./types";
+import { EMPTY_SUDOKU_STATS } from "./storage";
+import type { SudokuStats } from "./storage";
 
 export interface SudokuScoreboardSnapshot {
   elapsed: number;
   difficulty: Difficulty;
   errorCount: number;
   hasGame: boolean;
+  stats: SudokuStats;
 }
 
 const initial: SudokuScoreboardSnapshot = {
@@ -13,6 +16,7 @@ const initial: SudokuScoreboardSnapshot = {
   difficulty: "easy",
   errorCount: 0,
   hasGame: false,
+  stats: EMPTY_SUDOKU_STATS,
 };
 
 interface ContextValue {

--- a/frontend/src/game/sudoku/storage.ts
+++ b/frontend/src/game/sudoku/storage.ts
@@ -200,3 +200,59 @@ export async function clearGame(): Promise<void> {
     });
   }
 }
+
+// ---------------------------------------------------------------------------
+// Stats persistence (#762)
+// ---------------------------------------------------------------------------
+
+const STATS_KEY = "sudoku_stats_v1";
+
+export interface DifficultyStats {
+  bestTimeS: number;
+  gamesSolved: number;
+}
+
+export interface SudokuStats {
+  easy: DifficultyStats;
+  medium: DifficultyStats;
+  hard: DifficultyStats;
+}
+
+export const EMPTY_SUDOKU_STATS: SudokuStats = {
+  easy: { bestTimeS: 0, gamesSolved: 0 },
+  medium: { bestTimeS: 0, gamesSolved: 0 },
+  hard: { bestTimeS: 0, gamesSolved: 0 },
+};
+
+function parseDiffStats(d: unknown): DifficultyStats {
+  if (d === null || typeof d !== "object") return { bestTimeS: 0, gamesSolved: 0 };
+  const o = d as Partial<DifficultyStats>;
+  return {
+    bestTimeS: typeof o.bestTimeS === "number" ? o.bestTimeS : 0,
+    gamesSolved: typeof o.gamesSolved === "number" ? o.gamesSolved : 0,
+  };
+}
+
+export async function loadStats(): Promise<SudokuStats> {
+  try {
+    const raw = await AsyncStorage.getItem(STATS_KEY);
+    if (!raw) return { ...EMPTY_SUDOKU_STATS };
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      easy: parseDiffStats(parsed?.easy),
+      medium: parseDiffStats(parsed?.medium),
+      hard: parseDiffStats(parsed?.hard),
+    };
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "sudoku.storage", op: "loadStats" } });
+    return { ...EMPTY_SUDOKU_STATS };
+  }
+}
+
+export async function saveStats(stats: SudokuStats): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "sudoku.storage", op: "saveStats" } });
+  }
+}

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -245,18 +245,14 @@ export default function SudokuScreen() {
       clearGame().catch(() => {});
 
       const finalElapsed =
-        startMsRef.current !== null
-          ? Math.floor((Date.now() - startMsRef.current) / 1000)
-          : 0;
+        startMsRef.current !== null ? Math.floor((Date.now() - startMsRef.current) / 1000) : 0;
       const diff = state.difficulty;
       const prev = statsRef.current[diff];
       const updatedStats: SudokuStats = {
         ...statsRef.current,
         [diff]: {
           bestTimeS:
-            prev.bestTimeS === 0 || finalElapsed < prev.bestTimeS
-              ? finalElapsed
-              : prev.bestTimeS,
+            prev.bestTimeS === 0 || finalElapsed < prev.bestTimeS ? finalElapsed : prev.bestTimeS,
           gamesSolved: prev.gamesSolved + 1,
         },
       };

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -52,7 +52,15 @@ import {
   undo,
 } from "../game/sudoku/engine";
 import type { CellValue, Difficulty, SudokuState } from "../game/sudoku/types";
-import { clearGame, loadGame, saveGame } from "../game/sudoku/storage";
+import {
+  clearGame,
+  loadGame,
+  saveGame,
+  loadStats,
+  saveStats,
+  EMPTY_SUDOKU_STATS,
+  type SudokuStats,
+} from "../game/sudoku/storage";
 import { useSudokuScoreboard } from "../game/sudoku/SudokuScoreboardContext";
 import { scoreQueue } from "../game/_shared/scoreQueue";
 import { useGameSync } from "../game/_shared/useGameSync";
@@ -105,6 +113,8 @@ export default function SudokuScreen() {
   const digitCountRef = useRef(0);
   const prevCompleteRef = useRef(false);
 
+  const statsRef = useRef<SudokuStats>(EMPTY_SUDOKU_STATS);
+
   const flashOpacity = useRef(new Animated.Value(0)).current;
   const isComplete = state?.isComplete ?? false;
 
@@ -124,6 +134,7 @@ export default function SudokuScreen() {
       difficulty: state.difficulty,
       errorCount: state.errorCount,
       hasGame: true,
+      stats: statsRef.current,
     });
   }, [state, elapsed, setScoreboardSnapshot]);
 
@@ -131,9 +142,10 @@ export default function SudokuScreen() {
   // pre-game picker shows.
   useEffect(() => {
     let alive = true;
-    loadGame()
-      .then((saved) => {
+    Promise.all([loadGame(), loadStats()])
+      .then(([saved, savedStats]) => {
         if (!alive) return;
+        statsRef.current = savedStats;
         hasLoadedRef.current = true;
         if (saved !== null) {
           setState(saved);
@@ -231,9 +243,35 @@ export default function SudokuScreen() {
         );
       }
       clearGame().catch(() => {});
+
+      const finalElapsed =
+        startMsRef.current !== null
+          ? Math.floor((Date.now() - startMsRef.current) / 1000)
+          : 0;
+      const diff = state.difficulty;
+      const prev = statsRef.current[diff];
+      const updatedStats: SudokuStats = {
+        ...statsRef.current,
+        [diff]: {
+          bestTimeS:
+            prev.bestTimeS === 0 || finalElapsed < prev.bestTimeS
+              ? finalElapsed
+              : prev.bestTimeS,
+          gamesSolved: prev.gamesSolved + 1,
+        },
+      };
+      statsRef.current = updatedStats;
+      saveStats(updatedStats).catch(() => {});
+      setScoreboardSnapshot({
+        elapsed: finalElapsed,
+        difficulty: state.difficulty,
+        errorCount: state.errorCount,
+        hasGame: true,
+        stats: updatedStats,
+      });
     }
     prevCompleteRef.current = state.isComplete;
-  }, [state, syncComplete, syncGetGameId]);
+  }, [state, syncComplete, syncGetGameId, setScoreboardSnapshot]);
 
   // Abandon on back-navigation when a digit has been placed and the
   // puzzle isn't finished.  useGameSync's own unmount handler provides


### PR DESCRIPTION
## Summary

- Adds `SudokuStats` / `DifficultyStats` types and `loadStats` / `saveStats` functions to `storage.ts` (persisted under `sudoku_stats_v1`)
- Extends `SudokuScoreboardSnapshot` with a `stats` field carrying per-difficulty data
- Loads stats on mount (alongside the saved game) and updates them on win: best time per difficulty and a `gamesSolved` counter
- Wires Easy Best, Medium Best, Hard Best (MM:SS), and total Games Solved into the `SudokuScoreboard` card display — replacing the hardcoded `—`

Closes #762

## Test plan

- [ ] Play and complete an Easy puzzle — verify Easy Best populates in the scoreboard and Games Solved increments
- [ ] Complete a second Easy puzzle faster — verify best time updates; complete one slower — verify it stays
- [ ] Complete Medium and Hard puzzles — verify their cards populate independently
- [ ] Kill and relaunch the app — verify all stats survive (AsyncStorage round-trip)
- [ ] Fresh install (or clear storage) — all four cards show `—`
- [ ] All 55 Sudoku unit tests pass (`npx jest src/game/sudoku --no-coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)