### PR TITLE
feat(#808): FreeCell game engine — deal, supermove, move validation, undo

### DIFF
--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -1,0 +1,360 @@
+/**
+ * FreeCell engine (#808).
+ *
+ * Pure TypeScript. No React, AsyncStorage, HTTP, timers, or other
+ * side-effect imports. The UI replaces the entire FreeCellState object
+ * on each transition — state is immutable.
+ */
+
+import type { Card, Foundations, FreeCellState, FreeCells, Move, Rank, Suit } from "./types";
+import { cardColor, RANKS, SUITS } from "./types";
+
+const UNDO_CAP = 50;
+const TABLEAU_COLUMNS = 8;
+const DECK_SIZE = 52;
+const FREE_CELL_COUNT = 4;
+
+// ---------------------------------------------------------------------------
+// Seedable RNG — same LCG used by Solitaire/Cascade/Blackjack/Twenty48.
+// Tests can pin shuffles via `setRng(createSeededRng(seed))`.
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deck construction
+// ---------------------------------------------------------------------------
+
+function createDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ suit, rank });
+    }
+  }
+  return deck;
+}
+
+function fisherYates(deck: Card[], rng: RandomSource): Card[] {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const a = deck[i];
+    const b = deck[j];
+    if (a !== undefined && b !== undefined) {
+      deck[i] = b;
+      deck[j] = a;
+    }
+  }
+  return deck;
+}
+
+// ---------------------------------------------------------------------------
+// Deal
+// ---------------------------------------------------------------------------
+
+function emptyFoundations(): Foundations {
+  return { spades: [], hearts: [], diamonds: [], clubs: [] };
+}
+
+function emptyFreeCells(): FreeCells {
+  return [null, null, null, null];
+}
+
+/**
+ * Deal a new FreeCell game. 52 cards dealt face-up across 8 columns:
+ * columns 0–3 receive 7 cards each; columns 4–7 receive 6 cards each.
+ */
+export function dealGame(explicitSeed?: number): FreeCellState {
+  const seed = explicitSeed ?? (Math.floor(_rng() * 0xffffffff) >>> 0);
+  const deck = fisherYates(createDeck(), createSeededRng(seed));
+
+  const tableau: Card[][] = [];
+  let k = 0;
+  for (let col = 0; col < TABLEAU_COLUMNS; col++) {
+    const count = col < 4 ? 7 : 6;
+    const pile: Card[] = [];
+    for (let i = 0; i < count; i++) {
+      const card = deck[k++];
+      if (card === undefined) throw new Error("deck underflow during deal");
+      pile.push(card);
+    }
+    tableau.push(pile);
+  }
+
+  if (k !== DECK_SIZE) throw new Error("deal did not consume exactly 52 cards");
+
+  return {
+    _v: 1,
+    tableau,
+    freeCells: emptyFreeCells(),
+    foundations: emptyFoundations(),
+    undoStack: [],
+    isComplete: false,
+    moveCount: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Move validation helpers
+// ---------------------------------------------------------------------------
+
+function canStackOnTableau(moving: Card, dest: Card | undefined): boolean {
+  if (dest === undefined) return moving.rank === 13;
+  return cardColor(moving) !== cardColor(dest) && moving.rank === dest.rank - 1;
+}
+
+function canStackOnFoundation(moving: Card, pile: readonly Card[]): boolean {
+  if (pile.length === 0) return moving.rank === 1;
+  const top = pile[pile.length - 1];
+  if (top === undefined) return false;
+  return moving.suit === top.suit && moving.rank === ((top.rank + 1) as Rank);
+}
+
+/** A tableau run to be moved must form a valid alternating-color descending sequence.
+ * All FreeCell tableau cards are face-up, so no faceUp check is needed. */
+function isValidTableauRun(run: readonly Card[]): boolean {
+  if (run.length === 0) return false;
+  for (let i = 1; i < run.length; i++) {
+    const prev = run[i - 1];
+    const curr = run[i];
+    if (prev === undefined || curr === undefined) return false;
+    if (cardColor(prev) === cardColor(curr)) return false;
+    if (curr.rank !== prev.rank - 1) return false;
+  }
+  return true;
+}
+
+/**
+ * Maximum cards movable as a stack to `toCol`.
+ * Formula: (1 + emptyCells) × 2^emptyColumns
+ * The destination column is excluded from the empty-column count even when empty.
+ */
+function supermoveMax(state: FreeCellState, toCol: number): number {
+  const emptyCells = state.freeCells.filter((c) => c === null).length;
+  const emptyColumns = state.tableau.filter((col, idx) => idx !== toCol && col.length === 0).length;
+  return (1 + emptyCells) * Math.pow(2, emptyColumns);
+}
+
+function topOf<T>(arr: readonly T[]): T | undefined {
+  return arr.length === 0 ? undefined : arr[arr.length - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function validateMove(state: FreeCellState, move: Move): boolean {
+  switch (move.type) {
+    case "tableau-to-tableau": {
+      if (move.fromCol < 0 || move.fromCol >= TABLEAU_COLUMNS) return false;
+      if (move.toCol < 0 || move.toCol >= TABLEAU_COLUMNS) return false;
+      if (move.fromCol === move.toCol) return false;
+      const src = state.tableau[move.fromCol];
+      const dst = state.tableau[move.toCol];
+      if (src === undefined || dst === undefined) return false;
+      if (move.fromIndex < 0 || move.fromIndex >= src.length) return false;
+      const run = src.slice(move.fromIndex);
+      if (!isValidTableauRun(run)) return false;
+      const head = run[0];
+      if (head === undefined) return false;
+      if (!canStackOnTableau(head, topOf(dst))) return false;
+      return run.length <= supermoveMax(state, move.toCol);
+    }
+    case "tableau-to-freecell": {
+      if (move.fromCol < 0 || move.fromCol >= TABLEAU_COLUMNS) return false;
+      if (move.toCell < 0 || move.toCell >= FREE_CELL_COUNT) return false;
+      if (state.freeCells[move.toCell] !== null) return false;
+      const src = state.tableau[move.fromCol];
+      if (src === undefined || src.length === 0) return false;
+      return true;
+    }
+    case "tableau-to-foundation": {
+      if (move.fromCol < 0 || move.fromCol >= TABLEAU_COLUMNS) return false;
+      const src = state.tableau[move.fromCol];
+      if (src === undefined) return false;
+      const card = topOf(src);
+      if (card === undefined) return false;
+      return canStackOnFoundation(card, state.foundations[card.suit]);
+    }
+    case "freecell-to-tableau": {
+      if (move.fromCell < 0 || move.fromCell >= FREE_CELL_COUNT) return false;
+      if (move.toCol < 0 || move.toCol >= TABLEAU_COLUMNS) return false;
+      const card = state.freeCells[move.fromCell];
+      if (card === null || card === undefined) return false;
+      const dst = state.tableau[move.toCol];
+      if (dst === undefined) return false;
+      return canStackOnTableau(card, topOf(dst));
+    }
+    case "freecell-to-foundation": {
+      if (move.fromCell < 0 || move.fromCell >= FREE_CELL_COUNT) return false;
+      const card = state.freeCells[move.fromCell];
+      if (card === null || card === undefined) return false;
+      return canStackOnFoundation(card, state.foundations[card.suit]);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State transitions
+// ---------------------------------------------------------------------------
+
+function replaceAt<T>(arr: readonly T[], idx: number, value: T): readonly T[] {
+  const out = arr.slice();
+  out[idx] = value;
+  return out;
+}
+
+function withFoundation(foundations: Foundations, suit: Suit, pile: readonly Card[]): Foundations {
+  return { ...foundations, [suit]: pile };
+}
+
+function isWin(foundations: Foundations): boolean {
+  let total = 0;
+  for (const suit of SUITS) {
+    total += foundations[suit].length;
+  }
+  return total === DECK_SIZE;
+}
+
+/** Take a snapshot of `prev` (undoStack cleared to []), append to the stack,
+ * cap at UNDO_CAP, then attach to `next`. */
+function withUndo(
+  prev: FreeCellState,
+  next: Omit<FreeCellState, "undoStack">
+): FreeCellState {
+  const snapshot: FreeCellState = { ...prev, undoStack: [] };
+  const stack = [...prev.undoStack, snapshot];
+  const capped = stack.length > UNDO_CAP ? stack.slice(stack.length - UNDO_CAP) : stack;
+  return { ...next, undoStack: capped };
+}
+
+function finalizeAfterMove(
+  prev: FreeCellState,
+  next: Omit<FreeCellState, "undoStack" | "isComplete">
+): FreeCellState {
+  return withUndo(prev, { ...next, isComplete: isWin(next.foundations) });
+}
+
+// ---------------------------------------------------------------------------
+// applyMove
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a card-moving `Move`. Returns the (immutable) next state; if the
+ * move is invalid, returns `state` unchanged.
+ */
+export function applyMove(state: FreeCellState, move: Move): FreeCellState {
+  if (!validateMove(state, move)) return state;
+
+  switch (move.type) {
+    case "tableau-to-tableau": {
+      const src = state.tableau[move.fromCol];
+      const dst = state.tableau[move.toCol];
+      if (src === undefined || dst === undefined) return state;
+      const run = src.slice(move.fromIndex);
+      const newSrc = src.slice(0, move.fromIndex);
+      const newDst: readonly Card[] = [...dst, ...run];
+      let tableau = replaceAt(state.tableau, move.fromCol, newSrc);
+      tableau = replaceAt(tableau, move.toCol, newDst);
+      return finalizeAfterMove(state, {
+        _v: 1,
+        tableau,
+        freeCells: state.freeCells,
+        foundations: state.foundations,
+        moveCount: state.moveCount + 1,
+      });
+    }
+    case "tableau-to-freecell": {
+      const src = state.tableau[move.fromCol];
+      if (src === undefined) return state;
+      const card = topOf(src);
+      if (card === undefined) return state;
+      const newSrc = src.slice(0, -1);
+      const tableau = replaceAt(state.tableau, move.fromCol, newSrc);
+      const freeCells = replaceAt(state.freeCells, move.toCell, card) as FreeCells;
+      return finalizeAfterMove(state, {
+        _v: 1,
+        tableau,
+        freeCells,
+        foundations: state.foundations,
+        moveCount: state.moveCount + 1,
+      });
+    }
+    case "tableau-to-foundation": {
+      const src = state.tableau[move.fromCol];
+      if (src === undefined) return state;
+      const card = topOf(src);
+      if (card === undefined) return state;
+      const newSrc = src.slice(0, -1);
+      const tableau = replaceAt(state.tableau, move.fromCol, newSrc);
+      const newPile: readonly Card[] = [...state.foundations[card.suit], card];
+      const foundations = withFoundation(state.foundations, card.suit, newPile);
+      return finalizeAfterMove(state, {
+        _v: 1,
+        tableau,
+        freeCells: state.freeCells,
+        foundations,
+        moveCount: state.moveCount + 1,
+      });
+    }
+    case "freecell-to-tableau": {
+      const card = state.freeCells[move.fromCell];
+      if (card === null || card === undefined) return state;
+      const dst = state.tableau[move.toCol];
+      if (dst === undefined) return state;
+      const freeCells = replaceAt(state.freeCells, move.fromCell, null) as FreeCells;
+      const tableau = replaceAt(state.tableau, move.toCol, [...dst, card]);
+      return finalizeAfterMove(state, {
+        _v: 1,
+        tableau,
+        freeCells,
+        foundations: state.foundations,
+        moveCount: state.moveCount + 1,
+      });
+    }
+    case "freecell-to-foundation": {
+      const card = state.freeCells[move.fromCell];
+      if (card === null || card === undefined) return state;
+      const freeCells = replaceAt(state.freeCells, move.fromCell, null) as FreeCells;
+      const newPile: readonly Card[] = [...state.foundations[card.suit], card];
+      const foundations = withFoundation(state.foundations, card.suit, newPile);
+      return finalizeAfterMove(state, {
+        _v: 1,
+        tableau: state.tableau,
+        freeCells,
+        foundations,
+        moveCount: state.moveCount + 1,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Undo
+// ---------------------------------------------------------------------------
+
+/**
+ * Pop the most recent snapshot off the undo stack. Returns `state` unchanged
+ * when the stack is empty.
+ */
+export function undoMove(state: FreeCellState): FreeCellState {
+  if (state.undoStack.length === 0) return state;
+  const last = state.undoStack[state.undoStack.length - 1];
+  if (last === undefined) return state;
+  const remaining = state.undoStack.slice(0, -1);
+  return { ...last, undoStack: remaining };
+}

--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -79,7 +79,7 @@ function emptyFreeCells(): FreeCells {
  * columns 0–3 receive 7 cards each; columns 4–7 receive 6 cards each.
  */
 export function dealGame(explicitSeed?: number): FreeCellState {
-  const seed = explicitSeed ?? (Math.floor(_rng() * 0xffffffff) >>> 0);
+  const seed = explicitSeed ?? Math.floor(_rng() * 0xffffffff) >>> 0;
   const deck = fisherYates(createDeck(), createSeededRng(seed));
 
   const tableau: Card[][] = [];
@@ -232,10 +232,7 @@ function isWin(foundations: Foundations): boolean {
 
 /** Take a snapshot of `prev` (undoStack cleared to []), append to the stack,
  * cap at UNDO_CAP, then attach to `next`. */
-function withUndo(
-  prev: FreeCellState,
-  next: Omit<FreeCellState, "undoStack">
-): FreeCellState {
+function withUndo(prev: FreeCellState, next: Omit<FreeCellState, "undoStack">): FreeCellState {
   const snapshot: FreeCellState = { ...prev, undoStack: [] };
   const stack = [...prev.undoStack, snapshot];
   const capped = stack.length > UNDO_CAP ? stack.slice(stack.length - UNDO_CAP) : stack;

--- a/frontend/src/game/freecell/types.ts
+++ b/frontend/src/game/freecell/types.ts
@@ -1,0 +1,59 @@
+/**
+ * FreeCell — shared types (#808).
+ *
+ * Pure data. No React, no AsyncStorage, no side effects. Imported by the
+ * engine, UI components, and persistence layer alike.
+ */
+
+export type Suit = "spades" | "hearts" | "diamonds" | "clubs";
+
+export const SUITS: readonly Suit[] = ["spades", "hearts", "diamonds", "clubs"];
+
+/** 1 = Ace, 11 = Jack, 12 = Queen, 13 = King. */
+export type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;
+
+export const RANKS: readonly Rank[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+/** All FreeCell cards are always face-up — no faceUp field needed. */
+export interface Card {
+  readonly suit: Suit;
+  readonly rank: Rank;
+}
+
+/** 4 temporary holding cells; each slot holds at most one card. */
+export type FreeCells = readonly [Card | null, Card | null, Card | null, Card | null];
+
+/** 4 foundation piles keyed by suit; each is ascending A→K. */
+export type Foundations = Readonly<Record<Suit, readonly Card[]>>;
+
+/** Immutable snapshot of the full game. `_v` is a schema version. */
+export interface FreeCellState {
+  readonly _v: 1;
+  /** 8 columns. Cols 0–3 start with 7 cards; cols 4–7 start with 6 cards. */
+  readonly tableau: readonly (readonly Card[])[];
+  readonly freeCells: FreeCells;
+  readonly foundations: Foundations;
+  /** Prior-state snapshots, most recent last. Capped at 50 entries (FIFO eviction).
+   * Nested undoStack is always [] to prevent exponential nesting. */
+  readonly undoStack: readonly FreeCellState[];
+  readonly isComplete: boolean;
+  readonly moveCount: number;
+}
+
+export type Move =
+  | {
+      readonly type: "tableau-to-tableau";
+      readonly fromCol: number;
+      /** Index of the first card in the run to move (inclusive). */
+      readonly fromIndex: number;
+      readonly toCol: number;
+    }
+  | { readonly type: "tableau-to-freecell"; readonly fromCol: number; readonly toCell: number }
+  | { readonly type: "tableau-to-foundation"; readonly fromCol: number }
+  | { readonly type: "freecell-to-tableau"; readonly fromCell: number; readonly toCol: number }
+  | { readonly type: "freecell-to-foundation"; readonly fromCell: number };
+
+/** Red suits (hearts, diamonds) must alternate with black (spades, clubs) in the tableau. */
+export function cardColor(card: Card): "red" | "black" {
+  return card.suit === "hearts" || card.suit === "diamonds" ? "red" : "black";
+}


### PR DESCRIPTION
## Summary
- Implements `frontend/src/game/freecell/types.ts` — `Card`, `FreeCells`, `Foundations`, `FreeCellState`, and the 5-variant `Move` union
- Implements `frontend/src/game/freecell/engine.ts` — pure, side-effect-free engine with `dealGame`, `validateMove`, `applyMove`, `undoMove`, and the supermove cap formula `(1 + emptyCells) × 2^emptyColumns`
- No `faceUp` field on `Card` (all FreeCell cards are always face-up); UI layer adds `faceUp: true` when passing to `SharedPlayingCard`

## Child of
Epic #807 — FreeCell solitaire variant

## Test plan
- [ ] TypeScript compiles with no new errors
- [ ] Engine unit tests in #812 (next PR) will cover: deal shape, all 5 move types, supermove boundary, undo, win condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)