### PR TITLE
feat(#801): Star Swarm rendering — GameCanvas native (Skia) + web (Canvas 2D)

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -1,13 +1,6 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import {
-  Canvas,
-  Circle,
-  Fill,
-  Group,
-  Image as SkiaImage,
-  Rect,
-} from "@shopify/react-native-skia";
+import { Canvas, Circle, Fill, Group, Image as SkiaImage, Rect } from "@shopify/react-native-skia";
 import { useTranslation } from "react-i18next";
 import { initStarSwarm, tick } from "../../game/starswarm/engine";
 import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
@@ -196,11 +189,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                     ? images.enemyElite
                     : images.enemyBoss;
               const fallbackColor =
-                enemy.tier === "Grunt"
-                  ? "#8888ff"
-                  : enemy.tier === "Elite"
-                    ? "#ff88ff"
-                    : "#ffff44";
+                enemy.tier === "Grunt" ? "#8888ff" : enemy.tier === "Elite" ? "#ff88ff" : "#ffff44";
               return img ? (
                 <SkiaImage
                   key={enemy.id}

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -1,0 +1,395 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import {
+  Canvas,
+  Circle,
+  Fill,
+  Group,
+  Image as SkiaImage,
+  Rect,
+} from "@shopify/react-native-skia";
+import { useTranslation } from "react-i18next";
+import { initStarSwarm, tick } from "../../game/starswarm/engine";
+import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
+import type { StarfieldState } from "../../game/starswarm/starfield";
+import { useStarSwarmImages } from "../../game/starswarm/assets";
+import type { StarSwarmState } from "../../game/starswarm/types";
+
+const EXPLOSION_DRAW_SIZE = 48;
+const DT_CAP_MS = 33;
+const INVINCIBLE_BLINK_INTERVAL = 120; // ms
+
+export interface GameCanvasHandle {
+  reset: () => void;
+  setPlayerX: (x: number) => void;
+  setFire: (fire: boolean) => void;
+}
+
+interface Props {
+  highScore?: number;
+  onGameOver?: (finalScore: number) => void;
+  onScoreChange?: (score: number) => void;
+  width: number;
+  height: number;
+  scale: number;
+}
+
+interface RenderState {
+  game: StarSwarmState;
+  sf: StarfieldState;
+}
+
+const GameCanvas = forwardRef<GameCanvasHandle, Props>(
+  ({ highScore = 0, onGameOver, onScoreChange, width, height, scale }, ref) => {
+    const { t } = useTranslation("starswarm");
+    const images = useStarSwarmImages();
+
+    const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height));
+    const sfRef = useRef<StarfieldState>(initStarfield(width, height));
+    const inputRef = useRef({ playerX: width / 2, fire: true });
+    const lastFrameTimeRef = useRef(0);
+    const prevScoreRef = useRef(0);
+    const onGameOverRef = useRef(onGameOver);
+    const onScoreChangeRef = useRef(onScoreChange);
+
+    useEffect(() => {
+      onGameOverRef.current = onGameOver;
+    }, [onGameOver]);
+    useEffect(() => {
+      onScoreChangeRef.current = onScoreChange;
+    }, [onScoreChange]);
+
+    const [renderState, setRenderState] = useState<RenderState>({
+      game: gameRef.current,
+      sf: sfRef.current,
+    });
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        reset() {
+          gameRef.current = initStarSwarm(width, height);
+          sfRef.current = initStarfield(width, height);
+          inputRef.current.playerX = width / 2;
+          prevScoreRef.current = 0;
+          setRenderState({ game: gameRef.current, sf: sfRef.current });
+        },
+        setPlayerX(x) {
+          inputRef.current.playerX = x;
+        },
+        setFire(fire) {
+          inputRef.current.fire = fire;
+        },
+      }),
+      [width, height]
+    );
+
+    // RAF game loop — drives both engine tick and Skia re-renders
+    useEffect(() => {
+      let id: number;
+
+      function loop(timestamp: number) {
+        if (lastFrameTimeRef.current === 0) lastFrameTimeRef.current = timestamp;
+        const dtMs = Math.min(timestamp - lastFrameTimeRef.current, DT_CAP_MS);
+        lastFrameTimeRef.current = timestamp;
+
+        const prev = gameRef.current;
+        if (prev.phase !== "GameOver") {
+          const next = tick(prev, dtMs, {
+            playerX: inputRef.current.playerX,
+            fire: inputRef.current.fire,
+          });
+          gameRef.current = next;
+          if (next.score !== prevScoreRef.current) {
+            prevScoreRef.current = next.score;
+            onScoreChangeRef.current?.(next.score);
+          }
+          if (next.phase === "GameOver") {
+            onGameOverRef.current?.(next.score);
+          }
+        }
+        // Starfield scrolls continuously
+        sfRef.current = tickStarfield(sfRef.current, dtMs);
+
+        setRenderState({ game: gameRef.current, sf: sfRef.current });
+        id = requestAnimationFrame(loop);
+      }
+
+      id = requestAnimationFrame(loop);
+      return () => cancelAnimationFrame(id);
+    }, []); // intentionally empty — loop lives for component lifetime
+
+    const { game: state, sf } = renderState;
+    const { player } = state;
+    const displayW = Math.round(width * scale);
+    const displayH = Math.round(height * scale);
+    const hs = Math.max(highScore, state.score);
+
+    const blink =
+      player.invincibleTimer > 0 &&
+      Math.floor(player.invincibleTimer / INVINCIBLE_BLINK_INTERVAL) % 2 === 1;
+
+    return (
+      <View style={{ width: displayW, height: displayH }}>
+        <Canvas
+          style={[styles.canvas, { width: displayW, height: displayH }]}
+          accessibilityLabel={t("game.canvasLabel")}
+          accessibilityRole="none"
+        >
+          <Group transform={[{ scale }]}>
+            <Fill color="#000010" />
+
+            {/* Starfield */}
+            {sf.stars.map((star, i) => (
+              <Circle
+                key={i}
+                cx={star.x}
+                cy={star.y}
+                r={star.r}
+                color={`rgba(255,255,255,${star.opacity})`}
+              />
+            ))}
+
+            {/* Enemy bullets */}
+            {state.enemyBullets.map((b) => (
+              <Rect
+                key={b.id}
+                x={b.x - b.width / 2}
+                y={b.y - b.height / 2}
+                width={b.width}
+                height={b.height}
+                color="#ff4422"
+              />
+            ))}
+
+            {/* Player bullets */}
+            {state.playerBullets.map((b) =>
+              images.bulletPlayer ? (
+                <SkiaImage
+                  key={b.id}
+                  image={images.bulletPlayer}
+                  x={b.x - b.width / 2}
+                  y={b.y - b.height / 2}
+                  width={b.width}
+                  height={b.height}
+                  fit="fill"
+                />
+              ) : (
+                <Rect
+                  key={b.id}
+                  x={b.x - b.width / 2}
+                  y={b.y - b.height / 2}
+                  width={b.width}
+                  height={b.height}
+                  color="#00ffcc"
+                />
+              )
+            )}
+
+            {/* Enemies */}
+            {state.enemies.map((enemy) => {
+              if (!enemy.isAlive) return null;
+              const img =
+                enemy.tier === "Grunt"
+                  ? images.enemyGrunt
+                  : enemy.tier === "Elite"
+                    ? images.enemyElite
+                    : images.enemyBoss;
+              const fallbackColor =
+                enemy.tier === "Grunt"
+                  ? "#8888ff"
+                  : enemy.tier === "Elite"
+                    ? "#ff88ff"
+                    : "#ffff44";
+              return img ? (
+                <SkiaImage
+                  key={enemy.id}
+                  image={img}
+                  x={enemy.x - enemy.width / 2}
+                  y={enemy.y - enemy.height / 2}
+                  width={enemy.width}
+                  height={enemy.height}
+                  fit="fill"
+                />
+              ) : (
+                <Rect
+                  key={enemy.id}
+                  x={enemy.x - enemy.width / 2}
+                  y={enemy.y - enemy.height / 2}
+                  width={enemy.width}
+                  height={enemy.height}
+                  color={fallbackColor}
+                />
+              );
+            })}
+
+            {/* Player */}
+            {!blink &&
+              (images.playerShip ? (
+                <SkiaImage
+                  image={images.playerShip}
+                  x={player.x - player.width / 2}
+                  y={player.y - player.height / 2}
+                  width={player.width}
+                  height={player.height}
+                  fit="fill"
+                />
+              ) : (
+                <Rect
+                  x={player.x - player.width / 2}
+                  y={player.y - player.height / 2}
+                  width={player.width}
+                  height={player.height}
+                  color="#00ffcc"
+                />
+              ))}
+
+            {/* Explosions */}
+            {state.explosions.map((exp) => {
+              const frameImg = images.explosionFrames[exp.frame] ?? null;
+              const half = EXPLOSION_DRAW_SIZE / 2;
+              if (frameImg) {
+                return (
+                  <SkiaImage
+                    key={exp.id}
+                    image={frameImg}
+                    x={exp.x - half}
+                    y={exp.y - half}
+                    width={EXPLOSION_DRAW_SIZE}
+                    height={EXPLOSION_DRAW_SIZE}
+                    fit="fill"
+                  />
+                );
+              }
+              const progress = exp.frame / 20;
+              return (
+                <Circle
+                  key={exp.id}
+                  cx={exp.x}
+                  cy={exp.y}
+                  r={6 + progress * 18}
+                  color={progress < 0.4 ? "#ffcc00" : "#ff4400"}
+                  opacity={1 - progress}
+                />
+              );
+            })}
+          </Group>
+        </Canvas>
+
+        {/* HUD overlay — React Native Text over the Skia canvas */}
+        <View style={styles.hud} pointerEvents="none">
+          <View style={styles.hudTop}>
+            <Text style={styles.hudText}>{`${t("hud.score")} ${state.score}`}</Text>
+            <Text style={styles.hudText}>{`${t("hud.best")} ${hs}`}</Text>
+            <Text style={styles.hudText}>{`${t("hud.wave")} ${state.wave}`}</Text>
+          </View>
+
+          <View style={styles.hudBottom}>
+            {Array.from({ length: player.lives }, (_, i) => (
+              <View key={i} style={styles.lifeIndicator} />
+            ))}
+          </View>
+
+          {state.phase === "WaveClear" && (
+            <View style={styles.phaseOverlay}>
+              <Text style={styles.overlayTitle}>{t("phase.waveClear")}</Text>
+            </View>
+          )}
+
+          {state.phase === "ChallengingStage" && (
+            <View style={styles.phaseOverlay}>
+              <Text style={[styles.overlayTitle, styles.challengingTitle]}>
+                {t("phase.challengingStage")}
+              </Text>
+              <Text style={styles.overlaySubtitle}>
+                {t("phase.hits", { count: state.challengingHits })}
+              </Text>
+            </View>
+          )}
+
+          {state.phase === "GameOver" && (
+            <View style={[styles.phaseOverlay, styles.gameOverOverlay]}>
+              <Text style={styles.gameOverTitle}>{t("phase.gameOver")}</Text>
+              <Text style={styles.gameOverScore}>{`${t("hud.score")} ${state.score}`}</Text>
+            </View>
+          )}
+        </View>
+      </View>
+    );
+  }
+);
+
+GameCanvas.displayName = "GameCanvas";
+export default GameCanvas;
+
+const styles = StyleSheet.create({
+  canvas: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+  },
+  hud: {
+    ...StyleSheet.absoluteFillObject,
+    paddingHorizontal: 10,
+    paddingTop: 8,
+    paddingBottom: 8,
+  },
+  hudTop: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  hudText: {
+    color: "#ffffff",
+    fontSize: 12,
+    fontWeight: "bold",
+    fontVariant: ["tabular-nums"],
+  },
+  hudBottom: {
+    position: "absolute",
+    bottom: 8,
+    left: 10,
+    flexDirection: "row",
+    gap: 6,
+  },
+  lifeIndicator: {
+    width: 10,
+    height: 14,
+    backgroundColor: "#00ffcc",
+  },
+  phaseOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  overlayTitle: {
+    color: "#00ffcc",
+    fontSize: 22,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  challengingTitle: {
+    color: "#ffdd00",
+  },
+  overlaySubtitle: {
+    color: "#ffffff",
+    fontSize: 14,
+    textAlign: "center",
+    marginTop: 8,
+  },
+  gameOverOverlay: {
+    backgroundColor: "rgba(0,0,0,0.65)",
+  },
+  gameOverTitle: {
+    color: "#ff4422",
+    fontSize: 28,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  gameOverScore: {
+    color: "#ffffff",
+    fontSize: 18,
+    textAlign: "center",
+    marginTop: 16,
+    fontVariant: ["tabular-nums"],
+  },
+});

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -35,8 +35,26 @@ import ef18 from "../../../assets/starswarm/explosion/frame18.png";
 import ef19 from "../../../assets/starswarm/explosion/frame19.png";
 
 const EXPLOSION_SRCS = [
-  ef00, ef01, ef02, ef03, ef04, ef05, ef06, ef07, ef08, ef09,
-  ef10, ef11, ef12, ef13, ef14, ef15, ef16, ef17, ef18, ef19,
+  ef00,
+  ef01,
+  ef02,
+  ef03,
+  ef04,
+  ef05,
+  ef06,
+  ef07,
+  ef08,
+  ef09,
+  ef10,
+  ef11,
+  ef12,
+  ef13,
+  ef14,
+  ef15,
+  ef16,
+  ef17,
+  ef18,
+  ef19,
 ] as const;
 
 const EXPLOSION_DRAW_SIZE = 48;
@@ -141,8 +159,15 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           ...EXPLOSION_SRCS.map((s) => loadImg(s as number)),
         ]);
         if (cancelled) return;
-        const [playerShip, enemyGrunt, enemyElite, enemyBoss, bulletPlayer, bulletEnemy, ...frames] =
-          results;
+        const [
+          playerShip,
+          enemyGrunt,
+          enemyElite,
+          enemyBoss,
+          bulletPlayer,
+          bulletEnemy,
+          ...frames
+        ] = results;
         imagesRef.current = {
           playerShip: playerShip ?? null,
           enemyGrunt: enemyGrunt ?? null,
@@ -288,7 +313,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         const frameImg = imgs.explosionFrames[exp.frame] ?? null;
         const half = EXPLOSION_DRAW_SIZE / 2;
         if (frameImg) {
-          ctx.drawImage(frameImg, exp.x - half, exp.y - half, EXPLOSION_DRAW_SIZE, EXPLOSION_DRAW_SIZE);
+          ctx.drawImage(
+            frameImg,
+            exp.x - half,
+            exp.y - half,
+            EXPLOSION_DRAW_SIZE,
+            EXPLOSION_DRAW_SIZE
+          );
         } else {
           const progress = exp.frame / 20;
           ctx.globalAlpha = 1 - progress;
@@ -406,12 +437,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         accessibilityLabel={t("game.canvasLabel")}
         accessibilityRole="image"
       >
-        <canvas
-          ref={canvasRef}
-          width={displayW}
-          height={displayH}
-          style={{ display: "block" }}
-        />
+        <canvas ref={canvasRef} width={displayW} height={displayH} style={{ display: "block" }} />
       </View>
     );
   }

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -1,0 +1,421 @@
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import { View } from "react-native";
+import { Asset } from "expo-asset";
+import { useTranslation } from "react-i18next";
+import { initStarSwarm, tick } from "../../game/starswarm/engine";
+import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
+import type { StarfieldState } from "../../game/starswarm/starfield";
+import type { StarSwarmState } from "../../game/starswarm/types";
+
+import playerShipSrc from "../../../assets/starswarm/player-ship.webp";
+import enemyGruntSrc from "../../../assets/starswarm/enemy-grunt.webp";
+import enemyEliteSrc from "../../../assets/starswarm/enemy-elite.webp";
+import enemyBossSrc from "../../../assets/starswarm/enemy-boss.webp";
+import bulletPlayerSrc from "../../../assets/starswarm/bullet-player.webp";
+import bulletEnemySrc from "../../../assets/starswarm/bullet-enemy.webp";
+import ef00 from "../../../assets/starswarm/explosion/frame00.png";
+import ef01 from "../../../assets/starswarm/explosion/frame01.png";
+import ef02 from "../../../assets/starswarm/explosion/frame02.png";
+import ef03 from "../../../assets/starswarm/explosion/frame03.png";
+import ef04 from "../../../assets/starswarm/explosion/frame04.png";
+import ef05 from "../../../assets/starswarm/explosion/frame05.png";
+import ef06 from "../../../assets/starswarm/explosion/frame06.png";
+import ef07 from "../../../assets/starswarm/explosion/frame07.png";
+import ef08 from "../../../assets/starswarm/explosion/frame08.png";
+import ef09 from "../../../assets/starswarm/explosion/frame09.png";
+import ef10 from "../../../assets/starswarm/explosion/frame10.png";
+import ef11 from "../../../assets/starswarm/explosion/frame11.png";
+import ef12 from "../../../assets/starswarm/explosion/frame12.png";
+import ef13 from "../../../assets/starswarm/explosion/frame13.png";
+import ef14 from "../../../assets/starswarm/explosion/frame14.png";
+import ef15 from "../../../assets/starswarm/explosion/frame15.png";
+import ef16 from "../../../assets/starswarm/explosion/frame16.png";
+import ef17 from "../../../assets/starswarm/explosion/frame17.png";
+import ef18 from "../../../assets/starswarm/explosion/frame18.png";
+import ef19 from "../../../assets/starswarm/explosion/frame19.png";
+
+const EXPLOSION_SRCS = [
+  ef00, ef01, ef02, ef03, ef04, ef05, ef06, ef07, ef08, ef09,
+  ef10, ef11, ef12, ef13, ef14, ef15, ef16, ef17, ef18, ef19,
+] as const;
+
+const EXPLOSION_DRAW_SIZE = 48;
+const DT_CAP_MS = 33;
+const INVINCIBLE_BLINK_INTERVAL = 120; // ms
+
+interface Images {
+  playerShip: HTMLImageElement | null;
+  enemyGrunt: HTMLImageElement | null;
+  enemyElite: HTMLImageElement | null;
+  enemyBoss: HTMLImageElement | null;
+  bulletPlayer: HTMLImageElement | null;
+  bulletEnemy: HTMLImageElement | null;
+  explosionFrames: (HTMLImageElement | null)[];
+}
+
+export interface GameCanvasHandle {
+  reset: () => void;
+  setPlayerX: (x: number) => void;
+  setFire: (fire: boolean) => void;
+}
+
+interface Props {
+  highScore?: number;
+  onGameOver?: (finalScore: number) => void;
+  onScoreChange?: (score: number) => void;
+  width: number;
+  height: number;
+  scale: number;
+}
+
+const GameCanvas = forwardRef<GameCanvasHandle, Props>(
+  ({ highScore = 0, onGameOver, onScoreChange, width, height, scale }, ref) => {
+    const { t } = useTranslation("starswarm");
+    const tRef = useRef(t);
+    useEffect(() => {
+      tRef.current = t;
+    }, [t]);
+
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const scaleRef = useRef(scale);
+    const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height));
+    const sfRef = useRef<StarfieldState>(initStarfield(width, height));
+    const inputRef = useRef({ playerX: width / 2, fire: true });
+    const lastFrameTimeRef = useRef(0);
+    const highScoreRef = useRef(highScore);
+    const onGameOverRef = useRef(onGameOver);
+    const onScoreChangeRef = useRef(onScoreChange);
+    const prevScoreRef = useRef(0);
+    const imagesRef = useRef<Images>({
+      playerShip: null,
+      enemyGrunt: null,
+      enemyElite: null,
+      enemyBoss: null,
+      bulletPlayer: null,
+      bulletEnemy: null,
+      explosionFrames: Array(20).fill(null) as null[],
+    });
+
+    useEffect(() => {
+      scaleRef.current = scale;
+    }, [scale]);
+    useEffect(() => {
+      highScoreRef.current = highScore;
+    }, [highScore]);
+    useEffect(() => {
+      onGameOverRef.current = onGameOver;
+    }, [onGameOver]);
+    useEffect(() => {
+      onScoreChangeRef.current = onScoreChange;
+    }, [onScoreChange]);
+
+    useEffect(() => {
+      let cancelled = false;
+
+      async function loadImg(src: number): Promise<HTMLImageElement | null> {
+        try {
+          const asset = Asset.fromModule(src);
+          await asset.downloadAsync();
+          const uri = asset.localUri ?? asset.uri;
+          if (!uri) return null;
+          return new Promise((resolve) => {
+            const img = new window.Image();
+            img.crossOrigin = "anonymous";
+            img.src = uri;
+            img.onload = () => resolve(img);
+            img.onerror = () => resolve(null);
+          });
+        } catch {
+          return null;
+        }
+      }
+
+      (async () => {
+        const results = await Promise.all([
+          loadImg(playerShipSrc as number),
+          loadImg(enemyGruntSrc as number),
+          loadImg(enemyEliteSrc as number),
+          loadImg(enemyBossSrc as number),
+          loadImg(bulletPlayerSrc as number),
+          loadImg(bulletEnemySrc as number),
+          ...EXPLOSION_SRCS.map((s) => loadImg(s as number)),
+        ]);
+        if (cancelled) return;
+        const [playerShip, enemyGrunt, enemyElite, enemyBoss, bulletPlayer, bulletEnemy, ...frames] =
+          results;
+        imagesRef.current = {
+          playerShip: playerShip ?? null,
+          enemyGrunt: enemyGrunt ?? null,
+          enemyElite: enemyElite ?? null,
+          enemyBoss: enemyBoss ?? null,
+          bulletPlayer: bulletPlayer ?? null,
+          bulletEnemy: bulletEnemy ?? null,
+          explosionFrames: frames.map((f) => f ?? null),
+        };
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, []);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        reset() {
+          stateRef.current = initStarSwarm(width, height);
+          sfRef.current = initStarfield(width, height);
+          inputRef.current.playerX = width / 2;
+          prevScoreRef.current = 0;
+        },
+        setPlayerX(x) {
+          inputRef.current.playerX = x;
+        },
+        setFire(fire) {
+          inputRef.current.fire = fire;
+        },
+      }),
+      [width, height]
+    );
+
+    const draw = useCallback(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const s = scaleRef.current;
+      const state = stateRef.current;
+      const sf = sfRef.current;
+      const imgs = imagesRef.current;
+      const t = tRef.current;
+      const hs = Math.max(highScoreRef.current, state.score);
+      const { player } = state;
+
+      const displayW = width * s;
+      const displayH = height * s;
+      ctx.clearRect(0, 0, displayW, displayH);
+      ctx.save();
+      ctx.scale(s, s);
+
+      // Background
+      ctx.fillStyle = "#000010";
+      ctx.fillRect(0, 0, width, height);
+
+      // Starfield
+      for (const star of sf.stars) {
+        ctx.globalAlpha = star.opacity;
+        ctx.fillStyle = "#ffffff";
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+
+      // Enemy bullets
+      ctx.fillStyle = "#ff4422";
+      for (const b of state.enemyBullets) {
+        ctx.fillRect(b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
+      }
+
+      // Player bullets
+      for (const b of state.playerBullets) {
+        const img = imgs.bulletPlayer;
+        if (img) {
+          ctx.drawImage(img, b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
+        } else {
+          ctx.fillStyle = "#00ffcc";
+          ctx.fillRect(b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
+        }
+      }
+
+      // Enemies
+      for (const enemy of state.enemies) {
+        if (!enemy.isAlive) continue;
+        const img =
+          enemy.tier === "Grunt"
+            ? imgs.enemyGrunt
+            : enemy.tier === "Elite"
+              ? imgs.enemyElite
+              : imgs.enemyBoss;
+        if (img) {
+          ctx.drawImage(
+            img,
+            enemy.x - enemy.width / 2,
+            enemy.y - enemy.height / 2,
+            enemy.width,
+            enemy.height
+          );
+        } else {
+          ctx.fillStyle =
+            enemy.tier === "Grunt" ? "#8888ff" : enemy.tier === "Elite" ? "#ff88ff" : "#ffff44";
+          ctx.fillRect(
+            enemy.x - enemy.width / 2,
+            enemy.y - enemy.height / 2,
+            enemy.width,
+            enemy.height
+          );
+        }
+      }
+
+      // Player (blink during invincibility)
+      const blink =
+        player.invincibleTimer > 0 &&
+        Math.floor(player.invincibleTimer / INVINCIBLE_BLINK_INTERVAL) % 2 === 1;
+      if (!blink) {
+        const img = imgs.playerShip;
+        if (img) {
+          ctx.drawImage(
+            img,
+            player.x - player.width / 2,
+            player.y - player.height / 2,
+            player.width,
+            player.height
+          );
+        } else {
+          ctx.fillStyle = "#00ffcc";
+          ctx.beginPath();
+          ctx.moveTo(player.x, player.y - player.height / 2);
+          ctx.lineTo(player.x - player.width / 2, player.y + player.height / 2);
+          ctx.lineTo(player.x + player.width / 2, player.y + player.height / 2);
+          ctx.closePath();
+          ctx.fill();
+        }
+      }
+
+      // Explosions
+      for (const exp of state.explosions) {
+        const frameImg = imgs.explosionFrames[exp.frame] ?? null;
+        const half = EXPLOSION_DRAW_SIZE / 2;
+        if (frameImg) {
+          ctx.drawImage(frameImg, exp.x - half, exp.y - half, EXPLOSION_DRAW_SIZE, EXPLOSION_DRAW_SIZE);
+        } else {
+          const progress = exp.frame / 20;
+          ctx.globalAlpha = 1 - progress;
+          ctx.fillStyle = progress < 0.4 ? "#ffcc00" : "#ff4400";
+          ctx.beginPath();
+          ctx.arc(exp.x, exp.y, 6 + progress * 18, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.globalAlpha = 1;
+        }
+      }
+
+      // HUD
+      ctx.font = "bold 13px 'Courier New', monospace";
+      ctx.textBaseline = "top";
+      ctx.fillStyle = "#ffffff";
+      ctx.textAlign = "left";
+      ctx.fillText(`${t("hud.score")} ${state.score}`, 10, 8);
+      ctx.textAlign = "center";
+      ctx.fillText(`${t("hud.best")} ${hs}`, width / 2, 8);
+      ctx.textAlign = "right";
+      ctx.fillText(`${t("hud.wave")} ${state.wave}`, width - 10, 8);
+
+      // Lives — small cyan rectangles at bottom-left
+      for (let i = 0; i < player.lives; i++) {
+        ctx.fillStyle = "#00ffcc";
+        ctx.fillRect(10 + i * 16, height - 18, 10, 14);
+      }
+
+      // Phase overlays
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+
+      if (state.phase === "WaveClear") {
+        ctx.font = "bold 22px 'Courier New', monospace";
+        ctx.fillStyle = "#00ffcc";
+        ctx.fillText(t("phase.waveClear"), width / 2, height / 2);
+      }
+
+      if (state.phase === "ChallengingStage") {
+        ctx.font = "bold 20px 'Courier New', monospace";
+        ctx.fillStyle = "#ffdd00";
+        ctx.fillText(t("phase.challengingStage"), width / 2, height / 2 - 18);
+        ctx.font = "14px 'Courier New', monospace";
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText(t("phase.hits", { count: state.challengingHits }), width / 2, height / 2 + 12);
+      }
+
+      if (state.phase === "GameOver") {
+        ctx.fillStyle = "rgba(0,0,0,0.65)";
+        ctx.fillRect(0, 0, width, height);
+        ctx.font = "bold 28px 'Courier New', monospace";
+        ctx.fillStyle = "#ff4422";
+        ctx.fillText(t("phase.gameOver"), width / 2, height / 2 - 22);
+        ctx.font = "16px 'Courier New', monospace";
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText(`${t("hud.score")} ${state.score}`, width / 2, height / 2 + 18);
+      }
+
+      ctx.restore();
+    }, [width, height]);
+
+    const drawRef = useRef(draw);
+    useEffect(() => {
+      drawRef.current = draw;
+    }, [draw]);
+
+    // Single long-lived RAF loop — reads all mutable game state from refs
+    useEffect(() => {
+      let id: number;
+
+      function loop(timestamp: number) {
+        if (lastFrameTimeRef.current === 0) lastFrameTimeRef.current = timestamp;
+        const dtMs = Math.min(timestamp - lastFrameTimeRef.current, DT_CAP_MS);
+        lastFrameTimeRef.current = timestamp;
+
+        const prev = stateRef.current;
+        if (prev.phase !== "GameOver") {
+          const next = tick(prev, dtMs, {
+            playerX: inputRef.current.playerX,
+            fire: inputRef.current.fire,
+          });
+          stateRef.current = next;
+          if (next.score !== prevScoreRef.current) {
+            prevScoreRef.current = next.score;
+            onScoreChangeRef.current?.(next.score);
+          }
+          if (next.phase === "GameOver") {
+            onGameOverRef.current?.(next.score);
+          }
+        }
+        // Starfield scrolls continuously, even on game over
+        sfRef.current = tickStarfield(sfRef.current, dtMs);
+
+        drawRef.current();
+        id = requestAnimationFrame(loop);
+      }
+
+      function handleVisibilityChange() {
+        if (!document.hidden) lastFrameTimeRef.current = 0;
+      }
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+      id = requestAnimationFrame(loop);
+      return () => {
+        cancelAnimationFrame(id);
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+      };
+    }, []); // intentionally empty — loop lives for component lifetime
+
+    const displayW = Math.round(width * scale);
+    const displayH = Math.round(height * scale);
+
+    return (
+      <View
+        style={{ width: displayW, height: displayH }}
+        accessibilityLabel={t("game.canvasLabel")}
+        accessibilityRole="image"
+      >
+        <canvas
+          ref={canvasRef}
+          width={displayW}
+          height={displayH}
+          style={{ display: "block" }}
+        />
+      </View>
+    );
+  }
+);
+
+GameCanvas.displayName = "GameCanvas";
+export default GameCanvas;

--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -16,7 +16,8 @@ type Namespace =
   | "hearts"
   | "sudoku"
   | "feedback"
-  | "profile";
+  | "profile"
+  | "starswarm";
 type TranslationModule = Promise<{ default: Record<string, string> }>;
 
 // Resolve the best supported locale from the device's preference list
@@ -47,6 +48,7 @@ const localeLoaders: Record<string, Partial<Record<Namespace, () => TranslationM
     sudoku: () => import("./locales/en/sudoku.json") as TranslationModule,
     feedback: () => import("./locales/en/feedback.json") as TranslationModule,
     profile: () => import("./locales/en/profile.json") as TranslationModule,
+    starswarm: () => import("./locales/en/starswarm.json") as TranslationModule,
   },
   "fr-CA": {
     common: () => import("./locales/fr-CA/common.json") as TranslationModule,
@@ -203,6 +205,7 @@ i18n
       "sudoku",
       "feedback",
       "profile",
+      "starswarm",
     ],
     defaultNS: "common",
     interpolation: { escapeValue: false },

--- a/frontend/src/i18n/locales/_meta/starswarm.meta.json
+++ b/frontend/src/i18n/locales/_meta/starswarm.meta.json
@@ -1,0 +1,110 @@
+{
+  "game.title": {
+    "component": "HomeScreen",
+    "description": "Name of the Star Swarm game card.",
+    "tone": "neutral",
+    "characterLimit": 15,
+    "placeholders": [],
+    "doNotTranslate": ["Star Swarm"],
+    "notes": "Do not translate the game name."
+  },
+  "game.description": {
+    "component": "HomeScreen",
+    "description": "One-line description on the Star Swarm game card.",
+    "tone": "casual, punchy",
+    "characterLimit": 55,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "game.playLabel": {
+    "component": "HomeScreen",
+    "description": "Accessibility label for the Star Swarm play button.",
+    "tone": "functional",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": ["Star Swarm"],
+    "notes": null
+  },
+  "game.canvasLabel": {
+    "component": "GameCanvas",
+    "description": "Accessible label for the game canvas — describes game and interaction.",
+    "tone": "functional, descriptive",
+    "characterLimit": 100,
+    "placeholders": [],
+    "doNotTranslate": ["Star Swarm"],
+    "notes": null
+  },
+  "hud.score": {
+    "component": "GameCanvas",
+    "description": "Short uppercase label for the current score in the HUD.",
+    "tone": "functional",
+    "characterLimit": 8,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "hud.best": {
+    "component": "GameCanvas",
+    "description": "Short uppercase label for the high score in the HUD.",
+    "tone": "functional",
+    "characterLimit": 6,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "hud.wave": {
+    "component": "GameCanvas",
+    "description": "Short uppercase label for the current wave number in the HUD.",
+    "tone": "functional",
+    "characterLimit": 6,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "phase.waveClear": {
+    "component": "GameCanvas",
+    "description": "Overlay text shown for a moment when the player clears a wave.",
+    "tone": "celebratory, brief",
+    "characterLimit": 15,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "phase.challengingStage": {
+    "component": "GameCanvas",
+    "description": "Overlay text shown at the start of a bonus Challenging Stage wave.",
+    "tone": "dramatic, arcade",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Borrowed from Galaga — keep the arcade feel."
+  },
+  "phase.hits": {
+    "component": "GameCanvas",
+    "description": "Sub-line during Challenging Stage showing how many enemies the player has hit.",
+    "tone": "neutral",
+    "characterLimit": 15,
+    "placeholders": ["{{count}}"],
+    "doNotTranslate": [],
+    "notes": "{{count}} is an integer hit count."
+  },
+  "phase.gameOver": {
+    "component": "GameCanvas",
+    "description": "Large overlay text when the player loses all lives.",
+    "tone": "dramatic, classic arcade",
+    "characterLimit": 12,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "score.display": {
+    "component": "GameCanvas",
+    "description": "Accessibility label for the score display.",
+    "tone": "functional",
+    "characterLimit": 20,
+    "placeholders": ["{{score}}"],
+    "doNotTranslate": [],
+    "notes": null
+  }
+}

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -1,0 +1,14 @@
+{
+  "game.title": "Star Swarm",
+  "game.description": "Blast waves of alien invaders before they reach you.",
+  "game.playLabel": "Play Star Swarm",
+  "game.canvasLabel": "Star Swarm game — drag horizontally to move your ship and blast the alien formation.",
+  "hud.score": "SCORE",
+  "hud.best": "BEST",
+  "hud.wave": "WAVE",
+  "phase.waveClear": "WAVE CLEAR",
+  "phase.challengingStage": "CHALLENGING STAGE",
+  "phase.hits": "HITS: {{count}}",
+  "phase.gameOver": "GAME OVER",
+  "score.display": "Score: {{score}}"
+}

--- a/frontend/src/types/images.d.ts
+++ b/frontend/src/types/images.d.ts
@@ -3,3 +3,9 @@ declare module "*.png" {
   const content: ImageSourcePropType;
   export default content;
 }
+
+declare module "*.webp" {
+  import { ImageSourcePropType } from "react-native";
+  const content: ImageSourcePropType;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- Implements `GameCanvas.tsx` (Skia) and `GameCanvas.web.tsx` (Canvas 2D) for Star Swarm — closes #801
- Both renderers own the RAF game loop: `tick()` + `tickStarfield()` each frame, 33 ms dt cap
- Draws starfield parallax → enemy/player bullets → enemies (by tier) → player (invincibility blink) → frame-based explosions (procedural fallback when sprites not loaded) → HUD
- HUD: score / best / wave in top strip; life indicators at bottom-left; phase overlays for Wave Clear, Challenging Stage, Game Over
- `GameCanvasHandle` exposes `reset()`, `setPlayerX(x)`, `setFire(fire)` — ready for #802 touch controls
- Registers `starswarm` i18n namespace (en locale + meta); all HUD/phase strings are translated
- Adds `.webp` module declaration to `images.d.ts` (fixes pre-existing TS errors in `assets.ts`)

## Test plan
- [ ] TypeScript: `npx tsc --noEmit` — zero new errors in `components/starswarm/`
- [ ] Web: open Expo Web, confirm Canvas 2D game loop runs (starfield scrolls, enemies swoop)
- [ ] Native: confirm Skia canvas renders on iOS/Android simulator
- [ ] Fallback shapes render correctly when sprite images are not yet loaded
- [ ] Invincibility blink visible after player respawns
- [ ] Game Over overlay darkens screen and shows final score

🤖 Generated with [Claude Code](https://claude.com/claude-code)