### PR TITLE
fix(#883): stable star IDs eliminate duplicate-key warning in StarSwarm

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -182,9 +182,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             <Fill color="#000010" />
 
             {/* Starfield */}
-            {sf.stars.map((star, i) => (
+            {sf.stars.map((star) => (
               <Circle
-                key={i}
+                key={star.id}
                 cx={star.x}
                 cy={star.y}
                 r={star.r}

--- a/frontend/src/game/starswarm/starfield.ts
+++ b/frontend/src/game/starswarm/starfield.ts
@@ -1,4 +1,5 @@
 export interface Star {
+  id: number;
   x: number;
   y: number;
   /** Logical radius in canvas pixels. */
@@ -34,9 +35,11 @@ function makePrng(seed: number) {
 export function initStarfield(width: number, height: number, seed = 42): StarfieldState {
   const rand = makePrng(seed);
   const stars: Star[] = [];
+  let id = 0;
   for (const layer of LAYERS) {
     for (let i = 0; i < layer.count; i++) {
       stars.push({
+        id: id++,
         x: rand() * width,
         y: rand() * height,
         r: layer.r,


### PR DESCRIPTION
## Summary
- Adds a stable `id: number` field to the `Star` interface in `starfield.ts`
- Assigns sequential IDs at `initStarfield` time; `tickStarfield` preserves them via spread
- `GameCanvas` switches from `key={i}` (array index) to `key={star.id}` for the starfield render

At 60fps the RAF loop calls `setRenderState` every frame. Array-index keys gave React's reconciler two in-flight renders with the same numeric keys as siblings, producing the repeated warning seen during play.

Fixes #883
Epic: #798

## Test plan
- [ ] No duplicate-key warning in Metro console when playing Star Swarm
- [ ] Starfield scrolls and wraps correctly
- [ ] Existing starfield unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)