### PR TITLE
feat(#802): Star Swarm controls — relative-drag, charge shot, haptics, pause

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -63,6 +63,7 @@ export type HomeStackParamList = {
   Home: undefined;
   Game: { initialState: GameState };
   Cascade: undefined;
+  StarSwarm: undefined;
   BlackjackBetting: undefined;
   BlackjackTable: undefined;
   Twenty48: undefined;
@@ -136,6 +137,7 @@ function withSuspense<P extends object>(
 }
 
 const LazyCascadeScreen = withSuspense(LazyScreens.Cascade, "cascade");
+const LazyStarSwarmScreen = withSuspense(LazyScreens.StarSwarm, "starswarm");
 const LazyBlackjackBettingScreen = withSuspense(LazyScreens.BlackjackBetting, "blackjack_betting");
 const LazyBlackjackTableScreen = withSuspense(LazyScreens.BlackjackTable, "blackjack_table");
 const LazyTwenty48Screen = withSuspense(LazyScreens.Twenty48, "twenty48");
@@ -159,6 +161,7 @@ function LobbyStack() {
       <HomeStack.Screen name="Home" component={HomeScreen} />
       <HomeStack.Screen name="Game" component={GameScreen} />
       <HomeStack.Screen name="Cascade" component={LazyCascadeScreen} />
+      <HomeStack.Screen name="StarSwarm" component={LazyStarSwarmScreen} />
       <HomeStack.Screen name="BlackjackBetting" component={LazyBlackjackBettingScreen} />
       <HomeStack.Screen name="BlackjackTable" component={LazyBlackjackTableScreen} />
       <HomeStack.Screen name="Twenty48" component={LazyTwenty48Screen} />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "expo": "~55.0.17",
         "expo-audio": "~55.0.14",
         "expo-blur": "~55.0.14",
+        "expo-haptics": "~55.0.14",
         "expo-linear-gradient": "~55.0.13",
         "expo-localization": "^55.0.13",
         "expo-modules-core": "^55.0.22",
@@ -8767,6 +8768,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-55.0.14.tgz",
+      "integrity": "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "expo": "~55.0.17",
     "expo-audio": "~55.0.14",
     "expo-blur": "~55.0.14",
+    "expo-haptics": "~55.0.14",
     "expo-linear-gradient": "~55.0.13",
     "expo-localization": "^55.0.13",
     "expo-modules-core": "^55.0.22",

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -1,11 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
-import {
-  Platform,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import * as Haptics from "expo-haptics";
 import { useTranslation } from "react-i18next";

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useRef, useState } from "react";
+import {
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import * as Haptics from "expo-haptics";
+import { useTranslation } from "react-i18next";
+import type { GameCanvasHandle } from "./GameCanvas";
+import type { GamePhase } from "../../game/starswarm/types";
+import { CANVAS_W, CANVAS_H } from "../../game/starswarm/engine";
+
+const DRAG_ZONE_Y_RATIO = 0.6; // bottom 40% is the drag zone
+const CHARGE_BTN_SIZE = 56;
+const CHARGE_BTN_HIT_SLOP = 12;
+
+interface Props {
+  canvasRef: React.RefObject<GameCanvasHandle | null>;
+  scale: number;
+  phase: GamePhase;
+  isPaused: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onNewGame: () => void;
+}
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export default function Controls({
+  canvasRef,
+  scale,
+  phase,
+  isPaused,
+  onPause,
+  onResume,
+  onNewGame,
+}: Props) {
+  const { t } = useTranslation("starswarm");
+
+  const displayW = Math.round(CANVAS_W * scale);
+  const displayH = Math.round(CANVAS_H * scale);
+  const dragZoneY = displayH * DRAG_ZONE_Y_RATIO;
+
+  const playerXRef = useRef(CANVAS_W / 2);
+  const activeDragRef = useRef(false);
+
+  const [isCharging, setIsCharging] = useState(false);
+
+  const resetPlayerX = useCallback(() => {
+    playerXRef.current = CANVAS_W / 2;
+  }, []);
+
+  // Reset player X tracking on new game
+  const handleNewGame = useCallback(() => {
+    resetPlayerX();
+    onNewGame();
+  }, [resetPlayerX, onNewGame]);
+
+  const panGesture = Gesture.Pan()
+    .runOnJS(true)
+    .minDistance(0)
+    .onBegin((e) => {
+      activeDragRef.current = e.y > dragZoneY;
+    })
+    .onChange((e) => {
+      if (!activeDragRef.current) return;
+      const logicalDx = e.changeX / scale;
+      const newX = clamp(playerXRef.current + logicalDx, 0, CANVAS_W);
+      playerXRef.current = newX;
+      canvasRef.current?.setPlayerX(newX);
+    })
+    .onEnd((e) => {
+      if (!activeDragRef.current && e.y < dragZoneY && Math.abs(e.translationX) < 10) {
+        // Short tap in top zone → pause
+        if (!isPaused && phase === "Playing") onPause();
+      }
+      activeDragRef.current = false;
+    })
+    .onFinalize(() => {
+      activeDragRef.current = false;
+    });
+
+  const isGameOver = phase === "GameOver";
+  const gameActive = !isGameOver && !isPaused;
+
+  return (
+    <GestureDetector gesture={panGesture}>
+      <View
+        style={[styles.overlay, { width: displayW, height: displayH }]}
+        pointerEvents="box-none"
+      >
+        {/* Charge shot button — bottom-right corner, only during active play */}
+        {gameActive && (
+          <Pressable
+            style={[
+              styles.chargeBtn,
+              isCharging && styles.chargeBtnActive,
+              {
+                bottom: Platform.OS === "web" ? 20 : 28,
+                right: 12,
+              },
+            ]}
+            hitSlop={CHARGE_BTN_HIT_SLOP}
+            accessibilityLabel={t("controls.chargeShotLabel")}
+            accessibilityRole="button"
+            onPressIn={() => setIsCharging(true)}
+            onPressOut={() => {
+              setIsCharging(false);
+              canvasRef.current?.setChargeShot(true);
+            }}
+          >
+            <Text style={styles.chargeBtnIcon} aria-hidden>
+              ⚡
+            </Text>
+          </Pressable>
+        )}
+
+        {/* Pause overlay */}
+        {isPaused && !isGameOver && (
+          <Pressable
+            style={styles.pauseOverlay}
+            onPress={onResume}
+            accessibilityLabel={t("controls.resumeLabel")}
+            accessibilityRole="button"
+          >
+            <Text style={styles.pauseTitle}>{t("controls.paused")}</Text>
+            <Text style={styles.pauseHint}>{t("controls.tapToResume")}</Text>
+          </Pressable>
+        )}
+
+        {/* Game-over new-game button */}
+        {isGameOver && (
+          <View style={styles.gameOverActions}>
+            <Pressable
+              style={styles.newGameBtn}
+              onPress={handleNewGame}
+              accessibilityLabel={t("controls.newGameLabel")}
+              accessibilityRole="button"
+            >
+              <Text style={styles.newGameBtnText}>{t("controls.newGame")}</Text>
+            </Pressable>
+          </View>
+        )}
+      </View>
+    </GestureDetector>
+  );
+}
+
+/** Call from StarSwarmScreen when the player is hit (short impact). */
+export function hapticPlayerHit() {
+  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => undefined);
+}
+
+/** Call from StarSwarmScreen on player death / game over (medium impact). */
+export function hapticPlayerDeath() {
+  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => undefined);
+}
+
+/** Call from StarSwarmScreen on wave clear (light notification). */
+export function hapticWaveClear() {
+  Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success).catch(() => undefined);
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+  },
+  chargeBtn: {
+    position: "absolute",
+    width: CHARGE_BTN_SIZE,
+    height: CHARGE_BTN_SIZE,
+    borderRadius: CHARGE_BTN_SIZE / 2,
+    backgroundColor: "rgba(0, 200, 255, 0.18)",
+    borderWidth: 2,
+    borderColor: "rgba(0, 200, 255, 0.55)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  chargeBtnActive: {
+    backgroundColor: "rgba(0, 200, 255, 0.42)",
+    borderColor: "#00ffcc",
+  },
+  chargeBtnIcon: {
+    fontSize: 26,
+  },
+  pauseOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0, 0, 16, 0.72)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pauseTitle: {
+    color: "#00ffcc",
+    fontSize: 26,
+    fontWeight: "bold",
+    letterSpacing: 3,
+  },
+  pauseHint: {
+    color: "rgba(255,255,255,0.6)",
+    fontSize: 13,
+    marginTop: 12,
+  },
+  gameOverActions: {
+    position: "absolute",
+    bottom: 100,
+    left: 0,
+    right: 0,
+    alignItems: "center",
+  },
+  newGameBtn: {
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 8,
+    backgroundColor: "#00ffcc",
+  },
+  newGameBtnText: {
+    color: "#000010",
+    fontWeight: "bold",
+    fontSize: 16,
+    letterSpacing: 1,
+  },
+});

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -16,12 +16,16 @@ export interface GameCanvasHandle {
   reset: () => void;
   setPlayerX: (x: number) => void;
   setFire: (fire: boolean) => void;
+  setChargeShot: (fire: boolean) => void;
 }
 
 interface Props {
   highScore?: number;
   onGameOver?: (finalScore: number) => void;
   onScoreChange?: (score: number) => void;
+  onPlayerHit?: () => void;
+  onWaveClear?: () => void;
+  isPaused?: boolean;
   width: number;
   height: number;
   scale: number;
@@ -33,24 +37,40 @@ interface RenderState {
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ highScore = 0, onGameOver, onScoreChange, width, height, scale }, ref) => {
+  ({ highScore = 0, onGameOver, onScoreChange, onPlayerHit, onWaveClear, isPaused = false, width, height, scale }, ref) => {
     const { t } = useTranslation("starswarm");
     const images = useStarSwarmImages();
 
     const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
-    const inputRef = useRef({ playerX: width / 2, fire: true });
+    const inputRef = useRef({ playerX: width / 2, fire: true, chargeShot: false });
     const lastFrameTimeRef = useRef(0);
     const prevScoreRef = useRef(0);
+    const prevLivesRef = useRef(gameRef.current.player.lives);
+    const prevPhaseRef = useRef(gameRef.current.phase);
+    const isPausedRef = useRef(isPaused);
     const onGameOverRef = useRef(onGameOver);
     const onScoreChangeRef = useRef(onScoreChange);
+    const onPlayerHitRef = useRef(onPlayerHit);
+    const onWaveClearRef = useRef(onWaveClear);
 
+    useEffect(() => {
+      const wasPaused = isPausedRef.current;
+      isPausedRef.current = isPaused;
+      if (wasPaused && !isPaused) lastFrameTimeRef.current = 0; // prevent delta spike on resume
+    }, [isPaused]);
     useEffect(() => {
       onGameOverRef.current = onGameOver;
     }, [onGameOver]);
     useEffect(() => {
       onScoreChangeRef.current = onScoreChange;
     }, [onScoreChange]);
+    useEffect(() => {
+      onPlayerHitRef.current = onPlayerHit;
+    }, [onPlayerHit]);
+    useEffect(() => {
+      onWaveClearRef.current = onWaveClear;
+    }, [onWaveClear]);
 
     const [renderState, setRenderState] = useState<RenderState>({
       game: gameRef.current,
@@ -64,7 +84,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           gameRef.current = initStarSwarm(width, height);
           sfRef.current = initStarfield(width, height);
           inputRef.current.playerX = width / 2;
+          inputRef.current.chargeShot = false;
           prevScoreRef.current = 0;
+          prevLivesRef.current = gameRef.current.player.lives;
+          prevPhaseRef.current = gameRef.current.phase;
           setRenderState({ game: gameRef.current, sf: sfRef.current });
         },
         setPlayerX(x) {
@@ -72,6 +95,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         setFire(fire) {
           inputRef.current.fire = fire;
+        },
+        setChargeShot(fire) {
+          inputRef.current.chargeShot = fire;
         },
       }),
       [width, height]
@@ -87,16 +113,26 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         lastFrameTimeRef.current = timestamp;
 
         const prev = gameRef.current;
-        if (prev.phase !== "GameOver") {
+        if (prev.phase !== "GameOver" && !isPausedRef.current) {
           const next = tick(prev, dtMs, {
             playerX: inputRef.current.playerX,
             fire: inputRef.current.fire,
+            chargeShot: inputRef.current.chargeShot,
           });
+          if (inputRef.current.chargeShot) inputRef.current.chargeShot = false;
           gameRef.current = next;
           if (next.score !== prevScoreRef.current) {
             prevScoreRef.current = next.score;
             onScoreChangeRef.current?.(next.score);
           }
+          if (next.player.lives < prevLivesRef.current) {
+            if (next.phase !== "GameOver") onPlayerHitRef.current?.();
+          }
+          prevLivesRef.current = next.player.lives;
+          if (next.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
+            onWaveClearRef.current?.();
+          }
+          prevPhaseRef.current = next.phase;
           if (next.phase === "GameOver") {
             onGameOverRef.current?.(next.score);
           }

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -37,7 +37,20 @@ interface RenderState {
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ highScore = 0, onGameOver, onScoreChange, onPlayerHit, onWaveClear, isPaused = false, width, height, scale }, ref) => {
+  (
+    {
+      highScore = 0,
+      onGameOver,
+      onScoreChange,
+      onPlayerHit,
+      onWaveClear,
+      isPaused = false,
+      width,
+      height,
+      scale,
+    },
+    ref
+  ) => {
     const { t } = useTranslation("starswarm");
     const images = useStarSwarmImages();
 

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -91,7 +91,20 @@ interface Props {
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ highScore = 0, onGameOver, onScoreChange, onPlayerHit, onWaveClear, isPaused = false, width, height, scale }, ref) => {
+  (
+    {
+      highScore = 0,
+      onGameOver,
+      onScoreChange,
+      onPlayerHit,
+      onWaveClear,
+      isPaused = false,
+      width,
+      height,
+      scale,
+    },
+    ref
+  ) => {
     const { t } = useTranslation("starswarm");
     const tRef = useRef(t);
     useEffect(() => {

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -75,19 +75,23 @@ export interface GameCanvasHandle {
   reset: () => void;
   setPlayerX: (x: number) => void;
   setFire: (fire: boolean) => void;
+  setChargeShot: (fire: boolean) => void;
 }
 
 interface Props {
   highScore?: number;
   onGameOver?: (finalScore: number) => void;
   onScoreChange?: (score: number) => void;
+  onPlayerHit?: () => void;
+  onWaveClear?: () => void;
+  isPaused?: boolean;
   width: number;
   height: number;
   scale: number;
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
-  ({ highScore = 0, onGameOver, onScoreChange, width, height, scale }, ref) => {
+  ({ highScore = 0, onGameOver, onScoreChange, onPlayerHit, onWaveClear, isPaused = false, width, height, scale }, ref) => {
     const { t } = useTranslation("starswarm");
     const tRef = useRef(t);
     useEffect(() => {
@@ -98,12 +102,17 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const scaleRef = useRef(scale);
     const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
-    const inputRef = useRef({ playerX: width / 2, fire: true });
+    const inputRef = useRef({ playerX: width / 2, fire: true, chargeShot: false });
     const lastFrameTimeRef = useRef(0);
     const highScoreRef = useRef(highScore);
     const onGameOverRef = useRef(onGameOver);
     const onScoreChangeRef = useRef(onScoreChange);
+    const onPlayerHitRef = useRef(onPlayerHit);
+    const onWaveClearRef = useRef(onWaveClear);
+    const isPausedRef = useRef(isPaused);
     const prevScoreRef = useRef(0);
+    const prevLivesRef = useRef(stateRef.current.player.lives);
+    const prevPhaseRef = useRef(stateRef.current.phase);
     const imagesRef = useRef<Images>({
       playerShip: null,
       enemyGrunt: null,
@@ -126,6 +135,17 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onScoreChangeRef.current = onScoreChange;
     }, [onScoreChange]);
+    useEffect(() => {
+      onPlayerHitRef.current = onPlayerHit;
+    }, [onPlayerHit]);
+    useEffect(() => {
+      onWaveClearRef.current = onWaveClear;
+    }, [onWaveClear]);
+    useEffect(() => {
+      const wasPaused = isPausedRef.current;
+      isPausedRef.current = isPaused;
+      if (wasPaused && !isPaused) lastFrameTimeRef.current = 0;
+    }, [isPaused]);
 
     useEffect(() => {
       let cancelled = false;
@@ -191,13 +211,19 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           stateRef.current = initStarSwarm(width, height);
           sfRef.current = initStarfield(width, height);
           inputRef.current.playerX = width / 2;
+          inputRef.current.chargeShot = false;
           prevScoreRef.current = 0;
+          prevLivesRef.current = stateRef.current.player.lives;
+          prevPhaseRef.current = stateRef.current.phase;
         },
         setPlayerX(x) {
           inputRef.current.playerX = x;
         },
         setFire(fire) {
           inputRef.current.fire = fire;
+        },
+        setChargeShot(fire) {
+          inputRef.current.chargeShot = fire;
         },
       }),
       [width, height]
@@ -396,16 +422,26 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         lastFrameTimeRef.current = timestamp;
 
         const prev = stateRef.current;
-        if (prev.phase !== "GameOver") {
+        if (prev.phase !== "GameOver" && !isPausedRef.current) {
           const next = tick(prev, dtMs, {
             playerX: inputRef.current.playerX,
             fire: inputRef.current.fire,
+            chargeShot: inputRef.current.chargeShot,
           });
+          if (inputRef.current.chargeShot) inputRef.current.chargeShot = false;
           stateRef.current = next;
           if (next.score !== prevScoreRef.current) {
             prevScoreRef.current = next.score;
             onScoreChangeRef.current?.(next.score);
           }
+          if (next.player.lives < prevLivesRef.current) {
+            if (next.phase !== "GameOver") onPlayerHitRef.current?.();
+          }
+          prevLivesRef.current = next.player.lives;
+          if (next.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
+            onWaveClearRef.current?.();
+          }
+          prevPhaseRef.current = next.phase;
           if (next.phase === "GameOver") {
             onGameOverRef.current?.(next.score);
           }

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../engine";
 import type { Bullet, StarSwarmInput, StarSwarmState } from "../types";
 
-const NO_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: false };
-const FIRE_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: true };
+const NO_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: false, chargeShot: false };
+const FIRE_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: true, chargeShot: false };
 
 function advanceMs(state: StarSwarmState, ms: number, input = NO_INPUT): StarSwarmState {
   const step = 16;
@@ -173,6 +173,7 @@ describe("Collision: player bullets vs enemies", () => {
       owner: "player",
       width: 5,
       height: 14,
+      damage: 1,
     };
     s = { ...s, playerBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -189,7 +190,7 @@ describe("Collision: player bullets vs enemies", () => {
     const target = s.enemies.find((e) => e.isAlive && e.tier === "Grunt");
     if (!target) return; // no grunt on this wave config, skip
 
-    const aim: StarSwarmInput = { playerX: target.x, fire: true };
+    const aim: StarSwarmInput = { playerX: target.x, fire: true, chargeShot: false };
     s = advanceMs(s, 3000, aim);
     expect(s.score).toBeGreaterThan(scoreBefore);
   });
@@ -201,7 +202,7 @@ describe("Collision: player bullets vs enemies", () => {
     const target = s.enemies.find((e) => e.isAlive);
     if (!target) return;
 
-    const aim: StarSwarmInput = { playerX: target.x, fire: true };
+    const aim: StarSwarmInput = { playerX: target.x, fire: true, chargeShot: false };
     s = tick(s, 16, aim); // fire one bullet
     const bulletsBefore = s.playerBullets.length;
 
@@ -234,6 +235,7 @@ describe("Collision: enemy bullets vs player", () => {
       owner: "enemy" as const,
       width: 5,
       height: 10,
+      damage: 1,
     };
     s = { ...s, enemyBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -257,6 +259,7 @@ describe("Collision: enemy bullets vs player", () => {
       owner: "enemy" as const,
       width: 5,
       height: 10,
+      damage: 1,
     };
     s = { ...s, enemyBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -278,6 +281,7 @@ describe("Collision: enemy bullets vs player", () => {
       owner: "enemy" as const,
       width: 5,
       height: 10,
+      damage: 1,
     };
     s = { ...s, enemyBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -299,6 +303,7 @@ describe("Collision: enemy bullets vs player", () => {
       owner: "enemy" as const,
       width: 50,
       height: 50,
+      damage: 1,
     };
     s = { ...s, enemyBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -329,6 +334,7 @@ describe("Scoring", () => {
       owner: "player" as const,
       width: 5,
       height: 14,
+      damage: 1,
     };
     s = { ...s, playerBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);
@@ -351,6 +357,7 @@ describe("Scoring", () => {
       owner: "player" as const,
       width: 5,
       height: 14,
+      damage: 1,
     });
     const scoreBeforeKill = s.score;
     s = { ...s, playerBullets: [makeBullet(1)] };
@@ -445,6 +452,7 @@ describe("ChallengingStage", () => {
       owner: "player",
       width: 5,
       height: 14,
+      damage: 1,
     };
     s = { ...s, playerBullets: [bullet] };
     s = tick(s, 16, NO_INPUT);

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -27,6 +27,10 @@ const BULLET_P_W = 5;
 const BULLET_P_H = 14;
 const BULLET_P_VY = -0.56; // px/ms upward
 
+const BULLET_C_W = 12; // charge shot — wider
+const BULLET_C_H = 22;
+const CHARGE_SHOOT_COOLDOWN = 900; // ms; longer cooldown than auto-fire
+
 const BULLET_E_W = 5;
 const BULLET_E_H = 10;
 const BULLET_E_VY = 0.2; // px/ms downward
@@ -394,22 +398,43 @@ function tickPlayer(state: StarSwarmState, dtMs: number, input: StarSwarmInput):
 
   const player: Player = { ...p, x: newX, invincibleTimer, shootCooldown };
 
-  if (input.fire && shootCooldown === 0) {
-    const bullet: Bullet = {
-      id: nextId(),
-      x: newX,
-      y: p.y - p.height / 2,
-      vx: 0,
-      vy: BULLET_P_VY,
-      owner: "player",
-      width: BULLET_P_W,
-      height: BULLET_P_H,
-    };
-    return {
-      ...state,
-      player: { ...player, shootCooldown: PLAYER_SHOOT_COOLDOWN },
-      playerBullets: [...state.playerBullets, bullet],
-    };
+  if (shootCooldown === 0) {
+    if (input.chargeShot) {
+      const bullet: Bullet = {
+        id: nextId(),
+        x: newX,
+        y: p.y - p.height / 2,
+        vx: 0,
+        vy: BULLET_P_VY,
+        owner: "player",
+        width: BULLET_C_W,
+        height: BULLET_C_H,
+        damage: 2,
+      };
+      return {
+        ...state,
+        player: { ...player, shootCooldown: CHARGE_SHOOT_COOLDOWN },
+        playerBullets: [...state.playerBullets, bullet],
+      };
+    }
+    if (input.fire) {
+      const bullet: Bullet = {
+        id: nextId(),
+        x: newX,
+        y: p.y - p.height / 2,
+        vx: 0,
+        vy: BULLET_P_VY,
+        owner: "player",
+        width: BULLET_P_W,
+        height: BULLET_P_H,
+        damage: 1,
+      };
+      return {
+        ...state,
+        player: { ...player, shootCooldown: PLAYER_SHOOT_COOLDOWN },
+        playerBullets: [...state.playerBullets, bullet],
+      };
+    }
   }
 
   return { ...state, player };
@@ -506,6 +531,7 @@ function tickFormation(
       owner: "enemy",
       width: BULLET_E_W,
       height: BULLET_E_H,
+      damage: 1,
     };
     return {
       enemy: {
@@ -668,7 +694,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
       if (!aabb(b.x, b.y, b.width, b.height, enemy.x, enemy.y, enemy.width, enemy.height)) continue;
 
       hitBulletIds.add(b.id);
-      const newHp = enemy.hp - 1;
+      const newHp = enemy.hp - b.damage;
 
       if (newHp <= 0) {
         newExplosions.push(spawnExplosion(enemy.x, enemy.y));

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -74,6 +74,7 @@ export interface Bullet {
   readonly owner: "player" | "enemy";
   readonly width: number;
   readonly height: number;
+  readonly damage: number;
 }
 
 export interface Player {
@@ -121,6 +122,8 @@ export interface StarSwarmState {
 export interface StarSwarmInput {
   /** Desired player center X in logical canvas pixels. */
   readonly playerX: number;
-  /** true while fire button is held. */
+  /** true while auto-fire is active. */
   readonly fire: boolean;
+  /** One-shot: fire a charge bullet this tick (Controls resets to false after one frame). */
+  readonly chargeShot: boolean;
 }

--- a/frontend/src/i18n/locales/_meta/starswarm.meta.json
+++ b/frontend/src/i18n/locales/_meta/starswarm.meta.json
@@ -106,5 +106,59 @@
     "placeholders": ["{{score}}"],
     "doNotTranslate": [],
     "notes": null
+  },
+  "controls.chargeShotLabel": {
+    "component": "Controls",
+    "description": "Accessibility label for the charge shot button.",
+    "tone": "functional, descriptive",
+    "characterLimit": 50,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "controls.paused": {
+    "component": "Controls",
+    "description": "Large text shown in the pause overlay.",
+    "tone": "neutral, arcade",
+    "characterLimit": 10,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "controls.tapToResume": {
+    "component": "Controls",
+    "description": "Hint text under the PAUSED heading — instructs user to tap to resume.",
+    "tone": "functional",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "controls.resumeLabel": {
+    "component": "Controls",
+    "description": "Accessibility label for the pause-overlay resume pressable.",
+    "tone": "functional",
+    "characterLimit": 20,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "controls.newGame": {
+    "component": "Controls",
+    "description": "Label on the new-game button shown on the game-over screen.",
+    "tone": "action, brief",
+    "characterLimit": 10,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
+  },
+  "controls.newGameLabel": {
+    "component": "Controls",
+    "description": "Accessibility label for the new-game button.",
+    "tone": "functional",
+    "characterLimit": 25,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": null
   }
 }

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -10,5 +10,11 @@
   "phase.challengingStage": "CHALLENGING STAGE",
   "phase.hits": "HITS: {{count}}",
   "phase.gameOver": "GAME OVER",
-  "score.display": "Score: {{score}}"
+  "score.display": "Score: {{score}}",
+  "controls.chargeShotLabel": "Charge shot — hold and release to fire",
+  "controls.paused": "PAUSED",
+  "controls.tapToResume": "Tap to resume",
+  "controls.resumeLabel": "Resume game",
+  "controls.newGame": "NEW GAME",
+  "controls.newGameLabel": "Start a new game"
 }

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -23,7 +23,6 @@ export default function StarSwarmScreen() {
 
   const canvasRef = useRef<GameCanvasHandle>(null);
 
-  const [score, setScore] = useState(0);
   const [highScore, setHighScore] = useState(0);
   const [phase, setPhase] = useState<GamePhase>("SwoopIn");
   const [isPaused, setIsPaused] = useState(false);
@@ -41,7 +40,6 @@ export default function StarSwarmScreen() {
 
   const handleScoreChange = useCallback((s: number) => {
     scoreRef.current = s;
-    setScore(s);
   }, []);
 
   const handleGameOver = useCallback((finalScore: number) => {
@@ -62,16 +60,8 @@ export default function StarSwarmScreen() {
     hapticWaveClear();
   }, []);
 
-  // GameCanvas reports phase changes only for GameOver / WaveClear via callbacks.
-  // For other phases we rely on the game loop advancing — this is cosmetic only
-  // (phase is used by Controls to know when to show buttons).
-  const handlePhaseResume = useCallback(() => {
-    setPhase("Playing");
-  }, []);
-
   const handleNewGame = useCallback(() => {
     scoreRef.current = 0;
-    setScore(0);
     setPhase("SwoopIn");
     setIsPaused(false);
     canvasRef.current?.reset();
@@ -86,9 +76,7 @@ export default function StarSwarmScreen() {
   }, []);
 
   const scale =
-    containerW > 0 && containerH > 0
-      ? Math.min(containerW / CANVAS_W, containerH / CANVAS_H)
-      : 0;
+    containerW > 0 && containerH > 0 ? Math.min(containerW / CANVAS_W, containerH / CANVAS_H) : 0;
 
   const displayW = Math.round(CANVAS_W * scale);
   const displayH = Math.round(CANVAS_H * scale);

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -1,0 +1,145 @@
+import React, { useCallback, useRef, useState } from "react";
+import { LayoutChangeEvent, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { HomeStackParamList } from "../../App";
+import { GameShell } from "../components/shared/GameShell";
+import GameCanvas from "../components/starswarm/GameCanvas";
+import type { GameCanvasHandle } from "../components/starswarm/GameCanvas";
+import Controls, {
+  hapticPlayerHit,
+  hapticPlayerDeath,
+  hapticWaveClear,
+} from "../components/starswarm/Controls";
+import { CANVAS_W, CANVAS_H } from "../game/starswarm/engine";
+import type { GamePhase } from "../game/starswarm/types";
+
+export default function StarSwarmScreen() {
+  const { t } = useTranslation("starswarm");
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList, "StarSwarm">>();
+
+  const canvasRef = useRef<GameCanvasHandle>(null);
+
+  const [score, setScore] = useState(0);
+  const [highScore, setHighScore] = useState(0);
+  const [phase, setPhase] = useState<GamePhase>("SwoopIn");
+  const [isPaused, setIsPaused] = useState(false);
+  const [containerW, setContainerW] = useState(0);
+  const [containerH, setContainerH] = useState(0);
+
+  const scoreRef = useRef(0);
+  const highScoreRef = useRef(0);
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    const { width, height } = e.nativeEvent.layout;
+    setContainerW(Math.floor(width));
+    setContainerH(Math.floor(height));
+  }, []);
+
+  const handleScoreChange = useCallback((s: number) => {
+    scoreRef.current = s;
+    setScore(s);
+  }, []);
+
+  const handleGameOver = useCallback((finalScore: number) => {
+    setPhase("GameOver");
+    hapticPlayerDeath();
+    if (finalScore > highScoreRef.current) {
+      highScoreRef.current = finalScore;
+      setHighScore(finalScore);
+    }
+  }, []);
+
+  const handlePlayerHit = useCallback(() => {
+    hapticPlayerHit();
+  }, []);
+
+  const handleWaveClear = useCallback(() => {
+    setPhase("WaveClear");
+    hapticWaveClear();
+  }, []);
+
+  // GameCanvas reports phase changes only for GameOver / WaveClear via callbacks.
+  // For other phases we rely on the game loop advancing — this is cosmetic only
+  // (phase is used by Controls to know when to show buttons).
+  const handlePhaseResume = useCallback(() => {
+    setPhase("Playing");
+  }, []);
+
+  const handleNewGame = useCallback(() => {
+    scoreRef.current = 0;
+    setScore(0);
+    setPhase("SwoopIn");
+    setIsPaused(false);
+    canvasRef.current?.reset();
+  }, []);
+
+  const handlePause = useCallback(() => {
+    setIsPaused(true);
+  }, []);
+
+  const handleResume = useCallback(() => {
+    setIsPaused(false);
+  }, []);
+
+  const scale =
+    containerW > 0 && containerH > 0
+      ? Math.min(containerW / CANVAS_W, containerH / CANVAS_H)
+      : 0;
+
+  const displayW = Math.round(CANVAS_W * scale);
+  const displayH = Math.round(CANVAS_H * scale);
+
+  return (
+    <GameShell
+      title={t("game.title")}
+      requireBack
+      onBack={() => navigation.popToTop()}
+      onNewGame={handleNewGame}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 8),
+        paddingLeft: Math.max(insets.left, 0),
+        paddingRight: Math.max(insets.right, 0),
+      }}
+    >
+      <View style={styles.canvasOuter} onLayout={onLayout}>
+        {scale > 0 && (
+          <View style={{ width: displayW, height: displayH }}>
+            <GameCanvas
+              ref={canvasRef}
+              highScore={highScore}
+              onScoreChange={handleScoreChange}
+              onGameOver={handleGameOver}
+              onPlayerHit={handlePlayerHit}
+              onWaveClear={handleWaveClear}
+              isPaused={isPaused}
+              width={CANVAS_W}
+              height={CANVAS_H}
+              scale={scale}
+            />
+            <Controls
+              canvasRef={canvasRef}
+              scale={scale}
+              phase={phase}
+              isPaused={isPaused}
+              onPause={handlePause}
+              onResume={handleResume}
+              onNewGame={handleNewGame}
+            />
+          </View>
+        )}
+      </View>
+    </GameShell>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvasOuter: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -5,6 +5,7 @@ import React from "react";
 // React.lazy promise resolves synchronously on navigation.
 const factories = {
   Cascade: () => import("../screens/CascadeScreen"),
+  StarSwarm: () => import("../screens/StarSwarmScreen"),
   BlackjackBetting: () => import("../screens/BlackjackBettingScreen"),
   BlackjackTable: () => import("../screens/BlackjackTableScreen"),
   Twenty48: () => import("../screens/Twenty48Screen"),
@@ -20,6 +21,7 @@ const factories = {
 
 export const LazyScreens = {
   Cascade: React.lazy(factories.Cascade),
+  StarSwarm: React.lazy(factories.StarSwarm),
   BlackjackBetting: React.lazy(factories.BlackjackBetting),
   BlackjackTable: React.lazy(factories.BlackjackTable),
   Twenty48: React.lazy(factories.Twenty48),


### PR DESCRIPTION
Closes #802

## Summary
- **`Controls.tsx`** — gesture layer over the game canvas: relative-drag movement (bottom 40% zone), charge shot Pressable (hold → release fires a wider damage-2 bullet), tap-in-top-zone pause, game-over new-game button
- **`StarSwarmScreen.tsx`** — full portrait screen wiring `GameCanvas` + `Controls`, routes haptic callbacks to `expo-haptics`
- **Engine** — `Bullet.damage` field; `StarSwarmInput.chargeShot` fires a 12×22px bullet that deals 2 HP with a 900ms cooldown; collision uses `b.damage`
- **GameCanvas (native + web)** — `setChargeShot` handle method; `isPaused` prop freezes `tick()` without killing the RAF (delta resets on resume); `onPlayerHit` / `onWaveClear` callbacks detected from lives/phase changes in the RAF loop
- **Routing** — `StarSwarm` registered in `HomeStackParamList`, `lazyScreens.ts`, and `App.tsx` nav stack

## Test plan
- [ ] Pan gesture moves ship left/right relative to finger delta (not absolute position)
- [ ] Drag zone only activates in bottom 40% of canvas
- [ ] Charge shot button lights up on press-in, fires wider bullet on release
- [ ] Short tap in top 60% pauses game; tap on pause overlay resumes
- [ ] Player hit → short haptic; player death → medium haptic; wave clear → success notification
- [ ] New Game button on game-over resets score and board
- [ ] Mouse drag + click work on Expo Web
- [ ] All 38 engine unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)