### PR TITLE
feat(#805): Star Swarm backend — score submission + leaderboard

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from hearts.router import router as hearts_router
 from solitaire.router import router as solitaire_router
 from sudoku.router import router as sudoku_router
 from yacht.router import router as yacht_router
+from starswarm.router import router as starswarm_router
 from games.router import router as games_router
 from logs.router import router as logs_router
 from stats.router import router as stats_router
@@ -58,6 +59,7 @@ app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(sudoku_router, prefix="/sudoku")
+app.include_router(starswarm_router, prefix="/starswarm")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")
 app.include_router(stats_router, prefix="/stats")

--- a/backend/starswarm/router.py
+++ b/backend/starswarm/router.py
@@ -1,0 +1,77 @@
+"""Star Swarm high score submission + leaderboard (#805).
+
+In-memory store — no DB required. Top-10 by score, tie-broken by submission
+time (earlier submission wins on equal score).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from limiter import limiter, session_key
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+
+_scores: list[dict] = []
+
+
+class ScoreRequest(BaseModel):
+    player_id: str = Field(..., min_length=1, max_length=64)
+    score: int = Field(..., ge=0)
+    wave_reached: int = Field(..., ge=1)
+
+
+class LeaderboardEntry(BaseModel):
+    player_id: str
+    score: int
+    wave_reached: int
+    timestamp: str
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[LeaderboardEntry]
+
+
+def _top10() -> list[LeaderboardEntry]:
+    ranked = sorted(_scores, key=lambda s: (-s["score"], s["submitted_at"]))[:LEADERBOARD_LIMIT]
+    return [
+        LeaderboardEntry(
+            player_id=s["player_id"],
+            score=s["score"],
+            wave_reached=s["wave_reached"],
+            timestamp=s["submitted_at"].isoformat(),
+            rank=i + 1,
+        )
+        for i, s in enumerate(ranked)
+    ]
+
+
+@router.post("/score", response_model=LeaderboardResponse, status_code=200)
+@limiter.limit("10/minute", key_func=session_key)
+async def submit_score(request: Request, body: ScoreRequest) -> LeaderboardResponse:
+    _scores.append(
+        {
+            "player_id": body.player_id,
+            "score": body.score,
+            "wave_reached": body.wave_reached,
+            "submitted_at": datetime.now(tz=timezone.utc),
+        }
+    )
+    return LeaderboardResponse(scores=_top10())
+
+
+@router.get("/leaderboard", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_leaderboard(request: Request) -> LeaderboardResponse:
+    return LeaderboardResponse(scores=_top10())
+
+
+def reset_leaderboard() -> None:
+    """Test helper — clears the in-memory store."""
+    _scores.clear()


### PR DESCRIPTION
## Summary
- `POST /starswarm/score` — validates `player_id`, `score` (≥ 0), `wave_reached` (≥ 1); stores in-memory; returns updated top-10 leaderboard; rate-limited 10/min by session ID
- `GET /starswarm/leaderboard` — top-10 sorted by score desc, tie-broken by submission time; rate-limited 60/min by IP
- Router registered at `/starswarm` in `main.py`

## Test plan
- [ ] Existing 603-test suite passes (82% coverage, above 80% threshold)
- [ ] `POST /starswarm/score` with valid payload returns 200 + leaderboard
- [ ] `POST /starswarm/score` with `score: -1` returns 422
- [ ] `POST /starswarm/score` with `wave_reached: 0` returns 422
- [ ] `GET /starswarm/leaderboard` returns top-10 ordered correctly
- [ ] Dedicated tests to follow in #806

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)