### PR TITLE
fix(#951): lower dive-to-circle threshold so enemies can ram player

### DIFF
--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -583,8 +583,8 @@ function tickDiving(enemy: Enemy, dtMs: number, canvasH: number): EnemyTickResul
   const newX = enemy.x + hSpeed * dtMs;
   const newY = enemy.y + DIVE_SPEED * dtMs;
 
-  // Transition to Circling when past 60% of canvas height
-  if (newY > canvasH * 0.6) {
+  // Transition to Circling when past 85% of canvas height (#951: was 0.6 — enemy looped 184 px above player)
+  if (newY > canvasH * 0.85) {
     const circleCx = newX;
     const circleCy = newY;
     return {


### PR DESCRIPTION
## Summary

- Changes dive→circle transition in `tickDiving` from `canvasH * 0.6` → `canvasH * 0.85`
- Old threshold (y=384) caused enemies to enter `Circling` 184 px above the player (y=568), making the `hitByShip` collision path unreachable
- New threshold (y=544) lets diving enemies pass through the player zone before looping away

## Math

| | Value |
|---|---|
| Player center y | 568 (640 − 72) |
| Old circle entry | 384 — enemy looped **184 px above** player |
| New circle entry | 544 — enemy passes through player zone first |
| Circle radius | 42 px → max y ≈ 586, just past player bottom edge |

## Test plan

- [x] All 40 StarSwarm engine tests pass
- [ ] Verify diving enemies visibly reach the player y-zone during gameplay
- [ ] Confirm player can be hit by a ramming enemy

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)