### PR TITLE
fix(deploy): set SKIP_SKIA_DOWNLOAD=1 for Expo Web frontend build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -38,6 +38,11 @@ services:
         value: "https://dev-games-api.buffingchi.com"
       - key: EXPO_PUBLIC_SENTRY_DSN
         sync: false
+      # react-native-skia's postinstall downloads native binaries for all platforms.
+      # This build only targets Expo Web; native binaries are not needed and the
+      # download fails transiently on CDN errors. Skip it unconditionally.
+      - key: SKIP_SKIA_DOWNLOAD
+        value: "1"
     headers:
       - path: /*
         name: Content-Security-Policy


### PR DESCRIPTION
## Summary

- Adds `SKIP_SKIA_DOWNLOAD=1` to `render.yaml` for the frontend service

## Root cause

`@shopify/react-native-skia@2.4.18` runs a postinstall script (`install-skia.mjs`) during `npm ci` that downloads prebuilt native binaries for every platform: Android (arm/arm64/x86), iOS, macOS, and tvOS. This is ~6 large tarballs per build.

The Render frontend build only produces `expo export --platform web`. None of the native binaries are needed for the web output. On 2026-04-26, the tvOS tarball download returned a 502 from the CDN, failing `npm ci` and the entire deploy.

`install-skia.mjs` supports `SKIP_SKIA_DOWNLOAD=1` to exit immediately (already set in the Render dashboard; this PR encodes it in source).

## Effect

- Eliminates ~30s of unnecessary downloads per build
- Removes CDN flakiness as a deploy failure vector
- No runtime impact (web bundle doesn't use native Skia binaries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)