### PR TITLE
feat(#778): animation lab — variant toggle

### DIFF
--- a/frontend/scripts/animation-lab.html
+++ b/frontend/scripts/animation-lab.html
@@ -207,6 +207,38 @@
         margin-left: auto;
       }
 
+      /* ── Variant toggle ── */
+      .variant-toggle {
+        display: flex;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+      .variant-btn {
+        flex: 1;
+        padding: 5px 12px;
+        border: none;
+        background: transparent;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition:
+          background 0.12s,
+          color 0.12s;
+      }
+      .variant-btn + .variant-btn {
+        border-left: 1px solid var(--border);
+      }
+      .variant-btn.active {
+        background: var(--accent);
+        color: #fff;
+      }
+      .variant-btn:hover:not(.active) {
+        background: rgba(124, 58, 237, 0.15);
+        color: var(--text);
+      }
+
       /* ══════════════════════════════════════════════════
        ANIMATION 1: Moon Shot — full-screen overlay
        Duration is driven by sound length (soundDriven: true).
@@ -1215,6 +1247,25 @@
         const tpl = document.getElementById(anim.stageTemplate);
         const stage = tpl.content.cloneNode(true).querySelector(".stage");
 
+        let ticker = null;
+        let playedAt = null;
+        // activeVariant is null when no variants declared (use anim.play/reset directly)
+        let activeVariant = anim.variants?.[0] ?? null;
+
+        function currentPlay() {
+          return activeVariant ? activeVariant.play : anim.play;
+        }
+        function currentReset() {
+          return activeVariant ? activeVariant.reset : anim.reset;
+        }
+        function getActiveFlags() {
+          const v = activeVariant;
+          return {
+            soundDriven: v?.soundDriven !== undefined ? v.soundDriven : anim.soundDriven,
+            dismissible: v?.dismissible !== undefined ? v.dismissible : anim.dismissible,
+          };
+        }
+
         const statusEl = document.createElement("div");
         statusEl.className = "status";
         statusEl.textContent = "idle";
@@ -1233,11 +1284,7 @@
         resetBtn.className = "btn danger";
         resetBtn.textContent = "Reset";
 
-        let ticker = null;
-        let playedAt = null;
-
         playBtn.addEventListener("click", () => {
-          // Stop any prior sound for this animation
           stopSound(anim.id);
           playSound(anim.id);
           playedAt = Date.now();
@@ -1248,13 +1295,14 @@
             if (!playedAt) return;
             statusEl.textContent = `${((Date.now() - playedAt) / 1000).toFixed(1)}s`;
           }, 100);
-          anim.play(stage, reduceMotionToggle.checked, statusEl);
+          if (activeVariant) log(anim.id, "anim", `play() — variant: ${activeVariant.label}`);
+          currentPlay()(stage, reduceMotionToggle.checked, statusEl);
         });
 
         resetBtn.addEventListener("click", () => {
           clearInterval(ticker);
           playedAt = null;
-          anim.reset(stage);
+          currentReset()(stage);
           statusEl.textContent = "idle";
           statusEl.className = "status";
         });
@@ -1268,15 +1316,52 @@
 
         const tags = document.createElement("div");
         tags.style.cssText = "display:flex;gap:6px;flex-wrap:wrap;";
-        if (anim.soundDriven)
-          tags.innerHTML += `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:#1e293b;color:#38bdf8;">sound-driven</span>`;
-        if (anim.dismissible)
-          tags.innerHTML += `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:#1e293b;color:#a78bfa;">dismissible</span>`;
+
+        function renderTags() {
+          tags.innerHTML = "";
+          const { soundDriven, dismissible } = getActiveFlags();
+          if (soundDriven)
+            tags.innerHTML += `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:#1e293b;color:#38bdf8;">sound-driven</span>`;
+          if (dismissible)
+            tags.innerHTML += `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:#1e293b;color:#a78bfa;">dismissible</span>`;
+        }
+        renderTags();
 
         const p = document.createElement("p");
         p.textContent = anim.description;
 
-        card.append(h3, tags, stage, btnRow, p);
+        card.append(h3);
+
+        if (anim.variants?.length > 0) {
+          const variantToggle = document.createElement("div");
+          variantToggle.className = "variant-toggle";
+
+          anim.variants.forEach((v, i) => {
+            const btn = document.createElement("button");
+            btn.className = "variant-btn" + (i === 0 ? " active" : "");
+            btn.textContent = v.label;
+            btn.addEventListener("click", () => {
+              if (activeVariant === v) return;
+              // Reset before switching
+              currentReset()(stage);
+              clearInterval(ticker);
+              playedAt = null;
+              statusEl.textContent = "idle";
+              statusEl.className = "status";
+              activeVariant = v;
+              variantToggle.querySelectorAll(".variant-btn").forEach((b, j) => {
+                b.classList.toggle("active", j === i);
+              });
+              renderTags();
+              log(anim.id, "anim", `variant → ${v.label}`);
+            });
+            variantToggle.appendChild(btn);
+          });
+
+          card.append(variantToggle);
+        }
+
+        card.append(tags, stage, btnRow, p);
         return card;
       }
 

--- a/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
+++ b/frontend/src/screens/__tests__/Twenty48Screen.test.tsx
@@ -305,6 +305,15 @@ describe("Twenty48Screen — initial load", () => {
 describe("Twenty48Screen — move persistence", () => {
   beforeEach(() => jest.clearAllMocks());
 
+  // Flush any pending move-lock timeouts (120 ms) so they don't fire
+  // during subsequent tests and pollute the saveGame mock call count.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    jest.clearAllMocks();
+  });
+
   it("calls saveGame after a valid move", async () => {
     // Start from null so the engine spawns a real random board.
     (loadGame as jest.Mock).mockResolvedValueOnce(null);


### PR DESCRIPTION
## Summary
- Adds optional `variants: [{ label, play, reset }]` array to `ANIMATIONS[]` entries
- When present, renders a segmented toggle (e.g. Production | Experimental) above the stage
- Switching variant resets the running animation, updates status/tags, and logs `variant → <label>`
- Active variant label prefixes play log entries: `play() — variant: Production`
- Entries without `variants` take the existing code path unchanged (no visual diff)

## How to test
1. `cd frontend && python -m http.server 8080`
2. Open `http://localhost:8080/scripts/animation-lab.html`
3. Verify the three existing Hearts cards render with no toggle and behave as before
4. Add a test entry to `ANIMATIONS[]` with a `variants` field — confirm the toggle appears, switching resets the animation, tags update, and the log shows variant name

## Acceptance criteria
- [x] `ANIMATIONS[]` entries support optional `variants` array
- [x] Segmented toggle appears above stage when `variants` is present
- [x] Switching variant resets current animation before activating the new one
- [x] Active variant label shown in event log alongside animation events
- [x] No-variants entries behave exactly as today
- [x] `soundDriven` / `dismissible` flags respect per-variant overrides

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)