### PR TITLE
feat(#910): FreeCell E2E Playwright smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,11 @@ jobs:
               - 'frontend/src/components/mahjong/**'
               - 'frontend/src/game/mahjong/**'
               - 'backend/mahjong/**'
+            freecell:
+              - 'frontend/src/screens/FreeCellScreen*'
+              - 'frontend/src/components/freecell/**'
+              - 'frontend/src/game/freecell/**'
+              - 'backend/freecell/**'
             starswarm:
               - 'frontend/src/screens/StarSwarmScreen*'
               - 'frontend/src/components/starswarm/**'
@@ -179,7 +184,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]] || \
              [[ "${{ github.base_ref }}" == "main" ]] || \
              [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
-            echo "projects=yacht blackjack twenty48 cascade mahjong starswarm cross logs-budget" >> "$GITHUB_OUTPUT"
+            echo "projects=yacht blackjack twenty48 cascade mahjong freecell starswarm cross logs-budget" >> "$GITHUB_OUTPUT"
             echo "label=full suite (push/main/shared change)" >> "$GITHUB_OUTPUT"
           else
             projects="cross"
@@ -189,6 +194,7 @@ jobs:
 
             [[ "${{ steps.filter.outputs.cascade }}"   == "true" ]] && projects="$projects cascade"
             [[ "${{ steps.filter.outputs.mahjong }}"   == "true" ]] && projects="$projects mahjong"
+            [[ "${{ steps.filter.outputs.freecell }}"  == "true" ]] && projects="$projects freecell"
             [[ "${{ steps.filter.outputs.starswarm }}" == "true" ]] && projects="$projects starswarm"
             [[ "${{ steps.filter.outputs.logstore }}"  == "true" ]] && projects="$projects logs-budget"
             echo "projects=$projects" >> "$GITHUB_OUTPUT"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,6 +12,7 @@ import { join } from "path";
  *   blackjack   — blackjack-*.spec.ts
  *   twenty48    — twenty48-*.spec.ts
  *   mahjong     — mahjong-*.spec.ts
+ *   freecell    — freecell-*.spec.ts
  *   cross       — accessibility.spec.ts, cascade-flow.spec.ts, ui-preferences.spec.ts
  *   logs-budget — logs-*.spec.ts (#373 acceptance gate, CPU-throttled to
  *                  approximate mid-tier mobile device performance)
@@ -67,6 +68,11 @@ export default defineConfig({
     {
       name: "mahjong",
       testMatch: "mahjong-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "freecell",
+      testMatch: "freecell-*.spec.ts",
       use: { ...devices["Desktop Chrome"] },
     },
     {

--- a/e2e/tests/freecell-smoke.spec.ts
+++ b/e2e/tests/freecell-smoke.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * freecell-smoke.spec.ts — GH #910
+ *
+ * Smoke tests for FreeCell: navigation, HUD display, board accessibility,
+ * and crash-free interaction.
+ *
+ * FreeCell's board is DOM-based (React Native View components), not canvas.
+ * All backend API calls are intercepted via page.route() — no backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+
+test.describe("FreeCell — smoke tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(`${API_BASE}/freecell/**`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.removeItem("freecell_game");
+    });
+  });
+
+  test("navigates from Home to FreeCell screen", async ({ page }) => {
+    await page.getByRole("button", { name: "Play FreeCell" }).click();
+    await expect(
+      page.getByRole("heading", { name: "FreeCell", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("move counter is visible", async ({ page }) => {
+    await page.getByRole("button", { name: "Play FreeCell" }).click();
+    await expect(
+      page.getByRole("heading", { name: "FreeCell", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/Moves:\s*\d+/)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("board region is accessible", async ({ page }) => {
+    await page.getByRole("button", { name: "Play FreeCell" }).click();
+    await expect(
+      page.getByRole("heading", { name: "FreeCell", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByLabel("FreeCell board"),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("interacting with the board does not crash the app", async ({ page }) => {
+    await page.getByRole("button", { name: "Play FreeCell" }).click();
+    await expect(
+      page.getByRole("heading", { name: "FreeCell", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const board = page.getByLabel("FreeCell board");
+    await expect(board).toBeVisible({ timeout: 5_000 });
+
+    const box = await board.boundingBox();
+    if (box) {
+      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    }
+
+    await expect(page.getByRole("alert")).not.toBeVisible();
+    await expect(page.getByText(/Moves:\s*\d+/)).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/freecell-smoke.spec.ts
+++ b/e2e/tests/freecell-smoke.spec.ts
@@ -48,7 +48,7 @@ test.describe("FreeCell — smoke tests", () => {
       page.getByRole("heading", { name: "FreeCell", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
     await expect(
-      page.getByLabel("FreeCell board"),
+      page.getByLabel("FreeCell board").first(),
     ).toBeVisible({ timeout: 5_000 });
   });
 
@@ -58,7 +58,7 @@ test.describe("FreeCell — smoke tests", () => {
       page.getByRole("heading", { name: "FreeCell", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
 
-    const board = page.getByLabel("FreeCell board");
+    const board = page.getByLabel("FreeCell board").first();
     await expect(board).toBeVisible({ timeout: 5_000 });
 
     const box = await board.boundingBox();


### PR DESCRIPTION
## Summary
- Adds `e2e/tests/freecell-smoke.spec.ts` with 4 smoke tests: navigation, move counter visibility, board region accessibility, and crash-free interaction
- Registers a `freecell` Playwright project in `playwright.config.ts` (`freecell-*.spec.ts`, Desktop Chrome)
- Wires `freecell` into CI selective-mode path filters and adds it to the full-suite projects string

## Notes
- FreeCell's board is DOM-based (not canvas), so tests use `getByLabel("FreeCell board")` directly
- The issue spec'd `{ entries: [] }` as the mock shape but the backend returns `{ scores: [] }` — used the correct shape
- Leaderboard criterion from the issue was adapted to board-region accessibility since FreeCell has no leaderboard UI

## Test plan
- [ ] `npx playwright test --project=freecell` passes locally against a built frontend
- [ ] CI selective mode triggers `freecell` project when a freecell file changes
- [ ] Full suite runs on push/main PRs include `freecell`

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)