### PR TITLE
fix(migrations): shorten 0010 revision ID to fit alembic_version VARCHAR(32)

### DIFF
--- a/backend/alembic/versions/0010_seed_event_types.py
+++ b/backend/alembic/versions/0010_seed_event_types.py
@@ -1,6 +1,6 @@
 """seed event_types for solitaire, hearts, and sudoku (#697)
 
-Revision ID: 0010_add_event_types_solitaire_hearts_sudoku
+Revision ID: 0010_seed_event_types
 Revises: 0009_add_sudoku_game_type
 Create Date: 2026-04-21
 
@@ -18,7 +18,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0010_add_event_types_solitaire_hearts_sudoku"
+revision: str = "0010_seed_event_types"
 down_revision: Union[str, None] = "0009_add_sudoku_game_type"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0010_add_event_types_solitaire_hearts_sudoku"
+        assert version == "0010_seed_event_types"

--- a/backend/tests/test_migration_invariants.py
+++ b/backend/tests/test_migration_invariants.py
@@ -136,6 +136,35 @@ def _parse_frontend_event_names() -> set[str]:
     return names
 
 
+_ALEMBIC_VERSION_MAX_LEN = 32  # alembic_version.version_num is VARCHAR(32)
+
+
+def test_revision_ids_fit_in_alembic_version_column() -> None:
+    """All migration revision IDs must be ≤ 32 chars to fit in alembic_version VARCHAR(32).
+
+    Regression guard for the bug that blocked deploys via migrations 0003 and 0010:
+    alembic writes version_num to the DB after running upgrade(), and Postgres rejects
+    values longer than VARCHAR(32) with StringDataRightTruncation, rolling back the
+    entire migration transaction and leaving the service undeployable.
+    """
+    too_long: list[str] = []
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        text = path.read_text(encoding="utf-8")
+        m = re.search(r'^revision\s*:\s*str\s*=\s*"([^"]+)"', text, re.MULTILINE)
+        if m:
+            rev_id = m.group(1)
+            if len(rev_id) > _ALEMBIC_VERSION_MAX_LEN:
+                too_long.append(f"  {path.name}: '{rev_id}' ({len(rev_id)} chars)")
+
+    assert not too_long, (
+        "These migration revision IDs exceed VARCHAR(32) and will break 'alembic upgrade head':\n"
+        + "\n".join(too_long)
+        + "\n\nFix: shorten the revision string to ≤ 32 characters."
+    )
+
+
 def test_event_queue_config_names_are_seeded_in_backend() -> None:
     """Every event type declared in frontend/eventQueueConfig.ts must exist in at
     least one game's event_types rows across all migrations (#746 PR-B).


### PR DESCRIPTION
## Summary

- Renames migration `0010_add_event_types_solitaire_hearts_sudoku` → `0010_seed_event_types` (44 → 21 chars)
- Adds `test_revision_ids_fit_in_alembic_version_column` to `test_migration_invariants.py`

## Root cause

`alembic_version.version_num` is `VARCHAR(32)`. After migration 0010's data inserts ran successfully, alembic tried to write the 44-char revision ID back to the `alembic_version` table. Postgres threw `StringDataRightTruncation`, rolling back the entire transaction. The migration appeared to apply but was never stamped, so every subsequent deploy retried and failed identically — blocking all backend deploys from 2026-04-22 through today (5 failures).

Same root cause as migration 0003 (#658).

Fixes #878. Closes by adding a CI guard so this can't recur.

## Test plan

- [x] `alembic upgrade head` ran successfully against the live dev DB with the renamed revision ID
- [x] `test_revision_ids_fit_in_alembic_version_column` passes locally
- [x] All revision IDs in `alembic/versions/` are ≤ 32 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)