### PR TITLE
fix(#733): wire Hit glow and Cascade error panel to theme tokens

### DIFF
--- a/frontend/src/components/blackjack/ActionButtons.tsx
+++ b/frontend/src/components/blackjack/ActionButtons.tsx
@@ -51,8 +51,14 @@ export default function ActionButtons({
         style={[
           styles.btn,
           compact && styles.btnCompact,
-          styles.btnHit,
-          { backgroundColor: colors.accent },
+          {
+            backgroundColor: colors.accent,
+            shadowColor: colors.accent,
+            shadowOffset: { width: 0, height: 0 },
+            shadowOpacity: 0.4,
+            shadowRadius: 12,
+            elevation: 6,
+          },
         ]}
         onPress={onHit}
         disabled={loading}
@@ -160,14 +166,6 @@ const styles = StyleSheet.create({
     width: 62,
     height: 62,
     borderRadius: 31,
-  },
-  btnHit: {
-    // Shadow for the primary CTA glow effect
-    shadowColor: "#8ff5ff",
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.4,
-    shadowRadius: 12,
-    elevation: 6,
   },
   btnLabel: {
     fontSize: 9,

--- a/frontend/src/components/cascade/GameCanvas.tsx
+++ b/frontend/src/components/cascade/GameCanvas.tsx
@@ -277,8 +277,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
     if (engineError) {
       return (
-        <View style={[styles.errorContainer, { width, height }]}>
-          <Text style={styles.errorText}>{t("game.engineUnsupported")}</Text>
+        <View style={[styles.errorContainer, { width, height, backgroundColor: colors.surface }]}>
+          <Text style={[styles.errorText, { color: colors.textMuted }]}>
+            {t("game.engineUnsupported")}
+          </Text>
         </View>
       );
     }
@@ -391,10 +393,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     borderRadius: 12,
-    backgroundColor: "#1a1a2e",
   },
   errorText: {
-    color: "#aaa",
     fontSize: 14,
     textAlign: "center",
     paddingHorizontal: 24,


### PR DESCRIPTION
## Summary
- **Blackjack Hit button glow** — `shadowColor` was hardcoded to `#8ff5ff` (dark cyan) inside `StyleSheet.create()`, so it never updated in light mode. Moved shadow styles inline on the `Pressable` so `colors.accent` is read at render time (desaturates to `#1bc5d4` on cream).
- **Cascade engine-error panel** — hardcoded dark navy background and gray text replaced with `colors.surface` / `colors.textMuted`.
- **Neon deck** — confirmed it already forces dark card bodies regardless of `ThemeContext`; no change needed.

Remaining visual audit items (per-screen checks, contrast, game-art) are tracked as a checklist in #733.

## Test plan
- [ ] Toggle Settings → Light mode
- [ ] Open Blackjack — Hit button glow should be teal, not cyan
- [ ] Trigger Cascade engine-error state (or inspect code) — panel should use cream surface colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)