### PR TITLE
feat(#874): MahjongScreen — navigation, lobby, provider, and screen tests

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -32,6 +32,7 @@ import { Twenty48ScoreboardProvider } from "./src/game/twenty48/Twenty48Scoreboa
 import { SolitaireScoreboardProvider } from "./src/game/solitaire/SolitaireScoreboardContext";
 import { SudokuScoreboardProvider } from "./src/game/sudoku/SudokuScoreboardContext";
 import { CascadeScoreboardProvider } from "./src/game/cascade/CascadeScoreboardContext";
+import { MahjongScoreboardProvider } from "./src/game/mahjong/MahjongScoreboardContext";
 import { SessionLogger } from "./src/components/FeedbackWidget/SessionLogger";
 import { installSentryConsoleErrorCapture } from "./src/utils/sentryConsoleError";
 import { LazyScreens } from "./src/utils/lazyScreens";
@@ -71,8 +72,17 @@ export type HomeStackParamList = {
   FreeCell: undefined;
   Hearts: undefined;
   Sudoku: undefined;
+  Mahjong: undefined;
   Scoreboard: {
-    gameKey: "hearts" | "yacht" | "blackjack" | "twenty48" | "solitaire" | "sudoku" | "cascade";
+    gameKey:
+      | "hearts"
+      | "yacht"
+      | "blackjack"
+      | "twenty48"
+      | "solitaire"
+      | "sudoku"
+      | "cascade"
+      | "mahjong";
   };
 };
 
@@ -145,6 +155,7 @@ const LazySolitaireScreen = withSuspense(LazyScreens.Solitaire, "solitaire");
 const LazyFreeCellScreen = withSuspense(LazyScreens.FreeCell, "freecell");
 const LazyHeartsScreen = withSuspense(LazyScreens.Hearts, "hearts");
 const LazySudokuScreen = withSuspense(LazyScreens.Sudoku, "sudoku");
+const LazyMahjongScreen = withSuspense(LazyScreens.Mahjong, "mahjong");
 const LazyLeaderboardScreen = withSuspense(LazyScreens.Leaderboard, "leaderboard");
 const LazyGameDetailScreen = withSuspense(LazyScreens.GameDetail, "game_detail");
 const LazySettingsScreen = withSuspense(LazyScreens.Settings, "settings");
@@ -169,6 +180,7 @@ function LobbyStack() {
       <HomeStack.Screen name="FreeCell" component={LazyFreeCellScreen} />
       <HomeStack.Screen name="Hearts" component={LazyHeartsScreen} />
       <HomeStack.Screen name="Sudoku" component={LazySudokuScreen} />
+      <HomeStack.Screen name="Mahjong" component={LazyMahjongScreen} />
       <HomeStack.Screen name="Scoreboard" component={LazyScoreboardScreen} />
     </HomeStack.Navigator>
   );
@@ -222,11 +234,13 @@ function AppInner() {
                     <SolitaireScoreboardProvider>
                       <SudokuScoreboardProvider>
                         <CascadeScoreboardProvider>
-                          <NavigationContainer>
-                            <Stack.Navigator screenOptions={{ headerShown: false }}>
-                              <Stack.Screen name="MainTabs" component={MainTabs} />
-                            </Stack.Navigator>
-                          </NavigationContainer>
+                          <MahjongScoreboardProvider>
+                            <NavigationContainer>
+                              <Stack.Navigator screenOptions={{ headerShown: false }}>
+                                <Stack.Screen name="MainTabs" component={MainTabs} />
+                              </Stack.Navigator>
+                            </NavigationContainer>
+                          </MahjongScoreboardProvider>
                         </CascadeScoreboardProvider>
                       </SudokuScoreboardProvider>
                     </SolitaireScoreboardProvider>

--- a/frontend/src/game/mahjong/MahjongScoreboardContext.tsx
+++ b/frontend/src/game/mahjong/MahjongScoreboardContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState } from "react";
+
+export interface MahjongScoreboardSnapshot {
+  score: number;
+  pairsRemoved: number;
+  shufflesLeft: number;
+  elapsedMs: number;
+  hasGame: boolean;
+  bestScore: number;
+  bestTimeMs: number;
+  gamesPlayed: number;
+  gamesWon: number;
+}
+
+const initial: MahjongScoreboardSnapshot = {
+  score: 0,
+  pairsRemoved: 0,
+  shufflesLeft: 3,
+  elapsedMs: 0,
+  hasGame: false,
+  bestScore: 0,
+  bestTimeMs: 0,
+  gamesPlayed: 0,
+  gamesWon: 0,
+};
+
+interface ContextValue {
+  snapshot: MahjongScoreboardSnapshot;
+  setSnapshot: (s: MahjongScoreboardSnapshot) => void;
+}
+
+const MahjongScoreboardContext = createContext<ContextValue | null>(null);
+
+export function MahjongScoreboardProvider({ children }: { children: React.ReactNode }) {
+  const [snapshot, setSnapshot] = useState(initial);
+  return (
+    <MahjongScoreboardContext.Provider value={{ snapshot, setSnapshot }}>
+      {children}
+    </MahjongScoreboardContext.Provider>
+  );
+}
+
+export function useMahjongScoreboard() {
+  const ctx = useContext(MahjongScoreboardContext);
+  if (!ctx) throw new Error("useMahjongScoreboard must be inside MahjongScoreboardProvider");
+  return ctx;
+}

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -40,6 +40,7 @@ export default function HomeScreen() {
     "hearts",
     "sudoku",
     "starswarm",
+    "mahjong",
     "errors",
   ]);
   const { colors } = useTheme();
@@ -135,6 +136,13 @@ export default function HomeScreen() {
       description: t("starswarm:game.description"),
       action: () => navigation.navigate("StarSwarm"),
     },
+    {
+      key: "mahjong",
+      emoji: "🀄",
+      title: t("mahjong:game.title"),
+      description: t("mahjong:game.description"),
+      action: () => navigation.navigate("Mahjong"),
+    },
   ];
 
   const playLabels: Record<string, string> = {
@@ -147,6 +155,7 @@ export default function HomeScreen() {
     [t("hearts:game.title")]: t("hearts:game.playLabel"),
     [t("sudoku:game.title")]: t("sudoku:game.playLabel"),
     [t("starswarm:game.title")]: t("starswarm:game.playLabel"),
+    [t("mahjong:game.title")]: t("mahjong:game.playLabel"),
   };
 
   // Cycle through BC Arcade accent colors for the gradient top border on each card.

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -1,0 +1,595 @@
+/**
+ * MahjongScreen — Mahjong Solitaire with full lifecycle wiring (#874).
+ *
+ * Concerns:
+ *   1. Game logic — dispatches engine functions (selectTile, shuffleBoard,
+ *      undoMove) in response to GameCanvas callbacks; engine is pure and
+ *      replaces state wholesale on every transition.
+ *   2. Persistence — AsyncStorage save/resume on every mutation.
+ *   3. Instrumentation — useGameSync session started on first tile tap,
+ *      completed on win, abandoned on back-navigation.
+ *   4. Score submission — scoreQueue.enqueue("mahjong", …) on win; never
+ *      calls mahjongApi.submitScore directly.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  LayoutChangeEvent,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  ViewStyle,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+import { HomeStackParamList } from "../../App";
+import { useTheme } from "../theme/ThemeContext";
+import { typography } from "../theme/typography";
+import { GameShell } from "../components/shared/GameShell";
+import { OfflineBanner } from "../components/shared/OfflineBanner";
+import GameCanvas, { BOARD_W, BOARD_H } from "../components/mahjong/GameCanvas";
+import { createGame, elapsedMs, selectTile, shuffleBoard, undoMove } from "../game/mahjong/engine";
+import { TURTLE_LAYOUT } from "../game/mahjong/layouts/turtle";
+import type { MahjongState } from "../game/mahjong/types";
+import {
+  clearGame,
+  loadGame,
+  loadStats,
+  saveGame,
+  saveStats,
+  type MahjongStats,
+} from "../game/mahjong/storage";
+import { useMahjongScoreboard } from "../game/mahjong/MahjongScoreboardContext";
+import { scoreQueue } from "../game/_shared/scoreQueue";
+import { useGameSync } from "../game/_shared/useGameSync";
+import { useNetwork } from "../game/_shared/NetworkContext";
+
+const MAX_NAME_LENGTH = 32;
+
+export default function MahjongScreen() {
+  const { t } = useTranslation("mahjong");
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+
+  const [state, setState] = useState<MahjongState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [outerWidth, setOuterWidth] = useState(0);
+  const [stats, setStats] = useState<MahjongStats>({
+    bestScore: 0,
+    bestTimeMs: 0,
+    gamesPlayed: 0,
+    gamesWon: 0,
+  });
+
+  const hasLoadedRef = useRef(false);
+  const stateRef = useRef<MahjongState | null>(null);
+  const winRecordedRef = useRef(false);
+  const prevCompleteRef = useRef(false);
+
+  const {
+    start: syncStart,
+    markStarted: syncMarkStarted,
+    complete: syncComplete,
+    getGameId: syncGetGameId,
+  } = useGameSync("mahjong");
+
+  const { setSnapshot: setScoreboardSnapshot } = useMahjongScoreboard();
+
+  // Scoreboard snapshot — updated on every state change.
+  useEffect(() => {
+    if (!state) return;
+    const elapsed = elapsedMs(state, Date.now());
+    setScoreboardSnapshot({
+      score: state.score,
+      pairsRemoved: state.pairsRemoved,
+      shufflesLeft: state.shufflesLeft,
+      elapsedMs: elapsed,
+      hasGame: true,
+      bestScore: stats.bestScore,
+      bestTimeMs: stats.bestTimeMs,
+      gamesPlayed: stats.gamesPlayed,
+      gamesWon: stats.gamesWon,
+    });
+  }, [state, stats, setScoreboardSnapshot]);
+
+  // Mount: restore saved game or deal fresh.
+  useEffect(() => {
+    let alive = true;
+    Promise.all([loadGame(), loadStats()]).then(([saved, savedStats]) => {
+      if (!alive) return;
+      hasLoadedRef.current = true;
+      if (saved !== null) {
+        setState(saved);
+        if (saved.isComplete) winRecordedRef.current = true;
+      } else {
+        setState(createGame(TURTLE_LAYOUT));
+        setStats((prev) => {
+          const updated = { ...prev, gamesPlayed: prev.gamesPlayed + 1 };
+          saveStats(updated).catch(() => {});
+          return updated;
+        });
+      }
+      setStats(savedStats);
+      setLoading(false);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Persist on every state change after mount load resolves.
+  useEffect(() => {
+    stateRef.current = state;
+    if (!hasLoadedRef.current || state === null) return;
+    saveGame(state).catch(() => {});
+  }, [state]);
+
+  // Win lifecycle: complete sync session, record stats.
+  useEffect(() => {
+    if (state === null) {
+      prevCompleteRef.current = false;
+      return;
+    }
+    if (state.isComplete && !prevCompleteRef.current) {
+      syncComplete(
+        { finalScore: state.score, outcome: "completed", durationMs: state.accumulatedMs },
+        { final_score: state.score, outcome: "completed", pairs: state.pairsRemoved }
+      );
+      clearGame().catch(() => {});
+      if (!winRecordedRef.current) {
+        winRecordedRef.current = true;
+        const finalMs = state.accumulatedMs;
+        const finalScore = state.score;
+        setStats((prev) => {
+          const updated: MahjongStats = {
+            ...prev,
+            gamesWon: prev.gamesWon + 1,
+            bestScore: finalScore > prev.bestScore ? finalScore : prev.bestScore,
+            bestTimeMs:
+              prev.bestTimeMs === 0 || finalMs < prev.bestTimeMs ? finalMs : prev.bestTimeMs,
+          };
+          saveStats(updated).catch(() => {});
+          return updated;
+        });
+      }
+    }
+    prevCompleteRef.current = state.isComplete;
+  }, [state, syncComplete]);
+
+  // Abandon on back-navigation.
+  useEffect(() => {
+    const unsub = navigation.addListener("beforeRemove", () => {
+      if (!syncGetGameId()) return;
+      const s = stateRef.current;
+      if (s?.isComplete) return;
+      syncComplete(
+        { outcome: "abandoned", finalScore: s?.score ?? 0, durationMs: 0 },
+        { outcome: "abandoned" }
+      );
+    });
+    return unsub;
+  }, [navigation, syncComplete, syncGetGameId]);
+
+  const ensureSyncStarted = useCallback(
+    (s: MahjongState) => {
+      if (syncGetGameId()) return;
+      syncStart({ layout: "turtle" });
+      syncMarkStarted();
+      // Count the new game on the first real action (first tile tap).
+      if (s.pairsRemoved === 0 && !hasLoadedRef.current) return;
+    },
+    [syncGetGameId, syncStart, syncMarkStarted]
+  );
+
+  const handleTilePress = useCallback(
+    (tileId: number) => {
+      setState((prev) => {
+        if (!prev) return prev;
+        const next = selectTile(prev, tileId);
+        if (next === prev) return prev;
+        ensureSyncStarted(next);
+        return next;
+      });
+    },
+    [ensureSyncStarted]
+  );
+
+  const handleShuffle = useCallback(() => {
+    setState((prev) => {
+      if (!prev) return prev;
+      const next = shuffleBoard(prev);
+      if (next === prev) return prev;
+      ensureSyncStarted(next);
+      return next;
+    });
+  }, [ensureSyncStarted]);
+
+  const handleUndo = useCallback(() => {
+    setState((prev) => {
+      if (!prev) return prev;
+      return undoMove(prev);
+    });
+  }, []);
+
+  const startNewGame = useCallback(() => {
+    winRecordedRef.current = false;
+    prevCompleteRef.current = false;
+    const fresh = createGame(TURTLE_LAYOUT);
+    setState(fresh);
+    setStats((prev) => {
+      const updated = { ...prev, gamesPlayed: prev.gamesPlayed + 1 };
+      saveStats(updated).catch(() => {});
+      return updated;
+    });
+    // Abandon any open session before starting a new one.
+    if (syncGetGameId()) {
+      syncComplete(
+        { outcome: "abandoned", finalScore: 0, durationMs: 0 },
+        { outcome: "abandoned" }
+      );
+    }
+    syncStart({ layout: "turtle" });
+    syncMarkStarted();
+  }, [syncGetGameId, syncComplete, syncStart, syncMarkStarted]);
+
+  const scale = outerWidth > 0 ? Math.min(1, outerWidth / BOARD_W) : 1;
+
+  const onOuterLayout = useCallback((e: LayoutChangeEvent) => {
+    setOuterWidth(Math.floor(e.nativeEvent.layout.width));
+  }, []);
+
+  const undoDisabled = !state || state.undoStack.length === 0 || state.isComplete;
+
+  return (
+    <GameShell
+      title={t("game.title")}
+      requireBack
+      loading={loading}
+      onBack={() => navigation.popToTop()}
+      style={{
+        paddingBottom: Math.max(insets.bottom, 16),
+        paddingLeft: Math.max(insets.left, 12),
+        paddingRight: Math.max(insets.right, 12),
+      }}
+      onNewGame={startNewGame}
+      onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "mahjong" })}
+      rightSlot={
+        <Pressable
+          onPress={handleUndo}
+          disabled={undoDisabled}
+          style={[
+            styles.headerBtn,
+            { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel={t("action.undoLabel")}
+          accessibilityState={{ disabled: undoDisabled }}
+        >
+          <Text style={[styles.headerBtnText, { color: colors.accent }]}>{t("action.undo")}</Text>
+        </Pressable>
+      }
+    >
+      <ScrollView
+        style={styles.scrollArea}
+        contentContainerStyle={styles.scrollContent}
+        onLayout={onOuterLayout}
+        showsVerticalScrollIndicator={false}
+      >
+        {state !== null && (
+          <>
+            <View style={styles.hudRow} accessibilityRole="summary">
+              <Text style={[styles.hudText, { color: colors.text }]}>
+                {t("hud.score")} {state.score}
+              </Text>
+              <Text style={[styles.hudText, { color: colors.textMuted }]}>
+                {t("hud.pairs")} {state.pairsRemoved}/72
+              </Text>
+              <Text style={[styles.hudText, { color: colors.textMuted }]}>
+                {t("action.shuffle")} {state.shufflesLeft}
+              </Text>
+            </View>
+
+            <View style={[styles.boardWrap, outerWidth > 0 ? { height: BOARD_H * scale } : null]}>
+              <View style={[styles.board, { width: BOARD_W, transform: [{ scale }] } as ViewStyle]}>
+                <GameCanvas
+                  state={state}
+                  onTilePress={handleTilePress}
+                  onShufflePress={handleShuffle}
+                  onNewGamePress={startNewGame}
+                />
+              </View>
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      {state?.isComplete && (
+        <WinModal score={state.score} pairsRemoved={state.pairsRemoved} onNewGame={startNewGame} />
+      )}
+    </GameShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Win modal — name entry + ScoreQueue submission
+// ---------------------------------------------------------------------------
+
+function WinModal({
+  score,
+  pairsRemoved,
+  onNewGame,
+}: {
+  readonly score: number;
+  readonly pairsRemoved: number;
+  readonly onNewGame: () => void;
+}) {
+  const { t } = useTranslation("mahjong");
+  const { colors } = useTheme();
+  const { isOnline, isInitialized } = useNetwork();
+
+  const [name, setName] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const offline = isInitialized && !isOnline;
+  const trimmed = name.trim();
+  const canSubmit = !submitting && !offline && trimmed.length > 0;
+
+  const gradient: ViewStyle =
+    Platform.OS === "web"
+      ? ({
+          backgroundImage: `linear-gradient(135deg, ${colors.accent}, ${colors.accentBright})`,
+        } as ViewStyle)
+      : { backgroundColor: colors.accentBright };
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await scoreQueue.enqueue("mahjong", { player_name: trimmed, score });
+      setSubmitted(true);
+      scoreQueue.flush().catch(() => undefined);
+    } catch {
+      setError(t("error.submitFailed", { defaultValue: "Couldn't save score. Tap to retry." }));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const submitLabel = error
+    ? t("error.submitRetry", { defaultValue: "Retry" })
+    : t("action.submitScore", { defaultValue: "Submit Score" });
+
+  return (
+    <Modal visible transparent animationType="fade" accessibilityViewIsModal>
+      <View style={styles.modalOverlay}>
+        <View
+          style={[
+            styles.modalCard,
+            { backgroundColor: colors.surfaceHigh, borderColor: colors.border },
+          ]}
+        >
+          <Text style={[styles.modalTitle, { color: colors.text }]} accessibilityRole="header">
+            {t("overlay.youWon")}
+          </Text>
+          <Text style={[styles.modalBody, { color: colors.textMuted }]}>
+            {t("overlay.youWonDetail", { count: pairsRemoved })}
+          </Text>
+          <Text style={[styles.modalScore, { color: colors.text }]}>
+            {t("score.display", { score })}
+          </Text>
+
+          {!submitted ? (
+            <>
+              <TextInput
+                style={[
+                  styles.nameInput,
+                  {
+                    backgroundColor: colors.surfaceAlt,
+                    borderColor: colors.border,
+                    color: colors.text,
+                  },
+                ]}
+                placeholder={t("win.namePlaceholder", { defaultValue: "Your name" })}
+                placeholderTextColor={colors.textMuted}
+                value={name}
+                onChangeText={setName}
+                maxLength={MAX_NAME_LENGTH}
+                editable={!submitting}
+                accessibilityLabel={t("win.nameLabel", { defaultValue: "Enter your name" })}
+              />
+              {offline ? (
+                <OfflineBanner />
+              ) : (
+                error !== null && (
+                  <Text
+                    style={[styles.errorText, { color: colors.error }]}
+                    accessibilityLiveRegion="assertive"
+                    accessibilityRole="alert"
+                  >
+                    {error}
+                  </Text>
+                )
+              )}
+              <Pressable
+                style={[styles.modalPrimary, gradient, !canSubmit && styles.modalPrimaryDisabled]}
+                onPress={handleSubmit}
+                disabled={!canSubmit}
+                accessibilityRole="button"
+                accessibilityLabel={submitLabel}
+                accessibilityState={{ disabled: !canSubmit, busy: submitting }}
+              >
+                {submitting ? (
+                  <ActivityIndicator color={colors.textOnAccent} />
+                ) : (
+                  <Text style={[styles.modalPrimaryText, { color: colors.textOnAccent }]}>
+                    {submitLabel}
+                  </Text>
+                )}
+              </Pressable>
+            </>
+          ) : (
+            <Text
+              style={[styles.submittedText, { color: colors.bonus }]}
+              accessibilityLiveRegion="polite"
+            >
+              {t("win.submitted", { defaultValue: "Score saved! 🎉" })}
+            </Text>
+          )}
+
+          <Pressable
+            style={[styles.modalSecondary, { borderColor: colors.accent }]}
+            onPress={onNewGame}
+            accessibilityRole="button"
+            accessibilityLabel={t("action.newGameLabel")}
+          >
+            <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
+              {t("action.newGame")}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  scrollArea: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  headerBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 32,
+    justifyContent: "center",
+  },
+  headerBtnText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+  },
+  hudRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingHorizontal: 4,
+    paddingVertical: 8,
+  },
+  hudText: {
+    fontFamily: typography.heading,
+    fontSize: 14,
+    letterSpacing: 0.5,
+  },
+  boardWrap: {
+    alignSelf: "stretch",
+    alignItems: "flex-start",
+    overflow: "hidden",
+  },
+  board: {
+    alignSelf: "flex-start",
+    transformOrigin: "top left",
+  } as ViewStyle,
+  modalOverlay: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#000000bf",
+  },
+  modalCard: {
+    borderRadius: 20,
+    borderWidth: 1,
+    padding: 24,
+    alignItems: "center",
+    width: "86%",
+    maxWidth: 360,
+  },
+  modalTitle: {
+    fontFamily: typography.heading,
+    fontSize: 22,
+    fontWeight: "900",
+    letterSpacing: 0.5,
+    marginBottom: 6,
+    textAlign: "center",
+  },
+  modalBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 4,
+    textAlign: "center",
+  },
+  modalScore: {
+    fontSize: 20,
+    fontWeight: "700",
+    marginBottom: 16,
+    fontVariant: ["tabular-nums"],
+  },
+  nameInput: {
+    width: "100%",
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    fontSize: 15,
+    marginBottom: 12,
+  },
+  errorText: {
+    fontSize: 13,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  submittedText: {
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: 12,
+  },
+  modalPrimary: {
+    paddingHorizontal: 32,
+    paddingVertical: 12,
+    borderRadius: 999,
+    marginBottom: 10,
+    alignItems: "center",
+    minWidth: 180,
+  },
+  modalPrimaryDisabled: {
+    opacity: 0.5,
+  },
+  modalPrimaryText: {
+    fontSize: 14,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+  },
+  modalSecondary: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  modalSecondaryText: {
+    fontSize: 13,
+    fontWeight: "800",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+  },
+});

--- a/frontend/src/screens/__tests__/MahjongScreen.test.tsx
+++ b/frontend/src/screens/__tests__/MahjongScreen.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * MahjongScreen — screen-level lifecycle, HUD, and win-modal tests.
+ *
+ * Engine purity is tested in engine.test.ts (#891). These tests cover the
+ * screen's mount/resume lifecycle, HUD wiring, undo affordance, score
+ * submission via scoreQueue, and stats tracking.
+ */
+
+import React from "react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import MahjongScreen from "../MahjongScreen";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import { MahjongScoreboardProvider } from "../../game/mahjong/MahjongScoreboardContext";
+import type { MahjongState } from "../../game/mahjong/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("../../components/mahjong/GameCanvas", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { View, Pressable } = require("react-native");
+  function MockGameCanvas({
+    onNewGamePress,
+  }: {
+    onTilePress: (id: number) => void;
+    onShufflePress: () => void;
+    onNewGamePress: () => void;
+  }) {
+    return (
+      <View testID="game-canvas">
+        <Pressable accessibilityLabel="mock-new-game" onPress={onNewGamePress} />
+      </View>
+    );
+  }
+  MockGameCanvas.displayName = "MockGameCanvas";
+  return { __esModule: true, default: MockGameCanvas, BOARD_W: 572, BOARD_H: 508 };
+});
+
+const mockNavListeners = new Map<string, Array<() => void>>();
+const mockAddListener = jest.fn((event: string, handler: () => void) => {
+  const arr = mockNavListeners.get(event) ?? [];
+  arr.push(handler);
+  mockNavListeners.set(event, arr);
+  return () => {
+    const current = mockNavListeners.get(event) ?? [];
+    mockNavListeners.set(
+      event,
+      current.filter((h) => h !== handler)
+    );
+  };
+});
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    popToTop: jest.fn(),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    addListener: mockAddListener,
+  }),
+}));
+
+jest.mock("@sentry/react-native", () => ({
+  addBreadcrumb: jest.fn(),
+  captureMessage: jest.fn(),
+  captureException: jest.fn(),
+  init: jest.fn(),
+  wrap: <T,>(x: T) => x,
+}));
+
+const mockStartGame = jest.fn<string, [string, Record<string, unknown>, Record<string, unknown>]>();
+const mockEnqueueEvent = jest.fn();
+const mockCompleteGame = jest.fn();
+jest.mock("../../game/_shared/gameEventClient", () => ({
+  gameEventClient: {
+    startGame: (...args: unknown[]) => (mockStartGame as unknown as jest.Mock)(...args),
+    enqueueEvent: (...args: unknown[]) => (mockEnqueueEvent as unknown as jest.Mock)(...args),
+    completeGame: (...args: unknown[]) => (mockCompleteGame as unknown as jest.Mock)(...args),
+    init: jest.fn().mockResolvedValue(undefined),
+    reportBug: jest.fn(),
+    getQueueStats: jest.fn(),
+    clearAll: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock("../../game/_shared/scoreQueue", () => ({
+  scoreQueue: {
+    enqueue: jest.fn().mockResolvedValue({ id: "q-1" }),
+    flush: jest.fn().mockResolvedValue({ attempted: 0, succeeded: 0, failed: 0, remaining: 0 }),
+    registerHandler: jest.fn(),
+  },
+}));
+// eslint-disable-next-line import/order
+import { scoreQueue } from "../../game/_shared/scoreQueue";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <MahjongScoreboardProvider>
+        <MahjongScreen />
+      </MahjongScoreboardProvider>
+    </ThemeProvider>
+  );
+}
+
+async function mount() {
+  const api = renderScreen();
+  // Flush the initial loadGame()/loadStats() promises so the screen renders
+  // its post-load state (mirrors the pattern used in SolitaireScreen tests).
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return api;
+}
+
+/** A minimal valid win state that passes loadGame() validation. */
+function makeWinState(overrides: Partial<MahjongState> = {}): MahjongState {
+  return {
+    _v: 1,
+    tiles: [],
+    selected: null,
+    pairsRemoved: 72,
+    score: 3600,
+    shufflesLeft: 3,
+    undoStack: [],
+    isComplete: true,
+    isDeadlocked: false,
+    startedAt: null,
+    accumulatedMs: 180000,
+    ...overrides,
+  } as unknown as MahjongState;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  mockNavListeners.clear();
+  mockAddListener.mockClear();
+  mockStartGame.mockReset();
+  mockStartGame.mockReturnValue("game-uuid-test");
+  mockEnqueueEvent.mockReset();
+  mockCompleteGame.mockReset();
+  (scoreQueue.enqueue as jest.Mock).mockReset();
+  (scoreQueue.enqueue as jest.Mock).mockResolvedValue({ id: "q-1" });
+  (scoreQueue.flush as jest.Mock).mockReset();
+  (scoreQueue.flush as jest.Mock).mockResolvedValue({
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    remaining: 0,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mount / HUD
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — mount and HUD", () => {
+  it("renders the game canvas after loading resolves", async () => {
+    const api = await mount();
+    expect(api.getByTestId("game-canvas")).toBeTruthy();
+  });
+
+  it("renders score and pairs HUD on a fresh game", async () => {
+    const api = await mount();
+    expect(api.getByText(/hud\.score/)).toBeTruthy();
+    expect(api.getByText(/hud\.pairs/)).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Undo affordance
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — undo affordance", () => {
+  it("undo button is disabled on a fresh game (no moves yet)", async () => {
+    const api = await mount();
+    const undo = api.getByLabelText("action.undoLabel");
+    expect(undo.props.accessibilityState?.disabled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Save / resume
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — save/resume lifecycle", () => {
+  it("resumes a saved game without re-incrementing gamesPlayed", async () => {
+    const saved: MahjongState = makeWinState({ isComplete: false, pairsRemoved: 4, score: 200 });
+    await AsyncStorage.setItem("mahjong_game", JSON.stringify(saved));
+    await mount();
+    const raw = await AsyncStorage.getItem("mahjong_stats_v1");
+    const gamesPlayed = raw ? JSON.parse(raw).gamesPlayed : 0;
+    expect(gamesPlayed).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Win modal
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — win modal", () => {
+  async function mountAtWin() {
+    await AsyncStorage.setItem("mahjong_game", JSON.stringify(makeWinState()));
+    return mount();
+  }
+
+  it("shows the win modal when the game is complete", async () => {
+    const api = await mountAtWin();
+    expect(api.getByText("overlay.youWon")).toBeTruthy();
+  });
+
+  it("enqueues the score via scoreQueue when name is submitted", async () => {
+    const api = await mountAtWin();
+    await act(async () => {
+      fireEvent.changeText(api.getByLabelText(/enter your name/i), "Alice");
+    });
+    await act(async () => {
+      fireEvent.press(api.getByLabelText(/submit score/i));
+    });
+    await waitFor(() => {
+      expect(scoreQueue.enqueue).toHaveBeenCalledWith(
+        "mahjong",
+        expect.objectContaining({ player_name: "Alice", score: 3600 })
+      );
+    });
+  });
+
+  it("shows submitted confirmation after successful enqueue", async () => {
+    const api = await mountAtWin();
+    await act(async () => {
+      fireEvent.changeText(api.getByLabelText(/enter your name/i), "Alice");
+    });
+    // Wrap press + async handler resolution in a single act so setSubmitted(true)
+    // is flushed before we query the tree.
+    await act(async () => {
+      fireEvent.press(api.getByLabelText(/submit score/i));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(api.getByText(/Score saved/i)).toBeTruthy();
+  });
+
+  it("tapping New Game in the win modal resets the board", async () => {
+    const api = await mountAtWin();
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("action.newGameLabel"));
+    });
+    // After new game, win modal is gone and fresh game canvas remains.
+    await waitFor(() => {
+      expect(api.queryByText("overlay.youWon")).toBeNull();
+      expect(api.getByTestId("game-canvas")).toBeTruthy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stats tracking
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — stats tracking", () => {
+  it("increments gamesPlayed on a fresh deal", async () => {
+    await mount();
+    await waitFor(async () => {
+      const raw = await AsyncStorage.getItem("mahjong_stats_v1");
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw!).gamesPlayed).toBe(1);
+    });
+  });
+
+  it("does not double-count gamesWon when resuming an already-complete game", async () => {
+    await AsyncStorage.setItem(
+      "mahjong_stats_v1",
+      JSON.stringify({ bestScore: 3600, bestTimeMs: 180000, gamesPlayed: 1, gamesWon: 1 })
+    );
+    await AsyncStorage.setItem("mahjong_game", JSON.stringify(makeWinState()));
+    await mount();
+    await waitFor(async () => {
+      const raw = await AsyncStorage.getItem("mahjong_stats_v1");
+      const stats = raw ? JSON.parse(raw) : { gamesWon: 1 };
+      expect(stats.gamesWon).toBe(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useGameSync lifecycle
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — useGameSync lifecycle", () => {
+  it("completes the sync session as abandoned on beforeRemove after a move would have started it", async () => {
+    // Seed a game in progress so syncGetGameId() would return a session.
+    // Since we can't tap tiles through the mock, we rely on the abandon guard
+    // — if no session is active, beforeRemove is a no-op.
+    await mount();
+    const handlers = mockNavListeners.get("beforeRemove") ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+    await act(async () => {
+      for (const h of handlers) h();
+    });
+    // No session was started (no tile tap through mock), so completeGame is not called.
+    expect(mockCompleteGame).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -13,6 +13,7 @@ const factories = {
   FreeCell: () => import("../screens/FreeCellScreen"),
   Hearts: () => import("../screens/HeartsScreen"),
   Sudoku: () => import("../screens/SudokuScreen"),
+  Mahjong: () => import("../screens/MahjongScreen"),
   Leaderboard: () => import("../screens/LeaderboardScreen"),
   GameDetail: () => import("../screens/GameDetailScreen"),
   Settings: () => import("../screens/SettingsScreen"),
@@ -29,6 +30,7 @@ export const LazyScreens = {
   FreeCell: React.lazy(factories.FreeCell),
   Hearts: React.lazy(factories.Hearts),
   Sudoku: React.lazy(factories.Sudoku),
+  Mahjong: React.lazy(factories.Mahjong),
   Leaderboard: React.lazy(factories.Leaderboard),
   GameDetail: React.lazy(factories.GameDetail),
   Settings: React.lazy(factories.Settings),
@@ -50,4 +52,5 @@ export function prefetchLobbyGameScreens(): void {
   factories.FreeCell().catch(() => undefined);
   factories.Hearts().catch(() => undefined);
   factories.Sudoku().catch(() => undefined);
+  factories.Mahjong().catch(() => undefined);
 }


### PR DESCRIPTION
## Summary

- **MahjongScreen** (`src/screens/MahjongScreen.tsx`): Full lifecycle — load saved game or deal fresh on mount, persist on every mutation, win modal with `scoreQueue.enqueue`, stats tracking (bestScore/bestTimeMs/gamesPlayed/gamesWon), abandon-on-back via `beforeRemove`, scale-to-fit board with `onLayout`
- **MahjongScoreboardContext** (`src/game/mahjong/MahjongScoreboardContext.tsx`): Context + provider + hook; wired into provider tree in `App.tsx`
- **Navigation wiring** (`App.tsx`, `lazyScreens.ts`): Mahjong route added to `HomeStackParamList`, `LazyScreens`, `withSuspense`, `LobbyStack`, and `prefetchLobbyGameScreens`
- **Lobby card** (`HomeScreen.tsx`): 🀄 game card with i18n title/description/playLabel; `"mahjong"` added to namespace list
- **Scoreboard** (`App.tsx`): `gameKey` union expanded to include `"mahjong"`
- **Tests** (`MahjongScreen.test.tsx`): 11 tests — mount/HUD, undo disabled on fresh game, save/resume lifecycle, win modal (show, enqueue, confirmation, new game), stats tracking (gamesPlayed, no double-count gamesWon), beforeRemove guard

## Test plan

- [x] `npx jest src/screens/__tests__/MahjongScreen.test.tsx` → 11/11 pass
- [x] `npx jest --no-coverage` → 1819 tests (1 pre-existing CapacityWarningToast failure, unrelated)
- [x] ESLint: 0 errors, 0 warnings on all changed files
- [x] Prettier: formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)