### PR TITLE
fix(#818): fan up to 3 waste cards in draw-3 solitaire mode

### DIFF
--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -47,7 +47,7 @@ export default function StockWastePile({
         drawMode={drawMode}
         t={t}
       />
-      <Waste waste={waste} selected={wasteSelected} onPress={onWastePress} t={t} />
+      <Waste waste={waste} drawMode={drawMode} selected={wasteSelected} onPress={onWastePress} t={t} />
     </View>
   );
 }
@@ -107,13 +107,17 @@ function Stock({
   );
 }
 
+const WASTE_FAN_OFFSET = 16;
+
 function Waste({
   waste,
+  drawMode,
   selected,
   onPress,
   t,
 }: {
   readonly waste: readonly Card[];
+  readonly drawMode: DrawMode;
   readonly selected: boolean;
   readonly onPress?: () => void;
   readonly t: TFunction<"solitaire">;
@@ -127,11 +131,36 @@ function Waste({
       />
     );
   }
-  const top = waste[waste.length - 1];
-  if (top === undefined) {
-    return null;
+
+  if (drawMode !== 3) {
+    const top = waste[waste.length - 1];
+    if (top === undefined) return null;
+    return <CardView card={top} selected={selected} onPress={onPress} />;
   }
-  return <CardView card={top} selected={selected} onPress={onPress} />;
+
+  const visibleCount = Math.min(3, waste.length);
+  const visible = waste.slice(waste.length - visibleCount);
+  const containerWidth = (visibleCount - 1) * WASTE_FAN_OFFSET + CARD_WIDTH;
+
+  return (
+    <View style={[styles.wasteFanContainer, { width: containerWidth }]}>
+      {visible.map((card, i) => {
+        const isTop = i === visible.length - 1;
+        return (
+          <View
+            key={`${card.suit}-${card.rank}`}
+            style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}
+          >
+            <CardView
+              card={card}
+              selected={isTop && selected}
+              onPress={isTop ? onPress : undefined}
+            />
+          </View>
+        );
+      })}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -149,6 +178,14 @@ const styles = StyleSheet.create({
   wasteEmpty: {
     width: CARD_WIDTH,
     height: CARD_HEIGHT,
+  },
+  wasteFanContainer: {
+    height: CARD_HEIGHT,
+    position: "relative",
+  },
+  wasteFanCard: {
+    position: "absolute",
+    top: 0,
   },
   recycleSymbol: {
     fontSize: 28,

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -47,7 +47,13 @@ export default function StockWastePile({
         drawMode={drawMode}
         t={t}
       />
-      <Waste waste={waste} drawMode={drawMode} selected={wasteSelected} onPress={onWastePress} t={t} />
+      <Waste
+        waste={waste}
+        drawMode={drawMode}
+        selected={wasteSelected}
+        onPress={onWastePress}
+        t={t}
+      />
     </View>
   );
 }

--- a/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
@@ -68,4 +68,49 @@ describe("StockWastePile", () => {
     );
     expect(getByLabelText(/Empty waste pile/)).toBeTruthy();
   });
+
+  describe("draw-3 fan", () => {
+    it("shows all 3 visible waste cards when 3+ are present", () => {
+      const waste = [card(2), card(5), card(9), card(11)];
+      const { getByLabelText } = render(
+        withTheme(<StockWastePile stock={[card(1)]} waste={waste} drawMode={3} />)
+      );
+      expect(getByLabelText(/9 of Spades/)).toBeTruthy();
+      expect(getByLabelText(/J of Spades/)).toBeTruthy();
+      // card(2) is not in the visible top-3; card(5) is the oldest visible
+      expect(getByLabelText(/5 of Spades/)).toBeTruthy();
+    });
+
+    it("shows only the cards present when waste has fewer than 3", () => {
+      const waste = [card(3), card(7)];
+      const { getByLabelText, queryByLabelText } = render(
+        withTheme(<StockWastePile stock={[card(1)]} waste={waste} drawMode={3} />)
+      );
+      expect(getByLabelText(/3 of Spades/)).toBeTruthy();
+      expect(getByLabelText(/7 of Spades/)).toBeTruthy();
+      // only 2 cards; nothing else visible
+      expect(queryByLabelText(/Ace of Spades/)).toBeNull();
+    });
+
+    it("only the top card is interactive; background cards have image role", () => {
+      const onWastePress = jest.fn();
+      const waste = [card(2), card(5), card(9)];
+      const { getByLabelText } = render(
+        withTheme(
+          <StockWastePile
+            stock={[card(1)]}
+            waste={waste}
+            drawMode={3}
+            onWastePress={onWastePress}
+          />
+        )
+      );
+      expect(getByLabelText(/9 of Spades/).props.accessibilityRole).toBe("button");
+      expect(getByLabelText(/5 of Spades/).props.accessibilityRole).toBe("image");
+      expect(getByLabelText(/2 of Spades/).props.accessibilityRole).toBe("image");
+
+      fireEvent.press(getByLabelText(/9 of Spades/));
+      expect(onWastePress).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #818

## Summary
- Passes `drawMode` into the `Waste` sub-component (previously only forwarded to `Stock`)
- In draw-3 mode, renders up to 3 waste cards in a horizontally fanned layout with a 16 px offset per card
- Only the top card is interactive (`Pressable` / `accessibilityRole="button"`); the 2 behind it are face-up `View`s with no press handler
- Draw-1 mode is unaffected

## Test plan
- [ ] All 8 `StockWastePile` tests pass (3 new draw-3 fan tests added)
- [ ] Manually start a draw-3 game and confirm waste shows up to 3 fanned cards after drawing from stock
- [ ] Confirm only tapping the top card selects/plays it; the cards behind are non-interactive
- [ ] Start a draw-1 game and confirm waste still shows only the single top card

🤖 Generated with [Claude Code](https://claude.com/claude-code)