### PR TITLE
feat(#773): hearts — shoot the moon sound + animation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -168,6 +168,21 @@ Verifies the crack sound and burst animation fire exactly once when hearts break
 5. **Reduced-motion fallback:** Enable Reduce Motion in device accessibility settings, repeat steps 2–3.
    Confirm only an instant red tint flash (~0.3 s) occurs, no spring or crack-line motion.
 
+### Hearts: shoot-the-moon sound + animation (#773)
+
+Verifies the fanfare sound and full-screen moon overlay fire exactly once when someone shoots the moon.
+
+1. Start a Hearts game and engineer a moon shot (one player takes all 13 hearts and Q♠). The easiest way in a local dev build is to seed the engine state via the console so that one AI player holds all 26 point cards after trick 13.
+2. Once all 13 tricks resolve, confirm:
+   - A triumphant fanfare (hearts-moon-shot.mp3) plays once.
+   - A dark semi-transparent full-screen overlay appears with a 🌙 moon icon spring-scaling from 0 → 1.
+   - Six ★ stars stagger in around the moon (each 120 ms apart).
+   - The shooter label appears below the moon (e.g. "You shot the moon!" or "{Name} shot the moon!").
+   - The overlay auto-dismisses after ~2.2 s. Play is **not blocked** — the hand-end modal (or game-over modal) appears after the animation.
+3. Re-mount the Hearts screen mid-game (e.g. navigate away and back). Confirm the moon shot animation does **not** replay on re-render.
+4. **Mute toggle:** Enable the global mute, trigger a moon shot. Confirm the animation still shows but the sound is suppressed.
+5. **Reduced-motion fallback:** Enable Reduce Motion in device accessibility settings, trigger a moon shot. Confirm the moon icon and stars appear instantly (no spring motion) and the label is visible immediately; overlay still auto-dismisses after 2.2 s.
+
 ---
 
 ## E2E Test Conventions

--- a/frontend/src/components/hearts/HeartsMoonShotAnimation.tsx
+++ b/frontend/src/components/hearts/HeartsMoonShotAnimation.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AccessibilityInfo, StyleSheet, View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  visible: boolean;
+  shooterLabel: string;
+  onAnimationEnd: () => void;
+}
+
+// Six stars scattered around the moon icon
+const STAR_OFFSETS = [
+  { x: -90, y: -80 },
+  { x: 90, y: -80 },
+  { x: -120, y: 10 },
+  { x: 120, y: 10 },
+  { x: -70, y: 90 },
+  { x: 70, y: 90 },
+] as const;
+
+export function HeartsMoonShotAnimation({ visible, shooterLabel, onAnimationEnd }: Props) {
+  const { t } = useTranslation("hearts");
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const backdropOpacity = useSharedValue(0);
+  const moonScale = useSharedValue(0);
+  const moonOpacity = useSharedValue(0);
+  const labelOpacity = useSharedValue(0);
+
+  // One shared value per star — hooks cannot be called in a loop
+  const star0 = useSharedValue(0);
+  const star1 = useSharedValue(0);
+  const star2 = useSharedValue(0);
+  const star3 = useSharedValue(0);
+  const star4 = useSharedValue(0);
+  const star5 = useSharedValue(0);
+  const stars = [star0, star1, star2, star3, star4, star5];
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      backdropOpacity.value = 0;
+      moonScale.value = 0;
+      moonOpacity.value = 0;
+      labelOpacity.value = 0;
+      stars.forEach((s) => {
+        s.value = 0;
+      });
+      return;
+    }
+
+    if (reduceMotion) {
+      // Reduced motion: static display, 2.2 s dismiss
+      backdropOpacity.value = 0.65;
+      moonScale.value = 1;
+      moonOpacity.value = 1;
+      labelOpacity.value = 1;
+      stars.forEach((s) => {
+        s.value = 1;
+      });
+      const t1 = setTimeout(onAnimationEnd, 2200);
+      timersRef.current.push(t1);
+      return () => {
+        clearTimeout(t1);
+        timersRef.current = [];
+      };
+    }
+
+    // Phase 1 — burst in
+    backdropOpacity.value = withTiming(0.65, { duration: 300 });
+    moonOpacity.value = 1;
+    moonScale.value = withSpring(1, { damping: 8, stiffness: 180 });
+    stars.forEach((s, i) => {
+      s.value = withDelay(i * 120, withSpring(1, { damping: 10, stiffness: 200 }));
+    });
+    labelOpacity.value = withDelay(400, withTiming(1, { duration: 300 }));
+
+    // Phase 2 — fade everything out at 1700 ms (total 2200 ms)
+    const t1 = setTimeout(() => {
+      backdropOpacity.value = withTiming(0, { duration: 500 });
+      moonScale.value = withTiming(0, { duration: 500 });
+      moonOpacity.value = withTiming(0, { duration: 500 });
+      labelOpacity.value = withTiming(0, { duration: 300 });
+      stars.forEach((s) => {
+        s.value = withTiming(0, { duration: 400 });
+      });
+    }, 1700);
+
+    const t2 = setTimeout(onAnimationEnd, 2200);
+    timersRef.current.push(t1, t2);
+
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+      cancelAnimation(backdropOpacity);
+      cancelAnimation(moonScale);
+      cancelAnimation(moonOpacity);
+      cancelAnimation(labelOpacity);
+      stars.forEach((s) => cancelAnimation(s));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, reduceMotion]);
+
+  const backdropStyle = useAnimatedStyle(() => ({ opacity: backdropOpacity.value }));
+  const moonStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: moonScale.value }],
+    opacity: moonOpacity.value,
+  }));
+  const labelStyle = useAnimatedStyle(() => ({ opacity: labelOpacity.value }));
+  const star0Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[0].x },
+      { translateY: STAR_OFFSETS[0].y },
+      { scale: star0.value },
+    ],
+    opacity: star0.value,
+  }));
+  const star1Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[1].x },
+      { translateY: STAR_OFFSETS[1].y },
+      { scale: star1.value },
+    ],
+    opacity: star1.value,
+  }));
+  const star2Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[2].x },
+      { translateY: STAR_OFFSETS[2].y },
+      { scale: star2.value },
+    ],
+    opacity: star2.value,
+  }));
+  const star3Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[3].x },
+      { translateY: STAR_OFFSETS[3].y },
+      { scale: star3.value },
+    ],
+    opacity: star3.value,
+  }));
+  const star4Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[4].x },
+      { translateY: STAR_OFFSETS[4].y },
+      { scale: star4.value },
+    ],
+    opacity: star4.value,
+  }));
+  const star5Style = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: STAR_OFFSETS[5].x },
+      { translateY: STAR_OFFSETS[5].y },
+      { scale: star5.value },
+    ],
+    opacity: star5.value,
+  }));
+  const starStyles = [star0Style, star1Style, star2Style, star3Style, star4Style, star5Style];
+
+  return (
+    // Non-interactive wrapper — never blocks touches
+    <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
+      {/* Dark backdrop — separate opacity so it doesn't affect child elements */}
+      <Animated.View style={[StyleSheet.absoluteFillObject, styles.backdrop, backdropStyle]} />
+      {/* Content: moon icon, staggered stars, shooter label */}
+      <View style={styles.content}>
+        {starStyles.map((style, i) => (
+          <Animated.Text key={i} style={[styles.star, style]}>
+            ★
+          </Animated.Text>
+        ))}
+        <Animated.Text
+          style={[styles.moonIcon, moonStyle]}
+          accessibilityLabel={t("events.moonShot", { name: shooterLabel })}
+          accessibilityRole="text"
+          accessibilityLiveRegion="polite"
+        >
+          🌙
+        </Animated.Text>
+        <Animated.Text style={[styles.label, labelStyle]}>
+          {t("events.moonShot", { name: shooterLabel })}
+        </Animated.Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    backgroundColor: "#000000",
+    zIndex: 100,
+  },
+  content: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 101,
+  },
+  moonIcon: {
+    fontSize: 64,
+    lineHeight: 72,
+  },
+  star: {
+    position: "absolute",
+    fontSize: 24,
+    color: "#fbbf24",
+  },
+  label: {
+    marginTop: 16,
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#ffffff",
+    textAlign: "center",
+    paddingHorizontal: 24,
+  },
+});

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -10,4 +10,6 @@ export type SoundKey = string;
 export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "hearts.heartsBroken": require("../../../assets/sounds/hearts-broken.mp3"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "hearts.moonShot": require("../../../assets/sounds/hearts-moon-shot.mp3"),
 };

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -717,6 +717,74 @@ describe("applyHandScoring — moon shot", () => {
   });
 });
 
+describe("applyHandScoring — moonShot event", () => {
+  it("appends moonShot event when detectMoon returns non-null", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [26, 0, 0, 0],
+      cumulativeScores: [0, 0, 0, 0],
+      wonCards: [[...allHearts, c("spades", 12)], [], [], []],
+    });
+    const next = applyHandScoring(state);
+    expect(next.events).toContainEqual({ type: "moonShot", shooter: 0 });
+  });
+
+  it("emits correct shooter index when player 2 shoots the moon", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [0, 0, 26, 0],
+      cumulativeScores: [0, 0, 0, 0],
+      wonCards: [[], [], [...allHearts, c("spades", 12)], []],
+    });
+    const next = applyHandScoring(state);
+    expect(next.events).toContainEqual({ type: "moonShot", shooter: 2 });
+  });
+
+  it("does not append moonShot event when no moon was shot", () => {
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [10, 8, 5, 3],
+      cumulativeScores: [0, 0, 0, 0],
+      wonCards: [[c("hearts", 1)], [c("hearts", 2)], [c("hearts", 3)], [c("hearts", 4)]],
+    });
+    const next = applyHandScoring(state);
+    const moonEvents = (next.events ?? []).filter((e) => e.type === "moonShot");
+    expect(moonEvents).toHaveLength(0);
+  });
+
+  it("does not mutate pre-existing events entries", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const existing = [{ type: "heartsBroken" as const }];
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [26, 0, 0, 0],
+      cumulativeScores: [0, 0, 0, 0],
+      wonCards: [[...allHearts, c("spades", 12)], [], [], []],
+      events: existing,
+    });
+    const next = applyHandScoring(state);
+    expect(next.events).toContainEqual({ type: "heartsBroken" });
+    expect(next.events).toContainEqual({ type: "moonShot", shooter: 0 });
+    expect(state.events).toHaveLength(1); // original not mutated
+  });
+
+  it("emits moonShot even when the hand also triggers game_over", () => {
+    const allHearts = Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank));
+    // Player 1 shoots the moon; player 0 is at 80, so +26 pushes them to 106 → game_over
+    const state = mkState({
+      phase: "hand_end",
+      handScores: [0, 26, 0, 0],
+      cumulativeScores: [80, 0, 0, 0],
+      wonCards: [[], [...allHearts, c("spades", 12)], [], []],
+    });
+    const next = applyHandScoring(state);
+    expect(next.phase).toBe("game_over");
+    expect(next.events).toContainEqual({ type: "moonShot", shooter: 1 });
+  });
+});
+
 describe("applyHandScoring — game over", () => {
   it("transitions to game_over when any score reaches 100", () => {
     const state = mkState({

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -380,9 +380,7 @@ export function applyHandScoring(state: HeartsState): HeartsState {
   const newScoreHistory = [...state.scoreHistory, appliedDelta];
 
   const moonEvent =
-    moonShooter !== null
-      ? ([{ type: "moonShot", shooter: moonShooter }] as const)
-      : ([] as const);
+    moonShooter !== null ? ([{ type: "moonShot", shooter: moonShooter }] as const) : ([] as const);
 
   if (isGameOver(newCumulative)) {
     return {

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -379,6 +379,11 @@ export function applyHandScoring(state: HeartsState): HeartsState {
   const appliedDelta = newCumulative.map((c, i) => c - (state.cumulativeScores[i] ?? 0));
   const newScoreHistory = [...state.scoreHistory, appliedDelta];
 
+  const moonEvent =
+    moonShooter !== null
+      ? ([{ type: "moonShot", shooter: moonShooter }] as const)
+      : ([] as const);
+
   if (isGameOver(newCumulative)) {
     return {
       ...state,
@@ -387,6 +392,7 @@ export function applyHandScoring(state: HeartsState): HeartsState {
       phase: "game_over",
       isComplete: true,
       winnerIndex: getWinner(newCumulative),
+      events: [...(state.events ?? []), ...moonEvent],
     };
   }
 
@@ -395,6 +401,7 @@ export function applyHandScoring(state: HeartsState): HeartsState {
     cumulativeScores: newCumulative,
     scoreHistory: newScoreHistory,
     phase: "dealing",
+    events: [...(state.events ?? []), ...moonEvent],
   };
 }
 

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "كُسرت القلوب"
-,
+  "events.heartsBroken": "كُسرت القلوب",
   "events.moonShot": "{{name}} سيطر على الجولة!"
 }

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "كُسرت القلوب"
+,
+  "events.moonShot": "{{name}} سيطر على الجولة!"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Herz gebrochen"
-,
+  "events.heartsBroken": "Herz gebrochen",
   "events.moonShot": "{{name}} hat den Mond geschossen!"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Herz gebrochen"
+,
+  "events.moonShot": "{{name}} hat den Mond geschossen!"
 }

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -70,5 +70,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Hearts broken"
+  "events.heartsBroken": "Hearts broken",
+  "events.moonShot": "{{name}} shot the moon!"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Corazones descubiertos"
+,
+  "events.moonShot": "¡{{name}} hizo luna!"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Corazones descubiertos"
-,
+  "events.heartsBroken": "Corazones descubiertos",
   "events.moonShot": "¡{{name}} hizo luna!"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Cœurs brisés"
-,
+  "events.heartsBroken": "Cœurs brisés",
   "events.moonShot": "{{name}} a raflé la mise!"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Cœurs brisés"
+,
+  "events.moonShot": "{{name}} a raflé la mise!"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "הלבבות נשברו"
-,
+  "events.heartsBroken": "הלבבות נשברו",
   "events.moonShot": "{{name}} לקח את הכל!"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "הלבבות נשברו"
+,
+  "events.moonShot": "{{name}} לקח את הכל!"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "दिल टूटे"
-,
+  "events.heartsBroken": "दिल टूटे",
   "events.moonShot": "{{name}} ने चांद मारा!"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "दिल टूटे"
+,
+  "events.moonShot": "{{name}} ने चांद मारा!"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "ハートが解禁"
+,
+  "events.moonShot": "{{name}}が月を射抜いた！"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "ハートが解禁"
-,
+  "events.heartsBroken": "ハートが解禁",
   "events.moonShot": "{{name}}が月を射抜いた！"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "하트 해제"
+,
+  "events.moonShot": "{{name}}이(가) 올킬 성공!"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "하트 해제"
-,
+  "events.heartsBroken": "하트 해제",
   "events.moonShot": "{{name}}이(가) 올킬 성공!"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Harten gebroken"
+,
+  "events.moonShot": "{{name}} ging voor de volle maan!"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Harten gebroken"
-,
+  "events.heartsBroken": "Harten gebroken",
   "events.moonShot": "{{name}} ging voor de volle maan!"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Copas abertas"
-,
+  "events.heartsBroken": "Copas abertas",
   "events.moonShot": "{{name}} fez a limpa!"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Copas abertas"
+,
+  "events.moonShot": "{{name}} fez a limpa!"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "Черви раскрыты"
-,
+  "events.heartsBroken": "Черви раскрыты",
   "events.moonShot": "{{name}} собрал всё!"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Черви раскрыты"
+,
+  "events.moonShot": "{{name}} собрал всё!"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -54,7 +54,6 @@
   "settings.save": "Save",
   "settings.cancel": "Cancel",
 
-  "events.heartsBroken": "红心已开"
-,
+  "events.heartsBroken": "红心已开",
   "events.moonShot": "{{name}}收全红心！"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -55,4 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "红心已开"
+,
+  "events.moonShot": "{{name}}收全红心！"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -39,6 +39,7 @@ import { useGameEvents } from "../game/_shared/useGameEvents";
 import { useSound } from "../game/_shared/useSound";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
 import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
+import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnimation";
 import type { Card, HeartsState, TrickCard } from "../game/hearts/types";
 
 const HUMAN = 0;
@@ -70,6 +71,8 @@ export default function HeartsScreen() {
   const [gameState, setGameState] = useState<HeartsState>(() => dealGame());
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
   const [showHeartsBroken, setShowHeartsBroken] = useState(false);
+  const [showMoonShot, setShowMoonShot] = useState(false);
+  const [moonShotLabel, setMoonShotLabel] = useState("");
   const [showRename, setShowRename] = useState(false);
   const [playerName, setPlayerName] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
@@ -162,6 +165,7 @@ export default function HeartsScreen() {
   }, [navigation, syncComplete, syncGetGameId]);
 
   const { play: playHeartsBroken } = useSound("hearts.heartsBroken");
+  const { play: playMoonShot } = useSound("hearts.moonShot");
 
   useGameEvents(
     gameState.events,
@@ -169,6 +173,11 @@ export default function HeartsScreen() {
       heartsBroken: () => {
         playHeartsBroken();
         setShowHeartsBroken(true);
+      },
+      moonShot: (event) => {
+        playMoonShot();
+        setMoonShotLabel(playerNames[event.shooter] ?? "");
+        setShowMoonShot(true);
       },
     },
     () => setGameState((prev) => ({ ...prev, events: [] }))
@@ -364,7 +373,7 @@ export default function HeartsScreen() {
       onEditPlayerNames={handleOpenRename}
     >
       {/* ── Table ──────────────────────────────────────────────────── */}
-      <View style={[styles.table, { backgroundColor: colors.background }]}>
+      <View style={[styles.table, styles.tablePositioned, { backgroundColor: colors.background }]}>
         {/* Top AI (seat 2) */}
         <View style={styles.topArea}>
           <OpponentHand
@@ -428,6 +437,11 @@ export default function HeartsScreen() {
             onCardPress={isPassing ? handlePassCardPress : handleCardPress}
           />
         </View>
+        <HeartsMoonShotAnimation
+          visible={showMoonShot}
+          shooterLabel={moonShotLabel}
+          onAnimationEnd={() => setShowMoonShot(false)}
+        />
       </View>
 
       {/* ── Hand-end overlay (dealing phase = hand just finished) ──── */}
@@ -657,6 +671,9 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "space-between",
     paddingVertical: 12,
+  },
+  tablePositioned: {
+    position: "relative",
   },
   topArea: {
     alignItems: "center",


### PR DESCRIPTION
## Summary

- `applyHandScoring()` now emits `{ type: 'moonShot', shooter }` on `HeartsState.events` when `detectMoon()` returns non-null (both `dealing` and `game_over` transition branches), before phase changes
- `hearts.moonShot` sound key registered in `SOUND_REGISTRY` pointing to `hearts-moon-shot.mp3`
- New `HeartsMoonShotAnimation` component: dark semi-transparent full-screen overlay, 🌙 moon icon springs from 0→1, 6 ★ stars stagger in (120 ms apart with `withDelay + withSpring`), shooter label fades in, auto-dismisses after 2.2 s; reduced-motion path shows everything static with 2.2 s dismiss, no spring/spring motion
- `HeartsScreen` wires `useSound('hearts.moonShot')` and `useGameEvents` `moonShot` handler; renders `HeartsMoonShotAnimation` as last child of the table `View` (covers game area, non-blocking via `pointerEvents="none"`)
- `events.moonShot` i18n key (`{{name}}` interpolation) added to all 13 locale files (en, de, ja, ar, es, fr-CA, he, hi, ko, nl, pt, ru, zh)

## Test plan

- [x] Unit tests added: `applyHandScoring` appends `moonShot` event with correct shooter index, no event when no moon shot, pre-existing events not mutated, event emitted on `game_over` path
- [x] All 173 Hearts tests green; pre-existing `Twenty48Screen` flake confirmed pre-existing on `dev`
- [x] Lint clean, no type errors in changed files
- [ ] Manual: shoot the moon in a local game — confirm fanfare plays, overlay appears with shooter name, auto-dismisses ~2.2 s, no double-play on re-render, mute suppresses sound, reduced-motion fallback shows static overlay (see `docs/TESTING.md`)

Closes #773
Part of #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)