### PR TITLE
docs: add game architecture policy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,154 @@
+# BC Arcade — Game Architecture
+
+This document is policy. It applies to every game shipped in this repo. New games
+must be designed to fit; existing games that don't fit are tracked in linked
+issues for migration.
+
+## 1. Core principle
+
+**Offline-first single-player. Server-authoritative multi-player.**
+
+BC Arcade is a play-anywhere arcade. Players should be able to enjoy single-player
+games without a network connection. Cheating is not a meaningful threat to a
+casual single-player game; offline availability is. Multi-player justifies a
+different trust model and is treated separately.
+
+## 2. Single-player contract
+
+### 2.1 The client owns
+
+- The rule engine (`frontend/src/game/<name>/engine.ts`).
+- Session state during play, persisted to AsyncStorage so it survives app kill.
+- Event log generation with priority tags.
+- The submission queue (uses the shared pipeline — see §4).
+
+### 2.2 The server owns
+
+- Persistence: game records, final scores, event logs.
+- Identity and auth (when introduced).
+- **Boundary security:** input validation, payload size caps, rate limits,
+  content sanitization, ORM-only DB access. The OWASP layer stays even though
+  rule enforcement leaves. See §6.
+- Vocabulary: `GameType` and `GameOutcome` enums (see [GAME-CONTRACT.md](GAME-CONTRACT.md)).
+- Aggregates: leaderboards, ranks.
+
+### 2.3 The server explicitly does NOT
+
+- Validate game rules.
+- Recompute scores from event logs.
+- Hold in-memory session state for single-player games.
+
+## 3. The rule engine — written once
+
+For any game that may eventually support multi-player, the rule engine lives in
+**one place**: a TypeScript module at `frontend/src/game/<name>/engine.ts`.
+
+To allow the same engine to run server-side in multi-player, every engine must
+be:
+
+- **Headless** — no React, no UI, no platform imports inside `engine.ts`.
+- **Pure(ish)** — no AsyncStorage, network, audio, haptics, or other side
+  effects inside the engine itself. Side effects live one layer up (in screen /
+  hook / service code that consumes the engine).
+- **Runnable in Node** — covered by tests that import the engine and exercise it
+  outside React Native, to confirm portability.
+
+This is a discipline, not new infrastructure. Existing games are audited for
+compliance under epic #894.
+
+## 4. Persistence and offline contract
+
+Every game uses the shared submission pipeline. **No game implements its own
+queue.** The pipeline is:
+
+- `SyncWorker` — batched event flush with exponential backoff (1s → 30min).
+- `ScoreQueue` — outcome submissions, retried up to 5 attempts.
+- `PendingGamesStore` — pending games persisted across app restarts.
+- All three are AsyncStorage-backed and survive app kill.
+
+What we log:
+
+- **Outcomes:** final score, completion / abandonment, duration, metadata.
+- **Gameplay event logs:** per-move or per-action records, useful for analytics
+  and for diagnosing reported bugs.
+
+**Memory cap: 2 MB total queue size.** When the queue exceeds this, eviction
+kicks in (see §5). If 2 MB turns out to be too small in practice, that is a
+signal to revisit *how* we queue — not a signal to bump the cap.
+
+## 5. Eviction policy
+
+When the queue is over budget, evict oldest entries from the lowest non-empty
+tier first.
+
+| Tier | Contents | Eviction order |
+|------|----------|----------------|
+| **P0** (most precious) | High-priority bug reports / crashes | last to evict |
+| **P1** | Game outcomes (final score, completion, duration) | evicted after P2 / P3 |
+| **P2** | Low-priority bug reports / user feedback | evicted after P3 |
+| **P3** | Normal gameplay event logs | first to evict |
+
+Bug priority is **assigned automatically by the client**, not by the user:
+
+- Unhandled crash, error, or hang → **P0**.
+- User-submitted feedback or in-app bug report → **P2**.
+
+Users do not pick a priority. The client classifies.
+
+## 6. Boundary security
+
+Even though the server is not a referee, it remains the security boundary:
+
+- Every endpoint validates input shape and types.
+- Every endpoint is rate-limited (per [security.md](~/.claude/standards/security.md)).
+- Payload size caps on every POST.
+- Content sanitization on any user-supplied text (player names, bug report
+  bodies, etc.).
+- Database access through the ORM only — no raw SQL, no string-built queries.
+- Auth and authorization on anything user-scoped.
+
+This layer is anti-OWASP, not anti-cheat. The fact that we trust the client
+about *game rules* does not mean we trust it about *the request*.
+
+## 7. Multi-player
+
+When multi-player ships, it is server-authoritative. The MP server uses the same
+TypeScript rule engine the SP client uses (§3). One rule engine, two execution
+contexts.
+
+Multi-player does not get its own application — it lives in this repo, sharing
+identity, persistence, the event pipeline, and the UI shell. The MP service
+architecture (Node sidecar, embedded JS runtime, separate service) is deferred
+until at least one MP game design is on the table.
+
+## 8. Escape hatch
+
+The default answer is **no.** Server-authoritative single-player is not allowed
+in this repo because it fragments the architecture. If a game appears to require
+it — for example, server-side physics, daily-content tamper resistance, or
+prize-stakes tournaments — **stop and discuss before writing code.** Three
+possible outcomes:
+
+1. **Redesign to fit.** Many "we need server authority" instincts come from
+   anti-cheat reflex, not real requirements. Preferred outcome.
+2. **Accept as a documented exception.** Captured in this file, with a written
+   reason and the constraint kept narrow.
+3. **Carve out as a separate application.** If the requirement is real and the
+   constraint is broad (e.g., a prize tournament platform), the game does not
+   belong in BC Arcade.
+
+Do not silently introduce server-authoritative single-player for a new game.
+
+## 9. Implications for current games
+
+Existing games that don't fit the policy are **not** critiqued here. They are
+tracked in:
+
+- **#893 — Trouble-game migrations.** Yacht (server-authoritative SP), Blackjack
+  (two rule engines), Starswarm and Freecell (in-memory leaderboards).
+- **#894 — Shared TS rule engine epic.** Audit existing engines for headlessness
+  ahead of multi-player work, including Mahjong (WIP, #870) before its engine
+  ships.
+
+Both issues note that "first step is further research" — the snapshots in those
+issues are not authoritative.


### PR DESCRIPTION
## Summary

- Adds `docs/ARCHITECTURE.md` codifying offline-first single-player + server-authoritative multi-player as the unified game architecture for the repo.
- Locks in the persistence + eviction contract (shared `SyncWorker` / `ScoreQueue` / `PendingGamesStore`, 2 MB cap, P0–P3 tier eviction, client-classified bug priority).
- Establishes the "one TS rule engine, headless, runs on both sides" discipline so a future MP server can reuse the SP engine.
- Defines the escape hatch (default no — discuss tradeoffs first; redesign, exception, or separate app).

## Context

Existing games today vary in where rule enforcement lives, where state is persisted, and whether they integrate with the shared event pipeline. This PR doesn't change any code — it sets the policy and points at where the misfits get migrated.

## Linked issues

- #893 — trouble-game migrations (Yacht, Blackjack, Starswarm, Freecell)
- #894 — shared TS rule engine epic (audit existing engines, including Mahjong WIP #870)

Both linked issues note that the first step on pickup is further research; the snapshots they contain are not authoritative.

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] Cross-links to `GAME-CONTRACT.md` and the linked issues resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)