### PR TITLE
fix(#950): widen FORMATION_COL_W to prevent Boss sprite overlap

### DIFF
--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -36,7 +36,7 @@ const BULLET_E_H = 10;
 const BULLET_E_VY = 0.2; // px/ms downward
 
 const FORMATION_COLS = 8;
-const FORMATION_COL_W = 38;
+const FORMATION_COL_W = 44; // #950: was 38 — Boss (36 px) had only 1 px margin/side
 const FORMATION_ROW_H = 46;
 const FORMATION_TOP = 90;
 


### PR DESCRIPTION
## Summary

- Increases `FORMATION_COL_W` from 38 → 44 px in `frontend/src/game/starswarm/engine.ts`
- Boss sprites (36 px wide) had only 1 px margin per side in a 38 px column, causing visible overlap in the formation
- New margin: Boss 4 px/side, Elite 8 px/side, Grunt 10 px/side
- `MAX_SWAY` left unchanged — off-screen clipping at formation edges is expected arcade behavior (matches original Galaga)

## Test plan

- [x] All 40 StarSwarm engine tests pass
- [ ] Verify no visual enemy overlap in formation during gameplay
- [ ] Confirm sway still looks natural

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)