### PR TITLE
feat(#809): FreeCell board UI

### DIFF
--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+
+import { useTheme } from "../../theme/ThemeContext";
+import SharedPlayingCard from "../shared/PlayingCard";
+import { rankLabel } from "../../game/_shared/decks/cardId";
+import type { CanonicalSuit } from "../../game/_shared/decks/types";
+import type { Card, Suit } from "../../game/freecell/types";
+import { CARD_WIDTH, CARD_HEIGHT } from "./FreeCellSlot";
+
+const SUIT_SYMBOL: Record<Suit, string> = {
+  spades: "♠",
+  hearts: "♥",
+  diamonds: "♦",
+  clubs: "♣",
+};
+
+export interface FoundationPileProps {
+  readonly pile: readonly Card[];
+  readonly suit: Suit;
+  readonly selected?: boolean;
+  readonly onPress?: (suit: Suit) => void;
+}
+
+export default function FoundationPile({
+  pile,
+  suit,
+  selected = false,
+  onPress,
+}: FoundationPileProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation("freecell");
+
+  if (pile.length > 0) {
+    const top = pile[pile.length - 1];
+    if (top !== undefined) {
+      const rl = rankLabel(top.rank);
+      const suitName = t(`suit.${top.suit}` as const);
+      const label = selected
+        ? t("card.selected", { rank: rl, suit: suitName })
+        : t("card.label", { rank: rl, suit: suitName });
+      return (
+        <SharedPlayingCard
+          suit={top.suit as CanonicalSuit}
+          rank={top.rank}
+          width={CARD_WIDTH}
+          height={CARD_HEIGHT}
+          highlighted={selected}
+          onPress={onPress ? () => onPress(suit) : undefined}
+          accessibilityLabel={label}
+        />
+      );
+    }
+  }
+
+  const label = t("pile.foundation.empty", { suit: t(`suit.${suit}` as const) });
+  const pileStyle = [
+    styles.empty,
+    {
+      borderColor: selected ? colors.accent : colors.border,
+      borderWidth: selected ? 2 : 1,
+      backgroundColor: colors.background,
+    },
+  ];
+  const content = (
+    <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
+  );
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={() => onPress(suit)}
+        style={pileStyle}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
+        {content}
+      </Pressable>
+    );
+  }
+  return (
+    <View style={pileStyle} accessibilityRole="image" accessibilityLabel={label}>
+      {content}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  suit: {
+    fontSize: 24,
+    lineHeight: 28,
+  },
+});

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { SUITS } from "../../game/freecell/types";
 import { validateMove } from "../../game/freecell/engine";
-import type { FreeCellState, Move, Suit } from "../../game/freecell/types";
+import type { FreeCellState, Move } from "../../game/freecell/types";
 import FreeCellSlot, { CARD_WIDTH } from "./FreeCellSlot";
 import FoundationPile from "./FoundationPile";
 import TableauColumn from "./TableauColumn";
@@ -90,7 +90,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     }
   }
 
-  function handleFoundationPress(suit: Suit) {
+  function handleFoundationPress() {
     if (selection === null) return;
     if (selection.kind === "tableau") {
       tryMove({ type: "tableau-to-foundation", fromCol: selection.col });
@@ -100,11 +100,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   }
 
   return (
-    <View
-      style={styles.board}
-      accessibilityRole="none"
-      accessibilityLabel={t("a11y.boardRegion")}
-    >
+    <View style={styles.board} accessibilityRole="none" accessibilityLabel={t("a11y.boardRegion")}>
       <View style={styles.topRow}>
         <View style={styles.slotGroup}>
           {state.freeCells.map((card, i) => (
@@ -124,7 +120,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
               pile={state.foundations[suit]}
               suit={suit}
               selected={false}
-              onPress={handleFoundationPress}
+              onPress={() => handleFoundationPress()}
             />
           ))}
         </View>
@@ -137,9 +133,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
             pile={pile}
             colIndex={col}
             selectedIndex={
-              selection?.kind === "tableau" && selection.col === col
-                ? selection.index
-                : undefined
+              selection?.kind === "tableau" && selection.col === col ? selection.index : undefined
             }
             onCardPress={handleTableauCardPress}
             onEmptyPress={handleTableauEmptyPress}

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { useTranslation } from "react-i18next";
+
+import { SUITS } from "../../game/freecell/types";
+import { validateMove } from "../../game/freecell/engine";
+import type { FreeCellState, Move, Suit } from "../../game/freecell/types";
+import FreeCellSlot, { CARD_WIDTH } from "./FreeCellSlot";
+import FoundationPile from "./FoundationPile";
+import TableauColumn from "./TableauColumn";
+
+const TABLEAU_COLS = 8;
+const COL_GAP = 4;
+const SLOT_GAP = 6;
+const ROW_GAP = 8;
+
+const BOARD_WIDTH = TABLEAU_COLS * CARD_WIDTH + (TABLEAU_COLS - 1) * COL_GAP;
+
+type Selection =
+  | { kind: "tableau"; col: number; index: number }
+  | { kind: "freecell"; cell: number }
+  | null;
+
+export interface FreeCellBoardProps {
+  readonly state: FreeCellState;
+  readonly onMove: (move: Move) => void;
+}
+
+export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
+  const { t } = useTranslation("freecell");
+  const [selection, setSelection] = useState<Selection>(null);
+
+  function tryMove(move: Move) {
+    if (validateMove(state, move)) {
+      onMove(move);
+    }
+    setSelection(null);
+  }
+
+  function handleTableauCardPress(col: number, index: number) {
+    if (selection === null) {
+      setSelection({ kind: "tableau", col, index });
+      return;
+    }
+    if (selection.kind === "tableau" && selection.col === col && selection.index === index) {
+      setSelection(null);
+      return;
+    }
+    if (selection.kind === "tableau") {
+      tryMove({
+        type: "tableau-to-tableau",
+        fromCol: selection.col,
+        fromIndex: selection.index,
+        toCol: col,
+      });
+    } else {
+      tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
+    }
+  }
+
+  function handleTableauEmptyPress(col: number) {
+    if (selection === null) return;
+    if (selection.kind === "tableau") {
+      tryMove({
+        type: "tableau-to-tableau",
+        fromCol: selection.col,
+        fromIndex: selection.index,
+        toCol: col,
+      });
+    } else {
+      tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
+    }
+  }
+
+  function handleFreeCellPress(cell: number) {
+    if (selection === null) {
+      if (state.freeCells[cell] !== null) {
+        setSelection({ kind: "freecell", cell });
+      }
+      return;
+    }
+    if (selection.kind === "freecell" && selection.cell === cell) {
+      setSelection(null);
+      return;
+    }
+    if (selection.kind === "tableau") {
+      tryMove({ type: "tableau-to-freecell", fromCol: selection.col, toCell: cell });
+    } else {
+      setSelection(null);
+    }
+  }
+
+  function handleFoundationPress(suit: Suit) {
+    if (selection === null) return;
+    if (selection.kind === "tableau") {
+      tryMove({ type: "tableau-to-foundation", fromCol: selection.col });
+    } else {
+      tryMove({ type: "freecell-to-foundation", fromCell: selection.cell });
+    }
+  }
+
+  return (
+    <View
+      style={styles.board}
+      accessibilityRole="none"
+      accessibilityLabel={t("a11y.boardRegion")}
+    >
+      <View style={styles.topRow}>
+        <View style={styles.slotGroup}>
+          {state.freeCells.map((card, i) => (
+            <FreeCellSlot
+              key={i}
+              card={card}
+              cellIndex={i}
+              selected={selection?.kind === "freecell" && selection.cell === i}
+              onPress={handleFreeCellPress}
+            />
+          ))}
+        </View>
+        <View style={styles.slotGroup}>
+          {SUITS.map((suit) => (
+            <FoundationPile
+              key={suit}
+              pile={state.foundations[suit]}
+              suit={suit}
+              selected={false}
+              onPress={handleFoundationPress}
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.tableau}>
+        {state.tableau.map((pile, col) => (
+          <TableauColumn
+            key={col}
+            pile={pile}
+            colIndex={col}
+            selectedIndex={
+              selection?.kind === "tableau" && selection.col === col
+                ? selection.index
+                : undefined
+            }
+            onCardPress={handleTableauCardPress}
+            onEmptyPress={handleTableauEmptyPress}
+          />
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  board: {
+    alignItems: "center",
+    gap: ROW_GAP,
+  },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    width: BOARD_WIDTH,
+  },
+  slotGroup: {
+    flexDirection: "row",
+    gap: SLOT_GAP,
+  },
+  tableau: {
+    flexDirection: "row",
+    gap: COL_GAP,
+    alignItems: "flex-start",
+  },
+});

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -70,13 +70,7 @@ export default function FreeCellSlot({
     );
   }
 
-  return (
-    <View
-      style={slotStyle}
-      accessibilityRole="image"
-      accessibilityLabel={emptyLabel}
-    />
-  );
+  return <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel} />;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { useTranslation } from "react-i18next";
+
+import { useTheme } from "../../theme/ThemeContext";
+import SharedPlayingCard from "../shared/PlayingCard";
+import { rankLabel } from "../../game/_shared/decks/cardId";
+import type { CanonicalSuit } from "../../game/_shared/decks/types";
+import type { Card } from "../../game/freecell/types";
+
+export const CARD_WIDTH = 40;
+export const CARD_HEIGHT = 57;
+
+export interface FreeCellSlotProps {
+  readonly card: Card | null;
+  readonly cellIndex: number;
+  readonly selected?: boolean;
+  readonly onPress?: (cellIndex: number) => void;
+}
+
+export default function FreeCellSlot({
+  card,
+  cellIndex,
+  selected = false,
+  onPress,
+}: FreeCellSlotProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation("freecell");
+
+  const handlePress = onPress ? () => onPress(cellIndex) : undefined;
+
+  if (card !== null) {
+    const rl = rankLabel(card.rank);
+    const suitName = t(`suit.${card.suit}` as const);
+    const label = selected
+      ? t("card.selected", { rank: rl, suit: suitName })
+      : t("card.label", { rank: rl, suit: suitName });
+
+    return (
+      <SharedPlayingCard
+        suit={card.suit as CanonicalSuit}
+        rank={card.rank}
+        width={CARD_WIDTH}
+        height={CARD_HEIGHT}
+        highlighted={selected}
+        onPress={handlePress}
+        accessibilityLabel={label}
+      />
+    );
+  }
+
+  const emptyLabel = t("pile.freecell.empty", { cell: cellIndex + 1 });
+  const slotStyle = [
+    styles.empty,
+    {
+      borderColor: selected ? colors.accent : colors.border,
+      borderWidth: selected ? 2 : 1,
+      backgroundColor: colors.background,
+    },
+  ];
+
+  if (handlePress) {
+    return (
+      <Pressable
+        onPress={handlePress}
+        style={slotStyle}
+        accessibilityRole="button"
+        accessibilityLabel={emptyLabel}
+      />
+    );
+  }
+
+  return (
+    <View
+      style={slotStyle}
+      accessibilityRole="image"
+      accessibilityLabel={emptyLabel}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    borderStyle: "dashed",
+  },
+});

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -33,10 +33,7 @@ export default function TableauColumn({
     return (
       <Pressable
         onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
-        style={[
-          styles.empty,
-          { borderColor: colors.border, backgroundColor: colors.background },
-        ]}
+        style={[styles.empty, { borderColor: colors.border, backgroundColor: colors.background }]}
         accessibilityRole="button"
         accessibilityLabel={t("pile.tableau.empty", { col: colIndex + 1 })}
       />
@@ -70,10 +67,7 @@ export default function TableauColumn({
           : t("card.label", { rank: rl, suit: suitName });
         const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
         return (
-          <View
-            key={cardIndex}
-            style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}
-          >
+          <View key={cardIndex} style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}>
             <SharedPlayingCard
               suit={card.suit as CanonicalSuit}
               rank={card.rank}

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Pressable, StyleSheet, View, ViewStyle } from "react-native";
+import { useTranslation } from "react-i18next";
+
+import { useTheme } from "../../theme/ThemeContext";
+import SharedPlayingCard from "../shared/PlayingCard";
+import { rankLabel } from "../../game/_shared/decks/cardId";
+import type { CanonicalSuit } from "../../game/_shared/decks/types";
+import type { Card } from "../../game/freecell/types";
+import { CARD_WIDTH, CARD_HEIGHT } from "./FreeCellSlot";
+
+const FACE_UP_OFFSET = 24;
+
+export interface TableauColumnProps {
+  readonly pile: readonly Card[];
+  readonly colIndex: number;
+  readonly selectedIndex?: number;
+  readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
+  readonly onEmptyPress?: (colIndex: number) => void;
+}
+
+export default function TableauColumn({
+  pile,
+  colIndex,
+  selectedIndex,
+  onCardPress,
+  onEmptyPress,
+}: TableauColumnProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation("freecell");
+
+  if (pile.length === 0) {
+    return (
+      <Pressable
+        onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
+        style={[
+          styles.empty,
+          { borderColor: colors.border, backgroundColor: colors.background },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={t("pile.tableau.empty", { col: colIndex + 1 })}
+      />
+    );
+  }
+
+  const offsets: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < pile.length; i++) {
+    offsets.push(acc);
+    acc += FACE_UP_OFFSET;
+  }
+  const containerHeight = CARD_HEIGHT + (offsets[pile.length - 1] ?? 0);
+
+  const containerStyle: ViewStyle = {
+    width: CARD_WIDTH,
+    height: containerHeight,
+  };
+
+  return (
+    <View
+      style={containerStyle}
+      accessibilityLabel={t("pile.tableau.label", { col: colIndex + 1, count: pile.length })}
+    >
+      {pile.map((card, cardIndex) => {
+        const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
+        const rl = rankLabel(card.rank);
+        const suitName = t(`suit.${card.suit}` as const);
+        const label = isSelected
+          ? t("card.selected", { rank: rl, suit: suitName })
+          : t("card.label", { rank: rl, suit: suitName });
+        const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
+        return (
+          <View
+            key={cardIndex}
+            style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}
+          >
+            <SharedPlayingCard
+              suit={card.suit as CanonicalSuit}
+              rank={card.rank}
+              width={CARD_WIDTH}
+              height={CARD_HEIGHT}
+              highlighted={isSelected}
+              onPress={handlePress}
+              accessibilityLabel={label}
+            />
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  empty: {
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: "dashed",
+  },
+  cardSlot: {
+    position: "absolute",
+    left: 0,
+  },
+});

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -12,6 +12,7 @@ type Namespace =
   | "blackjack"
   | "twenty48"
   | "solitaire"
+  | "freecell"
   | "hearts"
   | "sudoku"
   | "feedback"
@@ -41,6 +42,7 @@ const localeLoaders: Record<string, Partial<Record<Namespace, () => TranslationM
     blackjack: () => import("./locales/en/blackjack.json") as TranslationModule,
     twenty48: () => import("./locales/en/twenty48.json") as TranslationModule,
     solitaire: () => import("./locales/en/solitaire.json") as TranslationModule,
+    freecell: () => import("./locales/en/freecell.json") as TranslationModule,
     hearts: () => import("./locales/en/hearts.json") as TranslationModule,
     sudoku: () => import("./locales/en/sudoku.json") as TranslationModule,
     feedback: () => import("./locales/en/feedback.json") as TranslationModule,
@@ -196,6 +198,7 @@ i18n
       "blackjack",
       "twenty48",
       "solitaire",
+      "freecell",
       "hearts",
       "sudoku",
       "feedback",

--- a/frontend/src/i18n/locales/_meta/freecell.meta.json
+++ b/frontend/src/i18n/locales/_meta/freecell.meta.json
@@ -1,0 +1,119 @@
+{
+  "game.title": {
+    "component": "HomeScreen",
+    "description": "Name of the FreeCell game card.",
+    "tone": "neutral",
+    "characterLimit": 15,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Use the locale's standard name for FreeCell. The name 'FreeCell' is widely recognised internationally."
+  },
+  "game.description": {
+    "component": "HomeScreen",
+    "description": "One-line description on the FreeCell game card.",
+    "tone": "casual, punchy",
+    "characterLimit": 60,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "suit.spades": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Suit name — Spades.",
+    "tone": "neutral",
+    "characterLimit": 16,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Use the standard card-game name in the locale."
+  },
+  "suit.hearts": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Suit name — Hearts.",
+    "tone": "neutral",
+    "characterLimit": 16,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Use the standard card-game name in the locale."
+  },
+  "suit.diamonds": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Suit name — Diamonds.",
+    "tone": "neutral",
+    "characterLimit": 16,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Use the standard card-game name in the locale."
+  },
+  "suit.clubs": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Suit name — Clubs.",
+    "tone": "neutral",
+    "characterLimit": 16,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Use the standard card-game name in the locale."
+  },
+  "card.label": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Accessibility label for a face-up card — 'Ace of Spades', etc.",
+    "tone": "functional",
+    "characterLimit": 40,
+    "placeholders": ["{{rank}}", "{{suit}}"],
+    "doNotTranslate": [],
+    "notes": "{{rank}} is rendered as 'A','2'-'10','J','Q','K' — do not translate single-letter ranks. {{suit}} is already-localized."
+  },
+  "card.selected": {
+    "component": "FreeCellSlot / FoundationPile / TableauColumn",
+    "description": "Accessibility label for a face-up card that is selected.",
+    "tone": "functional",
+    "characterLimit": 48,
+    "placeholders": ["{{rank}}", "{{suit}}"],
+    "doNotTranslate": [],
+    "notes": "Same conventions as card.label; add a '(selected)' annotation idiomatic to the locale."
+  },
+  "pile.tableau.label": {
+    "component": "TableauColumn",
+    "description": "Accessibility label on a non-empty tableau column.",
+    "tone": "functional",
+    "characterLimit": 60,
+    "placeholders": ["{{col}}", "{{count}}"],
+    "doNotTranslate": [],
+    "notes": "{{col}} is the 1-indexed column; {{count}} is the number of cards in it."
+  },
+  "pile.tableau.empty": {
+    "component": "TableauColumn",
+    "description": "Accessibility label on an empty tableau column slot.",
+    "tone": "functional",
+    "characterLimit": 40,
+    "placeholders": ["{{col}}"],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "pile.foundation.empty": {
+    "component": "FoundationPile",
+    "description": "Accessibility label on an empty foundation pile.",
+    "tone": "functional",
+    "characterLimit": 40,
+    "placeholders": ["{{suit}}"],
+    "doNotTranslate": [],
+    "notes": "{{suit}} is already-localized suit name."
+  },
+  "pile.freecell.empty": {
+    "component": "FreeCellSlot",
+    "description": "Accessibility label on an empty free cell slot.",
+    "tone": "functional",
+    "characterLimit": 40,
+    "placeholders": ["{{cell}}"],
+    "doNotTranslate": [],
+    "notes": "{{cell}} is the 1-indexed slot number (1–4)."
+  },
+  "a11y.boardRegion": {
+    "component": "FreeCellBoard",
+    "description": "Accessibility region label wrapping the whole FreeCell board.",
+    "tone": "functional",
+    "characterLimit": 30,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  }
+}

--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -1,0 +1,15 @@
+{
+  "game.title": "FreeCell",
+  "game.description": "Move all cards to the foundations — plan every move.",
+  "suit.spades": "Spades",
+  "suit.hearts": "Hearts",
+  "suit.diamonds": "Diamonds",
+  "suit.clubs": "Clubs",
+  "card.label": "{{rank}} of {{suit}}",
+  "card.selected": "{{rank}} of {{suit}} (selected)",
+  "pile.tableau.label": "Tableau column {{col}}, {{count}} cards",
+  "pile.tableau.empty": "Empty tableau column {{col}}",
+  "pile.foundation.empty": "Empty {{suit}} foundation",
+  "pile.freecell.empty": "Empty free cell {{cell}}",
+  "a11y.boardRegion": "FreeCell board"
+}


### PR DESCRIPTION
Closes #809

## Summary
- `FreeCellSlot` — single-card holding slot (empty placeholder or card, tappable for selection; 40×57px)
- `FoundationPile` — foundation pile showing top card or suit-symbol placeholder; accepts taps as move destination
- `TableauColumn` — 8-column face-up tableau with 24px fan offset and run highlighting
- `FreeCellBoard` — full board composing all piles; manages tap-to-select state internally; emits validated `Move` objects to parent via `onMove`; invalid taps deselect
- `en/freecell.json` + `_meta/freecell.meta.json` i18n namespace; registered in `i18n.ts`

## Test plan
- [ ] TypeScript compiles with no new errors (`npx tsc --noEmit`)
- [ ] 37 FreeCell engine tests still pass (`npx jest --testPathPattern=freecell`)
- [ ] i18n completeness check passes (`node scripts/check-i18n-strings.js`)
- [ ] 8 tableau columns fit in 375px portrait without horizontal scroll
- [ ] Tapping a card selects it (highlight border appears)
- [ ] Tapping a valid destination moves the card and clears selection
- [ ] Tapping an invalid destination deselects without error flash
- [ ] Free cell slots and foundation piles render correctly in top row

🤖 Generated with [Claude Code](https://claude.com/claude-code)