### PR TITLE
feat(#674, #813): drag-and-drop card moves for Solitaire and FreeCell

### DIFF
--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -8,6 +8,8 @@ import { rankLabel } from "../../game/_shared/decks/cardId";
 import type { CanonicalSuit } from "../../game/_shared/decks/types";
 import type { Card, Suit } from "../../game/freecell/types";
 import { CARD_WIDTH, CARD_HEIGHT } from "./FreeCellSlot";
+import { DropTarget } from "../../game/_shared/drag/DropTarget";
+import type { DropHandler } from "../../game/_shared/drag/DragContext";
 
 const SUIT_SYMBOL: Record<Suit, string> = {
   spades: "♠",
@@ -21,6 +23,8 @@ export interface FoundationPileProps {
   readonly suit: Suit;
   readonly selected?: boolean;
   readonly onPress?: (suit: Suit) => void;
+  readonly dropId?: string;
+  readonly onDrop?: DropHandler;
 }
 
 export default function FoundationPile({
@@ -28,62 +32,76 @@ export default function FoundationPile({
   suit,
   selected = false,
   onPress,
+  dropId,
+  onDrop,
 }: FoundationPileProps) {
   const { colors } = useTheme();
   const { t } = useTranslation("freecell");
+  const hasDrop = dropId !== undefined && onDrop !== undefined;
 
-  if (pile.length > 0) {
-    const top = pile[pile.length - 1];
-    if (top !== undefined) {
-      const rl = rankLabel(top.rank);
-      const suitName = t(`suit.${top.suit}` as const);
-      const label = selected
-        ? t("card.selected", { rank: rl, suit: suitName })
-        : t("card.label", { rank: rl, suit: suitName });
+  const inner = (() => {
+    if (pile.length > 0) {
+      const top = pile[pile.length - 1];
+      if (top !== undefined) {
+        const rl = rankLabel(top.rank);
+        const suitName = t(`suit.${top.suit}` as const);
+        const label = selected
+          ? t("card.selected", { rank: rl, suit: suitName })
+          : t("card.label", { rank: rl, suit: suitName });
+        return (
+          <SharedPlayingCard
+            suit={top.suit as CanonicalSuit}
+            rank={top.rank}
+            width={CARD_WIDTH}
+            height={CARD_HEIGHT}
+            highlighted={selected}
+            onPress={onPress ? () => onPress(suit) : undefined}
+            accessibilityLabel={label}
+          />
+        );
+      }
+    }
+
+    const label = t("pile.foundation.empty", { suit: t(`suit.${suit}` as const) });
+    const pileStyle = [
+      styles.empty,
+      {
+        borderColor: selected ? colors.accent : colors.border,
+        borderWidth: selected ? 2 : 1,
+        backgroundColor: colors.background,
+      },
+    ];
+    const content = (
+      <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
+    );
+
+    if (onPress) {
       return (
-        <SharedPlayingCard
-          suit={top.suit as CanonicalSuit}
-          rank={top.rank}
-          width={CARD_WIDTH}
-          height={CARD_HEIGHT}
-          highlighted={selected}
-          onPress={onPress ? () => onPress(suit) : undefined}
-          accessibilityLabel={label}
-        />
+        <Pressable onPress={() => onPress(suit)} style={pileStyle} accessibilityRole="button" accessibilityLabel={label}>
+          {content}
+        </Pressable>
       );
     }
-  }
-
-  const label = t("pile.foundation.empty", { suit: t(`suit.${suit}` as const) });
-  const pileStyle = [
-    styles.empty,
-    {
-      borderColor: selected ? colors.accent : colors.border,
-      borderWidth: selected ? 2 : 1,
-      backgroundColor: colors.background,
-    },
-  ];
-  const content = (
-    <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
-  );
-
-  if (onPress) {
     return (
-      <Pressable
-        onPress={() => onPress(suit)}
-        style={pileStyle}
-        accessibilityRole="button"
-        accessibilityLabel={label}
-      >
+      <View style={pileStyle} accessibilityRole="image" accessibilityLabel={label}>
         {content}
-      </Pressable>
+      </View>
+    );
+  })();
+
+  if (hasDrop) {
+    return (
+      <DropTarget
+        id={dropId!}
+        onDrop={onDrop!}
+        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+        dimStyle={{ opacity: 0.4 }}
+      >
+        {inner}
+      </DropTarget>
     );
   }
-  return (
-    <View style={pileStyle} accessibilityRole="image" accessibilityLabel={label}>
-      {content}
-    </View>
-  );
+  return inner;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -77,7 +77,12 @@ export default function FoundationPile({
 
     if (onPress) {
       return (
-        <Pressable onPress={() => onPress(suit)} style={pileStyle} accessibilityRole="button" accessibilityLabel={label}>
+        <Pressable
+          onPress={() => onPress(suit)}
+          style={pileStyle}
+          accessibilityRole="button"
+          accessibilityLabel={label}
+        >
           {content}
         </Pressable>
       );

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -50,7 +50,12 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
       return;
     }
     if (selection.kind === "tableau") {
-      tryMove({ type: "tableau-to-tableau", fromCol: selection.col, fromIndex: selection.index, toCol: col });
+      tryMove({
+        type: "tableau-to-tableau",
+        fromCol: selection.col,
+        fromIndex: selection.index,
+        toCol: col,
+      });
     } else {
       tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
     }
@@ -59,7 +64,12 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   function handleTableauEmptyPress(col: number) {
     if (selection === null) return;
     if (selection.kind === "tableau") {
-      tryMove({ type: "tableau-to-tableau", fromCol: selection.col, fromIndex: selection.index, toCol: col });
+      tryMove({
+        type: "tableau-to-tableau",
+        fromCol: selection.col,
+        fromIndex: selection.index,
+        toCol: col,
+      });
     } else {
       tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
     }
@@ -98,9 +108,21 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     (source: DragSource, toCol: number): boolean => {
       if (source.game !== "freecell") return false;
       if (source.type === "tableau") {
-        if (!validateMove(state, { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol }))
+        if (
+          !validateMove(state, {
+            type: "tableau-to-tableau",
+            fromCol: source.col,
+            fromIndex: source.fromIndex,
+            toCol,
+          })
+        )
           return false;
-        onMove({ type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol });
+        onMove({
+          type: "tableau-to-tableau",
+          fromCol: source.col,
+          fromIndex: source.fromIndex,
+          toCol,
+        });
         return true;
       }
       if (source.type === "freecell") {
@@ -118,12 +140,14 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     (source: DragSource): boolean => {
       if (source.game !== "freecell") return false;
       if (source.type === "tableau") {
-        if (!validateMove(state, { type: "tableau-to-foundation", fromCol: source.col })) return false;
+        if (!validateMove(state, { type: "tableau-to-foundation", fromCol: source.col }))
+          return false;
         onMove({ type: "tableau-to-foundation", fromCol: source.col });
         return true;
       }
       if (source.type === "freecell") {
-        if (!validateMove(state, { type: "freecell-to-foundation", fromCell: source.cell })) return false;
+        if (!validateMove(state, { type: "freecell-to-foundation", fromCell: source.cell }))
+          return false;
         onMove({ type: "freecell-to-foundation", fromCell: source.cell });
         return true;
       }
@@ -135,7 +159,8 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   const handleDropToFreeCell = useCallback(
     (source: DragSource, toCell: number): boolean => {
       if (source.game !== "freecell" || source.type !== "tableau") return false;
-      if (!validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell })) return false;
+      if (!validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell }))
+        return false;
       onMove({ type: "tableau-to-freecell", fromCol: source.col, toCell });
       return true;
     },
@@ -151,7 +176,12 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
       for (let col = 0; col < TABLEAU_COLS; col++) {
         let move: Move | null = null;
         if (source.type === "tableau" && source.col !== col) {
-          move = { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol: col };
+          move = {
+            type: "tableau-to-tableau",
+            fromCol: source.col,
+            fromIndex: source.fromIndex,
+            toCol: col,
+          };
         } else if (source.type === "freecell") {
           move = { type: "freecell-to-tableau", fromCell: source.cell, toCol: col };
         }
@@ -161,7 +191,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
       // Free cell slots (single-card only).
       if (cards.length === 1 && source.type === "tableau") {
         for (let cell = 0; cell < 4; cell++) {
-          if (validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell: cell })) {
+          if (
+            validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell: cell })
+          ) {
             ids.push(`freecell-slot-${cell}`);
           }
         }
@@ -187,7 +219,11 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   return (
     <DragProvider getLegalDropIds={getLegalDropIds}>
       <DragContainer>
-        <View style={styles.board} accessibilityRole="none" accessibilityLabel={t("a11y.boardRegion")}>
+        <View
+          style={styles.board}
+          accessibilityRole="none"
+          accessibilityLabel={t("a11y.boardRegion")}
+        >
           <View style={styles.topRow}>
             <View style={styles.slotGroup}>
               {state.freeCells.map((card, i) => (
@@ -224,7 +260,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 pile={pile}
                 colIndex={col}
                 selectedIndex={
-                  selection?.kind === "tableau" && selection.col === col ? selection.index : undefined
+                  selection?.kind === "tableau" && selection.col === col
+                    ? selection.index
+                    : undefined
                 }
                 onCardPress={handleTableauCardPress}
                 onEmptyPress={handleTableauEmptyPress}

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
@@ -8,6 +8,9 @@ import type { FreeCellState, Move } from "../../game/freecell/types";
 import FreeCellSlot, { CARD_WIDTH } from "./FreeCellSlot";
 import FoundationPile from "./FoundationPile";
 import TableauColumn from "./TableauColumn";
+import { DragProvider } from "../../game/_shared/drag/DragContext";
+import { DragContainer } from "../../game/_shared/drag/DragContainer";
+import type { DragSource, DragCard } from "../../game/_shared/drag/DragContext";
 
 const TABLEAU_COLS = 8;
 const COL_GAP = 4;
@@ -47,12 +50,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
       return;
     }
     if (selection.kind === "tableau") {
-      tryMove({
-        type: "tableau-to-tableau",
-        fromCol: selection.col,
-        fromIndex: selection.index,
-        toCol: col,
-      });
+      tryMove({ type: "tableau-to-tableau", fromCol: selection.col, fromIndex: selection.index, toCol: col });
     } else {
       tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
     }
@@ -61,12 +59,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   function handleTableauEmptyPress(col: number) {
     if (selection === null) return;
     if (selection.kind === "tableau") {
-      tryMove({
-        type: "tableau-to-tableau",
-        fromCol: selection.col,
-        fromIndex: selection.index,
-        toCol: col,
-      });
+      tryMove({ type: "tableau-to-tableau", fromCol: selection.col, fromIndex: selection.index, toCol: col });
     } else {
       tryMove({ type: "freecell-to-tableau", fromCell: selection.cell, toCol: col });
     }
@@ -99,48 +92,150 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     }
   }
 
-  return (
-    <View style={styles.board} accessibilityRole="none" accessibilityLabel={t("a11y.boardRegion")}>
-      <View style={styles.topRow}>
-        <View style={styles.slotGroup}>
-          {state.freeCells.map((card, i) => (
-            <FreeCellSlot
-              key={i}
-              card={card}
-              cellIndex={i}
-              selected={selection?.kind === "freecell" && selection.cell === i}
-              onPress={handleFreeCellPress}
-            />
-          ))}
-        </View>
-        <View style={styles.slotGroup}>
-          {SUITS.map((suit) => (
-            <FoundationPile
-              key={suit}
-              pile={state.foundations[suit]}
-              suit={suit}
-              selected={false}
-              onPress={() => handleFoundationPress()}
-            />
-          ))}
-        </View>
-      </View>
+  // ── Drag-and-drop handlers ──────────────────────────────────────────────────
 
-      <View style={styles.tableau}>
-        {state.tableau.map((pile, col) => (
-          <TableauColumn
-            key={col}
-            pile={pile}
-            colIndex={col}
-            selectedIndex={
-              selection?.kind === "tableau" && selection.col === col ? selection.index : undefined
-            }
-            onCardPress={handleTableauCardPress}
-            onEmptyPress={handleTableauEmptyPress}
-          />
-        ))}
-      </View>
-    </View>
+  const handleDropToTableau = useCallback(
+    (source: DragSource, toCol: number): boolean => {
+      if (source.game !== "freecell") return false;
+      if (source.type === "tableau") {
+        if (!validateMove(state, { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol }))
+          return false;
+        onMove({ type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol });
+        return true;
+      }
+      if (source.type === "freecell") {
+        if (!validateMove(state, { type: "freecell-to-tableau", fromCell: source.cell, toCol }))
+          return false;
+        onMove({ type: "freecell-to-tableau", fromCell: source.cell, toCol });
+        return true;
+      }
+      return false;
+    },
+    [state, onMove]
+  );
+
+  const handleDropToFoundation = useCallback(
+    (source: DragSource): boolean => {
+      if (source.game !== "freecell") return false;
+      if (source.type === "tableau") {
+        if (!validateMove(state, { type: "tableau-to-foundation", fromCol: source.col })) return false;
+        onMove({ type: "tableau-to-foundation", fromCol: source.col });
+        return true;
+      }
+      if (source.type === "freecell") {
+        if (!validateMove(state, { type: "freecell-to-foundation", fromCell: source.cell })) return false;
+        onMove({ type: "freecell-to-foundation", fromCell: source.cell });
+        return true;
+      }
+      return false;
+    },
+    [state, onMove]
+  );
+
+  const handleDropToFreeCell = useCallback(
+    (source: DragSource, toCell: number): boolean => {
+      if (source.game !== "freecell" || source.type !== "tableau") return false;
+      if (!validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell })) return false;
+      onMove({ type: "tableau-to-freecell", fromCol: source.col, toCell });
+      return true;
+    },
+    [state, onMove]
+  );
+
+  const getLegalDropIds = useCallback(
+    (source: DragSource, cards: DragCard[]): string[] => {
+      if (source.game !== "freecell") return [];
+      const ids: string[] = [];
+
+      // Tableau columns.
+      for (let col = 0; col < TABLEAU_COLS; col++) {
+        let move: Move | null = null;
+        if (source.type === "tableau" && source.col !== col) {
+          move = { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol: col };
+        } else if (source.type === "freecell") {
+          move = { type: "freecell-to-tableau", fromCell: source.cell, toCol: col };
+        }
+        if (move && validateMove(state, move)) ids.push(`freecell-tableau-${col}`);
+      }
+
+      // Free cell slots (single-card only).
+      if (cards.length === 1 && source.type === "tableau") {
+        for (let cell = 0; cell < 4; cell++) {
+          if (validateMove(state, { type: "tableau-to-freecell", fromCol: source.col, toCell: cell })) {
+            ids.push(`freecell-slot-${cell}`);
+          }
+        }
+      }
+
+      // Foundation (single-card only).
+      if (cards.length === 1) {
+        let foundMove: Move | null = null;
+        if (source.type === "tableau")
+          foundMove = { type: "tableau-to-foundation", fromCol: source.col };
+        else if (source.type === "freecell")
+          foundMove = { type: "freecell-to-foundation", fromCell: source.cell };
+        if (foundMove && validateMove(state, foundMove)) {
+          for (const suit of SUITS) ids.push(`freecell-foundation-${suit}`);
+        }
+      }
+
+      return ids;
+    },
+    [state]
+  );
+
+  return (
+    <DragProvider getLegalDropIds={getLegalDropIds}>
+      <DragContainer>
+        <View style={styles.board} accessibilityRole="none" accessibilityLabel={t("a11y.boardRegion")}>
+          <View style={styles.topRow}>
+            <View style={styles.slotGroup}>
+              {state.freeCells.map((card, i) => (
+                <FreeCellSlot
+                  key={i}
+                  card={card}
+                  cellIndex={i}
+                  selected={selection?.kind === "freecell" && selection.cell === i}
+                  onPress={handleFreeCellPress}
+                  dropId={`freecell-slot-${i}`}
+                  onDrop={(source) => handleDropToFreeCell(source, i)}
+                />
+              ))}
+            </View>
+            <View style={styles.slotGroup}>
+              {SUITS.map((suit) => (
+                <FoundationPile
+                  key={suit}
+                  pile={state.foundations[suit]}
+                  suit={suit}
+                  selected={false}
+                  onPress={() => handleFoundationPress()}
+                  dropId={`freecell-foundation-${suit}`}
+                  onDrop={(source) => handleDropToFoundation(source)}
+                />
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.tableau}>
+            {state.tableau.map((pile, col) => (
+              <TableauColumn
+                key={col}
+                pile={pile}
+                colIndex={col}
+                selectedIndex={
+                  selection?.kind === "tableau" && selection.col === col ? selection.index : undefined
+                }
+                onCardPress={handleTableauCardPress}
+                onEmptyPress={handleTableauEmptyPress}
+                dropId={`freecell-tableau-${col}`}
+                onDrop={(source) => handleDropToTableau(source, col)}
+              />
+            ))}
+          </View>
+        </View>
+      </DragContainer>
+    </DragProvider>
   );
 }
 

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -7,6 +7,9 @@ import SharedPlayingCard from "../shared/PlayingCard";
 import { rankLabel } from "../../game/_shared/decks/cardId";
 import type { CanonicalSuit } from "../../game/_shared/decks/types";
 import type { Card } from "../../game/freecell/types";
+import { DraggableCard } from "../../game/_shared/drag/DraggableCard";
+import { DropTarget } from "../../game/_shared/drag/DropTarget";
+import type { DropHandler } from "../../game/_shared/drag/DragContext";
 
 export const CARD_WIDTH = 40;
 export const CARD_HEIGHT = 57;
@@ -16,6 +19,8 @@ export interface FreeCellSlotProps {
   readonly cellIndex: number;
   readonly selected?: boolean;
   readonly onPress?: (cellIndex: number) => void;
+  readonly dropId?: string;
+  readonly onDrop?: DropHandler;
 }
 
 export default function FreeCellSlot({
@@ -23,11 +28,14 @@ export default function FreeCellSlot({
   cellIndex,
   selected = false,
   onPress,
+  dropId,
+  onDrop,
 }: FreeCellSlotProps) {
   const { colors } = useTheme();
   const { t } = useTranslation("freecell");
 
   const handlePress = onPress ? () => onPress(cellIndex) : undefined;
+  const hasDrop = dropId !== undefined && onDrop !== undefined;
 
   if (card !== null) {
     const rl = rankLabel(card.rank);
@@ -36,19 +44,43 @@ export default function FreeCellSlot({
       ? t("card.selected", { rank: rl, suit: suitName })
       : t("card.label", { rank: rl, suit: suitName });
 
-    return (
+    const cardEl = (
       <SharedPlayingCard
         suit={card.suit as CanonicalSuit}
         rank={card.rank}
         width={CARD_WIDTH}
         height={CARD_HEIGHT}
         highlighted={selected}
-        onPress={handlePress}
         accessibilityLabel={label}
       />
     );
+
+    const draggable = (
+      <DraggableCard
+        onTap={handlePress}
+        dragCards={[{ suit: card.suit as CanonicalSuit, rank: card.rank, faceDown: false, width: CARD_WIDTH, height: CARD_HEIGHT }]}
+        dragSource={{ game: "freecell", type: "freecell", cell: cellIndex }}
+      >
+        {cardEl}
+      </DraggableCard>
+    );
+
+    if (hasDrop) {
+      return (
+        <DropTarget
+          id={dropId!}
+          onDrop={onDrop!}
+          highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+          dimStyle={{ opacity: 0.4 }}
+        >
+          {draggable}
+        </DropTarget>
+      );
+    }
+    return draggable;
   }
 
+  // Empty slot.
   const emptyLabel = t("pile.freecell.empty", { cell: cellIndex + 1 });
   const slotStyle = [
     styles.empty,
@@ -59,18 +91,25 @@ export default function FreeCellSlot({
     },
   ];
 
-  if (handlePress) {
+  const emptyEl = handlePress ? (
+    <Pressable onPress={handlePress} style={slotStyle} accessibilityRole="button" accessibilityLabel={emptyLabel} />
+  ) : (
+    <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel} />
+  );
+
+  if (hasDrop) {
     return (
-      <Pressable
-        onPress={handlePress}
-        style={slotStyle}
-        accessibilityRole="button"
-        accessibilityLabel={emptyLabel}
-      />
+      <DropTarget
+        id={dropId!}
+        onDrop={onDrop!}
+        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+        dimStyle={{ opacity: 0.4 }}
+      >
+        {emptyEl}
+      </DropTarget>
     );
   }
-
-  return <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel} />;
+  return emptyEl;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -58,7 +58,15 @@ export default function FreeCellSlot({
     const draggable = (
       <DraggableCard
         onTap={handlePress}
-        dragCards={[{ suit: card.suit as CanonicalSuit, rank: card.rank, faceDown: false, width: CARD_WIDTH, height: CARD_HEIGHT }]}
+        dragCards={[
+          {
+            suit: card.suit as CanonicalSuit,
+            rank: card.rank,
+            faceDown: false,
+            width: CARD_WIDTH,
+            height: CARD_HEIGHT,
+          },
+        ]}
         dragSource={{ game: "freecell", type: "freecell", cell: cellIndex }}
       >
         {cardEl}
@@ -92,7 +100,12 @@ export default function FreeCellSlot({
   ];
 
   const emptyEl = handlePress ? (
-    <Pressable onPress={handlePress} style={slotStyle} accessibilityRole="button" accessibilityLabel={emptyLabel} />
+    <Pressable
+      onPress={handlePress}
+      style={slotStyle}
+      accessibilityRole="button"
+      accessibilityLabel={emptyLabel}
+    />
   ) : (
     <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel} />
   );

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -8,6 +8,9 @@ import { rankLabel } from "../../game/_shared/decks/cardId";
 import type { CanonicalSuit } from "../../game/_shared/decks/types";
 import type { Card } from "../../game/freecell/types";
 import { CARD_WIDTH, CARD_HEIGHT } from "./FreeCellSlot";
+import { DraggableCard } from "../../game/_shared/drag/DraggableCard";
+import { DropTarget } from "../../game/_shared/drag/DropTarget";
+import type { DropHandler } from "../../game/_shared/drag/DragContext";
 
 const FACE_UP_OFFSET = 24;
 
@@ -17,6 +20,8 @@ export interface TableauColumnProps {
   readonly selectedIndex?: number;
   readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
   readonly onEmptyPress?: (colIndex: number) => void;
+  readonly dropId?: string;
+  readonly onDrop?: DropHandler;
 }
 
 export default function TableauColumn({
@@ -25,12 +30,18 @@ export default function TableauColumn({
   selectedIndex,
   onCardPress,
   onEmptyPress,
+  dropId,
+  onDrop,
 }: TableauColumnProps) {
   const { colors } = useTheme();
   const { t } = useTranslation("freecell");
 
+  const highlightStyle: ViewStyle = { borderColor: colors.accent, borderWidth: 2, borderRadius: 8 };
+  const dimStyle: ViewStyle = { opacity: 0.4 };
+  const hasDrop = dropId !== undefined && onDrop !== undefined;
+
   if (pile.length === 0) {
-    return (
+    const empty = (
       <Pressable
         onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
         style={[styles.empty, { borderColor: colors.border, backgroundColor: colors.background }]}
@@ -38,6 +49,14 @@ export default function TableauColumn({
         accessibilityLabel={t("pile.tableau.empty", { col: colIndex + 1 })}
       />
     );
+    if (hasDrop) {
+      return (
+        <DropTarget id={dropId!} onDrop={onDrop!} highlightStyle={highlightStyle} dimStyle={dimStyle}>
+          {empty}
+        </DropTarget>
+      );
+    }
+    return empty;
   }
 
   const offsets: number[] = [];
@@ -47,39 +66,70 @@ export default function TableauColumn({
     acc += FACE_UP_OFFSET;
   }
   const containerHeight = CARD_HEIGHT + (offsets[pile.length - 1] ?? 0);
+  const containerStyle: ViewStyle = { width: CARD_WIDTH, height: containerHeight };
 
-  const containerStyle: ViewStyle = {
-    width: CARD_WIDTH,
-    height: containerHeight,
-  };
+  const cards = pile.map((card, cardIndex) => {
+    const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
+    const rl = rankLabel(card.rank);
+    const suitName = t(`suit.${card.suit}` as const);
+    const label = isSelected
+      ? t("card.selected", { rank: rl, suit: suitName })
+      : t("card.label", { rank: rl, suit: suitName });
+    const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
+
+    const dragCards = pile.slice(cardIndex).map((c) => ({
+      suit: c.suit as CanonicalSuit,
+      rank: c.rank,
+      faceDown: false,
+      width: CARD_WIDTH,
+      height: CARD_HEIGHT,
+    }));
+
+    return (
+      <DraggableCard
+        key={cardIndex}
+        style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}
+        onTap={handlePress}
+        dragCards={dragCards}
+        dragSource={{ game: "freecell", type: "tableau", col: colIndex, fromIndex: cardIndex }}
+      >
+        <SharedPlayingCard
+          suit={card.suit as CanonicalSuit}
+          rank={card.rank}
+          width={CARD_WIDTH}
+          height={CARD_HEIGHT}
+          highlighted={isSelected}
+          accessibilityLabel={label}
+        />
+      </DraggableCard>
+    );
+  });
+
+  if (hasDrop) {
+    return (
+      <DropTarget
+        id={dropId!}
+        onDrop={onDrop!}
+        style={containerStyle}
+        highlightStyle={highlightStyle}
+        dimStyle={dimStyle}
+      >
+        <View
+          style={StyleSheet.absoluteFill}
+          accessibilityLabel={t("pile.tableau.label", { col: colIndex + 1, count: pile.length })}
+        >
+          {cards}
+        </View>
+      </DropTarget>
+    );
+  }
 
   return (
     <View
       style={containerStyle}
       accessibilityLabel={t("pile.tableau.label", { col: colIndex + 1, count: pile.length })}
     >
-      {pile.map((card, cardIndex) => {
-        const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
-        const rl = rankLabel(card.rank);
-        const suitName = t(`suit.${card.suit}` as const);
-        const label = isSelected
-          ? t("card.selected", { rank: rl, suit: suitName })
-          : t("card.label", { rank: rl, suit: suitName });
-        const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
-        return (
-          <View key={cardIndex} style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}>
-            <SharedPlayingCard
-              suit={card.suit as CanonicalSuit}
-              rank={card.rank}
-              width={CARD_WIDTH}
-              height={CARD_HEIGHT}
-              highlighted={isSelected}
-              onPress={handlePress}
-              accessibilityLabel={label}
-            />
-          </View>
-        );
-      })}
+      {cards}
     </View>
   );
 }

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -51,7 +51,12 @@ export default function TableauColumn({
     );
     if (hasDrop) {
       return (
-        <DropTarget id={dropId!} onDrop={onDrop!} highlightStyle={highlightStyle} dimStyle={dimStyle}>
+        <DropTarget
+          id={dropId!}
+          onDrop={onDrop!}
+          highlightStyle={highlightStyle}
+          dimStyle={dimStyle}
+        >
           {empty}
         </DropTarget>
       );

--- a/frontend/src/game/_shared/drag/DragContainer.tsx
+++ b/frontend/src/game/_shared/drag/DragContainer.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback, useRef } from "react";
+import { View } from "react-native";
+import type { LayoutChangeEvent, ViewStyle } from "react-native";
+import { useDragContext } from "./DragContext";
+import { DragOverlay } from "./DragOverlay";
+
+/**
+ * Drop-in replacement for a plain View that:
+ *   1. Measures its own position and keeps the context's containerOffset shared
+ *      values up to date so DraggableCard worklets can compute container-local
+ *      card positions.
+ *   2. Renders the DragOverlay as a sibling of its children (so the overlay
+ *      is not clipped by any overflow:hidden descendant).
+ */
+export interface DragContainerProps {
+  children: React.ReactNode;
+  style?: ViewStyle | ViewStyle[];
+  onLayout?: (e: LayoutChangeEvent) => void;
+}
+
+export function DragContainer({ children, style, onLayout: externalOnLayout }: DragContainerProps) {
+  const viewRef = useRef<View>(null);
+  const { containerOffsetX, containerOffsetY } = useDragContext();
+
+  const onLayout = useCallback(
+    (e: LayoutChangeEvent) => {
+      viewRef.current?.measure((_x, _y, _w, _h, pageX, pageY) => {
+        containerOffsetX.value = pageX;
+        containerOffsetY.value = pageY;
+      });
+      externalOnLayout?.(e);
+    },
+    [containerOffsetX, containerOffsetY, externalOnLayout]
+  );
+
+  return (
+    <View ref={viewRef} style={style} onLayout={onLayout}>
+      {children}
+      <DragOverlay />
+    </View>
+  );
+}

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -1,0 +1,209 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+import { useSharedValue, runOnJS, withTiming } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+import type { CanonicalSuit } from "../decks/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DragCard {
+  suit: CanonicalSuit;
+  rank: number;
+  faceDown?: boolean;
+  width: number;
+  height: number;
+}
+
+export type DragSource =
+  | { game: "solitaire"; type: "tableau"; col: number; fromIndex: number }
+  | { game: "solitaire"; type: "waste" }
+  | { game: "solitaire"; type: "foundation"; suit: string }
+  | { game: "freecell"; type: "tableau"; col: number; fromIndex: number }
+  | { game: "freecell"; type: "freecell"; cell: number };
+
+export interface DragState {
+  cards: DragCard[];
+  source: DragSource;
+}
+
+/** Return true if the drop was accepted, false to trigger snap-back. */
+export type DropHandler = (source: DragSource, cards: DragCard[]) => boolean;
+
+interface DropZoneEntry {
+  getMeasurement: () => { x: number; y: number; width: number; height: number } | null;
+  onDrop: DropHandler;
+}
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+export interface DragContextValue {
+  // React state (JS thread)
+  dragState: DragState | null;
+  legalTargetIds: Set<string>;
+
+  // Reanimated shared values (readable from worklets)
+  cardX: SharedValue<number>;
+  cardY: SharedValue<number>;
+  originX: SharedValue<number>;
+  originY: SharedValue<number>;
+  containerOffsetX: SharedValue<number>;
+  containerOffsetY: SharedValue<number>;
+
+  // JS-thread actions
+  startDrag: (source: DragSource, cards: DragCard[]) => void;
+  endDrag: (absoluteX: number, absoluteY: number) => void;
+  snapBackAndClear: () => void;
+
+  // Drop zone registry
+  registerDropZone: (id: string, entry: DropZoneEntry) => void;
+  unregisterDropZone: (id: string) => void;
+}
+
+const DragContext = createContext<DragContextValue | null>(null);
+
+export function useDragContext(): DragContextValue {
+  const ctx = useContext(DragContext);
+  if (!ctx) throw new Error("useDragContext must be used within DragProvider");
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export interface DragProviderProps {
+  children: React.ReactNode;
+  getLegalDropIds?: (source: DragSource, cards: DragCard[]) => string[];
+}
+
+export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [legalTargetIds, setLegalTargetIds] = useState<Set<string>>(new Set());
+
+  const cardX = useSharedValue(0);
+  const cardY = useSharedValue(0);
+  const originX = useSharedValue(0);
+  const originY = useSharedValue(0);
+  const containerOffsetX = useSharedValue(0);
+  const containerOffsetY = useSharedValue(0);
+
+  const dropZonesRef = useRef<Map<string, DropZoneEntry>>(new Map());
+  const dragStateRef = useRef<DragState | null>(null);
+
+  const clearDrag = useCallback(() => {
+    setDragState(null);
+    setLegalTargetIds(new Set());
+    dragStateRef.current = null;
+  }, []);
+
+  const startDrag = useCallback(
+    (source: DragSource, cards: DragCard[]) => {
+      const state: DragState = { cards, source };
+      dragStateRef.current = state;
+      setDragState(state);
+      if (getLegalDropIds) {
+        setLegalTargetIds(new Set(getLegalDropIds(source, cards)));
+      }
+    },
+    [getLegalDropIds]
+  );
+
+  const snapBackAndClear = useCallback(() => {
+    cardX.value = withTiming(originX.value, { duration: 200 });
+    cardY.value = withTiming(originY.value, { duration: 200 }, (finished) => {
+      "worklet";
+      if (finished) runOnJS(clearDrag)();
+    });
+  }, [cardX, cardY, clearDrag, originX, originY]);
+
+  const endDrag = useCallback(
+    (absoluteX: number, absoluteY: number) => {
+      const state = dragStateRef.current;
+      if (!state) return;
+
+      for (const [, zone] of dropZonesRef.current) {
+        const bounds = zone.getMeasurement();
+        if (!bounds) continue;
+        if (
+          absoluteX >= bounds.x &&
+          absoluteX <= bounds.x + bounds.width &&
+          absoluteY >= bounds.y &&
+          absoluteY <= bounds.y + bounds.height
+        ) {
+          const accepted = zone.onDrop(state.source, state.cards);
+          if (accepted) {
+            clearDrag();
+            return;
+          }
+        }
+      }
+      snapBackAndClear();
+    },
+    [clearDrag, snapBackAndClear]
+  );
+
+  const registerDropZone = useCallback((id: string, entry: DropZoneEntry) => {
+    dropZonesRef.current.set(id, entry);
+  }, []);
+
+  const unregisterDropZone = useCallback((id: string) => {
+    dropZonesRef.current.delete(id);
+  }, []);
+
+  const value: DragContextValue = {
+    dragState,
+    legalTargetIds,
+    cardX,
+    cardY,
+    originX,
+    originY,
+    containerOffsetX,
+    containerOffsetY,
+    startDrag,
+    endDrag,
+    snapBackAndClear,
+    registerDropZone,
+    unregisterDropZone,
+  };
+
+  return <DragContext.Provider value={value}>{children}</DragContext.Provider>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** True when the given cardSource is part of the currently dragged stack. */
+export function isCardInDragStack(
+  activeSource: DragSource,
+  cardSource: DragSource
+): boolean {
+  if (activeSource.game !== cardSource.game || activeSource.type !== cardSource.type) return false;
+  switch (activeSource.type) {
+    case "tableau":
+      return (
+        cardSource.type === "tableau" &&
+        activeSource.col === cardSource.col &&
+        cardSource.fromIndex >= activeSource.fromIndex
+      );
+    case "freecell":
+      return cardSource.type === "freecell" && activeSource.cell === cardSource.cell;
+    case "waste":
+      return true;
+    case "foundation":
+      return (
+        cardSource.type === "foundation" &&
+        (activeSource as { suit: string }).suit ===
+          (cardSource as { suit: string }).suit
+      );
+  }
+}

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useRef,
-  useState,
-} from "react";
+import React, { createContext, useCallback, useContext, useRef, useState } from "react";
 import { useSharedValue, runOnJS, withTiming } from "react-native-reanimated";
 import type { SharedValue } from "react-native-reanimated";
 import type { CanonicalSuit } from "../decks/types";
@@ -183,10 +177,7 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
 // ---------------------------------------------------------------------------
 
 /** True when the given cardSource is part of the currently dragged stack. */
-export function isCardInDragStack(
-  activeSource: DragSource,
-  cardSource: DragSource
-): boolean {
+export function isCardInDragStack(activeSource: DragSource, cardSource: DragSource): boolean {
   if (activeSource.game !== cardSource.game || activeSource.type !== cardSource.type) return false;
   switch (activeSource.type) {
     case "tableau":
@@ -202,8 +193,7 @@ export function isCardInDragStack(
     case "foundation":
       return (
         cardSource.type === "foundation" &&
-        (activeSource as { suit: string }).suit ===
-          (cardSource as { suit: string }).suit
+        (activeSource as { suit: string }).suit === (cardSource as { suit: string }).suit
       );
   }
 }

--- a/frontend/src/game/_shared/drag/DragOverlay.tsx
+++ b/frontend/src/game/_shared/drag/DragOverlay.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import Animated, { useAnimatedStyle } from "react-native-reanimated";
+import SharedPlayingCard from "../../../components/shared/PlayingCard";
+import { useDragContext } from "./DragContext";
+
+const STACK_OFFSET = 24;
+
+/** Floating card stack that follows the user's finger during a drag.
+ *  Rendered inside DragContainer as a sibling of the game board so it
+ *  is never clipped by overflow:hidden descendants. */
+export function DragOverlay() {
+  const { dragState, cardX, cardY } = useDragContext();
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: cardX.value }, { translateY: cardY.value }],
+  }));
+
+  if (!dragState) return null;
+
+  const { cards } = dragState;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="none">
+      <Animated.View style={[styles.overlay, animStyle]}>
+        {cards.map((card, i) => (
+          <View key={i} style={[styles.card, { top: i * STACK_OFFSET }]}>
+            <SharedPlayingCard
+              suit={card.suit}
+              rank={card.rank}
+              faceDown={card.faceDown ?? false}
+              width={card.width}
+              height={card.height}
+            />
+          </View>
+        ))}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    // Elevation / shadow for "lifted" appearance.
+    elevation: 12,
+    shadowColor: "#000",
+    shadowOpacity: 0.35,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+  },
+  card: {
+    position: "absolute",
+  },
+});

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -100,8 +100,7 @@ export function DraggableCard({
 
   // Hide this card when it (or a card above it in the same run) is being dragged —
   // the DragOverlay renders the visual at the finger position instead.
-  const beingDragged =
-    dragState !== null && isCardInDragStack(dragState.source, dragSource);
+  const beingDragged = dragState !== null && isCardInDragStack(dragState.source, dragSource);
 
   // Clone the child to inject onPress so that:
   //   • In production: GestureDetector (RNGH) intercepts touches before the inner
@@ -112,11 +111,7 @@ export function DraggableCard({
   const innerEl = onTap ? React.cloneElement(child, { onPress: onTap }) : child;
 
   return (
-    <View
-      ref={viewRef}
-      style={[style, beingDragged && { opacity: 0 }]}
-      onLayout={onLayout}
-    >
+    <View ref={viewRef} style={[style, beingDragged && { opacity: 0 }]} onLayout={onLayout}>
       <GestureDetector gesture={gesture}>{innerEl}</GestureDetector>
     </View>
   );

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useRef } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { useSharedValue, runOnJS } from "react-native-reanimated";
+import { useDragContext, isCardInDragStack } from "./DragContext";
+import type { DragCard, DragSource } from "./DragContext";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = Record<string, any>;
+
+export interface DraggableCardProps {
+  children: React.ReactNode;
+  style?: object;
+  /** Tap fallback — same behavior as the old onPress. */
+  onTap?: () => void;
+  /** The card(s) that will be dragged. For a tableau run, pass all cards
+   *  from fromIndex to end of pile. */
+  dragCards: DragCard[];
+  /** Identifies this card in the drag system. */
+  dragSource: DragSource;
+  /** Set false for face-down cards that cannot be picked up. */
+  draggable?: boolean;
+}
+
+export function DraggableCard({
+  children,
+  style,
+  onTap,
+  dragCards,
+  dragSource,
+  draggable = true,
+}: DraggableCardProps) {
+  const viewRef = useRef<View>(null);
+
+  // Pre-measured card position in window coordinates, updated on every layout.
+  // Stored as shared values so the pan worklet can read them synchronously.
+  const cachedPageX = useSharedValue(0);
+  const cachedPageY = useSharedValue(0);
+
+  const {
+    dragState,
+    cardX,
+    cardY,
+    originX,
+    originY,
+    containerOffsetX,
+    containerOffsetY,
+    startDrag,
+    endDrag,
+    snapBackAndClear,
+  } = useDragContext();
+
+  // Re-measure on every layout change (handles initial render + orientation).
+  const onLayout = useCallback(() => {
+    viewRef.current?.measure((_x, _y, _w, _h, pageX, pageY) => {
+      cachedPageX.value = pageX;
+      cachedPageY.value = pageY;
+    });
+  }, [cachedPageX, cachedPageY]);
+
+  // Called from worklet via runOnJS to update React state.
+  const triggerStartDrag = useCallback(() => {
+    startDrag(dragSource, dragCards);
+  }, [dragSource, dragCards, startDrag]);
+
+  const pan = Gesture.Pan()
+    .minDistance(8)
+    .enabled(draggable)
+    .onStart(() => {
+      "worklet";
+      // Convert window position to container-local coordinates.
+      const localX = cachedPageX.value - containerOffsetX.value;
+      const localY = cachedPageY.value - containerOffsetY.value;
+      originX.value = localX;
+      originY.value = localY;
+      cardX.value = localX;
+      cardY.value = localY;
+      runOnJS(triggerStartDrag)();
+    })
+    .onUpdate((e) => {
+      "worklet";
+      cardX.value = originX.value + e.translationX;
+      cardY.value = originY.value + e.translationY;
+    })
+    .onEnd((e) => {
+      "worklet";
+      runOnJS(endDrag)(e.absoluteX, e.absoluteY);
+    })
+    .onFinalize((_e, success) => {
+      "worklet";
+      if (!success) runOnJS(snapBackAndClear)();
+    });
+
+  const tap = Gesture.Tap().onEnd(() => {
+    "worklet";
+    if (onTap) runOnJS(onTap)();
+  });
+
+  const gesture = draggable ? Gesture.Race(pan, tap) : tap;
+
+  // Hide this card when it (or a card above it in the same run) is being dragged —
+  // the DragOverlay renders the visual at the finger position instead.
+  const beingDragged =
+    dragState !== null && isCardInDragStack(dragState.source, dragSource);
+
+  // Clone the child to inject onPress so that:
+  //   • In production: GestureDetector (RNGH) intercepts touches before the inner
+  //     Pressable sees them — no double-firing.
+  //   • In tests: RNGH is mocked so GestureDetector does nothing; the inner
+  //     Pressable's onPress fires normally, keeping fireEvent.press working.
+  const child = React.Children.only(children) as React.ReactElement<AnyProps>;
+  const innerEl = onTap ? React.cloneElement(child, { onPress: onTap }) : child;
+
+  return (
+    <View
+      ref={viewRef}
+      style={[style, beingDragged && { opacity: 0 }]}
+      onLayout={onLayout}
+    >
+      <GestureDetector gesture={gesture}>{innerEl}</GestureDetector>
+    </View>
+  );
+}

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -54,8 +54,7 @@ export function DropTarget({
   const isDragActive = dragState !== null;
   const isLegal = legalTargetIds.has(id);
 
-  const overlayStyle =
-    isDragActive ? (isLegal ? highlightStyle : dimStyle) : undefined;
+  const overlayStyle = isDragActive ? (isLegal ? highlightStyle : dimStyle) : undefined;
 
   return (
     <View ref={viewRef} style={[style, overlayStyle]} onLayout={onLayout}>

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { View } from "react-native";
+import type { ViewStyle } from "react-native";
+import { useDragContext } from "./DragContext";
+import type { DropHandler } from "./DragContext";
+
+export interface DropTargetProps {
+  /** Unique ID used to match against legalTargetIds. */
+  id: string;
+  onDrop: DropHandler;
+  children: React.ReactNode;
+  style?: ViewStyle | ViewStyle[];
+  /** Style applied on top of `style` when drag is active AND this is legal. */
+  highlightStyle?: ViewStyle;
+  /** Style applied on top of `style` when drag is active AND this is not legal. */
+  dimStyle?: ViewStyle;
+}
+
+export function DropTarget({
+  id,
+  onDrop,
+  children,
+  style,
+  highlightStyle,
+  dimStyle,
+}: DropTargetProps) {
+  const viewRef = useRef<View>(null);
+  const boundsRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
+
+  // Keep the latest onDrop in a ref so re-renders don't force re-registration.
+  const onDropRef = useRef(onDrop);
+  useEffect(() => {
+    onDropRef.current = onDrop;
+  });
+
+  const { dragState, legalTargetIds, registerDropZone, unregisterDropZone } = useDragContext();
+
+  const getMeasurement = useCallback(() => boundsRef.current, []);
+
+  const onLayout = useCallback(() => {
+    viewRef.current?.measure((_x, _y, w, h, pageX, pageY) => {
+      boundsRef.current = { x: pageX, y: pageY, width: w, height: h };
+    });
+  }, []);
+
+  useEffect(() => {
+    registerDropZone(id, {
+      getMeasurement,
+      onDrop: (source, cards) => onDropRef.current(source, cards),
+    });
+    return () => unregisterDropZone(id);
+  }, [id, getMeasurement, registerDropZone, unregisterDropZone]);
+
+  const isDragActive = dragState !== null;
+  const isLegal = legalTargetIds.has(id);
+
+  const overlayStyle =
+    isDragActive ? (isLegal ? highlightStyle : dimStyle) : undefined;
+
+  return (
+    <View ref={viewRef} style={[style, overlayStyle]} onLayout={onLayout}>
+      {children}
+    </View>
+  );
+}

--- a/frontend/src/game/solitaire/components/FoundationPile.tsx
+++ b/frontend/src/game/solitaire/components/FoundationPile.tsx
@@ -13,6 +13,8 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "../../../theme/ThemeContext";
 import type { Card, Suit } from "../types";
 import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+import { DropTarget } from "../../_shared/drag/DropTarget";
+import type { DropHandler } from "../../_shared/drag/DragContext";
 
 const SUIT_SYMBOL: Record<Suit, string> = {
   spades: "♠",
@@ -26,6 +28,9 @@ export interface FoundationPileProps {
   readonly suit: Suit;
   readonly selected?: boolean;
   readonly onPress?: (suit: Suit) => void;
+  /** Unique drop-zone ID, e.g. "solitaire-foundation-spades". */
+  readonly dropId?: string;
+  readonly onDrop?: DropHandler;
 }
 
 export default function FoundationPile({
@@ -33,56 +38,71 @@ export default function FoundationPile({
   suit,
   selected = false,
   onPress,
+  dropId,
+  onDrop,
 }: FoundationPileProps) {
   const { colors } = useTheme();
   const { t } = useTranslation("solitaire");
+  const hasDrop = dropId !== undefined && onDrop !== undefined;
 
-  // Non-empty: show the top card (always face-up on foundations).
-  if (pile.length > 0) {
-    const top = pile[pile.length - 1];
-    if (top !== undefined) {
+  const highlightStyle = { borderColor: colors.accent, borderWidth: 2, borderRadius: 8 };
+  const dimStyle = { opacity: 0.4 };
+
+  const inner = (() => {
+    if (pile.length > 0) {
+      const top = pile[pile.length - 1];
+      if (top !== undefined) {
+        return (
+          <CardView
+            card={top}
+            selected={selected}
+            onPress={onPress ? () => onPress(suit) : undefined}
+          />
+        );
+      }
+    }
+
+    const label = t("pile.foundation.empty", { suit: t(`suit.${suit}` as const) });
+    const style = [
+      styles.empty,
+      {
+        borderColor: selected ? colors.accent : colors.border,
+        borderWidth: selected ? 2 : 1,
+        backgroundColor: colors.background,
+      },
+    ];
+    const content = (
+      <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
+    );
+
+    if (onPress) {
       return (
-        <CardView
-          card={top}
-          selected={selected}
-          onPress={onPress ? () => onPress(suit) : undefined}
-        />
+        <Pressable onPress={() => onPress(suit)} style={style} accessibilityRole="button" accessibilityLabel={label}>
+          {content}
+        </Pressable>
       );
     }
-  }
-
-  // Empty: suit-symbol placeholder.
-  const label = t("pile.foundation.empty", { suit: t(`suit.${suit}` as const) });
-  const style = [
-    styles.empty,
-    {
-      borderColor: selected ? colors.accent : colors.border,
-      borderWidth: selected ? 2 : 1,
-      backgroundColor: colors.background,
-    },
-  ];
-
-  const content = (
-    <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
-  );
-
-  if (onPress) {
     return (
-      <Pressable
-        onPress={() => onPress(suit)}
-        style={style}
-        accessibilityRole="button"
-        accessibilityLabel={label}
-      >
+      <View style={style} accessibilityRole="image" accessibilityLabel={label}>
         {content}
-      </Pressable>
+      </View>
+    );
+  })();
+
+  if (hasDrop) {
+    return (
+      <DropTarget
+        id={dropId!}
+        onDrop={onDrop!}
+        highlightStyle={highlightStyle}
+        dimStyle={dimStyle}
+      >
+        {inner}
+      </DropTarget>
     );
   }
-  return (
-    <View style={style} accessibilityRole="image" accessibilityLabel={label}>
-      {content}
-    </View>
-  );
+
+  return inner;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/game/solitaire/components/FoundationPile.tsx
+++ b/frontend/src/game/solitaire/components/FoundationPile.tsx
@@ -77,7 +77,12 @@ export default function FoundationPile({
 
     if (onPress) {
       return (
-        <Pressable onPress={() => onPress(suit)} style={style} accessibilityRole="button" accessibilityLabel={label}>
+        <Pressable
+          onPress={() => onPress(suit)}
+          style={style}
+          accessibilityRole="button"
+          accessibilityLabel={label}
+        >
           {content}
         </Pressable>
       );
@@ -91,12 +96,7 @@ export default function FoundationPile({
 
   if (hasDrop) {
     return (
-      <DropTarget
-        id={dropId!}
-        onDrop={onDrop!}
-        highlightStyle={highlightStyle}
-        dimStyle={dimStyle}
-      >
+      <DropTarget id={dropId!} onDrop={onDrop!} highlightStyle={highlightStyle} dimStyle={dimStyle}>
         {inner}
       </DropTarget>
     );

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -16,7 +16,9 @@ import type { TFunction } from "i18next";
 
 import { useTheme } from "../../../theme/ThemeContext";
 import type { Card, DrawMode } from "../types";
+import type { CanonicalSuit } from "../../_shared/decks/types";
 import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+import { DraggableCard } from "../../_shared/drag/DraggableCard";
 
 export interface StockWastePileProps {
   readonly stock: readonly Card[];
@@ -40,20 +42,8 @@ export default function StockWastePile({
 
   return (
     <View style={styles.row}>
-      <Stock
-        count={stock.length}
-        colors={colors}
-        onPress={onStockPress}
-        drawMode={drawMode}
-        t={t}
-      />
-      <Waste
-        waste={waste}
-        drawMode={drawMode}
-        selected={wasteSelected}
-        onPress={onWastePress}
-        t={t}
-      />
+      <Stock count={stock.length} colors={colors} onPress={onStockPress} drawMode={drawMode} t={t} />
+      <Waste waste={waste} drawMode={drawMode} selected={wasteSelected} onPress={onWastePress} t={t} />
     </View>
   );
 }
@@ -89,19 +79,12 @@ function Stock({
   const content = isEmpty ? (
     <Text style={[styles.recycleSymbol, { color: colors.textMuted }]}>↻</Text>
   ) : (
-    <>
-      <Text style={[styles.countText, { color: colors.textMuted }]}>{count}</Text>
-    </>
+    <Text style={[styles.countText, { color: colors.textMuted }]}>{count}</Text>
   );
 
   if (onPress) {
     return (
-      <Pressable
-        onPress={onPress}
-        style={style}
-        accessibilityRole="button"
-        accessibilityLabel={label}
-      >
+      <Pressable onPress={onPress} style={style} accessibilityRole="button" accessibilityLabel={label}>
         {content}
       </Pressable>
     );
@@ -138,10 +121,21 @@ function Waste({
     );
   }
 
+  const top = waste[waste.length - 1]!;
+  const topDragCards = [
+    { suit: top.suit as CanonicalSuit, rank: top.rank, faceDown: false, width: CARD_WIDTH, height: CARD_HEIGHT },
+  ];
+
   if (drawMode !== 3) {
-    const top = waste[waste.length - 1];
-    if (top === undefined) return null;
-    return <CardView card={top} selected={selected} onPress={onPress} />;
+    return (
+      <DraggableCard
+        onTap={onPress}
+        dragCards={topDragCards}
+        dragSource={{ game: "solitaire", type: "waste" }}
+      >
+        <CardView card={top} selected={selected} />
+      </DraggableCard>
+    );
   }
 
   const visibleCount = Math.min(3, waste.length);
@@ -152,16 +146,22 @@ function Waste({
     <View style={[styles.wasteFanContainer, { width: containerWidth }]}>
       {visible.map((card, i) => {
         const isTop = i === visible.length - 1;
+        if (isTop) {
+          return (
+            <View key={`${card.suit}-${card.rank}`} style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}>
+              <DraggableCard
+                onTap={onPress}
+                dragCards={topDragCards}
+                dragSource={{ game: "solitaire", type: "waste" }}
+              >
+                <CardView card={card} selected={selected} />
+              </DraggableCard>
+            </View>
+          );
+        }
         return (
-          <View
-            key={`${card.suit}-${card.rank}`}
-            style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}
-          >
-            <CardView
-              card={card}
-              selected={isTop && selected}
-              onPress={isTop ? onPress : undefined}
-            />
+          <View key={`${card.suit}-${card.rank}`} style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}>
+            <CardView card={card} selected={false} />
           </View>
         );
       })}

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -42,8 +42,20 @@ export default function StockWastePile({
 
   return (
     <View style={styles.row}>
-      <Stock count={stock.length} colors={colors} onPress={onStockPress} drawMode={drawMode} t={t} />
-      <Waste waste={waste} drawMode={drawMode} selected={wasteSelected} onPress={onWastePress} t={t} />
+      <Stock
+        count={stock.length}
+        colors={colors}
+        onPress={onStockPress}
+        drawMode={drawMode}
+        t={t}
+      />
+      <Waste
+        waste={waste}
+        drawMode={drawMode}
+        selected={wasteSelected}
+        onPress={onWastePress}
+        t={t}
+      />
     </View>
   );
 }
@@ -84,7 +96,12 @@ function Stock({
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} style={style} accessibilityRole="button" accessibilityLabel={label}>
+      <Pressable
+        onPress={onPress}
+        style={style}
+        accessibilityRole="button"
+        accessibilityLabel={label}
+      >
         {content}
       </Pressable>
     );
@@ -123,7 +140,13 @@ function Waste({
 
   const top = waste[waste.length - 1]!;
   const topDragCards = [
-    { suit: top.suit as CanonicalSuit, rank: top.rank, faceDown: false, width: CARD_WIDTH, height: CARD_HEIGHT },
+    {
+      suit: top.suit as CanonicalSuit,
+      rank: top.rank,
+      faceDown: false,
+      width: CARD_WIDTH,
+      height: CARD_HEIGHT,
+    },
   ];
 
   if (drawMode !== 3) {
@@ -148,7 +171,10 @@ function Waste({
         const isTop = i === visible.length - 1;
         if (isTop) {
           return (
-            <View key={`${card.suit}-${card.rank}`} style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}>
+            <View
+              key={`${card.suit}-${card.rank}`}
+              style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}
+            >
               <DraggableCard
                 onTap={onPress}
                 dragCards={topDragCards}
@@ -160,7 +186,10 @@ function Waste({
           );
         }
         return (
-          <View key={`${card.suit}-${card.rank}`} style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}>
+          <View
+            key={`${card.suit}-${card.rank}`}
+            style={[styles.wasteFanCard, { left: i * WASTE_FAN_OFFSET }]}
+          >
             <CardView card={card} selected={false} />
           </View>
         );

--- a/frontend/src/game/solitaire/components/TableauPile.tsx
+++ b/frontend/src/game/solitaire/components/TableauPile.tsx
@@ -12,24 +12,24 @@ import { useTranslation } from "react-i18next";
 
 import { useTheme } from "../../../theme/ThemeContext";
 import type { Card } from "../types";
+import type { CanonicalSuit } from "../../_shared/decks/types";
 import CardView, { CARD_HEIGHT, CARD_WIDTH } from "./CardView";
+import { DraggableCard } from "../../_shared/drag/DraggableCard";
+import { DropTarget } from "../../_shared/drag/DropTarget";
+import type { DropHandler } from "../../_shared/drag/DragContext";
 
-/** Vertical offset between stacked cards. Face-up cards overlap more
- * tightly than face-down ones so the rank/suit of each face-up card stays
- * readable even in long columns. */
 const FACE_UP_OFFSET = 24;
 const FACE_DOWN_OFFSET = 14;
 
 export interface TableauPileProps {
   readonly pile: readonly Card[];
   readonly colIndex: number;
-  /** Index of the card that is currently tap-selected in this column, if
-   * any. When the selected card is not at the top of the pile, the entire
-   * sub-run from that index to the end is highlighted — that matches
-   * Klondike's tap-to-select-run semantics. */
   readonly selectedIndex?: number;
   readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
   readonly onEmptyPress?: (colIndex: number) => void;
+  /** Unique drop-zone ID, e.g. "solitaire-tableau-0". Required for DnD. */
+  readonly dropId?: string;
+  readonly onDrop?: DropHandler;
 }
 
 export default function TableauPile({
@@ -38,30 +38,44 @@ export default function TableauPile({
   selectedIndex,
   onCardPress,
   onEmptyPress,
+  dropId,
+  onDrop,
 }: TableauPileProps) {
   const { colors } = useTheme();
   const { t } = useTranslation("solitaire");
 
+  const highlightStyle: ViewStyle = {
+    borderColor: colors.accent,
+    borderWidth: 2,
+    borderRadius: 8,
+  };
+  const dimStyle: ViewStyle = { opacity: 0.4 };
+  const hasDrop = dropId !== undefined && onDrop !== undefined;
+
   if (pile.length === 0) {
-    return (
+    const empty = (
       <Pressable
         onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
-        style={[
-          styles.empty,
-          {
-            borderColor: colors.border,
-            backgroundColor: colors.background,
-          },
-        ]}
+        style={[styles.empty, { borderColor: colors.border, backgroundColor: colors.background }]}
         accessibilityRole="button"
         accessibilityLabel={t("pile.tableau.empty", { col: colIndex + 1 })}
       />
     );
+    if (hasDrop) {
+      return (
+        <DropTarget
+          id={dropId!}
+          onDrop={onDrop!}
+          highlightStyle={highlightStyle}
+          dimStyle={dimStyle}
+        >
+          {empty}
+        </DropTarget>
+      );
+    }
+    return empty;
   }
 
-  // Compute cumulative vertical offset so the container height matches the
-  // visible extent of the pile — needed because child absolute positioning
-  // doesn't contribute to layout on web.
   const offsets: number[] = [];
   let acc = 0;
   for (let i = 0; i < pile.length; i++) {
@@ -71,28 +85,61 @@ export default function TableauPile({
     acc += card.faceUp ? FACE_UP_OFFSET : FACE_DOWN_OFFSET;
   }
   const containerHeight = CARD_HEIGHT + (offsets[pile.length - 1] ?? 0);
+  const containerStyle: ViewStyle = { width: CARD_WIDTH, height: containerHeight };
 
-  const containerStyle: ViewStyle = {
-    width: CARD_WIDTH,
-    height: containerHeight,
-  };
+  const cards = pile.map((card, cardIndex) => {
+    const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
+    const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
+    const dragCards = pile.slice(cardIndex).map((c) => ({
+      suit: c.suit as CanonicalSuit,
+      rank: c.rank,
+      faceDown: !c.faceUp,
+      width: CARD_WIDTH,
+      height: CARD_HEIGHT,
+    }));
+    return (
+      <DraggableCard
+        key={cardIndex}
+        style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}
+        onTap={handlePress}
+        dragCards={dragCards}
+        dragSource={{ game: "solitaire", type: "tableau", col: colIndex, fromIndex: cardIndex }}
+        draggable={card.faceUp}
+      >
+        <CardView card={card} selected={isSelected} />
+      </DraggableCard>
+    );
+  });
 
-  return (
+  const pileView = (
     <View
       style={containerStyle}
       accessibilityLabel={t("pile.tableau.label", { col: colIndex + 1, count: pile.length })}
     >
-      {pile.map((card, cardIndex) => {
-        const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
-        const handlePress = onCardPress ? () => onCardPress(colIndex, cardIndex) : undefined;
-        return (
-          <View key={cardIndex} style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}>
-            <CardView card={card} selected={isSelected} onPress={handlePress} />
-          </View>
-        );
-      })}
+      {cards}
     </View>
   );
+
+  if (hasDrop) {
+    return (
+      <DropTarget
+        id={dropId!}
+        onDrop={onDrop!}
+        style={containerStyle}
+        highlightStyle={highlightStyle}
+        dimStyle={dimStyle}
+      >
+        <View
+          style={StyleSheet.absoluteFill}
+          accessibilityLabel={t("pile.tableau.label", { col: colIndex + 1, count: pile.length })}
+        >
+          {cards}
+        </View>
+      </DropTarget>
+    );
+  }
+
+  return pileView;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/StockWastePile.test.tsx
@@ -4,9 +4,14 @@ import { render, fireEvent } from "@testing-library/react-native";
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import type { Card } from "../../types";
 import StockWastePile from "../StockWastePile";
+import { DragProvider } from "../../../_shared/drag/DragContext";
 
 function withTheme(children: React.ReactNode) {
-  return <ThemeProvider>{children}</ThemeProvider>;
+  return (
+    <DragProvider>
+      <ThemeProvider>{children}</ThemeProvider>
+    </DragProvider>
+  );
 }
 
 function card(rank: number): Card {

--- a/frontend/src/game/solitaire/components/__tests__/TableauPile.test.tsx
+++ b/frontend/src/game/solitaire/components/__tests__/TableauPile.test.tsx
@@ -4,9 +4,14 @@ import { render, fireEvent } from "@testing-library/react-native";
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import type { Card, Rank, Suit } from "../../types";
 import TableauPile from "../TableauPile";
+import { DragProvider } from "../../../_shared/drag/DragContext";
 
 function withTheme(children: React.ReactNode) {
-  return <ThemeProvider>{children}</ThemeProvider>;
+  return (
+    <DragProvider>
+      <ThemeProvider>{children}</ThemeProvider>
+    </DragProvider>
+  );
 }
 
 function card(suit: Suit, rank: Rank, faceUp = true): Card {

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -478,7 +478,12 @@ export default function SolitaireScreen() {
       for (let col = 0; col < TABLEAU_COLS; col++) {
         let move: Move | null = null;
         if (source.type === "tableau" && source.col !== col) {
-          move = { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol: col };
+          move = {
+            type: "tableau-to-tableau",
+            fromCol: source.col,
+            fromIndex: source.fromIndex,
+            toCol: col,
+          };
         } else if (source.type === "waste") {
           move = { type: "waste-to-tableau", toCol: col };
         } else if (source.type === "foundation") {
@@ -565,138 +570,138 @@ export default function SolitaireScreen() {
 
   return (
     <DragProvider getLegalDropIds={getLegalDropIds}>
-    <GameShell
-      title={t("solitaire:game.title")}
-      requireBack
-      loading={loading}
-      onBack={() => navigation.popToTop()}
-      style={{
-        paddingBottom: Math.max(insets.bottom, 16),
-        paddingLeft: Math.max(insets.left, 12),
-        paddingRight: Math.max(insets.right, 12),
-      }}
-      onNewGame={resetToPreGame}
-      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "solitaire" })}
-      rightSlot={
-        <Pressable
-          onPress={handleUndo}
-          disabled={undoDisabled}
-          style={[
-            styles.headerBtn,
-            { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel={t("solitaire:action.undo")}
-          accessibilityState={{ disabled: undoDisabled }}
-        >
-          <Text style={[styles.headerBtnText, { color: colors.accent }]}>
-            {t("solitaire:action.undo")}
-          </Text>
-        </Pressable>
-      }
-    >
-      {state === null ? (
-        <PreGameModal onChoose={deal} />
-      ) : (
-        <DragContainer style={styles.body as ViewStyle} onLayout={onOuterLayout}>
-          <View style={styles.hudRow} accessibilityRole="summary">
-            <Text
-              style={[styles.hudText, { color: colors.text }]}
-              accessibilityLabel={t("solitaire:score.label", { score: state.score })}
-            >
-              {t("solitaire:score.label", { score: state.score })}
-            </Text>
-            <Text
-              style={[styles.hudText, { color: colors.textMuted }]}
-              accessibilityLabel={t("solitaire:score.moves", { moves })}
-            >
-              {t("solitaire:score.moves", { moves })}
-            </Text>
-          </View>
-
-          <View
-            style={[styles.boardWrap, outerWidth > 0 ? { height: BOARD_HEIGHT * scale } : null]}
-            accessibilityLabel={t("solitaire:a11y.boardRegion")}
+      <GameShell
+        title={t("solitaire:game.title")}
+        requireBack
+        loading={loading}
+        onBack={() => navigation.popToTop()}
+        style={{
+          paddingBottom: Math.max(insets.bottom, 16),
+          paddingLeft: Math.max(insets.left, 12),
+          paddingRight: Math.max(insets.right, 12),
+        }}
+        onNewGame={resetToPreGame}
+        onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "solitaire" })}
+        rightSlot={
+          <Pressable
+            onPress={handleUndo}
+            disabled={undoDisabled}
+            style={[
+              styles.headerBtn,
+              { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={t("solitaire:action.undo")}
+            accessibilityState={{ disabled: undoDisabled }}
           >
+            <Text style={[styles.headerBtnText, { color: colors.accent }]}>
+              {t("solitaire:action.undo")}
+            </Text>
+          </Pressable>
+        }
+      >
+        {state === null ? (
+          <PreGameModal onChoose={deal} />
+        ) : (
+          <DragContainer style={styles.body as ViewStyle} onLayout={onOuterLayout}>
+            <View style={styles.hudRow} accessibilityRole="summary">
+              <Text
+                style={[styles.hudText, { color: colors.text }]}
+                accessibilityLabel={t("solitaire:score.label", { score: state.score })}
+              >
+                {t("solitaire:score.label", { score: state.score })}
+              </Text>
+              <Text
+                style={[styles.hudText, { color: colors.textMuted }]}
+                accessibilityLabel={t("solitaire:score.moves", { moves })}
+              >
+                {t("solitaire:score.moves", { moves })}
+              </Text>
+            </View>
+
             <View
-              style={[
-                styles.board,
-                {
-                  width: BOARD_WIDTH,
-                  transform: [{ scale }],
-                } as ViewStyle,
-              ]}
+              style={[styles.boardWrap, outerWidth > 0 ? { height: BOARD_HEIGHT * scale } : null]}
+              accessibilityLabel={t("solitaire:a11y.boardRegion")}
             >
-              <View style={styles.foundationsRow}>
-                {SUITS.map((suit) => (
-                  <FoundationPile
-                    key={suit}
-                    pile={state.foundations[suit]}
-                    suit={suit}
-                    selected={selection?.kind === "foundation" && selection.suit === suit}
-                    onPress={handleFoundationPress}
-                    dropId={`solitaire-foundation-${suit}`}
-                    onDrop={(source) => handleDropToFoundation(source)}
-                  />
-                ))}
-              </View>
+              <View
+                style={[
+                  styles.board,
+                  {
+                    width: BOARD_WIDTH,
+                    transform: [{ scale }],
+                  } as ViewStyle,
+                ]}
+              >
+                <View style={styles.foundationsRow}>
+                  {SUITS.map((suit) => (
+                    <FoundationPile
+                      key={suit}
+                      pile={state.foundations[suit]}
+                      suit={suit}
+                      selected={selection?.kind === "foundation" && selection.suit === suit}
+                      onPress={handleFoundationPress}
+                      dropId={`solitaire-foundation-${suit}`}
+                      onDrop={(source) => handleDropToFoundation(source)}
+                    />
+                  ))}
+                </View>
 
-              <View style={styles.tableauRow}>
-                {state.tableau.map((pile, col) => (
-                  <TableauPile
-                    key={col}
-                    pile={pile}
-                    colIndex={col}
-                    selectedIndex={tableauSelection(col)}
-                    onCardPress={handleTableauCardPress}
-                    onEmptyPress={handleEmptyTableauPress}
-                    dropId={`solitaire-tableau-${col}`}
-                    onDrop={(source) => handleDropToTableau(source, col)}
-                  />
-                ))}
-              </View>
+                <View style={styles.tableauRow}>
+                  {state.tableau.map((pile, col) => (
+                    <TableauPile
+                      key={col}
+                      pile={pile}
+                      colIndex={col}
+                      selectedIndex={tableauSelection(col)}
+                      onCardPress={handleTableauCardPress}
+                      onEmptyPress={handleEmptyTableauPress}
+                      dropId={`solitaire-tableau-${col}`}
+                      onDrop={(source) => handleDropToTableau(source, col)}
+                    />
+                  ))}
+                </View>
 
-              <View style={styles.stockWasteRow}>
-                <StockWastePile
-                  stock={state.stock}
-                  waste={state.waste}
-                  drawMode={state.drawMode}
-                  wasteSelected={selection?.kind === "waste"}
-                  onStockPress={handleStockPress}
-                  onWastePress={handleWastePress}
-                />
+                <View style={styles.stockWasteRow}>
+                  <StockWastePile
+                    stock={state.stock}
+                    waste={state.waste}
+                    drawMode={state.drawMode}
+                    wasteSelected={selection?.kind === "waste"}
+                    onStockPress={handleStockPress}
+                    onWastePress={handleWastePress}
+                  />
+                </View>
               </View>
             </View>
-          </View>
 
-          {showAutoComplete && (
-            <Pressable
-              onPress={handleAutoComplete}
-              style={[styles.autoBtn, { backgroundColor: colors.accent }]}
-              accessibilityRole="button"
-              accessibilityLabel={t("solitaire:action.autoComplete")}
-            >
-              <Text style={[styles.autoBtnText, { color: colors.textOnAccent }]}>
-                {t("solitaire:action.autoComplete")}
-              </Text>
-            </Pressable>
-          )}
+            {showAutoComplete && (
+              <Pressable
+                onPress={handleAutoComplete}
+                style={[styles.autoBtn, { backgroundColor: colors.accent }]}
+                accessibilityRole="button"
+                accessibilityLabel={t("solitaire:action.autoComplete")}
+              >
+                <Text style={[styles.autoBtnText, { color: colors.textOnAccent }]}>
+                  {t("solitaire:action.autoComplete")}
+                </Text>
+              </Pressable>
+            )}
 
-          <Animated.View
-            pointerEvents="none"
-            accessibilityElementsHidden
-            importantForAccessibility="no-hide-descendants"
-            style={[
-              StyleSheet.absoluteFill,
-              { backgroundColor: colors.error, opacity: flashOpacity },
-            ]}
-            testID="solitaire-invalid-flash"
-          />
-        </DragContainer>
-      )}
+            <Animated.View
+              pointerEvents="none"
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
+              style={[
+                StyleSheet.absoluteFill,
+                { backgroundColor: colors.error, opacity: flashOpacity },
+              ]}
+              testID="solitaire-invalid-flash"
+            />
+          </DragContainer>
+        )}
 
-      {state?.isComplete === true && <WinModal score={state.score} onNewGame={resetToPreGame} />}
-    </GameShell>
+        {state?.isComplete === true && <WinModal score={state.score} onNewGame={resetToPreGame} />}
+      </GameShell>
     </DragProvider>
   );
 }

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -51,9 +51,13 @@ import {
   drawFromStock,
   recycleWaste,
   undo,
+  validateMove,
 } from "../game/solitaire/engine";
 import type { DrawMode, Move, SolitaireState, Suit } from "../game/solitaire/types";
 import { SUITS } from "../game/solitaire/types";
+import { DragProvider } from "../game/_shared/drag/DragContext";
+import { DragContainer } from "../game/_shared/drag/DragContainer";
+import type { DragSource, DragCard } from "../game/_shared/drag/DragContext";
 import {
   clearGame,
   loadGame,
@@ -433,6 +437,73 @@ export default function SolitaireScreen() {
     [state, selection, autoCompleting, tryMove, flashInvalid]
   );
 
+  // ── Drag-and-drop handlers ─────────────────────────────────────────────────
+
+  const handleDropToTableau = useCallback(
+    (source: DragSource, toCol: number): boolean => {
+      if (source.game !== "solitaire") return false;
+      if (source.type === "tableau") {
+        return tryMove({
+          type: "tableau-to-tableau",
+          fromCol: source.col,
+          fromIndex: source.fromIndex,
+          toCol,
+        });
+      }
+      if (source.type === "waste") return tryMove({ type: "waste-to-tableau", toCol });
+      if (source.type === "foundation") {
+        return tryMove({ type: "foundation-to-tableau", fromSuit: source.suit as Suit, toCol });
+      }
+      return false;
+    },
+    [tryMove]
+  );
+
+  const handleDropToFoundation = useCallback(
+    (source: DragSource): boolean => {
+      if (source.game !== "solitaire") return false;
+      if (source.type === "tableau")
+        return tryMove({ type: "tableau-to-foundation", fromCol: source.col });
+      if (source.type === "waste") return tryMove({ type: "waste-to-foundation" });
+      return false;
+    },
+    [tryMove]
+  );
+
+  const getLegalDropIds = useCallback(
+    (source: DragSource, cards: DragCard[]): string[] => {
+      if (state === null || source.game !== "solitaire") return [];
+      const ids: string[] = [];
+
+      for (let col = 0; col < TABLEAU_COLS; col++) {
+        let move: Move | null = null;
+        if (source.type === "tableau" && source.col !== col) {
+          move = { type: "tableau-to-tableau", fromCol: source.col, fromIndex: source.fromIndex, toCol: col };
+        } else if (source.type === "waste") {
+          move = { type: "waste-to-tableau", toCol: col };
+        } else if (source.type === "foundation") {
+          move = { type: "foundation-to-tableau", fromSuit: source.suit as Suit, toCol: col };
+        }
+        if (move && validateMove(state, move)) ids.push(`solitaire-tableau-${col}`);
+      }
+
+      if (cards.length === 1) {
+        let foundMove: Move | null = null;
+        if (source.type === "tableau")
+          foundMove = { type: "tableau-to-foundation", fromCol: source.col };
+        else if (source.type === "waste") foundMove = { type: "waste-to-foundation" };
+        if (foundMove && validateMove(state, foundMove)) {
+          for (const suit of SUITS) ids.push(`solitaire-foundation-${suit}`);
+        }
+      }
+
+      return ids;
+    },
+    [state]
+  );
+
+  // ── Undo / auto-complete ────────────────────────────────────────────────────
+
   const handleUndo = useCallback(() => {
     if (state === null || autoCompleting) return;
     if (state.undoStack.length === 0) return;
@@ -493,6 +564,7 @@ export default function SolitaireScreen() {
   };
 
   return (
+    <DragProvider getLegalDropIds={getLegalDropIds}>
     <GameShell
       title={t("solitaire:game.title")}
       requireBack
@@ -526,7 +598,7 @@ export default function SolitaireScreen() {
       {state === null ? (
         <PreGameModal onChoose={deal} />
       ) : (
-        <View style={styles.body} onLayout={onOuterLayout}>
+        <DragContainer style={styles.body as ViewStyle} onLayout={onOuterLayout}>
           <View style={styles.hudRow} accessibilityRole="summary">
             <Text
               style={[styles.hudText, { color: colors.text }]}
@@ -563,6 +635,8 @@ export default function SolitaireScreen() {
                     suit={suit}
                     selected={selection?.kind === "foundation" && selection.suit === suit}
                     onPress={handleFoundationPress}
+                    dropId={`solitaire-foundation-${suit}`}
+                    onDrop={(source) => handleDropToFoundation(source)}
                   />
                 ))}
               </View>
@@ -576,6 +650,8 @@ export default function SolitaireScreen() {
                     selectedIndex={tableauSelection(col)}
                     onCardPress={handleTableauCardPress}
                     onEmptyPress={handleEmptyTableauPress}
+                    dropId={`solitaire-tableau-${col}`}
+                    onDrop={(source) => handleDropToTableau(source, col)}
                   />
                 ))}
               </View>
@@ -616,11 +692,12 @@ export default function SolitaireScreen() {
             ]}
             testID="solitaire-invalid-flash"
           />
-        </View>
+        </DragContainer>
       )}
 
       {state?.isComplete === true && <WinModal score={state.score} onNewGame={resetToPreGame} />}
     </GameShell>
+    </DragProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds shared DnD infrastructure (`DragContext`, `DragContainer`, `DragOverlay`, `DraggableCard`, `DropTarget`) built on react-native-gesture-handler + Reanimated 4
- Solitaire (#674): tableau cards/runs, waste top card, and foundations are all draggable; legal drop targets highlight in real time using `validateMove`; invalid drops spring back to origin
- FreeCell (#813): same pattern — tableau columns, free-cell slots, and foundations as both drag sources and drop zones
- Tap-to-move kept fully intact as a fallback on all affected components
- 147 existing Solitaire/FreeCell tests pass; 0 new TS errors; 0 lint warnings

## Test plan

- [ ] Drag a face-up tableau card to a legal tableau column — card moves
- [ ] Drag a run of cards from tableau — entire stack lifts and moves
- [ ] Drag to an illegal target — card snaps back with spring animation
- [ ] Drag waste top card to foundation and tableau
- [ ] Tap-to-move still works on all card types
- [ ] FreeCell: drag from tableau to free cell, foundation, and another column
- [ ] FreeCell: drag from free cell to tableau
- [ ] Works on web (mouse drag), iOS, and Android touch

Closes #674
Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)