### PR TITLE
feat(#811,#812): FreeCell backend leaderboard + engine/API tests

### DIFF
--- a/backend/freecell/models.py
+++ b/backend/freecell/models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+
+
+class ScoreSubmitRequest(BaseModel):
+    player_id: str = Field(..., min_length=1, max_length=64)
+    move_count: int = Field(..., gt=0)
+
+
+class ScoreEntry(BaseModel):
+    player_id: str
+    move_count: int
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/freecell/router.py
+++ b/backend/freecell/router.py
@@ -1,0 +1,71 @@
+"""FreeCell leaderboard (#811) — in-memory store.
+
+POST /freecell/score  — accepts { player_id, move_count }, stores in-memory,
+                        returns the submitter's rank in the top-10 list.
+GET  /freecell/leaderboard — returns top-10 scores sorted ascending by
+                             move_count (fewer moves = better).
+
+Sort order: ascending move_count; ties broken by insertion time (older wins).
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Request
+
+from limiter import limiter, session_key
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+
+
+@dataclass(order=False)
+class _Entry:
+    player_id: str
+    move_count: int
+    submitted_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+_lock = threading.Lock()
+_scores: list[_Entry] = []
+
+
+def _top_scores() -> list[ScoreEntry]:
+    sorted_entries = sorted(_scores, key=lambda e: (e.move_count, e.submitted_at))
+    top = sorted_entries[:LEADERBOARD_LIMIT]
+    return [
+        ScoreEntry(player_id=e.player_id, move_count=e.move_count, rank=i + 1)
+        for i, e in enumerate(top)
+    ]
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute", key_func=session_key)
+def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    entry = _Entry(player_id=body.player_id, move_count=body.move_count)
+    with _lock:
+        _scores.append(entry)
+        top = _top_scores()
+
+    for e in top:
+        if e.player_id == body.player_id and e.move_count == body.move_count:
+            return e
+    return ScoreEntry(player_id=body.player_id, move_count=body.move_count, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/leaderboard", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+def get_leaderboard(request: Request) -> LeaderboardResponse:
+    with _lock:
+        return LeaderboardResponse(scores=_top_scores())
+
+
+def reset_leaderboard() -> None:
+    with _lock:
+        _scores.clear()

--- a/backend/freecell/router.py
+++ b/backend/freecell/router.py
@@ -56,7 +56,9 @@ def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
     for e in top:
         if e.player_id == body.player_id and e.move_count == body.move_count:
             return e
-    return ScoreEntry(player_id=body.player_id, move_count=body.move_count, rank=LEADERBOARD_LIMIT + 1)
+    return ScoreEntry(
+        player_id=body.player_id, move_count=body.move_count, rank=LEADERBOARD_LIMIT + 1
+    )
 
 
 @router.get("/leaderboard", response_model=LeaderboardResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from db.base import DATABASE_URL, get_engine, is_configured
 from limiter import _real_ip, limiter
 from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
+from freecell.router import router as freecell_router
 from hearts.router import router as hearts_router
 from solitaire.router import router as solitaire_router
 from sudoku.router import router as sudoku_router
@@ -53,6 +54,7 @@ app = FastAPI(title="Gaming App API")
 app.include_router(yacht_router, prefix="/yacht")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
+app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(sudoku_router, prefix="/sudoku")

--- a/backend/tests/test_freecell.py
+++ b/backend/tests/test_freecell.py
@@ -1,0 +1,169 @@
+"""Tests for /freecell/score and /freecell/leaderboard (#812)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import freecell.router as freecell_router_module
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    freecell_router_module.reset_leaderboard()
+    yield
+    freecell_router_module.reset_leaderboard()
+
+
+def _submit(player_id: str, move_count: int):
+    return client.post("/freecell/score", json={"player_id": player_id, "move_count": move_count})
+
+
+# ---------------------------------------------------------------------------
+# POST /freecell/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("alice", 120)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_id"] == "alice"
+        assert body["move_count"] == 120
+        assert body["rank"] == 1
+
+    def test_missing_player_id_returns_422(self):
+        res = client.post("/freecell/score", json={"move_count": 50})
+        assert res.status_code == 422
+
+    def test_missing_move_count_returns_422(self):
+        res = client.post("/freecell/score", json={"player_id": "alice"})
+        assert res.status_code == 422
+
+    def test_empty_player_id_returns_422(self):
+        res = _submit("", 50)
+        assert res.status_code == 422
+
+    def test_zero_move_count_returns_422(self):
+        res = _submit("alice", 0)
+        assert res.status_code == 422
+
+    def test_negative_move_count_returns_422(self):
+        res = _submit("alice", -5)
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /freecell/leaderboard
+# ---------------------------------------------------------------------------
+
+
+class TestGetLeaderboard:
+    def test_empty_initially(self):
+        res = client.get("/freecell/leaderboard")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("alice", 80)
+        _submit("bob", 120)
+        scores = client.get("/freecell/leaderboard").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_ascending_by_move_count(self):
+        from limiter import limiter
+
+        _submit("alice", 200)
+        limiter.reset()
+        _submit("bob", 50)
+        limiter.reset()
+        _submit("carol", 120)
+        scores = client.get("/freecell/leaderboard").json()["scores"]
+        assert [s["move_count"] for s in scores] == [50, 120, 200]
+        assert scores[0]["rank"] == 1
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()
+            _submit(f"player{i}", (i + 1) * 10)
+        scores = client.get("/freecell/leaderboard").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["move_count"] == 10  # lowest move count wins
+
+    def test_fewer_moves_ranks_higher(self):
+        from limiter import limiter
+
+        _submit("alice", 300)
+        limiter.reset()
+        assert _submit("bob", 100).json()["rank"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("alice", 80).json()["rank"] == 1
+
+    def test_higher_move_count_ranked_lower(self):
+        from limiter import limiter
+
+        _submit("alice", 80)
+        limiter.reset()
+        assert _submit("bob", 200).json()["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"top{i}", i + 1)
+        limiter.reset()
+        assert _submit("slow", 9999).json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_entry_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        _submit("alice", 100)
+        limiter.reset()
+        body = _submit("bob", 100).json()
+
+        scores = client.get("/freecell/leaderboard").json()["scores"]
+        assert scores[0]["player_id"] == "alice"
+        assert scores[1]["player_id"] == "bob"
+        assert body["rank"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"player{i}", i + 1).status_code == 201
+
+        res = _submit("excess", 999)
+        assert res.status_code == 429
+        assert "Retry-After" in res.headers
+        limiter.reset()
+
+    def test_leaderboard_get_not_rate_limited_at_low_volume(self):
+        for _ in range(5):
+            assert client.get("/freecell/leaderboard").status_code == 200

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -1,0 +1,479 @@
+/**
+ * FreeCell engine unit tests (#812).
+ *
+ * Covers all acceptance criteria from the issue:
+ *   - Deal shape (52 unique cards, column sizes)
+ *   - Tableau→tableau: valid/invalid moves
+ *   - Tableau→free cell: available/full
+ *   - Free cell→tableau: valid/invalid
+ *   - Any→foundation: correct suit+rank; rejects out-of-order/wrong suit
+ *   - Supermove formula: (1 + emptyCells) × 2^emptyColumns ≥ N
+ *   - Supermove: destination excluded from empty column count
+ *   - Undo: state restored; stack decrements; no-op when empty
+ *   - Win condition: isComplete only when all 4 foundations have 13 cards
+ */
+
+import { applyMove, createSeededRng, dealGame, setRng, undoMove, validateMove } from "../engine";
+import type { Card, Foundations, FreeCellState, Rank, Suit } from "../types";
+import { SUITS } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function c(suit: Suit, rank: Rank): Card {
+  return { suit, rank };
+}
+
+function emptyFoundations(): Foundations {
+  return { spades: [], hearts: [], diamonds: [], clubs: [] };
+}
+
+function fullFoundations(): Foundations {
+  return {
+    spades: Array.from({ length: 13 }, (_, i) => c("spades", (i + 1) as Rank)),
+    hearts: Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank)),
+    diamonds: Array.from({ length: 13 }, (_, i) => c("diamonds", (i + 1) as Rank)),
+    clubs: Array.from({ length: 13 }, (_, i) => c("clubs", (i + 1) as Rank)),
+  };
+}
+
+function mkState(overrides: Partial<FreeCellState> = {}): FreeCellState {
+  return {
+    _v: 1,
+    tableau: [[], [], [], [], [], [], [], []],
+    freeCells: [null, null, null, null],
+    foundations: emptyFoundations(),
+    undoStack: [],
+    isComplete: false,
+    moveCount: 0,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  setRng(Math.random);
+});
+
+// ---------------------------------------------------------------------------
+// Deal
+// ---------------------------------------------------------------------------
+
+describe("dealGame", () => {
+  it("produces exactly 52 unique cards", () => {
+    const state = dealGame(1);
+    const all = [
+      ...state.tableau.flat(),
+      ...state.freeCells.filter((c): c is Card => c !== null),
+      ...SUITS.flatMap((s) => state.foundations[s]),
+    ];
+    expect(all).toHaveLength(52);
+    const ids = new Set(all.map((card) => `${card.suit}-${card.rank}`));
+    expect(ids.size).toBe(52);
+  });
+
+  it("cols 0–3 have 7 cards, cols 4–7 have 6 cards", () => {
+    const state = dealGame(42);
+    for (let col = 0; col < 8; col++) {
+      expect(state.tableau[col]).toHaveLength(col < 4 ? 7 : 6);
+    }
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = dealGame(99);
+    const b = dealGame(99);
+    expect(a.tableau).toEqual(b.tableau);
+  });
+
+  it("freeCells start empty and foundations start empty", () => {
+    const state = dealGame(7);
+    expect(state.freeCells).toEqual([null, null, null, null]);
+    for (const suit of SUITS) {
+      expect(state.foundations[suit]).toEqual([]);
+    }
+  });
+
+  it("uses _rng when no seed is supplied", () => {
+    setRng(createSeededRng(5));
+    const state = dealGame();
+    const all = state.tableau.flat();
+    expect(all).toHaveLength(52);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tableau → Tableau
+// ---------------------------------------------------------------------------
+
+describe("tableau → tableau", () => {
+  it("valid single-card move (alternating color, rank -1) succeeds", () => {
+    // 5♠ (black) onto 6♥ (red)
+    const state = mkState({
+      tableau: [[c("spades", 5)], [c("hearts", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+    const next = applyMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 });
+    expect(next.tableau[0]).toEqual([]);
+    expect(next.tableau[1]).toHaveLength(2);
+    expect(next.moveCount).toBe(1);
+  });
+
+  it("rejects same-color stacking", () => {
+    // 5♥ (red) onto 6♦ (red) — invalid
+    const state = mkState({
+      tableau: [[c("hearts", 5)], [c("diamonds", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+  });
+
+  it("rejects wrong-rank stacking", () => {
+    // 4♠ onto 6♥ — rank gap is 2, not 1
+    const state = mkState({
+      tableau: [[c("spades", 4)], [c("hearts", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+  });
+
+  it("rejects same-column move", () => {
+    const state = mkState({ tableau: [[c("spades", 5)], [], [], [], [], [], [], []] });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 0 })).toBe(false);
+  });
+
+  it("rejects out-of-bounds column indices", () => {
+    const state = mkState();
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: -1, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 8 })).toBe(false);
+  });
+
+  it("applyMove returns same reference on invalid move", () => {
+    const state = mkState({ tableau: [[c("hearts", 5)], [c("diamonds", 6)], [], [], [], [], [], []] });
+    expect(applyMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(state);
+  });
+
+  it("only allows a King on an empty column", () => {
+    const nonKing = mkState({ tableau: [[c("hearts", 7)], [], [], [], [], [], [], []] });
+    expect(validateMove(nonKing, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+
+    const king = mkState({ tableau: [[c("hearts", 13)], [], [], [], [], [], [], []] });
+    expect(validateMove(king, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tableau → Free Cell
+// ---------------------------------------------------------------------------
+
+describe("tableau → free cell", () => {
+  it("succeeds when a slot is available", () => {
+    const state = mkState({
+      tableau: [[c("spades", 5)], [], [], [], [], [], [], []],
+      freeCells: [null, null, null, null],
+    });
+    expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })).toBe(true);
+    const next = applyMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 });
+    expect(next.freeCells[0]).toEqual(c("spades", 5));
+    expect(next.tableau[0]).toEqual([]);
+    expect(next.moveCount).toBe(1);
+  });
+
+  it("rejected when target cell is already occupied", () => {
+    const state = mkState({
+      tableau: [[c("spades", 5)], [], [], [], [], [], [], []],
+      freeCells: [c("hearts", 3), null, null, null],
+    });
+    expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })).toBe(false);
+  });
+
+  it("rejected when all 4 cells are occupied", () => {
+    const state = mkState({
+      tableau: [[c("spades", 5)], [], [], [], [], [], [], []],
+      freeCells: [c("hearts", 1), c("diamonds", 2), c("clubs", 3), c("spades", 4)],
+    });
+    for (let cell = 0; cell < 4; cell++) {
+      expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: cell })).toBe(false);
+    }
+  });
+
+  it("rejected from an empty tableau column", () => {
+    const state = mkState({ freeCells: [null, null, null, null] });
+    expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Free Cell → Tableau
+// ---------------------------------------------------------------------------
+
+describe("free cell → tableau", () => {
+  it("valid placement succeeds", () => {
+    // 5♠ (black) from free cell onto 6♥ (red) on tableau
+    const state = mkState({
+      freeCells: [c("spades", 5), null, null, null],
+      tableau: [[], [c("hearts", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "freecell-to-tableau", fromCell: 0, toCol: 1 })).toBe(true);
+    const next = applyMove(state, { type: "freecell-to-tableau", fromCell: 0, toCol: 1 });
+    expect(next.freeCells[0]).toBeNull();
+    expect(next.tableau[1]).toHaveLength(2);
+    expect(next.moveCount).toBe(1);
+  });
+
+  it("rejected when the tableau placement is invalid (same color)", () => {
+    const state = mkState({
+      freeCells: [c("hearts", 5), null, null, null],
+      tableau: [[], [c("diamonds", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "freecell-to-tableau", fromCell: 0, toCol: 1 })).toBe(false);
+  });
+
+  it("rejected from an empty free cell", () => {
+    const state = mkState({
+      freeCells: [null, null, null, null],
+      tableau: [[], [c("hearts", 6)], [], [], [], [], [], []],
+    });
+    expect(validateMove(state, { type: "freecell-to-tableau", fromCell: 0, toCol: 1 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Any → Foundation
+// ---------------------------------------------------------------------------
+
+describe("any → foundation", () => {
+  it("tableau → foundation: accepts Ace onto empty foundation", () => {
+    const state = mkState({ tableau: [[c("spades", 1)], [], [], [], [], [], [], []] });
+    expect(validateMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(true);
+    const next = applyMove(state, { type: "tableau-to-foundation", fromCol: 0 });
+    expect(next.foundations.spades).toHaveLength(1);
+    expect(next.foundations.spades[0]).toEqual(c("spades", 1));
+    expect(next.moveCount).toBe(1);
+  });
+
+  it("tableau → foundation: accepts next rank of the same suit", () => {
+    const state = mkState({
+      tableau: [[c("hearts", 2)], [], [], [], [], [], [], []],
+      foundations: { ...emptyFoundations(), hearts: [c("hearts", 1)] },
+    });
+    expect(validateMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(true);
+  });
+
+  it("tableau → foundation: rejects wrong suit", () => {
+    const state = mkState({
+      tableau: [[c("diamonds", 1)], [], [], [], [], [], [], []],
+      foundations: { ...emptyFoundations(), spades: [c("spades", 1)] },
+    });
+    // diamonds ace should go to diamonds foundation, not spades
+    // validateMove checks if the top card can be placed — diamonds ace to empty diamonds is fine
+    // but moving diamonds onto spades pile is checked internally by suit
+    const next = applyMove(state, { type: "tableau-to-foundation", fromCol: 0 });
+    expect(next.foundations.diamonds).toHaveLength(1);
+    expect(next.foundations.spades).toHaveLength(1); // spades unchanged
+  });
+
+  it("tableau → foundation: rejects out-of-order rank (rank 3 onto rank 1)", () => {
+    const state = mkState({
+      tableau: [[c("spades", 3)], [], [], [], [], [], [], []],
+      foundations: { ...emptyFoundations(), spades: [c("spades", 1)] },
+    });
+    expect(validateMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(false);
+  });
+
+  it("free cell → foundation: succeeds when rank matches", () => {
+    const state = mkState({
+      freeCells: [c("clubs", 1), null, null, null],
+    });
+    expect(validateMove(state, { type: "freecell-to-foundation", fromCell: 0 })).toBe(true);
+    const next = applyMove(state, { type: "freecell-to-foundation", fromCell: 0 });
+    expect(next.freeCells[0]).toBeNull();
+    expect(next.foundations.clubs).toHaveLength(1);
+  });
+
+  it("free cell → foundation: rejects wrong rank", () => {
+    const state = mkState({
+      freeCells: [c("clubs", 3), null, null, null],
+    });
+    expect(validateMove(state, { type: "freecell-to-foundation", fromCell: 0 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Supermove formula
+// ---------------------------------------------------------------------------
+
+describe("supermove", () => {
+  it("allows moving N cards when (1 + emptyCells) × 2^emptyColumns ≥ N", () => {
+    // 4 free cells empty, 0 empty tableau columns (excluding dest) → max = (1+4) × 1 = 5
+    // Try moving a 3-card run: should succeed
+    const state = mkState({
+      freeCells: [null, null, null, null],
+      tableau: [
+        // col 0: valid 3-card descending alternating run: 7♥, 6♠, 5♥
+        [c("hearts", 7), c("spades", 6), c("hearts", 5)],
+        // col 1: destination — 8♠ (black), run head 7♥ (red) can stack
+        [c("spades", 8)],
+        [c("clubs", 2)],
+        [c("clubs", 3)],
+        [c("clubs", 4)],
+        [c("clubs", 5)],
+        [c("clubs", 6)],
+        [c("clubs", 7)],
+      ],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+  });
+
+  it("blocks moving N cards when supermove capacity is exceeded", () => {
+    // 0 free cells, 0 empty columns (excluding dest) → max = (1+0) × 1 = 1
+    // Trying to move 2 cards should fail
+    const state = mkState({
+      freeCells: [c("clubs", 1), c("clubs", 2), c("clubs", 3), c("clubs", 4)],
+      tableau: [
+        [c("hearts", 6), c("spades", 5)], // 2-card run
+        [c("diamonds", 7)],              // dest
+        [c("clubs", 9)],
+        [c("clubs", 10)],
+        [c("clubs", 11)],
+        [c("clubs", 12)],
+        [c("clubs", 13)],
+        [c("hearts", 1)],
+      ],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+  });
+
+  it("excludes the destination column from the empty column count", () => {
+    // dest col is empty — if it were counted, max would be higher than it should be
+    // 1 free cell empty, dest col is the only empty col → emptyColumns = 0 (dest excluded)
+    // max = (1+1) × 2^0 = 2
+    // Trying to move a 3-card run onto an empty column should fail (exceeds 2)
+    const state = mkState({
+      freeCells: [null, c("clubs", 1), c("clubs", 2), c("clubs", 3)],
+      tableau: [
+        [c("hearts", 7), c("spades", 6), c("hearts", 5)], // 3-card run
+        [],                                                // dest — empty but excluded
+        [c("clubs", 4)],
+        [c("clubs", 5)],
+        [c("clubs", 6)],
+        [c("clubs", 7)],
+        [c("clubs", 8)],
+        [c("clubs", 9)],
+      ],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+  });
+
+  it("includes non-destination empty columns in the count", () => {
+    // 0 free cells, 2 empty columns (neither is dest) → max = (1+0) × 2^2 = 4
+    // Moving a 3-card run should succeed
+    const state = mkState({
+      freeCells: [c("clubs", 1), c("clubs", 2), c("clubs", 3), c("clubs", 4)],
+      tableau: [
+        [c("hearts", 7), c("spades", 6), c("hearts", 5)], // 3-card run
+        [c("spades", 8)],                                  // dest
+        [],                                                // empty col 1
+        [],                                                // empty col 2
+        [c("clubs", 5)],
+        [c("clubs", 6)],
+        [c("clubs", 7)],
+        [c("clubs", 9)],
+      ],
+    });
+    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Undo
+// ---------------------------------------------------------------------------
+
+describe("undoMove", () => {
+  it("restores state exactly after one move", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], [], []],
+    });
+    const after = applyMove(state, { type: "tableau-to-foundation", fromCol: 0 });
+    expect(after.foundations.spades).toHaveLength(1);
+    expect(after.undoStack).toHaveLength(1);
+
+    const reverted = undoMove(after);
+    expect(reverted.foundations.spades).toEqual([]);
+    expect(reverted.tableau[0]).toEqual([c("spades", 1)]);
+    expect(reverted.moveCount).toBe(0);
+  });
+
+  it("undo stack decrements by one after undoMove", () => {
+    const s0 = mkState({ tableau: [[c("spades", 1)], [c("hearts", 1)], [], [], [], [], [], []] });
+    const s1 = applyMove(s0, { type: "tableau-to-foundation", fromCol: 0 });
+    const s2 = applyMove(s1, { type: "tableau-to-foundation", fromCol: 1 });
+    expect(s2.undoStack).toHaveLength(2);
+    const back = undoMove(s2);
+    expect(back.undoStack).toHaveLength(1);
+  });
+
+  it("is a no-op when the undo stack is empty", () => {
+    const state = mkState();
+    expect(undoMove(state)).toBe(state);
+  });
+
+  it("chains multiple undos back to the original state", () => {
+    const s0 = mkState({ tableau: [[c("spades", 1)], [c("hearts", 1)], [], [], [], [], [], []] });
+    const s1 = applyMove(s0, { type: "tableau-to-foundation", fromCol: 0 });
+    const s2 = applyMove(s1, { type: "tableau-to-foundation", fromCol: 1 });
+    const back1 = undoMove(s2);
+    const back2 = undoMove(back1);
+    expect(back2.foundations.spades).toEqual([]);
+    expect(back2.foundations.hearts).toEqual([]);
+    expect(back2.moveCount).toBe(0);
+  });
+
+  it("snapshots stored in undoStack have empty nested undoStack", () => {
+    const s0 = mkState({ tableau: [[c("spades", 1)], [c("hearts", 1)], [], [], [], [], [], []] });
+    const s1 = applyMove(s0, { type: "tableau-to-foundation", fromCol: 0 });
+    const s2 = applyMove(s1, { type: "tableau-to-foundation", fromCol: 1 });
+    for (const snap of s2.undoStack) {
+      expect(snap.undoStack).toEqual([]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Win condition
+// ---------------------------------------------------------------------------
+
+describe("isComplete", () => {
+  it("is true only when all 4 foundations have 13 cards", () => {
+    const foundations: Foundations = {
+      spades: Array.from({ length: 13 }, (_, i) => c("spades", (i + 1) as Rank)),
+      hearts: Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank)),
+      diamonds: Array.from({ length: 13 }, (_, i) => c("diamonds", (i + 1) as Rank)),
+      clubs: Array.from({ length: 12 }, (_, i) => c("clubs", (i + 1) as Rank)),
+    };
+    const state = mkState({
+      foundations,
+      tableau: [[c("clubs", 13)], [], [], [], [], [], [], []],
+    });
+    expect(state.isComplete).toBe(false);
+
+    const next = applyMove(state, { type: "tableau-to-foundation", fromCol: 0 });
+    expect(next.isComplete).toBe(true);
+    expect(next.foundations.clubs).toHaveLength(13);
+  });
+
+  it("is false when 3 foundations are full but 1 is not", () => {
+    const state = mkState({ foundations: fullFoundations() });
+    // fullFoundations already has all 13 — but let's check an incomplete state
+    const incomplete: Foundations = {
+      spades: Array.from({ length: 13 }, (_, i) => c("spades", (i + 1) as Rank)),
+      hearts: Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank)),
+      diamonds: Array.from({ length: 13 }, (_, i) => c("diamonds", (i + 1) as Rank)),
+      clubs: Array.from({ length: 12 }, (_, i) => c("clubs", (i + 1) as Rank)),
+    };
+    const s = mkState({ foundations: incomplete });
+    expect(s.isComplete).toBe(false);
+  });
+
+  it("starts as false on a freshly dealt game", () => {
+    const state = dealGame(1);
+    expect(state.isComplete).toBe(false);
+  });
+});

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -29,7 +29,6 @@ function emptyFoundations(): Foundations {
   return { spades: [], hearts: [], diamonds: [], clubs: [] };
 }
 
-
 function mkState(overrides: Partial<FreeCellState> = {}): FreeCellState {
   return {
     _v: 1,

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -29,14 +29,6 @@ function emptyFoundations(): Foundations {
   return { spades: [], hearts: [], diamonds: [], clubs: [] };
 }
 
-function fullFoundations(): Foundations {
-  return {
-    spades: Array.from({ length: 13 }, (_, i) => c("spades", (i + 1) as Rank)),
-    hearts: Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank)),
-    diamonds: Array.from({ length: 13 }, (_, i) => c("diamonds", (i + 1) as Rank)),
-    clubs: Array.from({ length: 13 }, (_, i) => c("clubs", (i + 1) as Rank)),
-  };
-}
 
 function mkState(overrides: Partial<FreeCellState> = {}): FreeCellState {
   return {
@@ -495,8 +487,6 @@ describe("isComplete", () => {
   });
 
   it("is false when 3 foundations are full but 1 is not", () => {
-    const state = mkState({ foundations: fullFoundations() });
-    // fullFoundations already has all 13 — but let's check an incomplete state
     const incomplete: Foundations = {
       spades: Array.from({ length: 13 }, (_, i) => c("spades", (i + 1) as Rank)),
       hearts: Array.from({ length: 13 }, (_, i) => c("hearts", (i + 1) as Rank)),

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -111,8 +111,15 @@ describe("tableau → tableau", () => {
     const state = mkState({
       tableau: [[c("spades", 5)], [c("hearts", 6)], [], [], [], [], [], []],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
-    const next = applyMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 });
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(true);
+    const next = applyMove(state, {
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    });
     expect(next.tableau[0]).toEqual([]);
     expect(next.tableau[1]).toHaveLength(2);
     expect(next.moveCount).toBe(1);
@@ -123,7 +130,9 @@ describe("tableau → tableau", () => {
     const state = mkState({
       tableau: [[c("hearts", 5)], [c("diamonds", 6)], [], [], [], [], [], []],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
   });
 
   it("rejects wrong-rank stacking", () => {
@@ -131,31 +140,47 @@ describe("tableau → tableau", () => {
     const state = mkState({
       tableau: [[c("spades", 4)], [c("hearts", 6)], [], [], [], [], [], []],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
   });
 
   it("rejects same-column move", () => {
     const state = mkState({ tableau: [[c("spades", 5)], [], [], [], [], [], [], []] });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 0 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 0 })
+    ).toBe(false);
   });
 
   it("rejects out-of-bounds column indices", () => {
     const state = mkState();
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: -1, fromIndex: 0, toCol: 1 })).toBe(false);
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 8 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: -1, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 8 })
+    ).toBe(false);
   });
 
   it("applyMove returns same reference on invalid move", () => {
-    const state = mkState({ tableau: [[c("hearts", 5)], [c("diamonds", 6)], [], [], [], [], [], []] });
-    expect(applyMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(state);
+    const state = mkState({
+      tableau: [[c("hearts", 5)], [c("diamonds", 6)], [], [], [], [], [], []],
+    });
+    expect(
+      applyMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(state);
   });
 
   it("only allows a King on an empty column", () => {
     const nonKing = mkState({ tableau: [[c("hearts", 7)], [], [], [], [], [], [], []] });
-    expect(validateMove(nonKing, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(
+      validateMove(nonKing, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
 
     const king = mkState({ tableau: [[c("hearts", 13)], [], [], [], [], [], [], []] });
-    expect(validateMove(king, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+    expect(
+      validateMove(king, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(true);
   });
 });
 
@@ -190,7 +215,9 @@ describe("tableau → free cell", () => {
       freeCells: [c("hearts", 1), c("diamonds", 2), c("clubs", 3), c("spades", 4)],
     });
     for (let cell = 0; cell < 4; cell++) {
-      expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: cell })).toBe(false);
+      expect(validateMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: cell })).toBe(
+        false
+      );
     }
   });
 
@@ -319,7 +346,9 @@ describe("supermove", () => {
         [c("clubs", 7)],
       ],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(true);
   });
 
   it("blocks moving N cards when supermove capacity is exceeded", () => {
@@ -329,7 +358,7 @@ describe("supermove", () => {
       freeCells: [c("clubs", 1), c("clubs", 2), c("clubs", 3), c("clubs", 4)],
       tableau: [
         [c("hearts", 6), c("spades", 5)], // 2-card run
-        [c("diamonds", 7)],              // dest
+        [c("diamonds", 7)], // dest
         [c("clubs", 9)],
         [c("clubs", 10)],
         [c("clubs", 11)],
@@ -338,7 +367,9 @@ describe("supermove", () => {
         [c("hearts", 1)],
       ],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
   });
 
   it("excludes the destination column from the empty column count", () => {
@@ -350,7 +381,7 @@ describe("supermove", () => {
       freeCells: [null, c("clubs", 1), c("clubs", 2), c("clubs", 3)],
       tableau: [
         [c("hearts", 7), c("spades", 6), c("hearts", 5)], // 3-card run
-        [],                                                // dest — empty but excluded
+        [], // dest — empty but excluded
         [c("clubs", 4)],
         [c("clubs", 5)],
         [c("clubs", 6)],
@@ -359,7 +390,9 @@ describe("supermove", () => {
         [c("clubs", 9)],
       ],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(false);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(false);
   });
 
   it("includes non-destination empty columns in the count", () => {
@@ -369,16 +402,18 @@ describe("supermove", () => {
       freeCells: [c("clubs", 1), c("clubs", 2), c("clubs", 3), c("clubs", 4)],
       tableau: [
         [c("hearts", 7), c("spades", 6), c("hearts", 5)], // 3-card run
-        [c("spades", 8)],                                  // dest
-        [],                                                // empty col 1
-        [],                                                // empty col 2
+        [c("spades", 8)], // dest
+        [], // empty col 1
+        [], // empty col 2
         [c("clubs", 5)],
         [c("clubs", 6)],
         [c("clubs", 7)],
         [c("clubs", 9)],
       ],
     });
-    expect(validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })).toBe(true);
+    expect(
+      validateMove(state, { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 1 })
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #811, #812. Part of epic #807.

## Summary
- **Backend** (`backend/freecell/`): in-memory `POST /freecell/score` + `GET /freecell/leaderboard` — ascending by `move_count` (fewer = better), top-10 capped, tie-break by insertion time, rate-limited via `session_key` (5/min write, 60/min read)
- **`backend/main.py`**: registers freecell router at `/freecell`
- **Backend tests** (`backend/tests/test_freecell.py`): 17 tests — validation, ranking, tie-break, rate limit (429 + `Retry-After` header), leaderboard sort and cap
- **Engine tests** (`frontend/src/game/freecell/__tests__/engine.test.ts`): 37 tests — deal shape, all move types, supermove formula, undo, win condition

## Test plan
- [ ] `python -m pytest tests/test_freecell.py -v` → 17 passed
- [ ] `npx jest src/game/freecell/__tests__/engine.test.ts --no-coverage` → 37 passed
- [ ] `GET /freecell/leaderboard` returns scores ascending by `move_count`
- [ ] `POST /freecell/score` with `move_count: 0` returns 422
- [ ] 6th `POST` within a minute returns 429 with `Retry-After` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)