### PR TITLE
feat(#810): FreeCell screen + navigation

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -67,6 +67,7 @@ export type HomeStackParamList = {
   BlackjackTable: undefined;
   Twenty48: undefined;
   Solitaire: undefined;
+  FreeCell: undefined;
   Hearts: undefined;
   Sudoku: undefined;
   Scoreboard: {
@@ -139,6 +140,7 @@ const LazyBlackjackBettingScreen = withSuspense(LazyScreens.BlackjackBetting, "b
 const LazyBlackjackTableScreen = withSuspense(LazyScreens.BlackjackTable, "blackjack_table");
 const LazyTwenty48Screen = withSuspense(LazyScreens.Twenty48, "twenty48");
 const LazySolitaireScreen = withSuspense(LazyScreens.Solitaire, "solitaire");
+const LazyFreeCellScreen = withSuspense(LazyScreens.FreeCell, "freecell");
 const LazyHeartsScreen = withSuspense(LazyScreens.Hearts, "hearts");
 const LazySudokuScreen = withSuspense(LazyScreens.Sudoku, "sudoku");
 const LazyLeaderboardScreen = withSuspense(LazyScreens.Leaderboard, "leaderboard");
@@ -161,6 +163,7 @@ function LobbyStack() {
       <HomeStack.Screen name="BlackjackTable" component={LazyBlackjackTableScreen} />
       <HomeStack.Screen name="Twenty48" component={LazyTwenty48Screen} />
       <HomeStack.Screen name="Solitaire" component={LazySolitaireScreen} />
+      <HomeStack.Screen name="FreeCell" component={LazyFreeCellScreen} />
       <HomeStack.Screen name="Hearts" component={LazyHeartsScreen} />
       <HomeStack.Screen name="Sudoku" component={LazySudokuScreen} />
       <HomeStack.Screen name="Scoreboard" component={LazyScoreboardScreen} />

--- a/frontend/src/game/freecell/storage.ts
+++ b/frontend/src/game/freecell/storage.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+import type { FreeCellState } from "./types";
+
+const GAME_KEY = "freecell_game";
+
+function stripNestedUndo(state: FreeCellState): FreeCellState {
+  return {
+    ...state,
+    undoStack: state.undoStack.map((snapshot) => ({ ...snapshot, undoStack: [] })),
+  };
+}
+
+export async function saveGame(state: FreeCellState): Promise<void> {
+  try {
+    await AsyncStorage.setItem(GAME_KEY, JSON.stringify(stripNestedUndo(state)));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "freecell.storage", op: "save" } });
+  }
+}
+
+export async function loadGame(): Promise<FreeCellState | null> {
+  try {
+    const raw = await AsyncStorage.getItem(GAME_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<FreeCellState>;
+    if (
+      parsed._v !== 1 ||
+      !Array.isArray(parsed.tableau) ||
+      parsed.tableau.length !== 8 ||
+      parsed.foundations === null ||
+      typeof parsed.foundations !== "object" ||
+      !Array.isArray(parsed.freeCells) ||
+      parsed.freeCells.length !== 4 ||
+      !Array.isArray(parsed.undoStack) ||
+      typeof parsed.isComplete !== "boolean" ||
+      typeof parsed.moveCount !== "number"
+    ) {
+      await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
+      return null;
+    }
+    return parsed as FreeCellState;
+  } catch (e) {
+    Sentry.captureMessage("freecell.storage: corrupt game payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "freecell.storage", op: "load" },
+      extra: { error: String(e), key: GAME_KEY },
+    });
+    await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
+    return null;
+  }
+}
+
+export async function clearGame(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(GAME_KEY);
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "freecell.storage", op: "clear" } });
+  }
+}

--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -1,6 +1,9 @@
 {
   "game.title": "FreeCell",
   "game.description": "Move all cards to the foundations — plan every move.",
+  "game.playLabel": "Play FreeCell",
+  "action.undo": "Undo",
+  "action.newGame": "New Game",
   "suit.spades": "Spades",
   "suit.hearts": "Hearts",
   "suit.diamonds": "Diamonds",
@@ -11,5 +14,10 @@
   "pile.tableau.empty": "Empty tableau column {{col}}",
   "pile.foundation.empty": "Empty {{suit}} foundation",
   "pile.freecell.empty": "Empty free cell {{cell}}",
-  "a11y.boardRegion": "FreeCell board"
+  "a11y.boardRegion": "FreeCell board",
+  "score.moves": "Moves: {{moves}}",
+  "win.title": "You Win!",
+  "win.moves": "Completed in {{moves}} moves",
+  "win.newGame": "New Game",
+  "win.goHome": "Go Home"
 }

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -1,0 +1,349 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  LayoutChangeEvent,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+import { HomeStackParamList } from "../../App";
+import { useTheme } from "../theme/ThemeContext";
+import { typography } from "../theme/typography";
+import { GameShell } from "../components/shared/GameShell";
+import FreeCellBoard from "../components/freecell/FreeCellBoard";
+import { CARD_WIDTH, CARD_HEIGHT } from "../components/freecell/FreeCellSlot";
+import { dealGame, applyMove, undoMove } from "../game/freecell/engine";
+import type { FreeCellState, Move } from "../game/freecell/types";
+import { clearGame, loadGame, saveGame } from "../game/freecell/storage";
+
+// 8 columns × 40px + 7 gaps × 4px
+const TABLEAU_COLS = 8;
+const COL_GAP = 4;
+const BOARD_WIDTH = TABLEAU_COLS * CARD_WIDTH + (TABLEAU_COLS - 1) * COL_GAP;
+// Top row (free cells + foundations) + gap + tableau worst case (12 cards stacked at 24px offset)
+const BOARD_HEIGHT = CARD_HEIGHT * 2 + 8 + 12 * 24 + CARD_HEIGHT;
+
+export default function FreeCellScreen() {
+  const { t } = useTranslation("freecell");
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+
+  const [state, setState] = useState<FreeCellState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [outerWidth, setOuterWidth] = useState(0);
+
+  const flashOpacity = useRef(new Animated.Value(0)).current;
+  const hasLoadedRef = useRef(false);
+
+  // Mount: resume saved game or deal fresh
+  useEffect(() => {
+    let alive = true;
+    loadGame().then((saved) => {
+      if (!alive) return;
+      hasLoadedRef.current = true;
+      setState(saved ?? dealGame());
+      setLoading(false);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Persist on every state change once the mount load has resolved
+  useEffect(() => {
+    if (!hasLoadedRef.current || state === null) return;
+    saveGame(state).catch(() => {});
+  }, [state]);
+
+  const flashInvalid = useCallback(() => {
+    Animated.sequence([
+      Animated.timing(flashOpacity, { toValue: 0.4, duration: 80, useNativeDriver: true }),
+      Animated.timing(flashOpacity, { toValue: 0, duration: 180, useNativeDriver: true }),
+    ]).start();
+  }, [flashOpacity]);
+
+  const handleMove = useCallback(
+    (move: Move) => {
+      if (state === null) return;
+      const next = applyMove(state, move);
+      if (next === state) {
+        flashInvalid();
+        return;
+      }
+      setState(next);
+    },
+    [state, flashInvalid]
+  );
+
+  const handleUndo = useCallback(() => {
+    if (state === null || state.undoStack.length === 0) return;
+    setState(undoMove(state));
+  }, [state]);
+
+  const handleNewGame = useCallback(() => {
+    clearGame().catch(() => {});
+    setState(dealGame());
+  }, []);
+
+  const onOuterLayout = useCallback((e: LayoutChangeEvent) => {
+    setOuterWidth(Math.floor(e.nativeEvent.layout.width));
+  }, []);
+
+  const undoDisabled = state === null || state.undoStack.length === 0 || state.isComplete;
+  const scale = outerWidth > 0 ? Math.min(1, outerWidth / BOARD_WIDTH) : 1;
+
+  return (
+    <GameShell
+      title={t("freecell:game.title")}
+      requireBack
+      loading={loading}
+      onBack={() => navigation.popToTop()}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 16),
+        paddingLeft: Math.max(insets.left, 12),
+        paddingRight: Math.max(insets.right, 12),
+      }}
+      onNewGame={handleNewGame}
+      rightSlot={
+        <Pressable
+          onPress={handleUndo}
+          disabled={undoDisabled}
+          style={[
+            styles.headerBtn,
+            { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={t("freecell:action.undo")}
+          accessibilityState={{ disabled: undoDisabled }}
+        >
+          <Text style={[styles.headerBtnText, { color: colors.accent }]}>
+            {t("freecell:action.undo")}
+          </Text>
+        </Pressable>
+      }
+    >
+      {state !== null && (
+        <View style={styles.body} onLayout={onOuterLayout}>
+          <View style={styles.hudRow} accessibilityRole="summary">
+            <Text
+              style={[styles.hudText, { color: colors.textMuted }]}
+              accessibilityLabel={t("freecell:score.moves", { moves: state.moveCount })}
+            >
+              {t("freecell:score.moves", { moves: state.moveCount })}
+            </Text>
+          </View>
+
+          <View
+            style={[styles.boardWrap, outerWidth > 0 ? { height: BOARD_HEIGHT * scale } : null]}
+            accessibilityLabel={t("freecell:a11y.boardRegion")}
+          >
+            <View
+              style={[
+                styles.board,
+                {
+                  width: BOARD_WIDTH,
+                  transform: [{ scale }],
+                } as ViewStyle,
+              ]}
+            >
+              <FreeCellBoard state={state} onMove={handleMove} />
+            </View>
+          </View>
+
+          <Animated.View
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: colors.error, opacity: flashOpacity },
+            ]}
+            testID="freecell-invalid-flash"
+          />
+        </View>
+      )}
+
+      {state?.isComplete === true && (
+        <WinModal
+          moves={state.moveCount}
+          onNewGame={handleNewGame}
+          onGoHome={() => navigation.popToTop()}
+        />
+      )}
+    </GameShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Win modal
+// ---------------------------------------------------------------------------
+
+function WinModal({
+  moves,
+  onNewGame,
+  onGoHome,
+}: {
+  readonly moves: number;
+  readonly onNewGame: () => void;
+  readonly onGoHome: () => void;
+}) {
+  const { t } = useTranslation("freecell");
+  const { colors } = useTheme();
+
+  const gradient: ViewStyle =
+    Platform.OS === "web"
+      ? ({
+          backgroundImage: `linear-gradient(135deg, ${colors.accent}, ${colors.accentBright})`,
+        } as ViewStyle)
+      : { backgroundColor: colors.accentBright };
+
+  return (
+    <Modal visible transparent animationType="fade" accessibilityViewIsModal>
+      <View style={styles.modalOverlay}>
+        <View
+          style={[
+            styles.modalCard,
+            { backgroundColor: colors.surfaceHigh, borderColor: colors.border },
+          ]}
+        >
+          <Text style={[styles.modalTitle, { color: colors.text }]} accessibilityRole="header">
+            {t("win.title")}
+          </Text>
+          <Text style={[styles.modalBody, { color: colors.textMuted }]}>
+            {t("win.moves", { moves })}
+          </Text>
+
+          <Pressable
+            style={[styles.modalPrimary, gradient]}
+            onPress={onNewGame}
+            accessibilityRole="button"
+            accessibilityLabel={t("win.newGame")}
+          >
+            <Text style={[styles.modalPrimaryText, { color: colors.textOnAccent }]}>
+              {t("win.newGame")}
+            </Text>
+          </Pressable>
+
+          <Pressable
+            style={[styles.modalSecondary, { borderColor: colors.accent }]}
+            onPress={onGoHome}
+            accessibilityRole="button"
+            accessibilityLabel={t("win.goHome")}
+          >
+            <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
+              {t("win.goHome")}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+  },
+  headerBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  headerBtnText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+  },
+  hudRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 4,
+    paddingVertical: 8,
+  },
+  hudText: {
+    fontFamily: typography.heading,
+    fontSize: 16,
+    letterSpacing: 0.5,
+  },
+  boardWrap: {
+    alignSelf: "stretch",
+    alignItems: "flex-start",
+    overflow: "hidden",
+  },
+  board: {
+    alignSelf: "flex-start",
+    transformOrigin: "top left",
+  } as ViewStyle,
+  modalOverlay: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#000000bf",
+  },
+  modalCard: {
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 24,
+    alignItems: "center",
+    width: "86%",
+    maxWidth: 360,
+  },
+  modalTitle: {
+    fontFamily: typography.heading,
+    fontSize: 20,
+    fontWeight: "900",
+    letterSpacing: 0.5,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  modalBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 20,
+    textAlign: "center",
+  },
+  modalPrimary: {
+    paddingHorizontal: 32,
+    paddingVertical: 12,
+    borderRadius: 999,
+    marginBottom: 10,
+    alignItems: "center",
+    minWidth: 180,
+  },
+  modalPrimaryText: {
+    fontSize: 14,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+  },
+  modalSecondary: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  modalSecondaryText: {
+    fontSize: 13,
+    fontWeight: "800",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+  },
+});

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -36,6 +36,7 @@ export default function HomeScreen() {
     "blackjack",
     "twenty48",
     "solitaire",
+    "freecell",
     "hearts",
     "sudoku",
     "errors",
@@ -104,6 +105,13 @@ export default function HomeScreen() {
       action: () => navigation.navigate("Solitaire"),
     },
     {
+      key: "freecell",
+      emoji: "🂡",
+      title: t("freecell:game.title"),
+      description: t("freecell:game.description"),
+      action: () => navigation.navigate("FreeCell"),
+    },
+    {
       key: "hearts",
       emoji: "♥",
       title: t("hearts:game.title"),
@@ -127,6 +135,7 @@ export default function HomeScreen() {
     [t("blackjack:game.title")]: t("blackjack:game.playLabel"),
     [t("twenty48:game.title")]: t("twenty48:game.playLabel"),
     [t("solitaire:game.title")]: t("solitaire:game.playLabel"),
+    [t("freecell:game.title")]: t("freecell:game.playLabel"),
     [t("hearts:game.title")]: t("hearts:game.playLabel"),
     [t("sudoku:game.title")]: t("sudoku:game.playLabel"),
   };

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -9,6 +9,7 @@ const factories = {
   BlackjackTable: () => import("../screens/BlackjackTableScreen"),
   Twenty48: () => import("../screens/Twenty48Screen"),
   Solitaire: () => import("../screens/SolitaireScreen"),
+  FreeCell: () => import("../screens/FreeCellScreen"),
   Hearts: () => import("../screens/HeartsScreen"),
   Sudoku: () => import("../screens/SudokuScreen"),
   Leaderboard: () => import("../screens/LeaderboardScreen"),
@@ -23,6 +24,7 @@ export const LazyScreens = {
   BlackjackTable: React.lazy(factories.BlackjackTable),
   Twenty48: React.lazy(factories.Twenty48),
   Solitaire: React.lazy(factories.Solitaire),
+  FreeCell: React.lazy(factories.FreeCell),
   Hearts: React.lazy(factories.Hearts),
   Sudoku: React.lazy(factories.Sudoku),
   Leaderboard: React.lazy(factories.Leaderboard),
@@ -42,6 +44,7 @@ export function prefetchLobbyGameScreens(): void {
   factories.BlackjackBetting().catch(() => undefined);
   factories.Twenty48().catch(() => undefined);
   factories.Solitaire().catch(() => undefined);
+  factories.FreeCell().catch(() => undefined);
   factories.Hearts().catch(() => undefined);
   factories.Sudoku().catch(() => undefined);
 }


### PR DESCRIPTION
## Summary
- `FreeCellScreen.tsx` — composes `FreeCellBoard` with undo button in header (disabled when stack empty or game won), move count HUD, `AsyncStorage` save/resume on every mutation, and win modal showing move count with New Game / Go Home options
- Navigation: `FreeCell` route added to `HomeStackParamList` and `LobbyStack`, lazy screen registered with Suspense + Sentry timing, added to prefetch list
- Home screen: FreeCell card (🂡) wired to the new route
- `freecell.json`: added `game.playLabel`, `action.undo/newGame`, `score.moves`, and `win.*` strings

Closes #810. Part of epic #807.

## Test plan
- [ ] Launch app — FreeCell card appears on home screen
- [ ] Tap Play FreeCell — screen opens with a dealt board
- [ ] Make a move — Undo button becomes enabled; tap Undo reverts the move
- [ ] Background and re-open app — board resumes from saved state
- [ ] Win a game — win modal appears with move count, New Game deals a fresh board, Go Home returns to lobby
- [ ] Undo button disabled on a fresh deal (empty undo stack) and after winning

🤖 Generated with [Claude Code](https://claude.com/claude-code)