### PR TITLE
feat(#804): Star Swarm screen + navigation

### DIFF
--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -39,6 +39,7 @@ export default function HomeScreen() {
     "freecell",
     "hearts",
     "sudoku",
+    "starswarm",
     "errors",
   ]);
   const { colors } = useTheme();
@@ -127,6 +128,13 @@ export default function HomeScreen() {
       description: t("sudoku:game.description"),
       action: () => navigation.navigate("Sudoku"),
     },
+    {
+      key: "starswarm",
+      emoji: "👾",
+      title: t("starswarm:game.title"),
+      description: t("starswarm:game.description"),
+      action: () => navigation.navigate("StarSwarm"),
+    },
   ];
 
   const playLabels: Record<string, string> = {
@@ -138,6 +146,7 @@ export default function HomeScreen() {
     [t("freecell:game.title")]: t("freecell:game.playLabel"),
     [t("hearts:game.title")]: t("hearts:game.playLabel"),
     [t("sudoku:game.title")]: t("sudoku:game.playLabel"),
+    [t("starswarm:game.title")]: t("starswarm:game.playLabel"),
   };
 
   // Cycle through BC Arcade accent colors for the gradient top border on each card.

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -43,6 +43,7 @@ export const LazyScreens = {
  */
 export function prefetchLobbyGameScreens(): void {
   factories.Cascade().catch(() => undefined);
+  factories.StarSwarm().catch(() => undefined);
   factories.BlackjackBetting().catch(() => undefined);
   factories.Twenty48().catch(() => undefined);
   factories.Solitaire().catch(() => undefined);


### PR DESCRIPTION
## Summary
- Adds Star Swarm game card to the home screen grid (`👾` emoji, i18n title/description, `navigate("StarSwarm")`)
- Adds `starswarm` to `useTranslation` namespaces and `playLabels` map in `HomeScreen.tsx`
- Adds `StarSwarm` to `prefetchLobbyGameScreens()` so the chunk is warm before the user taps

All other wiring (screen, navigation types, lazy screen registration, i18n keys) was already in place from prior PRs.

Closes #804

## Test plan
- [ ] Home screen shows "Star Swarm" card with alien emoji
- [ ] Tapping the card navigates to StarSwarmScreen without a Suspense flash
- [ ] No regression on other game cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)