### PR TITLE
feat(#817): add New Game option to Blackjack Betting Screen

### DIFF
--- a/frontend/src/screens/BlackjackBettingScreen.tsx
+++ b/frontend/src/screens/BlackjackBettingScreen.tsx
@@ -19,7 +19,7 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
   const { t } = useTranslation(["blackjack", "common"]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
-  const { engine, loading, error, apply, handleRulesChange } = useBlackjackGame();
+  const { engine, loading, error, apply, handleRulesChange, handlePlayAgain } = useBlackjackGame();
 
   // Redirect to TableScreen if loaded mid-hand (app restart, or injected state).
   useEffect(() => {
@@ -54,6 +54,7 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
         title={t("game.title")}
         requireBack
         onBack={() => navigation.popToTop()}
+        onNewGame={handlePlayAgain}
         onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "blackjack" })}
         rightSlot={
           state ? (


### PR DESCRIPTION
## Summary

- Pulls `handlePlayAgain` from `useBlackjackGame()` in `BlackjackBettingScreen`
- Passes it as `onNewGame` to `AppHeader`, surfacing the New Game menu item for players waiting on the Betting Screen between hands

No confirmation modal is needed here since no hand is in progress at this point (matches the issue spec).

## Test plan

- [ ] Launch Blackjack, tap the `⋯` menu on the Betting Screen — "New Game" option appears
- [ ] Tap New Game — chips reset to default and the betting UI refreshes
- [ ] Confirm the Table Screen's New Game flow (confirmation modal mid-hand) is unchanged
- [ ] `npx jest --testPathPattern="blackjack|AppHeader"` — all tests green

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)