### PR TITLE
feat(#891): client-side Mahjong Solitaire engine

### DIFF
--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -44,7 +44,7 @@ describe("TURTLE_LAYOUT", () => {
   it("has even slot count per layer", () => {
     const counts: Record<number, number> = {};
     for (const s of TURTLE_LAYOUT) counts[s.layer] = (counts[s.layer] ?? 0) + 1;
-    for (const [layer, count] of Object.entries(counts)) {
+    for (const [, count] of Object.entries(counts)) {
       expect(count % 2).toBe(0); // must be even so pairs can fill each layer
     }
   });
@@ -338,9 +338,7 @@ describe("selectTile", () => {
   });
 
   it("awards completion bonus when last pair is removed", () => {
-    // Build a minimal 2-tile layout (just 1 pair)
-    const miniLayout = [{ col: 0, row: 0, layer: 0 }, { col: 2, row: 0, layer: 0 }];
-    // Directly construct a state with 1 pair of matching tiles.
+    // Directly construct a minimal 2-tile state (1 pair).
     const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
     const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
     const state: MahjongState = {

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Mahjong Solitaire engine tests (#891).
+ *
+ * All tests use a seeded RNG so results are deterministic.
+ */
+
+import {
+  createGame,
+  createSeededRng,
+  elapsedMs,
+  hasFreePairs,
+  isFreeTile,
+  MAX_SHUFFLES,
+  pauseGame,
+  resumeGame,
+  selectTile,
+  setRng,
+  shuffleBoard,
+  tilesMatch,
+  undoMove,
+} from "../engine";
+import type { MahjongState, SlotTile } from "../types";
+import { TURTLE_LAYOUT } from "../layouts/turtle";
+
+// Pin the RNG so every test run is identical.
+beforeEach(() => {
+  setRng(createSeededRng(42));
+});
+
+// ---------------------------------------------------------------------------
+// Layout sanity
+// ---------------------------------------------------------------------------
+
+describe("TURTLE_LAYOUT", () => {
+  it("has exactly 144 slots", () => {
+    expect(TURTLE_LAYOUT.length).toBe(144);
+  });
+
+  it("has no duplicate positions", () => {
+    const keys = TURTLE_LAYOUT.map((s) => `${s.col},${s.row},${s.layer}`);
+    expect(new Set(keys).size).toBe(144);
+  });
+
+  it("has even slot count per layer", () => {
+    const counts: Record<number, number> = {};
+    for (const s of TURTLE_LAYOUT) counts[s.layer] = (counts[s.layer] ?? 0) + 1;
+    for (const [layer, count] of Object.entries(counts)) {
+      expect(count % 2).toBe(0); // must be even so pairs can fill each layer
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RNG utilities
+// ---------------------------------------------------------------------------
+
+describe("createSeededRng", () => {
+  it("produces values in [0, 1)", () => {
+    const rng = createSeededRng(1);
+    for (let i = 0; i < 100; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("is deterministic for the same seed", () => {
+    const rngA = createSeededRng(99);
+    const rngB = createSeededRng(99);
+    for (let i = 0; i < 20; i++) expect(rngA()).toBe(rngB());
+  });
+
+  it("differs for different seeds", () => {
+    const a = createSeededRng(1)();
+    const b = createSeededRng(2)();
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tilesMatch
+// ---------------------------------------------------------------------------
+
+function tile(overrides: Partial<SlotTile> = {}): SlotTile {
+  return {
+    id: 0,
+    suit: "characters",
+    rank: 1,
+    faceId: 8,
+    col: 0,
+    row: 0,
+    layer: 0,
+    ...overrides,
+  };
+}
+
+describe("tilesMatch", () => {
+  it("matches same suit and rank", () => {
+    const a = tile({ id: 0, suit: "characters", rank: 3 });
+    const b = tile({ id: 1, suit: "characters", rank: 3 });
+    expect(tilesMatch(a, b)).toBe(true);
+  });
+
+  it("does not match different ranks of same suit", () => {
+    const a = tile({ id: 0, rank: 1 });
+    const b = tile({ id: 1, rank: 2 });
+    expect(tilesMatch(a, b)).toBe(false);
+  });
+
+  it("does not match different suits", () => {
+    const a = tile({ id: 0, suit: "characters", rank: 1 });
+    const b = tile({ id: 1, suit: "circles", rank: 1 });
+    expect(tilesMatch(a, b)).toBe(false);
+  });
+
+  it("any flower matches any flower", () => {
+    const a = tile({ id: 0, suit: "flowers", rank: 1 });
+    const b = tile({ id: 1, suit: "flowers", rank: 4 });
+    expect(tilesMatch(a, b)).toBe(true);
+  });
+
+  it("any season matches any season", () => {
+    const a = tile({ id: 0, suit: "seasons", rank: 2 });
+    const b = tile({ id: 1, suit: "seasons", rank: 3 });
+    expect(tilesMatch(a, b)).toBe(true);
+  });
+
+  it("flower does not match season", () => {
+    const a = tile({ id: 0, suit: "flowers", rank: 1 });
+    const b = tile({ id: 1, suit: "seasons", rank: 1 });
+    expect(tilesMatch(a, b)).toBe(false);
+  });
+
+  it("a tile does not match itself", () => {
+    const a = tile({ id: 5, suit: "flowers", rank: 1 });
+    expect(tilesMatch(a, a)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFreeTile
+// ---------------------------------------------------------------------------
+
+describe("isFreeTile", () => {
+  it("is free when isolated", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    expect(isFreeTile(t, [t])).toBe(true);
+  });
+
+  it("is free when the only blocker is on one side", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const left = tile({ id: 1, col: 2, row: 2, layer: 0 });
+    expect(isFreeTile(t, [t, left])).toBe(true);
+  });
+
+  it("is blocked when tiles are on both sides", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const left = tile({ id: 1, col: 2, row: 2, layer: 0 });
+    const right = tile({ id: 2, col: 6, row: 2, layer: 0 });
+    expect(isFreeTile(t, [t, left, right])).toBe(false);
+  });
+
+  it("is blocked when covered by a tile above at same col/row", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const above = tile({ id: 1, col: 4, row: 2, layer: 1 });
+    expect(isFreeTile(t, [t, above])).toBe(false);
+  });
+
+  it("is not blocked by a tile above at a different col", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const other = tile({ id: 1, col: 6, row: 2, layer: 1 });
+    expect(isFreeTile(t, [t, other])).toBe(true);
+  });
+
+  it("is not blocked by tiles in a different row", () => {
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const otherRow = tile({ id: 1, col: 2, row: 3, layer: 0 });
+    expect(isFreeTile(t, [t, otherRow])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createGame
+// ---------------------------------------------------------------------------
+
+describe("createGame", () => {
+  it("produces exactly 144 tiles", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(state.tiles.length).toBe(144);
+  });
+
+  it("has unique tile ids 0..143", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const ids = state.tiles.map((t) => t.id).sort((a, b) => a - b);
+    expect(ids).toEqual(Array.from({ length: 144 }, (_, i) => i));
+  });
+
+  it("has no duplicate positions", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const keys = state.tiles.map((t) => `${t.col},${t.row},${t.layer}`);
+    expect(new Set(keys).size).toBe(144);
+  });
+
+  it("all tile positions are in the layout", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const layoutKeys = new Set(TURTLE_LAYOUT.map((s) => `${s.col},${s.row},${s.layer}`));
+    for (const t of state.tiles) {
+      expect(layoutKeys.has(`${t.col},${t.row},${t.layer}`)).toBe(true);
+    }
+  });
+
+  it("starts with shufflesLeft = MAX_SHUFFLES", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(state.shufflesLeft).toBe(MAX_SHUFFLES);
+  });
+
+  it("initial board has at least one free pair", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(hasFreePairs(state.tiles)).toBe(true);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const s1 = createGame(TURTLE_LAYOUT, 7);
+    const s2 = createGame(TURTLE_LAYOUT, 7);
+    const ids1 = s1.tiles.map((t) => `${t.faceId}@${t.col},${t.row},${t.layer}`).sort();
+    const ids2 = s2.tiles.map((t) => `${t.faceId}@${t.col},${t.row},${t.layer}`).sort();
+    expect(ids1).toEqual(ids2);
+  });
+
+  it("contains the right tile distribution (faceId counts)", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const counts: Record<number, number> = {};
+    for (const t of state.tiles) counts[t.faceId] = (counts[t.faceId] ?? 0) + 1;
+
+    // faceId 1–34: 4 copies each (regular tiles)
+    for (let fid = 1; fid <= 34; fid++) expect(counts[fid]).toBe(4);
+    // faceId 35–42: 1 copy each (seasons 35–38, flowers 39–42)
+    for (let fid = 35; fid <= 42; fid++) expect(counts[fid]).toBe(1);
+  });
+
+  it("initialises score, pairsRemoved, isComplete, isDeadlocked correctly", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(state.score).toBe(0);
+    expect(state.pairsRemoved).toBe(0);
+    expect(state.isComplete).toBe(false);
+    expect(state.isDeadlocked).toBe(false);
+    expect(state.selected).toBeNull();
+    expect(state.undoStack).toHaveLength(0);
+    expect(state.startedAt).toBeNull();
+    expect(state.accumulatedMs).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectTile
+// ---------------------------------------------------------------------------
+
+function firstFreePair(state: MahjongState): [SlotTile, SlotTile] {
+  const free = state.tiles.filter((t) => isFreeTile(t, state.tiles));
+  for (let i = 0; i < free.length; i++) {
+    for (let j = i + 1; j < free.length; j++) {
+      if (tilesMatch(free[i]!, free[j]!)) return [free[i]!, free[j]!];
+    }
+  }
+  throw new Error("no free pair found");
+}
+
+describe("selectTile", () => {
+  it("selects a free tile when none is selected", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const free = state.tiles.find((t) => isFreeTile(t, state.tiles))!;
+    const next = selectTile(state, free.id);
+    expect(next.selected?.id).toBe(free.id);
+  });
+
+  it("deselects when tapping the same tile again", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const free = state.tiles.find((t) => isFreeTile(t, state.tiles))!;
+    const withSel = selectTile(state, free.id);
+    const desel = selectTile(withSel, free.id);
+    expect(desel.selected).toBeNull();
+  });
+
+  it("replaces selection when a non-matching tile is chosen", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const free = state.tiles.filter((t) => isFreeTile(t, state.tiles));
+    // Find two free tiles that do NOT match
+    let a!: SlotTile, b!: SlotTile;
+    outer: for (let i = 0; i < free.length; i++) {
+      for (let j = i + 1; j < free.length; j++) {
+        if (!tilesMatch(free[i]!, free[j]!)) {
+          a = free[i]!;
+          b = free[j]!;
+          break outer;
+        }
+      }
+    }
+    const s1 = selectTile(state, a.id);
+    const s2 = selectTile(s1, b.id);
+    expect(s2.selected?.id).toBe(b.id);
+    expect(s2.tiles.length).toBe(144); // nothing removed
+  });
+
+  it("removes matched pair and increments score", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const [a, b] = firstFreePair(state);
+    const s1 = selectTile(state, a.id);
+    const s2 = selectTile(s1, b.id);
+    expect(s2.tiles.length).toBe(142);
+    expect(s2.pairsRemoved).toBe(1);
+    expect(s2.score).toBe(10);
+    expect(s2.selected).toBeNull();
+  });
+
+  it("pushes state to undoStack on a match", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const [a, b] = firstFreePair(state);
+    const s1 = selectTile(state, a.id);
+    const s2 = selectTile(s1, b.id);
+    expect(s2.undoStack.length).toBe(1);
+  });
+
+  it("sets startedAt on first selection", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(state.startedAt).toBeNull();
+    const free = state.tiles.find((t) => isFreeTile(t, state.tiles))!;
+    const next = selectTile(state, free.id);
+    expect(next.startedAt).not.toBeNull();
+  });
+
+  it("ignores a non-free tile", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    // A tile covered by another tile is not free; find one.
+    const covered = state.tiles.find((t) => !isFreeTile(t, state.tiles));
+    if (!covered) return; // edge case: all tiles are free (very unlikely layout)
+    const next = selectTile(state, covered.id);
+    expect(next).toBe(state);
+  });
+
+  it("awards completion bonus when last pair is removed", () => {
+    // Build a minimal 2-tile layout (just 1 pair)
+    const miniLayout = [{ col: 0, row: 0, layer: 0 }, { col: 2, row: 0, layer: 0 }];
+    // Directly construct a state with 1 pair of matching tiles.
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const state: MahjongState = {
+      _v: 1,
+      tiles: [a, b],
+      pairsRemoved: 0,
+      score: 0,
+      shufflesLeft: 3,
+      selected: null,
+      undoStack: [],
+      isComplete: false,
+      isDeadlocked: false,
+      startedAt: null,
+      accumulatedMs: 0,
+    };
+    const s1 = selectTile(state, a.id);
+    const s2 = selectTile(s1, b.id);
+    expect(s2.isComplete).toBe(true);
+    expect(s2.score).toBe(10 + 500); // SCORE_PER_PAIR + SCORE_COMPLETE_BONUS
+    expect(s2.tiles.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// undoMove
+// ---------------------------------------------------------------------------
+
+describe("undoMove", () => {
+  it("restores the previous state after a match", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const [a, b] = firstFreePair(state);
+    const s1 = selectTile(state, a.id);
+    const s2 = selectTile(s1, b.id);
+    expect(s2.tiles.length).toBe(142);
+
+    const reverted = undoMove(s2);
+    expect(reverted.tiles.length).toBe(144);
+    expect(reverted.pairsRemoved).toBe(0);
+    expect(reverted.score).toBe(0);
+    expect(reverted.selected).toBeNull();
+  });
+
+  it("returns the same state when undoStack is empty", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(undoMove(state)).toBe(state);
+  });
+
+  it("supports multiple undos", () => {
+    let state = createGame(TURTLE_LAYOUT);
+    for (let i = 0; i < 3; i++) {
+      const [a, b] = firstFreePair(state);
+      state = selectTile(selectTile(state, a.id), b.id);
+    }
+    expect(state.pairsRemoved).toBe(3);
+
+    state = undoMove(state);
+    expect(state.pairsRemoved).toBe(2);
+    state = undoMove(state);
+    expect(state.pairsRemoved).toBe(1);
+    state = undoMove(state);
+    expect(state.pairsRemoved).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shuffleBoard
+// ---------------------------------------------------------------------------
+
+describe("shuffleBoard", () => {
+  it("decrements shufflesLeft", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    expect(shuffled.shufflesLeft).toBe(MAX_SHUFFLES - 1);
+  });
+
+  it("keeps the same tile count", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    expect(shuffled.tiles.length).toBe(144);
+  });
+
+  it("preserves the same tile distribution (same faceId counts)", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    const countBefore: Record<number, number> = {};
+    const countAfter: Record<number, number> = {};
+    for (const t of state.tiles) countBefore[t.faceId] = (countBefore[t.faceId] ?? 0) + 1;
+    for (const t of shuffled.tiles) countAfter[t.faceId] = (countAfter[t.faceId] ?? 0) + 1;
+    expect(countAfter).toEqual(countBefore);
+  });
+
+  it("produces a board with at least one free pair", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    expect(hasFreePairs(shuffled.tiles)).toBe(true);
+  });
+
+  it("clears the selection", () => {
+    let state = createGame(TURTLE_LAYOUT);
+    const free = state.tiles.find((t) => isFreeTile(t, state.tiles))!;
+    state = selectTile(state, free.id);
+    expect(state.selected).not.toBeNull();
+    expect(shuffleBoard(state).selected).toBeNull();
+  });
+
+  it("does nothing when shufflesLeft is 0", () => {
+    let state = createGame(TURTLE_LAYOUT);
+    state = { ...state, shufflesLeft: 0 };
+    expect(shuffleBoard(state)).toBe(state);
+  });
+
+  it("pushes a snapshot to undoStack", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    expect(shuffled.undoStack.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasFreePairs
+// ---------------------------------------------------------------------------
+
+describe("hasFreePairs", () => {
+  it("returns false for an empty board", () => {
+    expect(hasFreePairs([])).toBe(false);
+  });
+
+  it("returns true when a matching free pair exists", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    expect(hasFreePairs([a, b])).toBe(true);
+  });
+
+  it("returns false when no matching pair among free tiles", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "circles", rank: 2, faceId: 18, col: 2, row: 0, layer: 0 };
+    expect(hasFreePairs([a, b])).toBe(false);
+  });
+
+  it("returns false when the only matching pair is blocked", () => {
+    // Tile a is at layer 0 but covered by tile c at layer 1 same position.
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const c: SlotTile = { id: 2, suit: "dragons", rank: 1, faceId: 1, col: 0, row: 0, layer: 1 };
+    // a is covered by c, b is free. But the pair (a,b) can't form since a is not free.
+    expect(hasFreePairs([a, b, c])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// elapsedMs, pauseGame, resumeGame
+// ---------------------------------------------------------------------------
+
+describe("timer helpers", () => {
+  it("elapsedMs returns accumulatedMs when startedAt is null", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    expect(elapsedMs(state, 9999)).toBe(0);
+  });
+
+  it("elapsedMs counts from startedAt", () => {
+    const state: MahjongState = {
+      ...createGame(TURTLE_LAYOUT),
+      startedAt: 1000,
+      accumulatedMs: 500,
+    };
+    expect(elapsedMs(state, 2000)).toBe(1500);
+  });
+
+  it("pauseGame accumulates time and clears startedAt", () => {
+    const state: MahjongState = {
+      ...createGame(TURTLE_LAYOUT),
+      startedAt: 1000,
+      accumulatedMs: 200,
+    };
+    const paused = pauseGame(state, 1600);
+    expect(paused.startedAt).toBeNull();
+    expect(paused.accumulatedMs).toBe(800);
+  });
+
+  it("resumeGame sets startedAt", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const resumed = resumeGame(state, 5000);
+    expect(resumed.startedAt).toBe(5000);
+  });
+
+  it("resumeGame is a no-op when already running", () => {
+    const state: MahjongState = { ...createGame(TURTLE_LAYOUT), startedAt: 1000 };
+    expect(resumeGame(state, 2000).startedAt).toBe(1000);
+  });
+});

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -254,8 +254,20 @@ function buildBoard(
         const slotA = rowSlots[i]!;
         const slotB = rowSlots[N - 1 - i]!;
         const pair = shuffledPairs[pairIdx++]!;
-        result.push({ ...pair[0], id: nextId++, col: slotA.col, row: slotA.row, layer: slotA.layer });
-        result.push({ ...pair[1], id: nextId++, col: slotB.col, row: slotB.row, layer: slotB.layer });
+        result.push({
+          ...pair[0],
+          id: nextId++,
+          col: slotA.col,
+          row: slotA.row,
+          layer: slotA.layer,
+        });
+        result.push({
+          ...pair[1],
+          id: nextId++,
+          col: slotB.col,
+          row: slotB.row,
+          layer: slotB.layer,
+        });
       }
     }
   }

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -1,0 +1,419 @@
+/**
+ * Mahjong Solitaire engine (#891).
+ *
+ * Pure TypeScript. No React, AsyncStorage, HTTP, timers, or other side-effect
+ * imports. The UI replaces the entire MahjongState on each transition.
+ *
+ * Solvability is guaranteed via a backwards-build algorithm: pairs are placed
+ * into free slots in a random order, so removing them in reverse is always
+ * valid. Tests can pin the shuffle via `setRng(createSeededRng(seed))`.
+ */
+
+import type { Layout, MahjongState, Slot, SlotTile, Suit, Rank } from "./types";
+
+// ---------------------------------------------------------------------------
+// Scoring / limits
+// ---------------------------------------------------------------------------
+
+const SCORE_PER_PAIR = 10;
+const SCORE_COMPLETE_BONUS = 500;
+const UNDO_CAP = 50;
+export const MAX_SHUFFLES = 3;
+
+// ---------------------------------------------------------------------------
+// Seedable RNG — LCG matching Cascade / Blackjack / Twenty48 / Solitaire.
+// ---------------------------------------------------------------------------
+
+export type RandomSource = () => number;
+
+let _rng: RandomSource = Math.random;
+
+export function setRng(fn: RandomSource): void {
+  _rng = fn;
+}
+
+export function createSeededRng(seed: number): RandomSource {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(1664525, state) + 1013904223) >>> 0;
+    return state / 4294967296;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tile matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Two tiles match if they are the same suit+rank, OR both are flowers (any
+ * flower matches any flower), OR both are seasons (any season matches any
+ * season). A tile never matches itself.
+ */
+export function tilesMatch(a: SlotTile, b: SlotTile): boolean {
+  if (a.id === b.id) return false;
+  if (a.suit === "flowers" && b.suit === "flowers") return true;
+  if (a.suit === "seasons" && b.suit === "seasons") return true;
+  return a.suit === b.suit && a.rank === b.rank;
+}
+
+// ---------------------------------------------------------------------------
+// Free-tile detection
+// ---------------------------------------------------------------------------
+
+/**
+ * A tile is FREE (selectable) if:
+ *   (a) no tile at layer+1 shares the exact same (col, row) — nothing above it, and
+ *   (b) at least one horizontal side is clear — no tile at (col−2, row, layer)
+ *       or no tile at (col+2, row, layer).
+ *
+ * Tiles are 2 grid units wide, so adjacent tiles step by ±2 in col.
+ */
+export function isFreeTile(tile: SlotTile, tiles: readonly SlotTile[]): boolean {
+  for (const t of tiles) {
+    if (t.id === tile.id) continue;
+    if (t.layer === tile.layer + 1 && t.col === tile.col && t.row === tile.row) return false;
+  }
+
+  let leftBlocked = false;
+  let rightBlocked = false;
+  for (const t of tiles) {
+    if (t.id === tile.id || t.layer !== tile.layer || t.row !== tile.row) continue;
+    if (t.col === tile.col - 2) leftBlocked = true;
+    if (t.col === tile.col + 2) rightBlocked = true;
+    if (leftBlocked && rightBlocked) return false;
+  }
+  return true;
+}
+
+/** Returns true if any two free tiles in `tiles` form a matching pair. */
+export function hasFreePairs(tiles: readonly SlotTile[]): boolean {
+  const free = tiles.filter((t) => isFreeTile(t, tiles));
+  for (let i = 0; i < free.length; i++) {
+    for (let j = i + 1; j < free.length; j++) {
+      if (tilesMatch(free[i]!, free[j]!)) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Elapsed time helper
+// ---------------------------------------------------------------------------
+
+export function elapsedMs(state: MahjongState, now: number = Date.now()): number {
+  if (state.startedAt === null) return state.accumulatedMs;
+  return state.accumulatedMs + (now - state.startedAt);
+}
+
+// ---------------------------------------------------------------------------
+// Tile-set construction — 144 tiles = 72 pairs
+// ---------------------------------------------------------------------------
+
+type TileSpec = { suit: Suit; rank: Rank; faceId: number };
+
+function buildFullTileSet(): TileSpec[] {
+  const tiles: TileSpec[] = [];
+
+  // Dragons 1–3 (faceId 1–3), 4 copies each
+  for (let rank = 1; rank <= 3; rank++) {
+    for (let c = 0; c < 4; c++) tiles.push({ suit: "dragons", rank: rank as Rank, faceId: rank });
+  }
+
+  // Winds 1–4 (faceId 4–7), 4 copies each
+  for (let rank = 1; rank <= 4; rank++) {
+    for (let c = 0; c < 4; c++) tiles.push({ suit: "winds", rank: rank as Rank, faceId: rank + 3 });
+  }
+
+  // Characters 1–9 (faceId 8–16), 4 copies each
+  for (let rank = 1; rank <= 9; rank++) {
+    for (let c = 0; c < 4; c++)
+      tiles.push({ suit: "characters", rank: rank as Rank, faceId: rank + 7 });
+  }
+
+  // Circles 1–9 (faceId 17–25), 4 copies each
+  for (let rank = 1; rank <= 9; rank++) {
+    for (let c = 0; c < 4; c++)
+      tiles.push({ suit: "circles", rank: rank as Rank, faceId: rank + 16 });
+  }
+
+  // Bamboos 1–9 (faceId 26–34), 4 copies each
+  for (let rank = 1; rank <= 9; rank++) {
+    for (let c = 0; c < 4; c++)
+      tiles.push({ suit: "bamboos", rank: rank as Rank, faceId: rank + 25 });
+  }
+
+  // Seasons 1–4 (faceId 35–38), 1 copy each (any season ↔ any season)
+  for (let rank = 1; rank <= 4; rank++) {
+    tiles.push({ suit: "seasons", rank: rank as Rank, faceId: rank + 34 });
+  }
+
+  // Flowers 1–4 (faceId 39–42), 1 copy each (any flower ↔ any flower)
+  for (let rank = 1; rank <= 4; rank++) {
+    tiles.push({ suit: "flowers", rank: rank as Rank, faceId: rank + 38 });
+  }
+
+  return tiles; // 12 + 16 + 36 + 36 + 36 + 4 + 4 = 144
+}
+
+/** Group tile specs into matching pairs. Works for both the full 144-set and
+ *  any even-count subset remaining after partial play. */
+function buildPairs(specs: TileSpec[]): [TileSpec, TileSpec][] {
+  const pairs: [TileSpec, TileSpec][] = [];
+  const flowers: TileSpec[] = [];
+  const seasons: TileSpec[] = [];
+  const byKey = new Map<string, TileSpec[]>();
+
+  for (const spec of specs) {
+    if (spec.suit === "flowers") {
+      flowers.push(spec);
+    } else if (spec.suit === "seasons") {
+      seasons.push(spec);
+    } else {
+      const key = `${spec.suit}:${spec.rank}`;
+      const g = byKey.get(key) ?? [];
+      g.push(spec);
+      byKey.set(key, g);
+    }
+  }
+
+  for (const g of byKey.values()) {
+    for (let i = 0; i + 1 < g.length; i += 2) pairs.push([g[i]!, g[i + 1]!]);
+  }
+  for (let i = 0; i + 1 < flowers.length; i += 2) pairs.push([flowers[i]!, flowers[i + 1]!]);
+  for (let i = 0; i + 1 < seasons.length; i += 2) pairs.push([seasons[i]!, seasons[i + 1]!]);
+
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Backwards-build algorithm — guarantees solvability
+// ---------------------------------------------------------------------------
+
+function fisherYates<T>(arr: T[], rng: RandomSource): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    const a = arr[i];
+    const b = arr[j];
+    if (a !== undefined && b !== undefined) {
+      arr[i] = b;
+      arr[j] = a;
+    }
+  }
+  return arr;
+}
+
+/**
+ * Deterministic backwards-build guaranteed never to get stuck on any layout
+ * where every row in every layer has an even number of slots.
+ *
+ * Strategy — layer-by-layer (lowest first), row-by-row (random order), slot
+ * pairs inner-to-outer within each row:
+ *
+ *   Placing inner tiles first in the backwards-build means they are removed
+ *   LAST in forward play (after outer tiles are gone from both sides), so
+ *   they are always accessible. Outer tiles are placed last in backwards-build
+ *   and removed first in forward play; they always have one clear side at the
+ *   layout boundary.
+ *
+ * Tile types are assigned to slot-pairs from a pre-shuffled pair list, giving
+ * the randomness needed for variety without any risk of getting stuck.
+ */
+function buildBoard(
+  slots: readonly Slot[],
+  pairs: [TileSpec, TileSpec][],
+  rng: RandomSource,
+  startId = 0
+): SlotTile[] {
+  const shuffledPairs = fisherYates([...pairs], rng);
+  let pairIdx = 0;
+  const result: SlotTile[] = [];
+  let nextId = startId;
+
+  const maxLayer = slots.reduce((m, s) => Math.max(m, s.layer), 0);
+
+  for (let layer = 0; layer <= maxLayer; layer++) {
+    const layerSlots = slots.filter((s) => s.layer === layer);
+
+    // Group by row, then shuffle row order for variety.
+    const byRow = new Map<number, Slot[]>();
+    for (const s of layerSlots) {
+      const arr = byRow.get(s.row) ?? [];
+      arr.push(s);
+      byRow.set(s.row, arr);
+    }
+    const rowList = fisherYates([...byRow.values()], rng);
+
+    for (const rowSlots of rowList) {
+      // Sort by col ascending so inner-to-outer indexing is well-defined.
+      rowSlots.sort((a, b) => a.col - b.col);
+      const N = rowSlots.length;
+
+      // Pair index i with N-1-i.  Start from the innermost pair (i=N/2-1)
+      // and work outward to i=0.
+      for (let i = N / 2 - 1; i >= 0; i--) {
+        const slotA = rowSlots[i]!;
+        const slotB = rowSlots[N - 1 - i]!;
+        const pair = shuffledPairs[pairIdx++]!;
+        result.push({ ...pair[0], id: nextId++, col: slotA.col, row: slotA.row, layer: slotA.layer });
+        result.push({ ...pair[1], id: nextId++, col: slotB.col, row: slotB.row, layer: slotB.layer });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Deal a fresh solvable game using the supplied layout. */
+export function createGame(layout: Layout, seed?: number): MahjongState {
+  const rng = seed !== undefined ? createSeededRng(seed) : _rng;
+  const specs = buildFullTileSet();
+  const pairs = buildPairs(specs);
+  const tiles = buildBoard(layout, pairs, rng);
+
+  return {
+    _v: 1,
+    tiles,
+    pairsRemoved: 0,
+    score: 0,
+    shufflesLeft: MAX_SHUFFLES,
+    selected: null,
+    undoStack: [],
+    isComplete: false,
+    isDeadlocked: false,
+    startedAt: null,
+    accumulatedMs: 0,
+  };
+}
+
+/**
+ * Select or deselect a tile.
+ *
+ * - If the tile is not free, the state is returned unchanged.
+ * - If no tile is selected, the tile becomes selected.
+ * - If the same tile is tapped again, it is deselected.
+ * - If a different tile is selected and they match, both are removed.
+ * - If a different tile is selected and they don't match, the new tile
+ *   becomes selected (replacing the old selection).
+ */
+export function selectTile(state: MahjongState, tileId: number): MahjongState {
+  const tile = state.tiles.find((t) => t.id === tileId);
+  if (!tile || !isFreeTile(tile, state.tiles)) return state;
+
+  const startedAt = state.startedAt ?? Date.now();
+
+  if (!state.selected) {
+    return { ...state, selected: tile, startedAt };
+  }
+
+  if (state.selected.id === tile.id) {
+    return { ...state, selected: null };
+  }
+
+  if (!tilesMatch(state.selected, tile)) {
+    return { ...state, selected: tile, startedAt };
+  }
+
+  // Matched pair — remove both tiles.
+  const removedA = state.selected;
+  const newTiles = state.tiles.filter((t) => t.id !== removedA.id && t.id !== tile.id);
+  const pairsRemoved = state.pairsRemoved + 1;
+  const isComplete = newTiles.length === 0;
+  const score = state.score + SCORE_PER_PAIR + (isComplete ? SCORE_COMPLETE_BONUS : 0);
+  const isDeadlocked = !isComplete && !hasFreePairs(newTiles) && state.shufflesLeft === 0;
+
+  const snapshot: MahjongState = { ...state, selected: null, undoStack: [] };
+  const undoStack = [...state.undoStack.slice(-(UNDO_CAP - 1)), snapshot];
+
+  return {
+    ...state,
+    tiles: newTiles,
+    pairsRemoved,
+    score,
+    selected: null,
+    undoStack,
+    isComplete,
+    isDeadlocked,
+    startedAt,
+  };
+}
+
+/**
+ * Redistribute all remaining tiles across their current slots in a new
+ * arrangement that has at least one playable free pair. Costs one shuffle
+ * token. Clears the selection.
+ *
+ * After partial play, rows can have odd tile counts so the inner-to-outer
+ * row approach used by createGame won't work. Instead we randomly reassign
+ * tile types to slots and retry until hasFreePairs returns true (≤ 50 tries,
+ * practically never exhausted).
+ */
+export function shuffleBoard(state: MahjongState): MahjongState {
+  if (state.shufflesLeft === 0) return state;
+
+  const slots: Slot[] = state.tiles.map(({ col, row, layer }) => ({ col, row, layer }));
+  const specs: TileSpec[] = state.tiles.map(({ suit, rank, faceId }) => ({ suit, rank, faceId }));
+  const pairs = buildPairs(specs);
+
+  let newTiles: SlotTile[] = [];
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const shuffledPairs = fisherYates([...pairs], _rng);
+    const shuffledSlots = fisherYates([...slots], _rng);
+    const candidate: SlotTile[] = [];
+    let id = 0;
+    for (let i = 0; i < shuffledPairs.length; i++) {
+      const pair = shuffledPairs[i]!;
+      const sA = shuffledSlots[i * 2]!;
+      const sB = shuffledSlots[i * 2 + 1]!;
+      candidate.push({ ...pair[0], id: id++, col: sA.col, row: sA.row, layer: sA.layer });
+      candidate.push({ ...pair[1], id: id++, col: sB.col, row: sB.row, layer: sB.layer });
+    }
+    if (hasFreePairs(candidate)) {
+      newTiles = candidate;
+      break;
+    }
+  }
+  if (newTiles.length === 0) return state; // extremely unlikely
+
+  const isDeadlocked = !hasFreePairs(newTiles) && state.shufflesLeft - 1 === 0;
+
+  const snapshot: MahjongState = { ...state, undoStack: [] };
+  const undoStack = [...state.undoStack.slice(-(UNDO_CAP - 1)), snapshot];
+
+  return {
+    ...state,
+    tiles: newTiles,
+    selected: null,
+    shufflesLeft: state.shufflesLeft - 1,
+    undoStack,
+    isDeadlocked,
+  };
+}
+
+/** Undo the last pair removal or shuffle. */
+export function undoMove(state: MahjongState): MahjongState {
+  if (state.undoStack.length === 0) return state;
+  const prev = state.undoStack[state.undoStack.length - 1]!;
+  // Restore the snapshot but give it the remaining undo history so that
+  // further undos can continue to chain without exponential nesting.
+  return { ...prev, undoStack: state.undoStack.slice(0, -1) };
+}
+
+/** Accumulate elapsed time when the session is paused (app goes to background). */
+export function pauseGame(state: MahjongState, now: number = Date.now()): MahjongState {
+  if (state.startedAt === null) return state;
+  return {
+    ...state,
+    accumulatedMs: state.accumulatedMs + (now - state.startedAt),
+    startedAt: null,
+  };
+}
+
+/** Resume the timer when the app returns to the foreground. */
+export function resumeGame(state: MahjongState, now: number = Date.now()): MahjongState {
+  if (state.startedAt !== null || state.isComplete) return state;
+  return { ...state, startedAt: now };
+}

--- a/frontend/src/game/mahjong/layouts/turtle.ts
+++ b/frontend/src/game/mahjong/layouts/turtle.ts
@@ -1,0 +1,74 @@
+/**
+ * Turtle layout — 144 slots (#891).
+ *
+ * Coordinate system: tiles are 2 grid units wide, 1 unit tall.
+ * Adjacent tiles in the same row step by col±2. Stacked tiles share the same
+ * (col, row) and differ only in layer.
+ *
+ * Layer breakdown:
+ *   Layer 0 — 64 tiles: body (rows 1–6, cols 4–18), head (rows 3–4, cols 20–22),
+ *              tail (rows 3–4, cols 0–2), top/bottom feet (row 0/7, cols 4,6,16,18)
+ *   Layer 1 — 36 tiles: body (rows 2–5, cols 4–18), head (rows 3–4, col 20),
+ *              tail (rows 3–4, col 2)
+ *   Layer 2 — 24 tiles: centre (rows 2–5, cols 6–16)
+ *   Layer 3 — 12 tiles: centre (rows 3–4, cols 6–16)
+ *   Layer 4 —  8 tiles: peak (rows 3–4, cols 8–14)
+ *   Total: 64 + 36 + 24 + 12 + 8 = 144
+ */
+
+import type { Layout } from "../types";
+
+function range(start: number, stopInclusive: number, step: number): number[] {
+  const out: number[] = [];
+  for (let v = start; v <= stopInclusive; v += step) out.push(v);
+  return out;
+}
+
+function slots(
+  layer: number,
+  cols: number[],
+  rows: number[]
+): { col: number; row: number; layer: number }[] {
+  const out: { col: number; row: number; layer: number }[] = [];
+  for (const row of rows) {
+    for (const col of cols) {
+      out.push({ col, row, layer });
+    }
+  }
+  return out;
+}
+
+export const TURTLE_LAYOUT: Layout = [
+  // --- Layer 0 ---
+  // Body
+  ...slots(0, range(4, 18, 2), range(1, 6, 1)),
+  // Head (right protrusion)
+  ...slots(0, [20, 22], [3, 4]),
+  // Tail (left protrusion)
+  ...slots(0, [0, 2], [3, 4]),
+  // Top feet
+  ...slots(0, [4, 6, 16, 18], [0]),
+  // Bottom feet
+  ...slots(0, [4, 6, 16, 18], [7]),
+
+  // --- Layer 1 ---
+  // Body
+  ...slots(1, range(4, 18, 2), range(2, 5, 1)),
+  // Head
+  ...slots(1, [20], [3, 4]),
+  // Tail
+  ...slots(1, [2], [3, 4]),
+
+  // --- Layer 2 ---
+  ...slots(2, range(6, 16, 2), range(2, 5, 1)),
+
+  // --- Layer 3 ---
+  ...slots(3, range(6, 16, 2), [3, 4]),
+
+  // --- Layer 4 ---
+  ...slots(4, range(8, 14, 2), [3, 4]),
+];
+
+if (TURTLE_LAYOUT.length !== 144) {
+  throw new Error(`TURTLE_LAYOUT has ${TURTLE_LAYOUT.length} slots, expected 144`);
+}

--- a/frontend/src/game/mahjong/types.ts
+++ b/frontend/src/game/mahjong/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Mahjong Solitaire — shared types (#891).
+ *
+ * Pure data. No React, no AsyncStorage, no side effects. Imported by the
+ * engine, UI components, and persistence layer alike.
+ */
+
+export type Suit =
+  | "characters"
+  | "circles"
+  | "bamboos"
+  | "winds"
+  | "dragons"
+  | "flowers"
+  | "seasons";
+
+/** Rank 1–9 covers all suits; suits with fewer ranks (e.g. dragons 1–3) simply
+ * never use the higher values. */
+export type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export interface Tile {
+  readonly suit: Suit;
+  readonly rank: Rank;
+  /**
+   * 1-based SVG asset index matching the filenames in assets/mahjong/:
+   *   01 = white dragon … 07 = north wind
+   *   08–16 = characters 1–9
+   *   17–25 = circles 1–9
+   *   26–34 = bamboos 1–9
+   *   35–38 = seasons (spring/summer/autumn/winter)
+   *   39–42 = flowers (plum/orchid/chrysanthemum/bamboo)
+   */
+  readonly faceId: number;
+}
+
+/** A tile instance placed on the board. */
+export interface SlotTile extends Tile {
+  /** Unique tile instance id within a game (0–143). */
+  readonly id: number;
+  /**
+   * Left column edge. Tiles are 2 grid units wide; adjacent tiles in the same
+   * row step by 2 (e.g. cols 4, 6, 8 …). Stacked tiles sit at the same col.
+   */
+  readonly col: number;
+  readonly row: number;
+  readonly layer: number;
+}
+
+/** A position on the layout (col/row/layer) before a tile is placed there. */
+export interface Slot {
+  readonly col: number;
+  readonly row: number;
+  readonly layer: number;
+}
+
+/** A layout is a static list of slot positions totalling 144. */
+export type Layout = readonly Slot[];
+
+/** Immutable snapshot of a Mahjong Solitaire game. `_v` is a schema version
+ * so persisted saves can be migrated or rejected safely. */
+export interface MahjongState {
+  readonly _v: 1;
+  /** All tiles currently on the board. Removed tiles are absent. */
+  readonly tiles: readonly SlotTile[];
+  readonly pairsRemoved: number;
+  readonly score: number;
+  readonly shufflesLeft: number;
+  /** Tile awaiting a match, or null. */
+  readonly selected: SlotTile | null;
+  /** Prior-state snapshots, most recent last. Capped at UNDO_CAP.
+   * Nested undoStack is always [] to prevent exponential nesting. */
+  readonly undoStack: readonly MahjongState[];
+  readonly isComplete: boolean;
+  /** True when no free matching pairs remain and no shuffles are left. */
+  readonly isDeadlocked: boolean;
+  /** Timestamp (Date.now()) when the current play session started; null if
+   * no move has been made yet. */
+  readonly startedAt: number | null;
+  /** Accumulated elapsed milliseconds from all sessions before the current. */
+  readonly accumulatedMs: number;
+}


### PR DESCRIPTION
## Summary

- **Turtle layout** (`layouts/turtle.ts`): 144-slot, 5-layer layout (64/36/24/12/8). Slot positions verified by the compile-time length check.
- **Engine** (`engine.ts`): headless pure TypeScript, no side effects. Exports `createGame`, `selectTile`, `shuffleBoard`, `undoMove`, `pauseGame`, `resumeGame`, `isFreeTile`, `tilesMatch`, `hasFreePairs`, `elapsedMs`, and the seeded LCG RNG (`setRng`/`createSeededRng`).
- **Board generation**: layer-by-layer (lowest first) + inner-to-outer row pairing — a deterministic backwards-build that provably never gets stuck, because inner tiles placed first are removed last in forward play (after outer tiles clear their sides).
- **Shuffle**: random tile-type reassignment over current slots with `hasFreePairs` retry guard (handles odd row counts after partial play).
- **Undo chain**: snapshots carry `selected: null` and nested `undoStack: []`; `undoMove` splices the remaining history back to enable multi-level undo without exponential nesting.
- **Types** (`types.ts`): `SlotTile`, `MahjongState`, `Layout`, all `readonly` for immutability. `faceId` 1–42 maps directly to the vendored SVG assets.
- **55 unit tests** — layout sanity, RNG, tile matching, free-tile detection, board generation, select/deselect/match, multi-step undo, shuffle, deadlock detection, timer helpers.

## Test plan

- [x] `npx jest src/game/mahjong` — 55/55 passing
- [x] Full frontend suite — 1761/1761 passing
- [ ] CI green

Closes #891. Part of Epic #870 (Mahjong Solitaire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)