### PR TITLE
fix(#814): clear AI loop events to prevent duplicate animations

### DIFF
--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -468,6 +468,38 @@ describe("playCard", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Event propagation — sequential calls (regression #814)
+// ---------------------------------------------------------------------------
+
+describe("playCard — stale-event regression (#814)", () => {
+  it("does not carry forward heartsBroken when caller clears events between calls", () => {
+    // P0 plays a heart, completing a 4-card trick and triggering the event.
+    const state = mkState({
+      playerHands: h4([c("hearts", 5), c("clubs", 3)]),
+      tricksPlayedInHand: 1,
+      heartsBroken: false,
+      currentTrick: [
+        { card: c("hearts", 2), playerIndex: 3 },
+        { card: c("hearts", 3), playerIndex: 1 },
+        { card: c("hearts", 4), playerIndex: 2 },
+      ],
+    });
+    const withEvent = playCard(state, 0, c("hearts", 5));
+    expect(withEvent.events).toContainEqual({ type: "heartsBroken" });
+
+    // Without the fix: stale events carry into the next playCard call,
+    // producing a new array reference with the same events — re-triggering animations.
+    const withoutClear = playCard(withEvent, 0, c("clubs", 3));
+    expect(withoutClear.events).toContainEqual({ type: "heartsBroken" });
+
+    // With the fix: caller clears events before the next playCard call.
+    const cleared = { ...withEvent, events: [] as typeof withEvent.events };
+    const withClear = playCard(cleared, 0, c("clubs", 3));
+    expect(withClear.events ?? []).not.toContainEqual({ type: "heartsBroken" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Trick resolution
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -206,7 +206,9 @@ export default function HeartsScreen() {
     if (loopActiveRef.current) return;
     loopActiveRef.current = true;
     try {
-      let s = initial;
+      // Start with a clean events slate; initial events are already in React state
+      // and will be processed by useGameEvents independently.
+      let s = { ...initial, events: [] as typeof initial.events };
       while (s.currentPlayerIndex !== HUMAN && s.phase === "playing") {
         const willComplete = s.currentTrick.length === 3;
         await delay(400);
@@ -229,6 +231,8 @@ export default function HeartsScreen() {
           void saveGame(s);
         }
         setGameState(s);
+        // Clear events so the next playCard call doesn't re-emit them via a new array reference.
+        s = { ...s, events: [] };
 
         if (completedTrick && s.phase === "playing") {
           await new Promise<void>((resolve) => {


### PR DESCRIPTION
Fixes #814

## Summary
- In `runAiTurns`, initialize the local `s` with `events: []` so events already in React state aren't re-emitted by the first `playCard` call
- After each `setGameState(s)`, clear `s.events` so subsequent `playCard` calls don't spread stale events into a new array reference
- Add regression test to `engine.test.ts` documenting the carry-forward behavior and verifying the cleared-events path

## Root cause
`useGameEvents` deduplicates by array identity. The AI loop's local `s` variable carried `events` across iterations — each `playCard` spread `s.events` into a new array, giving `useGameEvents` a new reference with the same events, triggering the callback (and animation) once per AI turn instead of once per event.

## Test plan
- [x] `npx jest --testPathPattern="useGameEvents|HeartsScreen|hearts/"` — 167 tests pass
- [ ] Manual: play a Hearts game, trigger heartsBroken and queen-of-spades events — confirm each animation plays exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)