### PR TITLE
fix(#919,#922): SFX volume control + stagger enemy shoot timers

### DIFF
--- a/frontend/src/game/_shared/useSound.ts
+++ b/frontend/src/game/_shared/useSound.ts
@@ -3,7 +3,7 @@ import { createAudioPlayer, AudioPlayer } from "expo-audio";
 import { useSoundSettings } from "./SoundContext";
 import { SOUND_REGISTRY, SoundKey } from "./sounds";
 
-export function useSound(key: SoundKey): { play: () => void } {
+export function useSound(key: SoundKey, volume = 1.0): { play: () => void } {
   const { muted } = useSoundSettings();
   const playerRef = useRef<AudioPlayer | null>(null);
   const mutedRef = useRef(muted);
@@ -17,6 +17,7 @@ export function useSound(key: SoundKey): { play: () => void } {
     const source = SOUND_REGISTRY[key];
     if (source == null) return;
     const player = createAudioPlayer(source);
+    player.volume = volume;
     playerRef.current = player;
     return () => {
       player.remove();

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -246,7 +246,7 @@ function makeEnemy(idx: number, slot: SlotDef, canvasW: number): Enemy {
     circleRadius: CIRCLE_RADIUS + rng() * 10,
     circleAngle: 0,
     circleSpeed: CIRCLE_SPEED * (0.85 + rng() * 0.3),
-    shootTimer: SHOOT_INTERVAL_BASE + rng() * SHOOT_INTERVAL_JITTER,
+    shootTimer: rng() * (SHOOT_INTERVAL_BASE + SHOOT_INTERVAL_JITTER),
     diveTargetX: 0,
     hp: TIER_HP[slot.tier],
     isAlive: true,

--- a/frontend/src/hooks/useStarSwarmAudio.ts
+++ b/frontend/src/hooks/useStarSwarmAudio.ts
@@ -7,13 +7,13 @@ const BG_KEYS = ["starswarm.bg1", "starswarm.bg2", "starswarm.bg3", "starswarm.b
 export function useStarSwarmAudio(bgMusicActive: boolean) {
   useBackgroundMusic(BG_KEYS as unknown as string[], bgMusicActive);
 
-  const { play: playLaser } = useSound("starswarm.laser");
-  const { play: playChargeShot } = useSound("starswarm.chargeshot");
-  const { play: playExplosion } = useSound("starswarm.explosion");
-  const { play: playPlayerHit } = useSound("starswarm.playerhit");
-  const { play: playWaveClear } = useSound("starswarm.waveclear");
-  const { play: playGameOver } = useSound("starswarm.gameover");
-  const { play: playChallengingStage } = useSound("starswarm.challengingstage");
+  const { play: playLaser } = useSound("starswarm.laser", 0.35);
+  const { play: playChargeShot } = useSound("starswarm.chargeshot", 0.6);
+  const { play: playExplosion } = useSound("starswarm.explosion", 0.45);
+  const { play: playPlayerHit } = useSound("starswarm.playerhit", 0.7);
+  const { play: playWaveClear } = useSound("starswarm.waveclear", 0.8);
+  const { play: playGameOver } = useSound("starswarm.gameover", 0.8);
+  const { play: playChallengingStage } = useSound("starswarm.challengingstage", 0.8);
 
   return {
     playLaser,


### PR DESCRIPTION
## Summary
- **#919** — `useSound`: adds optional `volume` param (default `1.0`), sets `player.volume` on player init so SFX no longer always play at 100%
- **#919** — `useStarSwarmAudio`: dials back per-SFX volumes (laser 0.35, explosion 0.45, others 0.6–0.8) so they sit under the background music level instead of overpowering it
- **#922** — `engine.ts`: randomizes `shootTimer` across `[0, SHOOT_INTERVAL_BASE + SHOOT_INTERVAL_JITTER]` on enemy spawn instead of always starting near `SHOOT_INTERVAL_BASE`, eliminating the tight bullet wall that hits the player ~3 s into wave 1

## Test plan
- [ ] Wave 1: first shots arrive spread out over time rather than in a cluster at ~3 s
- [ ] Laser SFX is clearly quieter than before; background music is audible during gameplay
- [ ] Explosion SFX doesn't peak above the music
- [ ] Mute toggle still silences all SFX and music
- [ ] `npx jest src/game/starswarm/__tests__/` — 47 passed

Closes #919, #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)