### PR TITLE
fix(#815): filter captured pile to scoring cards only

### DIFF
--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -40,6 +40,10 @@ export function penaltyPoints(cards: readonly Card[]): number {
   }, 0);
 }
 
+function scoringCards(cards: readonly Card[]): Card[] {
+  return cards.filter(c => c.suit === "hearts" || (c.suit === "spades" && c.rank === 12));
+}
+
 const OPP_CARD_W = 24;
 const OPP_CARD_H = 28;
 const OPP_OFFSET = 8;
@@ -64,7 +68,8 @@ export function OpponentCapturedPile({ cards, seatLabel }: OpponentProps) {
   const { colors } = useTheme();
   const count = cards.length;
   const points = penaltyPoints(cards);
-  const visible = Math.min(count, OPP_MAX_VISIBLE);
+  const scoredCount = scoringCards(cards).length;
+  const visible = Math.min(scoredCount, OPP_MAX_VISIBLE);
   const fanWidth = visible > 0 ? (visible - 1) * OPP_OFFSET + OPP_CARD_W : 0;
 
   return (
@@ -101,7 +106,7 @@ interface SelfProps {
 export function SelfCapturedPile({ cards }: SelfProps) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
-  const sorted = sortHand(cards);
+  const sorted = sortHand(scoringCards(cards));
   const count = sorted.length;
   const points = penaltyPoints(cards);
   const rowWidth = count > 0 ? (count - 1) * SELF_OFFSET + SELF_CARD_W : 0;

--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -41,7 +41,7 @@ export function penaltyPoints(cards: readonly Card[]): number {
 }
 
 function scoringCards(cards: readonly Card[]): Card[] {
-  return cards.filter(c => c.suit === "hearts" || (c.suit === "spades" && c.rank === 12));
+  return cards.filter((c) => c.suit === "hearts" || (c.suit === "spades" && c.rank === 12));
 }
 
 const OPP_CARD_W = 24;

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -387,8 +387,7 @@ describe("SelfCapturedPile", () => {
     expect(queryByText("+16")).toBeNull();
   });
 
-  it("sorts captured cards by suit then rank, matching PlayerHand order", () => {
-    // Insertion order is the order tricks were taken — deliberately scrambled.
+  it("excludes non-scoring cards (clubs, diamonds, non-queen spades) from display", () => {
     const cards: Card[] = [
       c("hearts", 5),
       c("clubs", 13),
@@ -400,14 +399,28 @@ describe("SelfCapturedPile", () => {
     const { UNSAFE_getAllByType } = wrap(<SelfCapturedPile cards={cards} />);
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Text: RNText } = require("react-native");
-    // Pull every Text node and join its string children — the rank+suit pairs
-    // appear in render order. We expect: ♣2 ♣K ♦7 ♠A ♥5 ♥J.
     const texts = UNSAFE_getAllByType(RNText)
       .map((n: { props: { children?: unknown } }) =>
         typeof n.props.children === "string" ? n.props.children : null
       )
       .filter((s: string | null): s is string => s !== null);
     const ranksInOrder = texts.filter((s: string) => /^(A|J|Q|K|[2-9]|10)$/.test(s));
-    expect(ranksInOrder).toEqual(["2", "K", "7", "A", "5", "J"]);
+    // Only the two hearts (5, J) should appear; clubs/diamonds/non-Q-spades are hidden.
+    expect(ranksInOrder).toEqual(["5", "J"]);
+  });
+
+  it("sorts scoring cards by suit then rank (Q♠ before hearts)", () => {
+    const cards: Card[] = [c("hearts", 11), c("spades", 12), c("hearts", 3)];
+    const { UNSAFE_getAllByType } = wrap(<SelfCapturedPile cards={cards} />);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Text: RNText } = require("react-native");
+    const texts = UNSAFE_getAllByType(RNText)
+      .map((n: { props: { children?: unknown } }) =>
+        typeof n.props.children === "string" ? n.props.children : null
+      )
+      .filter((s: string | null): s is string => s !== null);
+    const ranksInOrder = texts.filter((s: string) => /^(A|J|Q|K|[2-9]|10)$/.test(s));
+    // sortHand order: spades before hearts → Q♠, ♥3, ♥J
+    expect(ranksInOrder).toEqual(["Q", "3", "J"]);
   });
 });


### PR DESCRIPTION
## Summary
- `SelfCapturedPile` now filters the card list to hearts + Q♠ before rendering, hiding non-scoring clubs/diamonds/non-queen-spades
- `OpponentCapturedPile` fan tile count is now based on scored-card count (not total cards taken), showing one face-down tile per point card
- Added `scoringCards()` private helper to avoid duplicating the filter predicate

## Test plan
- [ ] Run `cd frontend && npx jest src/components/hearts/__tests__/components.test.tsx` — all 39 tests green
- [ ] Play a hand of Hearts; verify South's taken pile shows only hearts and Q♠ face-up
- [ ] Verify opponents with no point cards show an empty fan (no tiles)
- [ ] Verify opponents with point cards show one face-down tile per scoring card (capped at 4)

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)