### PR TITLE
feat(#873): Mahjong renderer — Skia native + Canvas 2D web

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -1,0 +1,297 @@
+/**
+ * Mahjong Solitaire — native canvas (iOS / Android).
+ *
+ * Rendered via @shopify/react-native-skia.
+ * Metro automatically uses GameCanvas.web.tsx on the web platform.
+ *
+ * Tile geometry (grid → pixels):
+ *   pixel_x = PAD_X + (col / 2) * TILE_W + layer * LAYER_DX
+ *   pixel_y = PAD_Y + row * TILE_H − layer * LAYER_DY
+ *
+ * Rendering order: layer ASC so higher layers appear on top.
+ * Hit-testing: topmost tile (highest layer) at touch point wins.
+ *
+ * SVG face art is gated behind a placeholder until Story #875 lands.
+ */
+
+import React, { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Canvas, Fill, Group, Rect } from "@shopify/react-native-skia";
+import { useTranslation } from "react-i18next";
+import { hasFreePairs, isFreeTile } from "../../game/mahjong/engine";
+import type { MahjongState, SlotTile } from "../../game/mahjong/types";
+
+// ---------------------------------------------------------------------------
+// Layout constants
+// ---------------------------------------------------------------------------
+
+const TILE_W = 44; // face width
+const TILE_H = 56; // face height
+const SIDE_W = 5; // 3-D side strip width (right + bottom)
+const LAYER_DX = 6; // rightward offset per layer
+const LAYER_DY = 5; // upward offset per layer
+const PAD_X = 10;
+const PAD_Y = 30; // extra top padding so layer-4 tiles don't clip
+
+export const BOARD_W = PAD_X + 12 * TILE_W + 4 * LAYER_DX + PAD_X; // 572
+export const BOARD_H = PAD_Y + 8 * TILE_H + 4 * LAYER_DY + PAD_Y; // 508
+
+function tileX(col: number, layer: number): number {
+  return PAD_X + (col / 2) * TILE_W + layer * LAYER_DX;
+}
+function tileY(row: number, layer: number): number {
+  return PAD_Y + row * TILE_H - layer * LAYER_DY;
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const BG = "#1a3a1a";
+const TILE_FACE = "#f5f0e8";
+const TILE_FACE_LOCKED = "#d0c8b8";
+const BORDER_NORMAL = "#8b7355";
+const BORDER_SELECTED = "#ffd700";
+const BORDER_HINT = "#5dbcd2";
+const SIDE_R = "#a89070";
+const SIDE_B = "#987860";
+const SHADOW = "rgba(0,0,0,0.35)";
+
+const SUIT_COLOR: Record<string, string> = {
+  characters: "#cc0000",
+  circles: "#006633",
+  bamboos: "#003322",
+  winds: "#334455",
+  dragons: "#880011",
+  flowers: "#aa2299",
+  seasons: "#0044aa",
+};
+
+// ---------------------------------------------------------------------------
+// Hit-testing
+// ---------------------------------------------------------------------------
+
+function hitTest(tiles: readonly SlotTile[], tapX: number, tapY: number): number | null {
+  const fw = TILE_W - SIDE_W;
+  const fh = TILE_H - SIDE_W;
+  // Iterate from highest layer down so the topmost tile wins.
+  const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
+  for (const tile of sorted) {
+    const x = tileX(tile.col, tile.layer);
+    const y = tileY(tile.row, tile.layer);
+    if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
+      return tile.id;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface Props {
+  state: MahjongState;
+  onTilePress: (tileId: number) => void;
+  onShufflePress: () => void;
+  onNewGamePress: () => void;
+}
+
+export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
+  const { t } = useTranslation("mahjong");
+
+  const freeTiles = useMemo(() => {
+    const s = new Set<number>();
+    for (const tile of state.tiles) {
+      if (isFreeTile(tile, state.tiles)) s.add(tile.id);
+    }
+    return s;
+  }, [state.tiles]);
+
+  const noFreePairs = useMemo(
+    () => !state.isComplete && !hasFreePairs(state.tiles),
+    [state.isComplete, state.tiles]
+  );
+  const showShuffleCTA = noFreePairs && state.shufflesLeft > 0;
+
+  const sortedTiles = useMemo(
+    () => [...state.tiles].sort((a, b) => a.layer - b.layer || a.row - b.row),
+    [state.tiles]
+  );
+
+  const selectedId = state.selected?.id ?? null;
+  const hasSelection = selectedId !== null;
+  const gameActive = !state.isComplete && !state.isDeadlocked && !showShuffleCTA;
+
+  function handleTap(e: { nativeEvent: { locationX: number; locationY: number } }) {
+    if (!gameActive) return;
+    const { locationX, locationY } = e.nativeEvent;
+    const tileId = hitTest(state.tiles, locationX, locationY);
+    if (tileId !== null) onTilePress(tileId);
+  }
+
+  return (
+    <View style={{ width: BOARD_W, height: BOARD_H }}>
+      <Canvas
+        style={{ width: BOARD_W, height: BOARD_H }}
+        accessibilityLabel={t("game.canvasLabel")}
+        accessibilityRole="none"
+      >
+        <Fill color={BG} />
+        {sortedTiles.map((tile) => {
+          const x = tileX(tile.col, tile.layer);
+          const y = tileY(tile.row, tile.layer);
+          const isSelected = tile.id === selectedId;
+          const isFree = freeTiles.has(tile.id);
+          const borderColor = isSelected
+            ? BORDER_SELECTED
+            : isFree && hasSelection
+              ? BORDER_HINT
+              : BORDER_NORMAL;
+          const faceColor = isFree ? TILE_FACE : TILE_FACE_LOCKED;
+          const suitColor = SUIT_COLOR[tile.suit] ?? "#888888";
+          const fw = TILE_W - SIDE_W;
+          const fh = TILE_H - SIDE_W;
+
+          return (
+            <Group key={tile.id}>
+              {/* Drop shadow */}
+              <Rect x={x + SIDE_W + 2} y={y + SIDE_W + 2} width={fw} height={fh} color={SHADOW} />
+              {/* Right 3-D side */}
+              <Rect x={x + fw} y={y + SIDE_W} width={SIDE_W} height={fh} color={SIDE_R} />
+              {/* Bottom 3-D side */}
+              <Rect x={x + SIDE_W} y={y + fh} width={fw} height={SIDE_W} color={SIDE_B} />
+              {/* Border */}
+              <Rect x={x} y={y} width={fw} height={fh} color={borderColor} />
+              {/* Face */}
+              <Rect x={x + 1} y={y + 1} width={fw - 2} height={fh - 2} color={faceColor} />
+              {/* Suit placeholder — replaced by SVG art in Story #875 */}
+              <Rect
+                x={x + 8}
+                y={y + 10}
+                width={fw - 16}
+                height={fh - 20}
+                color={suitColor}
+                opacity={isFree ? 0.8 : 0.35}
+              />
+            </Group>
+          );
+        })}
+      </Canvas>
+
+      {/* Touch capture layer — disabled during overlays */}
+      {gameActive && (
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleTap} accessibilityRole="none" />
+      )}
+
+      {/* Shuffle CTA overlay */}
+      {showShuffleCTA && (
+        <View style={[styles.overlay, styles.noMovesOverlay]}>
+          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onShufflePress}
+            accessibilityLabel={t("action.shuffleLabel")}
+          >
+            <Text style={styles.btnText}>
+              {t("overlay.shuffleButton")} ({state.shufflesLeft})
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Deadlock overlay */}
+      {state.isDeadlocked && (
+        <View style={[styles.overlay, styles.noMovesOverlay]}>
+          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onNewGamePress}
+            accessibilityLabel={t("action.newGameLabel")}
+          >
+            <Text style={styles.btnText}>{t("overlay.newGameButton")}</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Win overlay */}
+      {state.isComplete && (
+        <View style={[styles.overlay, styles.winOverlay]}>
+          <Text style={styles.winTitle}>{t("overlay.youWon")}</Text>
+          <Text style={styles.overlayDetail}>
+            {t("overlay.youWonDetail", { count: state.pairsRemoved })}
+          </Text>
+          <Text style={styles.winScore}>{t("score.display", { score: state.score })}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onNewGamePress}
+            accessibilityLabel={t("action.newGameLabel")}
+          >
+            <Text style={styles.btnText}>{t("overlay.newGameButton")}</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  noMovesOverlay: {
+    backgroundColor: "rgba(0,0,0,0.72)",
+  },
+  winOverlay: {
+    backgroundColor: "rgba(0,20,0,0.82)",
+  },
+  overlayTitle: {
+    color: "#ffffff",
+    fontSize: 24,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  overlayDetail: {
+    color: "#cccccc",
+    fontSize: 14,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  winTitle: {
+    color: "#ffd700",
+    fontSize: 30,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  winScore: {
+    color: "#ffffff",
+    fontSize: 18,
+    textAlign: "center",
+    marginBottom: 20,
+    fontVariant: ["tabular-nums"],
+  },
+  btn: {
+    backgroundColor: "#2a7a2a",
+    paddingVertical: 10,
+    paddingHorizontal: 28,
+    borderRadius: 6,
+    marginTop: 4,
+  },
+  btnText: {
+    color: "#ffffff",
+    fontSize: 15,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+});

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -1,0 +1,330 @@
+/**
+ * Mahjong Solitaire — web canvas (Expo Web / browser).
+ *
+ * Rendered via HTML Canvas 2D.
+ * Metro uses this file automatically on the web platform.
+ *
+ * Tile geometry (grid → pixels):
+ *   pixel_x = PAD_X + (col / 2) * TILE_W + layer * LAYER_DX
+ *   pixel_y = PAD_Y + row * TILE_H − layer * LAYER_DY
+ *
+ * SVG face art is gated behind a placeholder until Story #875 lands.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { hasFreePairs, isFreeTile } from "../../game/mahjong/engine";
+import type { MahjongState, SlotTile } from "../../game/mahjong/types";
+
+// ---------------------------------------------------------------------------
+// Layout constants (mirror GameCanvas.tsx exactly)
+// ---------------------------------------------------------------------------
+
+const TILE_W = 44;
+const TILE_H = 56;
+const SIDE_W = 5;
+const LAYER_DX = 6;
+const LAYER_DY = 5;
+const PAD_X = 10;
+const PAD_Y = 30;
+
+export const BOARD_W = PAD_X + 12 * TILE_W + 4 * LAYER_DX + PAD_X; // 572
+export const BOARD_H = PAD_Y + 8 * TILE_H + 4 * LAYER_DY + PAD_Y; // 508
+
+function tileX(col: number, layer: number): number {
+  return PAD_X + (col / 2) * TILE_W + layer * LAYER_DX;
+}
+function tileY(row: number, layer: number): number {
+  return PAD_Y + row * TILE_H - layer * LAYER_DY;
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+const BG = "#1a3a1a";
+const TILE_FACE = "#f5f0e8";
+const TILE_FACE_LOCKED = "#d0c8b8";
+const BORDER_NORMAL = "#8b7355";
+const BORDER_SELECTED = "#ffd700";
+const BORDER_HINT = "#5dbcd2";
+const SIDE_R = "#a89070";
+const SIDE_B = "#987860";
+
+const SUIT_COLOR: Record<string, string> = {
+  characters: "#cc0000",
+  circles: "#006633",
+  bamboos: "#003322",
+  winds: "#334455",
+  dragons: "#880011",
+  flowers: "#aa2299",
+  seasons: "#0044aa",
+};
+
+// ---------------------------------------------------------------------------
+// Hit-testing
+// ---------------------------------------------------------------------------
+
+function hitTest(tiles: readonly SlotTile[], tapX: number, tapY: number): number | null {
+  const fw = TILE_W - SIDE_W;
+  const fh = TILE_H - SIDE_W;
+  const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
+  for (const tile of sorted) {
+    const x = tileX(tile.col, tile.layer);
+    const y = tileY(tile.row, tile.layer);
+    if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
+      return tile.id;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Canvas 2D drawing
+// ---------------------------------------------------------------------------
+
+function drawBoard(
+  ctx: CanvasRenderingContext2D,
+  state: MahjongState,
+  freeTiles: ReadonlySet<number>
+): void {
+  ctx.clearRect(0, 0, BOARD_W, BOARD_H);
+
+  // Background
+  ctx.fillStyle = BG;
+  ctx.fillRect(0, 0, BOARD_W, BOARD_H);
+
+  const selectedId = state.selected?.id ?? null;
+  const hasSelection = selectedId !== null;
+
+  // Draw tiles lowest layer → highest so higher layers appear on top.
+  const sorted = [...state.tiles].sort((a, b) => a.layer - b.layer || a.row - b.row);
+
+  for (const tile of sorted) {
+    const x = tileX(tile.col, tile.layer);
+    const y = tileY(tile.row, tile.layer);
+    const isSelected = tile.id === selectedId;
+    const isFree = freeTiles.has(tile.id);
+    const fw = TILE_W - SIDE_W;
+    const fh = TILE_H - SIDE_W;
+
+    const borderColor = isSelected
+      ? BORDER_SELECTED
+      : isFree && hasSelection
+        ? BORDER_HINT
+        : BORDER_NORMAL;
+    const faceColor = isFree ? TILE_FACE : TILE_FACE_LOCKED;
+    const suitColor = SUIT_COLOR[tile.suit] ?? "#888888";
+
+    // Drop shadow
+    ctx.fillStyle = "rgba(0,0,0,0.35)";
+    ctx.fillRect(x + SIDE_W + 2, y + SIDE_W + 2, fw, fh);
+
+    // Right 3-D side
+    ctx.fillStyle = SIDE_R;
+    ctx.fillRect(x + fw, y + SIDE_W, SIDE_W, fh);
+
+    // Bottom 3-D side
+    ctx.fillStyle = SIDE_B;
+    ctx.fillRect(x + SIDE_W, y + fh, fw, SIDE_W);
+
+    // Border
+    ctx.fillStyle = borderColor;
+    ctx.fillRect(x, y, fw, fh);
+
+    // Face
+    ctx.fillStyle = faceColor;
+    ctx.fillRect(x + 1, y + 1, fw - 2, fh - 2);
+
+    // Suit placeholder — replaced by SVG art in Story #875
+    ctx.globalAlpha = isFree ? 0.8 : 0.35;
+    ctx.fillStyle = suitColor;
+    ctx.fillRect(x + 8, y + 10, fw - 16, fh - 20);
+    ctx.globalAlpha = 1;
+
+    // Rank text (placeholder — gives extra visual info on web)
+    ctx.font = "bold 11px monospace";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "bottom";
+    ctx.fillStyle = isFree ? "#ffffff" : "#aaaaaa";
+    ctx.fillText(String(tile.rank), x + fw / 2, y + fh - 2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface Props {
+  state: MahjongState;
+  onTilePress: (tileId: number) => void;
+  onShufflePress: () => void;
+  onNewGamePress: () => void;
+}
+
+export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
+  const { t } = useTranslation("mahjong");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const freeTiles = useMemo(() => {
+    const s = new Set<number>();
+    for (const tile of state.tiles) {
+      if (isFreeTile(tile, state.tiles)) s.add(tile.id);
+    }
+    return s;
+  }, [state.tiles]);
+
+  const noFreePairs = useMemo(
+    () => !state.isComplete && !hasFreePairs(state.tiles),
+    [state.isComplete, state.tiles]
+  );
+  const showShuffleCTA = noFreePairs && state.shufflesLeft > 0;
+  const gameActive = !state.isComplete && !state.isDeadlocked && !showShuffleCTA;
+
+  // Redraw whenever state changes.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    drawBoard(ctx, state, freeTiles);
+  }, [state, freeTiles]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!gameActive) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const tapX = e.clientX - rect.left;
+      const tapY = e.clientY - rect.top;
+      const tileId = hitTest(state.tiles, tapX, tapY);
+      if (tileId !== null) onTilePress(tileId);
+    },
+    [state.tiles, onTilePress, gameActive]
+  );
+
+  return (
+    <View style={{ width: BOARD_W, height: BOARD_H }}>
+      <canvas
+        ref={canvasRef}
+        width={BOARD_W}
+        height={BOARD_H}
+        onClick={handleClick}
+        style={{ display: "block", cursor: gameActive ? "pointer" : "default" }}
+        aria-label={t("game.canvasLabel")}
+        role="img"
+      />
+
+      {/* Shuffle CTA overlay */}
+      {showShuffleCTA && (
+        <View style={[styles.overlay, styles.noMovesOverlay]}>
+          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onShufflePress}
+            accessibilityLabel={t("action.shuffleLabel")}
+          >
+            <Text style={styles.btnText}>
+              {t("overlay.shuffleButton")} ({state.shufflesLeft})
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Deadlock overlay */}
+      {state.isDeadlocked && (
+        <View style={[styles.overlay, styles.noMovesOverlay]}>
+          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onNewGamePress}
+            accessibilityLabel={t("action.newGameLabel")}
+          >
+            <Text style={styles.btnText}>{t("overlay.newGameButton")}</Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Win overlay */}
+      {state.isComplete && (
+        <View style={[styles.overlay, styles.winOverlay]}>
+          <Text style={styles.winTitle}>{t("overlay.youWon")}</Text>
+          <Text style={styles.overlayDetail}>
+            {t("overlay.youWonDetail", { count: state.pairsRemoved })}
+          </Text>
+          <Text style={styles.winScore}>{t("score.display", { score: state.score })}</Text>
+          <Pressable
+            style={styles.btn}
+            onPress={onNewGamePress}
+            accessibilityLabel={t("action.newGameLabel")}
+          >
+            <Text style={styles.btnText}>{t("overlay.newGameButton")}</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  noMovesOverlay: {
+    backgroundColor: "rgba(0,0,0,0.72)",
+  },
+  winOverlay: {
+    backgroundColor: "rgba(0,20,0,0.82)",
+  },
+  overlayTitle: {
+    color: "#ffffff",
+    fontSize: 24,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  overlayDetail: {
+    color: "#cccccc",
+    fontSize: 14,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  winTitle: {
+    color: "#ffd700",
+    fontSize: 30,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  winScore: {
+    color: "#ffffff",
+    fontSize: 18,
+    textAlign: "center",
+    marginBottom: 20,
+    fontVariant: ["tabular-nums"],
+  },
+  btn: {
+    backgroundColor: "#2a7a2a",
+    paddingVertical: 10,
+    paddingHorizontal: 28,
+    borderRadius: 6,
+    marginTop: 4,
+  },
+  btnText: {
+    color: "#ffffff",
+    fontSize: 15,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+});

--- a/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
+++ b/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Smoke tests for the Mahjong GameCanvas component.
+ *
+ * Canvas rendering (Skia / Canvas 2D) is not assertable in Jest — tests
+ * verify that the component mounts without crashing and that overlays
+ * appear for the correct game states.
+ */
+
+import React from "react";
+import { create, act } from "react-test-renderer";
+import type { MahjongState } from "../../../game/mahjong/types";
+import { createGame } from "../../../game/mahjong/engine";
+import { TURTLE_LAYOUT } from "../../../game/mahjong/layouts/turtle";
+
+// Skia requires a native module — stub the whole package.
+jest.mock("@shopify/react-native-skia", () => ({
+  Canvas: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Fill: () => null,
+  Group: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  Rect: () => null,
+}));
+
+// Use the web variant (no Skia). The canvas ref will be null in jsdom, which
+// the component handles gracefully via the `if (!ctx) return` guard.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { default: GameCanvas } = require("../GameCanvas.web");
+
+function makeState(overrides: Partial<MahjongState> = {}): MahjongState {
+  return { ...createGame(TURTLE_LAYOUT, 12345), ...overrides };
+}
+
+const noop = () => {};
+
+describe("GameCanvas (web)", () => {
+  it("renders without crashing on a fresh game", () => {
+    expect(() => {
+      act(() => {
+        create(
+          <GameCanvas
+            state={makeState()}
+            onTilePress={noop}
+            onShufflePress={noop}
+            onNewGamePress={noop}
+          />
+        );
+      });
+    }).not.toThrow();
+  });
+
+  it("shows the win overlay when isComplete", () => {
+    const state = makeState({ isComplete: true, tiles: [], pairsRemoved: 72, score: 1220 });
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+      );
+    });
+    // i18n returns keys in tests — check for the key, not the translated string.
+    expect(JSON.stringify(tree!.toJSON())).toContain("overlay.youWon");
+  });
+
+  it("shows the no-moves overlay when isDeadlocked", () => {
+    const state = makeState({ isDeadlocked: true, shufflesLeft: 0 });
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+      );
+    });
+    expect(JSON.stringify(tree!.toJSON())).toContain("overlay.noMoves");
+  });
+
+  it("shows the shuffle CTA when no free pairs remain and shuffles are available", () => {
+    // tiles=[] means hasFreePairs([]) === false; isComplete=false, shufflesLeft>0 → shuffle CTA
+    const state = makeState({
+      tiles: [],
+      isComplete: false,
+      isDeadlocked: false,
+      shufflesLeft: 2,
+    });
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+      );
+    });
+    // Shuffle CTA shows the noMoves key + shuffle button
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).toContain("overlay.noMoves");
+    expect(str).toContain("overlay.shuffleButton");
+  });
+
+  it("does not show any overlay during normal play", () => {
+    const state = makeState();
+    let tree: ReturnType<typeof create>;
+    act(() => {
+      tree = create(
+        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+      );
+    });
+    const str = JSON.stringify(tree!.toJSON());
+    expect(str).not.toContain("overlay.youWon");
+    expect(str).not.toContain("overlay.noMoves");
+  });
+});


### PR DESCRIPTION
## Summary
- `GameCanvas.tsx` — native (iOS/Android): @shopify/react-native-skia canvas with Rect-based 3-D tile rendering, per-layer depth shadows, selection/free-tile highlight, touch hit-testing via Pressable overlay
- `GameCanvas.web.tsx` — web: HTML Canvas 2D with identical tile geometry, rank text labels, click hit-testing
- Both share: same pixel geometry (TILE_W=44, TILE_H=56, 5-layer depth offsets), suit color placeholders, and three overlay states (shuffle CTA, deadlock, win)
- SVG face art gated; placeholder colored rectangles + rank text on web render the game fully playable

## Test plan
- [x] 5 smoke tests: mounts without crash, win/deadlock/shuffle overlays appear for correct states, no overlay during normal play
- [x] 1800/1800 tests passing, lint + Prettier clean

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)