### PR TITLE
feat(#775): hearts — Queen of Spades sound + animation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -183,6 +183,21 @@ Verifies the fanfare sound and full-screen moon overlay fire exactly once when s
 4. **Mute toggle:** Enable the global mute, trigger a moon shot. Confirm the animation still shows but the sound is suppressed.
 5. **Reduced-motion fallback:** Enable Reduce Motion in device accessibility settings, trigger a moon shot. Confirm the moon icon and stars appear instantly (no spring motion) and the label is visible immediately; overlay still auto-dismisses after 2.2 s.
 
+### Hearts: Queen of Spades sound + animation (#775)
+
+Verifies the dark sting sound and card animation fire exactly once when the Queen of Spades is taken.
+
+1. Start a Hearts game and play until a trick containing Q♠ is resolved.
+2. The moment the trick resolves (four cards played):
+   - Confirm a dark ominous sting (hearts-queen-of-spades.mp3) plays once.
+   - Confirm a Q♠ card (white card face with "Q" and "♠") springs up at scale 0 → 1.4×.
+   - Confirm the card executes 4 left-right shake iterations (translateX ±8 px).
+   - Confirm the card fades to opacity 0 after the shakes.
+   - Confirm a full-screen red flash overlay (rgba(220,38,38,0.25)) fades in and out over the ~1.0 s duration.
+   - Confirm the taker's label is correctly identified (check the player who took the trick).
+3. Confirm play is **not blocked** — the animation runs in parallel with normal game flow.
+4. **Reduced-motion fallback:** Enable Reduce Motion in device accessibility settings, trigger a Q♠ trick. Confirm only a red flash (~0.8 s) occurs, no zoom or shake.
+
 ---
 
 ## E2E Test Conventions

--- a/frontend/src/components/hearts/HeartsQueenOfSpadesAnimation.tsx
+++ b/frontend/src/components/hearts/HeartsQueenOfSpadesAnimation.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AccessibilityInfo, StyleSheet, View } from "react-native";
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  visible: boolean;
+  takerLabel: string;
+  onAnimationEnd: () => void;
+}
+
+export function HeartsQueenOfSpadesAnimation({ visible, takerLabel, onAnimationEnd }: Props) {
+  const { t } = useTranslation("hearts");
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const overlayOpacity = useSharedValue(0);
+  const cardScale = useSharedValue(0);
+  const cardOpacity = useSharedValue(0);
+  const cardTranslateX = useSharedValue(0);
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      overlayOpacity.value = 0;
+      cardScale.value = 0;
+      cardOpacity.value = 0;
+      cardTranslateX.value = 0;
+      return;
+    }
+
+    if (reduceMotion) {
+      // Reduced motion: red flash only, 0.8 s
+      overlayOpacity.value = withSequence(
+        withTiming(0.25, { duration: 100 }),
+        withDelay(600, withTiming(0, { duration: 100 }))
+      );
+      const t1 = setTimeout(onAnimationEnd, 800);
+      timersRef.current.push(t1);
+      return () => {
+        clearTimeout(t1);
+        timersRef.current = [];
+      };
+    }
+
+    // Phase 1 (0–200ms): spring card in + overlay fade in
+    overlayOpacity.value = withTiming(0.25, { duration: 200 });
+    cardOpacity.value = 1;
+    cardScale.value = withSpring(1.4, { damping: 12, stiffness: 220 });
+
+    // Phase 2 (200–600ms): 4 shake iterations (translateX ±8 px)
+    const t1 = setTimeout(() => {
+      cardTranslateX.value = withSequence(
+        withTiming(8, { duration: 50 }),
+        withTiming(-8, { duration: 50 }),
+        withTiming(8, { duration: 50 }),
+        withTiming(-8, { duration: 50 }),
+        withTiming(8, { duration: 50 }),
+        withTiming(-8, { duration: 50 }),
+        withTiming(8, { duration: 50 }),
+        withTiming(-8, { duration: 50 }),
+        withTiming(0, { duration: 50 })
+      );
+    }, 200);
+
+    // Phase 3 (700–1000ms): fade card + overlay out
+    const t2 = setTimeout(() => {
+      cardOpacity.value = withTiming(0, { duration: 300 });
+      cardScale.value = withTiming(0, { duration: 300 });
+      overlayOpacity.value = withTiming(0, { duration: 300 });
+    }, 700);
+
+    const t3 = setTimeout(onAnimationEnd, 1000);
+    timersRef.current.push(t1, t2, t3);
+
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+      cancelAnimation(overlayOpacity);
+      cancelAnimation(cardScale);
+      cancelAnimation(cardOpacity);
+      cancelAnimation(cardTranslateX);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, reduceMotion]);
+
+  const overlayStyle = useAnimatedStyle(() => ({ opacity: overlayOpacity.value }));
+  const cardStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: cardScale.value }, { translateX: cardTranslateX.value }],
+    opacity: cardOpacity.value,
+  }));
+
+  return (
+    <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
+      <Animated.View style={[StyleSheet.absoluteFillObject, styles.overlay, overlayStyle]} />
+      <View style={styles.content}>
+        <Animated.View
+          style={[styles.card, cardStyle]}
+          accessibilityLabel={t("events.queenOfSpades", { name: takerLabel })}
+          accessibilityRole="text"
+          accessibilityLiveRegion="polite"
+        >
+          <Animated.Text style={styles.cardRank}>Q</Animated.Text>
+          <Animated.Text style={styles.cardSuit}>♠</Animated.Text>
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    backgroundColor: "#dc2626",
+    zIndex: 100,
+  },
+  content: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 101,
+  },
+  card: {
+    width: 72,
+    height: 100,
+    backgroundColor: "#ffffff",
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: "#1e1b4b",
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.4,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  cardRank: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: "#1e1b4b",
+    lineHeight: 32,
+  },
+  cardSuit: {
+    fontSize: 24,
+    color: "#1e1b4b",
+    lineHeight: 28,
+  },
+});

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -12,4 +12,6 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   "hearts.heartsBroken": require("../../../assets/sounds/hearts-broken.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "hearts.moonShot": require("../../../assets/sounds/hearts-moon-shot.mp3"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "hearts.queenOfSpades": require("../../../assets/sounds/hearts-queen-of-spades.mp3"),
 };

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -621,6 +621,129 @@ describe("trick resolution", () => {
 });
 
 // ---------------------------------------------------------------------------
+// queenOfSpades event
+// ---------------------------------------------------------------------------
+
+describe("resolveTrick — queenOfSpades event", () => {
+  it("appends queenOfSpades event with correct takerSeat when Q♠ is in the trick", () => {
+    // P0 leads K♠; P1 plays Q♠; P2,P3 play low spades — P0 wins (K > Q)
+    const hands = [
+      [c("spades", 13), c("clubs", 2)],
+      [c("spades", 12), c("clubs", 3)],
+      [c("spades", 3), c("clubs", 4)],
+      [c("spades", 4), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 13));
+    state = playCard(state, 1, c("spades", 12));
+    state = playCard(state, 2, c("spades", 3));
+    state = playCard(state, 3, c("spades", 4));
+
+    expect(state.events).toContainEqual({ type: "queenOfSpades", takerSeat: 0 });
+  });
+
+  it("sets takerSeat to the actual trick winner, not always player 0", () => {
+    // P0 leads 3♠; P1 plays A♠ (wins); P2 plays Q♠; P3 plays 5♠
+    const hands = [
+      [c("spades", 3), c("clubs", 2)],
+      [c("spades", 1), c("clubs", 3)],
+      [c("spades", 12), c("clubs", 4)],
+      [c("spades", 5), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 3));
+    state = playCard(state, 1, c("spades", 1));
+    state = playCard(state, 2, c("spades", 12));
+    state = playCard(state, 3, c("spades", 5));
+
+    expect(state.events).toContainEqual({ type: "queenOfSpades", takerSeat: 1 });
+  });
+
+  it("does NOT append queenOfSpades event when Q♠ is not in the trick", () => {
+    const hands = [
+      [c("spades", 5), c("clubs", 2)],
+      [c("hearts", 1), c("clubs", 3)],
+      [c("spades", 10), c("clubs", 4)],
+      [c("spades", 3), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 5));
+    state = playCard(state, 1, c("hearts", 1));
+    state = playCard(state, 2, c("spades", 10));
+    state = playCard(state, 3, c("spades", 3));
+
+    expect(state.events ?? []).not.toContainEqual(
+      expect.objectContaining({ type: "queenOfSpades" })
+    );
+  });
+
+  it("still awards 13 points to the correct player when Q♠ is in the trick", () => {
+    // P0 leads 3♠; P1 plays A♠ (wins); P2 plays Q♠
+    const hands = [
+      [c("spades", 3), c("clubs", 2)],
+      [c("spades", 1), c("clubs", 3)],
+      [c("spades", 12), c("clubs", 4)],
+      [c("spades", 5), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 3));
+    state = playCard(state, 1, c("spades", 1));
+    state = playCard(state, 2, c("spades", 12));
+    state = playCard(state, 3, c("spades", 5));
+
+    expect(state.handScores[1]).toBe(13);
+    expect(state.handScores[0]).toBe(0);
+  });
+
+  it("awards both heart points and Q♠ points when they appear in the same trick", () => {
+    // P0 leads 3♠; P1 A♠ (wins); P2 Q♠; P3 discards 2♥ — P1 takes 13+1=14 pts
+    const hands = [
+      [c("spades", 3), c("clubs", 2)],
+      [c("spades", 1), c("clubs", 3)],
+      [c("spades", 12), c("clubs", 4)],
+      [c("hearts", 2), c("clubs", 5)],
+    ] as Card[][];
+    let state = mkState({
+      playerHands: hands,
+      tricksPlayedInHand: 1,
+      heartsBroken: true,
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+    });
+    state = playCard(state, 0, c("spades", 3));
+    state = playCard(state, 1, c("spades", 1));
+    state = playCard(state, 2, c("spades", 12));
+    state = playCard(state, 3, c("hearts", 2));
+
+    expect(state.handScores[1]).toBe(14);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // detectMoon
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -63,7 +63,7 @@ function cardEquals(a: Card, b: Card): boolean {
   return a.suit === b.suit && a.rank === b.rank;
 }
 
-function isQueenOfSpades(c: Card): boolean {
+export function isQueenOfSpades(c: Card): boolean {
   return c.suit === "spades" && c.rank === 12;
 }
 
@@ -325,6 +325,10 @@ function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsSt
 
   const newTricksPlayed = state.tricksPlayedInHand + 1;
 
+  const queenEvent = trickCards.some(isQueenOfSpades)
+    ? ([{ type: "queenOfSpades", takerSeat: winnerPlayerIndex }] as const)
+    : ([] as const);
+
   let next: HeartsState = {
     ...state,
     currentTrick: [],
@@ -333,6 +337,7 @@ function resolveTrick(state: HeartsState, trick: readonly TrickCard[]): HeartsSt
     wonCards: newWonCards,
     handScores: newHandScores,
     tricksPlayedInHand: newTricksPlayed,
+    events: [...(state.events ?? []), ...queenEvent],
   };
 
   if (newTricksPlayed === 13) {

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "كُسرت القلوب",
-  "events.moonShot": "{{name}} سيطر على الجولة!"
+  "events.moonShot": "{{name}} سيطر على الجولة!",
+  "events.queenOfSpades": "{{name}} أخذ ملكة البستوني!"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Herz gebrochen",
-  "events.moonShot": "{{name}} hat den Mond geschossen!"
+  "events.moonShot": "{{name}} hat den Mond geschossen!",
+  "events.queenOfSpades": "{{name}} nimmt die Pik-Dame!"
 }

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -71,5 +71,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Hearts broken",
-  "events.moonShot": "{{name}} shot the moon!"
+  "events.moonShot": "{{name}} shot the moon!",
+  "events.queenOfSpades": "{{name}} takes the Queen of Spades!"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Corazones descubiertos",
-  "events.moonShot": "¡{{name}} hizo luna!"
+  "events.moonShot": "¡{{name}} hizo luna!",
+  "events.queenOfSpades": "¡{{name}} toma la Reina de Espadas!"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Cœurs brisés",
-  "events.moonShot": "{{name}} a raflé la mise!"
+  "events.moonShot": "{{name}} a raflé la mise!",
+  "events.queenOfSpades": "{{name}} prend la Dame de pique!"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "הלבבות נשברו",
-  "events.moonShot": "{{name}} לקח את הכל!"
+  "events.moonShot": "{{name}} לקח את הכל!",
+  "events.queenOfSpades": "{{name}} לקח את מלכת הספייד!"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "दिल टूटे",
-  "events.moonShot": "{{name}} ने चांद मारा!"
+  "events.moonShot": "{{name}} ने चांद मारा!",
+  "events.queenOfSpades": "{{name}} ने हुकुम की रानी ली!"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "ハートが解禁",
-  "events.moonShot": "{{name}}が月を射抜いた！"
+  "events.moonShot": "{{name}}が月を射抜いた！",
+  "events.queenOfSpades": "{{name}}がスペードのQを取った！"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "하트 해제",
-  "events.moonShot": "{{name}}이(가) 올킬 성공!"
+  "events.moonShot": "{{name}}이(가) 올킬 성공!",
+  "events.queenOfSpades": "{{name}}이(가) 스페이드 퀸을 가져갔습니다!"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Harten gebroken",
-  "events.moonShot": "{{name}} ging voor de volle maan!"
+  "events.moonShot": "{{name}} ging voor de volle maan!",
+  "events.queenOfSpades": "{{name}} pakt de Schoppenvrauw!"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Copas abertas",
-  "events.moonShot": "{{name}} fez a limpa!"
+  "events.moonShot": "{{name}} fez a limpa!",
+  "events.queenOfSpades": "{{name}} pega a Dama de Espadas!"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "Черви раскрыты",
-  "events.moonShot": "{{name}} собрал всё!"
+  "events.moonShot": "{{name}} собрал всё!",
+  "events.queenOfSpades": "{{name}} забирает Даму Пик!"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -55,5 +55,6 @@
   "settings.cancel": "Cancel",
 
   "events.heartsBroken": "红心已开",
-  "events.moonShot": "{{name}}收全红心！"
+  "events.moonShot": "{{name}}收全红心！",
+  "events.queenOfSpades": "{{name}}拿走了黑桃Q！"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -40,6 +40,7 @@ import { useSound } from "../game/_shared/useSound";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
 import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
 import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnimation";
+import { HeartsQueenOfSpadesAnimation } from "../components/hearts/HeartsQueenOfSpadesAnimation";
 import type { Card, HeartsState, TrickCard } from "../game/hearts/types";
 
 const HUMAN = 0;
@@ -73,6 +74,8 @@ export default function HeartsScreen() {
   const [showHeartsBroken, setShowHeartsBroken] = useState(false);
   const [showMoonShot, setShowMoonShot] = useState(false);
   const [moonShotLabel, setMoonShotLabel] = useState("");
+  const [showQueenOfSpades, setShowQueenOfSpades] = useState(false);
+  const [queenOfSpadesLabel, setQueenOfSpadesLabel] = useState("");
   const [showRename, setShowRename] = useState(false);
   const [playerName, setPlayerName] = useState("");
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
@@ -166,6 +169,7 @@ export default function HeartsScreen() {
 
   const { play: playHeartsBroken } = useSound("hearts.heartsBroken");
   const { play: playMoonShot } = useSound("hearts.moonShot");
+  const { play: playQueenOfSpades } = useSound("hearts.queenOfSpades");
 
   useGameEvents(
     gameState.events,
@@ -178,6 +182,11 @@ export default function HeartsScreen() {
         playMoonShot();
         setMoonShotLabel(playerNames[event.shooter] ?? "");
         setShowMoonShot(true);
+      },
+      queenOfSpades: (event) => {
+        playQueenOfSpades();
+        setQueenOfSpadesLabel(playerNames[event.takerSeat] ?? "");
+        setShowQueenOfSpades(true);
       },
     },
     () => setGameState((prev) => ({ ...prev, events: [] }))
@@ -441,6 +450,11 @@ export default function HeartsScreen() {
           visible={showMoonShot}
           shooterLabel={moonShotLabel}
           onAnimationEnd={() => setShowMoonShot(false)}
+        />
+        <HeartsQueenOfSpadesAnimation
+          visible={showQueenOfSpades}
+          takerLabel={queenOfSpadesLabel}
+          onAnimationEnd={() => setShowQueenOfSpades(false)}
         />
       </View>
 


### PR DESCRIPTION
## Summary
- `resolveTrick()` emits `{ type: 'queenOfSpades', takerSeat: winnerPlayerIndex }` on `HeartsState.events` when the completed trick contains Q♠; `isQueenOfSpades` exported for UI layer use
- `hearts.queenOfSpades` sound key registered in `SOUND_REGISTRY` pointing to the existing `hearts-queen-of-spades.mp3` asset
- `HeartsQueenOfSpadesAnimation` component: Q♠ card springs in (0→1.4× scale), shakes 4× (translateX ±8px), fades out; full-screen red flash overlay; reduced-motion fallback (red flash only, 0.8s); total ~1.0s, non-blocking
- `HeartsScreen` wired: `useSound('hearts.queenOfSpades')`, `queenOfSpades` event handler, animation rendered alongside existing `HeartsMoonShotAnimation`
- `events.queenOfSpades` i18n key with `{{name}}` interpolation added to all 13 locales
- 5 new unit tests: event emitted with correct takerSeat, event not emitted when QS absent, 13-point scoring regression, heart+QS same-trick regression

## Test plan
- [ ] All 1562 tests pass (`npx jest --no-coverage`)
- [ ] No new TypeScript errors in changed files (`npx tsc --noEmit`)
- [ ] Lint clean on changed files (`npx eslint ...`)
- [ ] Manual: play a trick containing Q♠ — dark sting plays, card springs/shakes/fades, red flash overlay visible; taker label correct
- [ ] Manual: confirm play not blocked during animation
- [ ] Manual: reduced-motion fallback (enable Reduce Motion, trigger Q♠ trick — red flash only, 0.8s)
- [ ] Manual: mute toggle — animation shows, sound suppressed

Closes #775
Part of #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)