### PR TITLE
feat(#871): Mahjong Solitaire backend leaderboard

### DIFF
--- a/backend/alembic/versions/0011_add_mahjong_game_type.py
+++ b/backend/alembic/versions/0011_add_mahjong_game_type.py
@@ -1,0 +1,77 @@
+"""add mahjong to game_types lookup table and seed lifecycle events (#871)
+
+Revision ID: 0011_add_mahjong_game_type
+Revises: 0010_seed_event_types
+Create Date: 2026-04-26
+
+Part of Epic #870 — Mahjong Solitaire. Seeds the DB row so the
+GameType.MAHJONG enum member stays in sync with the game_types lookup
+table, and immediately seeds the two lifecycle event_types so
+gameEventClient.startGame / completeGame work on first deploy.
+The per-game module lives in backend/mahjong/.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_add_mahjong_game_type"
+down_revision: Union[str, None] = "0010_seed_event_types"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    game_types = sa.table(
+        "game_types",
+        sa.column("id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("icon_emoji", sa.Text),
+        sa.column("sort_order", sa.SmallInteger),
+        sa.column("is_active", sa.Boolean),
+    )
+    op.bulk_insert(
+        game_types,
+        [
+            {
+                "id": 9,
+                "name": "mahjong",
+                "display_name": "Mahjong Solitaire",
+                "icon_emoji": "🀄",
+                "sort_order": 90,
+                "is_active": True,
+            }
+        ],
+    )
+
+    event_types = sa.table(
+        "event_types",
+        sa.column("game_type_id", sa.SmallInteger),
+        sa.column("name", sa.Text),
+        sa.column("display_name", sa.Text),
+        sa.column("description", sa.Text),
+    )
+    op.bulk_insert(
+        event_types,
+        [
+            {
+                "game_type_id": 9,
+                "name": "game_started",
+                "display_name": "Game Started",
+                "description": None,
+            },
+            {
+                "game_type_id": 9,
+                "name": "game_ended",
+                "display_name": "Game Ended",
+                "description": None,
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM event_types WHERE game_type_id = 9")
+    op.execute("DELETE FROM game_types WHERE name = 'mahjong'")

--- a/backend/mahjong/models.py
+++ b/backend/mahjong/models.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MahjongMetadata(BaseModel):
+    """Validated metadata shape for Mahjong Solitaire game rows (#871).
+
+    ``player_name`` is optional here because the generic ``POST /games``
+    endpoint may be called without a name; the Mahjong-specific
+    ``POST /mahjong/score`` route always supplies it internally.
+    ``extra="forbid"`` rejects unknown keys.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    player_name: str = Field(default="", max_length=64)
+
+
+class ScoreSubmitRequest(BaseModel):
+    player_name: str = Field(..., min_length=1, max_length=32)
+    score: int = Field(..., ge=0)
+
+
+class ScoreEntry(BaseModel):
+    player_name: str
+    score: int
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/mahjong/module.py
+++ b/backend/mahjong/module.py
@@ -1,0 +1,21 @@
+"""Mahjong Solitaire GameModule descriptor (#871).
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from mahjong.models import MahjongMetadata
+from vocab import GameType
+
+
+class MahjongModule:
+    game_type = GameType.MAHJONG
+    metadata_model = MahjongMetadata
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = MahjongModule()

--- a/backend/mahjong/router.py
+++ b/backend/mahjong/router.py
@@ -1,0 +1,102 @@
+"""Mahjong Solitaire leaderboard (#871) — mirrors the Solitaire pattern.
+
+POST /mahjong/score inserts-and-completes a Game row tagged with
+``mahjong`` and the player name in ``game_metadata``.
+GET /mahjong/scores returns the top 10 rows for this game type,
+sorted by ``final_score`` descending (older entries break ties).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import LeaderboardResponse, ScoreEntry, ScoreSubmitRequest
+
+router = APIRouter()
+
+LEADERBOARD_LIMIT = 10
+_MAHJONG_SESSION = "mahjong-anon"
+
+
+async def _mahjong_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.MAHJONG))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="mahjong game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _mahjong_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        name = (g.game_metadata or {}).get("player_name") or "anon"
+        entries.append(ScoreEntry(player_name=str(name), score=int(g.final_score or 0), rank=i + 1))
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: ScoreSubmitRequest) -> ScoreEntry:
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _mahjong_game_type_id(db)
+        game = Game(
+            session_id=_MAHJONG_SESSION,
+            game_type_id=gt_id,
+            final_score=body.score,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={"player_name": body.player_name},
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if entry.player_name == body.player_name and entry.score == body.score:
+            return entry
+    return ScoreEntry(player_name=body.player_name, score=body.score, rank=LEADERBOARD_LIMIT + 1)
+
+
+@router.get("/scores", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. DB isolation handled by conftest's ``clean_db_tables``."""
+    return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from cascade.router import router as cascade_router
 from blackjack.router import router as blackjack_router
 from freecell.router import router as freecell_router
 from hearts.router import router as hearts_router
+from mahjong.router import router as mahjong_router
 from solitaire.router import router as solitaire_router
 from sudoku.router import router as sudoku_router
 from yacht.router import router as yacht_router
@@ -57,6 +58,7 @@ app.include_router(cascade_router, prefix="/cascade")
 app.include_router(blackjack_router, prefix="/blackjack")
 app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")
+app.include_router(mahjong_router, prefix="/mahjong")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(sudoku_router, prefix="/sudoku")
 app.include_router(starswarm_router, prefix="/starswarm")

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0010_seed_event_types"
+        assert version == "0011_add_mahjong_game_type"

--- a/backend/tests/test_db_schema.py
+++ b/backend/tests/test_db_schema.py
@@ -41,6 +41,7 @@ async def test_seed_data_present() -> None:
             "solitaire",
             "hearts",
             "sudoku",
+            "mahjong",
         ]
 
         total = (await s.execute(select(func.count()).select_from(EventType))).scalar_one()

--- a/backend/tests/test_mahjong_api.py
+++ b/backend/tests/test_mahjong_api.py
@@ -1,0 +1,158 @@
+"""Tests for /mahjong/score and /mahjong/scores (#871).
+
+Mirrors ``test_solitaire_api.py`` — every behaviour locked in for the
+Solitaire leaderboard (rank math, top-10 capping, rate limit, tie-break)
+must hold for Mahjong too.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+import mahjong.router as mahjong_router_module
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    mahjong_router_module.reset_leaderboard()
+    yield
+    mahjong_router_module.reset_leaderboard()
+
+
+def _submit(player_name: str, score: int):
+    return client.post("/mahjong/score", json={"player_name": player_name, "score": score})
+
+
+# ---------------------------------------------------------------------------
+# POST /mahjong/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 500)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["score"] == 500
+        assert body["rank"] == 1
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/mahjong/score", json={"score": 100})
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post("/mahjong/score", json={"player_name": "Bob"})
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        res = _submit("", 100)
+        assert res.status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        res = _submit("x" * 33, 100)
+        assert res.status_code == 422
+
+    def test_negative_score_returns_422(self):
+        res = _submit("Alice", -1)
+        assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /mahjong/scores
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/mahjong/scores")
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("Alice", 300)
+        _submit("Bob", 100)
+        scores = client.get("/mahjong/scores").json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_score_descending(self):
+        _submit("Alice", 100)
+        _submit("Bob", 500)
+        _submit("Carol", 250)
+        scores = client.get("/mahjong/scores").json()["scores"]
+        assert [s["score"] for s in scores] == [500, 250, 100]
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(15):
+            limiter.reset()
+            _submit(f"Player{i}", i * 10)
+        scores = client.get("/mahjong/scores").json()["scores"]
+        assert len(scores) == 10
+        assert scores[0]["score"] == 140
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 500).json()["rank"] == 1
+
+    def test_lower_score_ranked_lower(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 500)
+        limiter.reset()
+        assert _submit("Bob", 200).json()["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 1000)
+        limiter.reset()
+        assert _submit("Lowly", 1).json()["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — POST /mahjong/score is 5/min
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"Player{i}", i * 10).status_code == 201
+
+        assert _submit("Excess", 999).status_code == 429
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)
+        limiter.reset()
+        body = _submit("Bob", 100).json()
+
+        scores = client.get("/mahjong/scores").json()["scores"]
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"
+        assert body["rank"] == 2

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -65,7 +65,16 @@ def test_game_outcome_ts_in_sync() -> None:
 
 def test_game_type_enum_values() -> None:
     """Regression guard — no value should be silently removed from GameType."""
-    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts", "sudoku", "mahjong"}
+    expected = {
+        "yacht",
+        "twenty48",
+        "blackjack",
+        "cascade",
+        "solitaire",
+        "hearts",
+        "sudoku",
+        "mahjong",
+    }
     assert {v.value for v in GameType} == expected
 
 

--- a/backend/tests/test_vocab.py
+++ b/backend/tests/test_vocab.py
@@ -65,7 +65,7 @@ def test_game_outcome_ts_in_sync() -> None:
 
 def test_game_type_enum_values() -> None:
     """Regression guard — no value should be silently removed from GameType."""
-    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts", "sudoku"}
+    expected = {"yacht", "twenty48", "blackjack", "cascade", "solitaire", "hearts", "sudoku", "mahjong"}
     assert {v.value for v in GameType} == expected
 
 

--- a/backend/vocab.py
+++ b/backend/vocab.py
@@ -36,6 +36,7 @@ class GameType(str, Enum):
     SOLITAIRE = "solitaire"
     HEARTS = "hearts"
     SUDOKU = "sudoku"
+    MAHJONG = "mahjong"
 
 
 class GameOutcome(str, Enum):

--- a/frontend/src/api/vocab.ts
+++ b/frontend/src/api/vocab.ts
@@ -17,6 +17,7 @@ export const GAME_TYPES = [
   "solitaire",
   "hearts",
   "sudoku",
+  "mahjong",
 ] as const;
 
 export type GameType = (typeof GAME_TYPES)[number];


### PR DESCRIPTION
Part of #870 — closes #871

## Summary
- `GameType.MAHJONG = "mahjong"` added to `backend/vocab.py`; `frontend/src/api/vocab.ts` regenerated
- Alembic migration `0011`: inserts `game_types` row (id=9, emoji 🀄) **and** seeds `game_started`/`game_ended` lifecycle `event_types` in the same migration (learned from the 0010 retro-fix pattern)
- `backend/mahjong/` module: `models.py`, `module.py`, `router.py` — mirrors `backend/solitaire/` exactly
  - `POST /mahjong/score` — 5/min rate-limited, returns rank
  - `GET /mahjong/scores` — top-10, score descending, FIFO tie-break
- Router registered in `main.py` at `/mahjong`
- 15 new tests in `test_mahjong_api.py`; updated `test_vocab.py`, `test_db_connection.py`, `test_db_schema.py` for the new game type
- Full suite: **619 passed, 82% coverage**

## Architecture note
Backend is leaderboard-only (no move/tap/shuffle endpoints). Game logic runs client-side in the frontend engine (Story #872) for offline support — same pattern as Solitaire.

## Test plan
- [ ] `POST /mahjong/score` returns 201 with rank
- [ ] `GET /mahjong/scores` returns ordered top-10
- [ ] 6th submission within a minute returns 429
- [ ] Score not in top-10 returns rank 11
- [ ] All 619 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)