### PR TITLE
fix(#942): deadlock overlay — correct copy + 500 ms delay

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -12,7 +12,7 @@
  * Hit-testing: topmost tile (highest layer) at touch point wins.
  */
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Canvas, Fill, Group, ImageSVG, Rect, useSVG } from "@shopify/react-native-skia";
 import { useTranslation } from "react-i18next";
@@ -127,6 +127,16 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
   );
   const showShuffleCTA = noFreePairs && state.shufflesLeft > 0;
 
+  const [showDeadlockOverlay, setShowDeadlockOverlay] = useState(false);
+  useEffect(() => {
+    if (!state.isDeadlocked) {
+      setShowDeadlockOverlay(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowDeadlockOverlay(true), 500);
+    return () => clearTimeout(timer);
+  }, [state.isDeadlocked]);
+
   const sortedTiles = useMemo(
     () => [...state.tiles].sort((a, b) => a.layer - b.layer || a.row - b.row),
     [state.tiles]
@@ -213,11 +223,11 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
         </View>
       )}
 
-      {/* Deadlock overlay */}
-      {state.isDeadlocked && (
+      {/* Deadlock overlay — shown after shake animation completes */}
+      {showDeadlockOverlay && (
         <View style={[styles.overlay, styles.noMovesOverlay]}>
-          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
-          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Text style={styles.overlayTitle}>{t("overlay.deadlocked")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.deadlockedDetail")}</Text>
           <Pressable
             style={styles.btn}
             onPress={onNewGamePress}

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -183,6 +183,16 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
   const showShuffleCTA = noFreePairs && state.shufflesLeft > 0;
   const gameActive = !state.isComplete && !state.isDeadlocked && !showShuffleCTA;
 
+  const [showDeadlockOverlay, setShowDeadlockOverlay] = useState(false);
+  useEffect(() => {
+    if (!state.isDeadlocked) {
+      setShowDeadlockOverlay(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowDeadlockOverlay(true), 500);
+    return () => clearTimeout(timer);
+  }, [state.isDeadlocked]);
+
   // Load all 42 SVG tile images once on mount.
   useEffect(() => {
     const images: (HTMLImageElement | null)[] = Array(42).fill(null);
@@ -272,11 +282,11 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
         </View>
       )}
 
-      {/* Deadlock overlay */}
-      {state.isDeadlocked && (
+      {/* Deadlock overlay — shown after shake animation completes */}
+      {showDeadlockOverlay && (
         <View style={[styles.overlay, styles.noMovesOverlay]}>
-          <Text style={styles.overlayTitle}>{t("overlay.noMoves")}</Text>
-          <Text style={styles.overlayDetail}>{t("overlay.noMovesDetail")}</Text>
+          <Text style={styles.overlayTitle}>{t("overlay.deadlocked")}</Text>
+          <Text style={styles.overlayDetail}>{t("overlay.deadlockedDetail")}</Text>
           <Pressable
             style={styles.btn}
             onPress={onNewGamePress}

--- a/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
+++ b/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
@@ -72,7 +72,8 @@ describe("GameCanvas (web)", () => {
     expect(JSON.stringify(tree!.toJSON())).toContain("overlay.youWon");
   });
 
-  it("shows the no-moves overlay when isDeadlocked", () => {
+  it("shows the deadlock overlay after 500 ms when isDeadlocked", () => {
+    jest.useFakeTimers();
     const state = makeState({ isDeadlocked: true, shufflesLeft: 0 });
     let tree: ReturnType<typeof create>;
     act(() => {
@@ -80,7 +81,13 @@ describe("GameCanvas (web)", () => {
         <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
       );
     });
-    expect(JSON.stringify(tree!.toJSON())).toContain("overlay.noMoves");
+    // Overlay is intentionally delayed — not visible before the timer fires.
+    expect(JSON.stringify(tree!.toJSON())).not.toContain("overlay.deadlocked");
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(JSON.stringify(tree!.toJSON())).toContain("overlay.deadlocked");
+    jest.useRealTimers();
   });
 
   it("shows the shuffle CTA when no free pairs remain and shuffles are available", () => {
@@ -114,5 +121,6 @@ describe("GameCanvas (web)", () => {
     const str = JSON.stringify(tree!.toJSON());
     expect(str).not.toContain("overlay.youWon");
     expect(str).not.toContain("overlay.noMoves");
+    expect(str).not.toContain("overlay.deadlocked");
   });
 });

--- a/frontend/src/i18n/locales/_meta/mahjong.meta.json
+++ b/frontend/src/i18n/locales/_meta/mahjong.meta.json
@@ -143,6 +143,24 @@
     "doNotTranslate": [],
     "notes": null
   },
+  "overlay.deadlocked": {
+    "component": "GameCanvas",
+    "description": "Large heading on the deadlock overlay when no free pairs remain and no shuffles are left.",
+    "tone": "neutral, informative",
+    "characterLimit": 16,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Distinct from overlay.noMoves (shuffle CTA). This fires only when shuffles are exhausted."
+  },
+  "overlay.deadlockedDetail": {
+    "component": "GameCanvas",
+    "description": "Detail line under the deadlock heading explaining the game is over.",
+    "tone": "helpful",
+    "characterLimit": 30,
+    "placeholders": [],
+    "doNotTranslate": [],
+    "notes": "Do not mention shuffling — there are none left."
+  },
   "overlay.youWon": {
     "component": "GameCanvas",
     "description": "Large heading on the win overlay when all tiles are cleared.",

--- a/frontend/src/i18n/locales/ar/mahjong.json
+++ b/frontend/src/i18n/locales/ar/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/de/mahjong.json
+++ b/frontend/src/i18n/locales/de/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/en/mahjong.json
+++ b/frontend/src/i18n/locales/en/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "Undo last matched pair",
   "overlay.noMoves": "NO MOVES",
   "overlay.noMovesDetail": "No matches available. Shuffle to continue.",
+  "overlay.deadlocked": "NO MORE MOVES",
+  "overlay.deadlockedDetail": "No free pairs remain.",
   "overlay.youWon": "YOU WIN!",
   "overlay.youWonDetail": "All {{count}} pairs cleared!",
   "overlay.shuffleButton": "Shuffle",

--- a/frontend/src/i18n/locales/es/mahjong.json
+++ b/frontend/src/i18n/locales/es/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/fr-CA/mahjong.json
+++ b/frontend/src/i18n/locales/fr-CA/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/he/mahjong.json
+++ b/frontend/src/i18n/locales/he/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/hi/mahjong.json
+++ b/frontend/src/i18n/locales/hi/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ja/mahjong.json
+++ b/frontend/src/i18n/locales/ja/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ko/mahjong.json
+++ b/frontend/src/i18n/locales/ko/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/nl/mahjong.json
+++ b/frontend/src/i18n/locales/nl/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/pt/mahjong.json
+++ b/frontend/src/i18n/locales/pt/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ru/mahjong.json
+++ b/frontend/src/i18n/locales/ru/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/zh/mahjong.json
+++ b/frontend/src/i18n/locales/zh/mahjong.json
@@ -15,6 +15,8 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
+  "overlay.deadlocked": "__NEEDS_TRANSLATION__",
+  "overlay.deadlockedDetail": "__NEEDS_TRANSLATION__",
   "overlay.youWon": "__NEEDS_TRANSLATION__",
   "overlay.youWonDetail": "__NEEDS_TRANSLATION__",
   "overlay.shuffleButton": "__NEEDS_TRANSLATION__",


### PR DESCRIPTION
## Summary

- Both `GameCanvas.tsx` and `GameCanvas.web.tsx` already had a deadlock overlay node, but it had two bugs:
  - **Wrong copy**: was reusing the shuffle-CTA strings (`overlay.noMoves` / `overlay.noMovesDetail` = "No matches available. Shuffle to continue.") — inappropriate when there are no shuffles left
  - **No delay**: rendered immediately on `state.isDeadlocked`, racing the 420 ms board shake animation
- Added `overlay.deadlocked` = "NO MORE MOVES" and `overlay.deadlockedDetail` = "No free pairs remain." to `en/mahjong.json` and all 12 other locale files as `__NEEDS_TRANSLATION__`
- Added the corresponding entries to `mahjong.meta.json`
- Wired a `useState(false)` + `useEffect` 500 ms `setTimeout` in both canvases so the overlay appears only after the shake completes; resets immediately on new game

## Test plan

- [ ] Start a Mahjong game and exhaust all shuffles, then reach a deadlock state
- [ ] Board shake plays; overlay does **not** appear during the shake
- [ ] ~500 ms after deadlock: "NO MORE MOVES / No free pairs remain." overlay appears with a **New Game** button
- [ ] Tapping New Game starts a fresh game and the overlay is gone
- [ ] Shuffle-CTA overlay (when shuffles remain) still shows its original "NO MOVES / Shuffle to continue." copy — unchanged
- [ ] Win overlay unaffected

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)