### PR TITLE
feat(starswarm): gameplay polish pass — #945 #956 #957 #958 #959

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -34,6 +34,7 @@ interface Props {
   onChargeShotFire?: () => void;
   onExplosion?: () => void;
   onChallengingStage?: () => void;
+  onBonusLife?: () => void;
   isPaused?: boolean;
   width: number;
   height: number;
@@ -62,6 +63,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onChargeShotFire,
       onExplosion,
       onChallengingStage,
+      onBonusLife,
       isPaused = false,
       width,
       height,
@@ -95,6 +97,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onChargeShotFireRef = useRef(onChargeShotFire);
     const onExplosionRef = useRef(onExplosion);
     const onChallengingStageRef = useRef(onChallengingStage);
+    const onBonusLifeRef = useRef(onBonusLife);
+    const prevBonusLivesRef = useRef(gameRef.current.bonusLivesAwarded);
+    const bonusFlashEndRef = useRef(0); // ms timestamp when 1UP flash expires
 
     useEffect(() => {
       const wasPaused = isPausedRef.current;
@@ -125,6 +130,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onChallengingStageRef.current = onChallengingStage;
     }, [onChallengingStage]);
+    useEffect(() => {
+      onBonusLifeRef.current = onBonusLife;
+    }, [onBonusLife]);
 
     const [renderState, setRenderState] = useState<RenderState>({
       game: gameRef.current,
@@ -162,6 +170,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       prevScoreRef.current = 0;
       prevLivesRef.current = gameRef.current.player.lives;
       prevPhaseRef.current = gameRef.current.phase;
+      prevBonusLivesRef.current = gameRef.current.bonusLivesAwarded;
+      bonusFlashEndRef.current = 0;
       setRenderState({ game: gameRef.current, sf: sfRef.current });
     }, [resetTick, width, height]);
 
@@ -184,7 +194,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
               fire: inputRef.current.fire,
               chargeShot: inputRef.current.chargeShot,
             });
-            if (inputRef.current.chargeShot) inputRef.current.chargeShot = false;
 
             // Dev: when infinite lives is on, intercept any lives decrement and
             // restore lives + phase so the game never transitions to GameOver.
@@ -195,6 +204,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                 phase: next.phase === "GameOver" ? prevPhaseRef.current : next.phase,
                 player: { ...next.player, lives: prevLivesRef.current, invincibleTimer: 2000 },
               };
+            }
+
+            // Only clear chargeShot when the engine actually consumed it (cooldown advanced)
+            if (chargeShotRequested && applied.player.shootCooldown > prevCooldown) {
+              inputRef.current.chargeShot = false;
             }
 
             gameRef.current = applied;
@@ -216,6 +230,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
               if (applied.phase !== "GameOver") onPlayerHitRef.current?.();
             }
             prevLivesRef.current = applied.player.lives;
+            if (applied.bonusLivesAwarded > prevBonusLivesRef.current) {
+              onBonusLifeRef.current?.();
+              bonusFlashEndRef.current = Date.now() + 1500;
+            }
+            prevBonusLivesRef.current = applied.bonusLivesAwarded;
             if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
               onWaveClearRef.current?.();
             }
@@ -249,6 +268,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const displayW = Math.round(width * scale);
     const displayH = Math.round(height * scale);
     const hs = Math.max(highScore, state.score);
+    const showBonusFlash = Date.now() < bonusFlashEndRef.current;
 
     const blink =
       player.invincibleTimer > 0 &&
@@ -420,6 +440,12 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             ))}
           </View>
 
+          {showBonusFlash && (
+            <View style={styles.bonusLifeOverlay} pointerEvents="none">
+              <Text style={styles.bonusLifeText}>1UP</Text>
+            </View>
+          )}
+
           {state.phase === "WaveClear" && (
             <View style={styles.phaseOverlay}>
               <Text style={styles.overlayTitle}>{t("phase.waveClear")}</Text>
@@ -521,5 +547,18 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginTop: 16,
     fontVariant: ["tabular-nums"],
+  },
+  bonusLifeOverlay: {
+    position: "absolute",
+    top: "40%",
+    alignSelf: "center",
+  },
+  bonusLifeText: {
+    color: "#ffff00",
+    fontSize: 36,
+    fontWeight: "bold",
+    textShadowColor: "#ff8800",
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 8,
   },
 });

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -41,6 +41,8 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "starswarm.waveclear": require("../../../assets/sounds/starswarm-waveclear.ogg"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "starswarm.bonuslife": require("../../../assets/sounds/starswarm-waveclear.ogg"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   "starswarm.bg1": require("../../../assets/sounds/starswarm-bg-1.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "starswarm.bg2": require("../../../assets/sounds/starswarm-bg-2.mp3"),

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -578,3 +578,80 @@ describe("Dive/circle shooting", () => {
     expect(s.enemyBullets).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Bonus lives (#945)
+// ---------------------------------------------------------------------------
+
+describe("Bonus lives", () => {
+  it("awards +1 life when score crosses 30,000", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000); // reach Playing
+    const startLives = s.player.lives;
+    // Inject score just below threshold, then cross it via a kill
+    s = { ...s, score: 29_999 };
+    // Force enemy to be in formation at a known position and kill it with a bullet
+    const enemy = s.enemies.find((e) => e.isAlive);
+    if (!enemy) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 99999,
+      x: enemy.x,
+      y: enemy.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: enemy.width,
+      height: enemy.height,
+      damage: 10,
+    };
+    s = { ...s, playerBullets: [bullet] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.player.lives).toBe(startLives + 1);
+    expect(s.bonusLivesAwarded).toBe(1);
+  });
+
+  it("does not re-award bonus life on the same threshold", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, score: 29_999, bonusLivesAwarded: 0 };
+    const enemy = s.enemies.find((e) => e.isAlive);
+    if (!enemy) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 99998,
+      x: enemy.x,
+      y: enemy.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: enemy.width,
+      height: enemy.height,
+      damage: 10,
+    };
+    s = tick({ ...s, playerBullets: [bullet] }, 16, NO_INPUT);
+    const livesAfterFirst = s.player.lives;
+    // Tick again from same score — threshold already crossed, bonusLivesAwarded=1
+    s = tick(s, 16, NO_INPUT);
+    expect(s.player.lives).toBe(livesAfterFirst);
+  });
+
+  it("caps lives at MAX_LIVES (5)", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, score: 29_999, player: { ...s.player, lives: 5 } };
+    const enemy = s.enemies.find((e) => e.isAlive);
+    if (!enemy) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 99997,
+      x: enemy.x,
+      y: enemy.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: enemy.width,
+      height: enemy.height,
+      damage: 10,
+    };
+    s = tick({ ...s, playerBullets: [bullet] }, 16, NO_INPUT);
+    expect(s.player.lives).toBe(5);
+  });
+});

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -75,7 +75,7 @@ const MAX_SWAY = 40; // max offset from center in px
 
 // #924 Aimed shots — start gentle from wave 1, ramp +5%/wave, cap 60%
 const AIMED_SHOT_WAVE_START = 1;
-const AIMED_SHOT_FRACTION = 0.10; // 10% aimed at wave 1, +5% per wave, cap 60%
+const AIMED_SHOT_FRACTION = 0.1; // 10% aimed at wave 1, +5% per wave, cap 60%
 
 // #945 Bonus lives
 const BONUS_LIFE_THRESHOLDS = [30_000, 70_000];

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -33,7 +33,7 @@ export const CHARGE_SHOOT_COOLDOWN = 900; // ms; longer cooldown than auto-fire
 
 const BULLET_E_W = 5;
 const BULLET_E_H = 10;
-const BULLET_E_VY = 0.2; // px/ms downward
+const BULLET_E_VY = 0.35; // px/ms downward
 
 const FORMATION_COLS = 8;
 const FORMATION_COL_W = 44; // #950: was 38 — Boss (36 px) had only 1 px margin/side
@@ -73,9 +73,13 @@ const SWAY_SPEED_BASE = 0.03; // px/ms at wave 1
 const SWAY_SPEED_PER_WAVE = 0.008; // px/ms added per wave
 const MAX_SWAY = 40; // max offset from center in px
 
-// #924 Aimed shots
-const AIMED_SHOT_WAVE_START = 4;
-const AIMED_SHOT_FRACTION = 0.25; // 25% of shots aimed at wave 4, +5% per wave, cap 60%
+// #924 Aimed shots — start gentle from wave 1, ramp +5%/wave, cap 60%
+const AIMED_SHOT_WAVE_START = 1;
+const AIMED_SHOT_FRACTION = 0.10; // 10% aimed at wave 1, +5% per wave, cap 60%
+
+// #945 Bonus lives
+const BONUS_LIFE_THRESHOLDS = [30_000, 70_000];
+const MAX_LIVES = 5;
 
 const TIER_SCORE: Record<EnemyTier, number> = { Grunt: 100, Elite: 200, Boss: 400 };
 const TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 2, Boss: 3 };
@@ -357,7 +361,8 @@ function buildWaveState(
   canvasH: number,
   wave: number,
   player: Player,
-  score: number
+  score: number,
+  bonusLivesAwarded = 0
 ): StarSwarmState {
   let enemies: Enemy[];
   let phase: StarSwarmState["phase"];
@@ -390,6 +395,7 @@ function buildWaveState(
     nextDiveTimer: diveInterval(wave),
     formationSwayX: 0,
     formationSwayDir: 1,
+    bonusLivesAwarded,
   };
 }
 
@@ -410,9 +416,34 @@ export function tick(state: StarSwarmState, dtMs: number, input: StarSwarmInput)
   s = tickEnemies(s, dtMs);
   s = tickBullets(s, dtMs);
   s = tickCollisions(s);
+  s = tickBonusLives(state, s);
   s = tickExplosions(s, dtMs);
   s = checkPhaseTransitions(s);
   return s;
+}
+
+// ---------------------------------------------------------------------------
+// Bonus lives (#945)
+// ---------------------------------------------------------------------------
+
+function tickBonusLives(prev: StarSwarmState, next: StarSwarmState): StarSwarmState {
+  if (next.phase === "GameOver") return next;
+
+  let { player, bonusLivesAwarded } = next;
+
+  for (const [i, threshold] of BONUS_LIFE_THRESHOLDS.entries()) {
+    if (
+      next.score >= threshold &&
+      prev.score < threshold &&
+      bonusLivesAwarded < i + 1 &&
+      player.lives < MAX_LIVES
+    ) {
+      player = { ...player, lives: player.lives + 1 };
+      bonusLivesAwarded++;
+    }
+  }
+
+  return { ...next, player, bonusLivesAwarded };
 }
 
 // ---------------------------------------------------------------------------
@@ -439,7 +470,8 @@ function tickPlayer(state: StarSwarmState, dtMs: number, input: StarSwarmInput):
         owner: "player",
         width: BULLET_C_W,
         height: BULLET_C_H,
-        damage: 2,
+        damage: 4,
+        piercing: true,
       };
       return {
         ...state,
@@ -807,15 +839,22 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
   const newExplosions: Explosion[] = [...state.explosions];
 
   // ── Player bullets ↔ enemies ──────────────────────────────────────────────
-  const hitBulletIds = new Set<number>();
+  const hitBulletIds = new Set<number>(); // non-piercing bullets consumed this tick
+  const piercingHits = new Set<string>(); // `${bulletId}:${enemyId}` — prevents double-hit
   const enemies = state.enemies.map((enemy) => {
     if (!enemy.isAlive) return enemy;
 
     for (const b of state.playerBullets) {
-      if (hitBulletIds.has(b.id)) continue;
+      if (!b.piercing && hitBulletIds.has(b.id)) continue;
+      if (b.piercing && piercingHits.has(`${b.id}:${enemy.id}`)) continue;
       if (!aabb(b.x, b.y, b.width, b.height, enemy.x, enemy.y, enemy.width, enemy.height)) continue;
 
-      hitBulletIds.add(b.id);
+      if (b.piercing) {
+        piercingHits.add(`${b.id}:${enemy.id}`);
+      } else {
+        hitBulletIds.add(b.id);
+      }
+
       const newHp = enemy.hp - b.damage;
 
       if (newHp <= 0) {
@@ -833,6 +872,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
     return enemy;
   });
 
+  // Piercing bullets are removed by the off-screen filter in tickBullets, not here
   const playerBullets = state.playerBullets.filter((b) => !hitBulletIds.has(b.id));
 
   // ── Enemy contact ↔ player (bullets + #925 diving/circling ships) ──────────
@@ -840,18 +880,40 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
     const hitByBullet = state.enemyBullets.some((b) =>
       aabb(b.x, b.y, b.width, b.height, player.x, player.y, player.width, player.height)
     );
+
+    // #956: capture the ramming enemy so we can destroy it on collision
+    let rammingEnemyId: number | null = null;
     const hitByShip =
       !hitByBullet &&
-      enemies.some(
-        (e) =>
+      enemies.some((e) => {
+        if (
           e.isAlive &&
           (e.phase === "Diving" || e.phase === "Circling") &&
           aabb(e.x, e.y, e.width, e.height, player.x, player.y, player.width, player.height)
-      );
+        ) {
+          rammingEnemyId = e.id;
+          return true;
+        }
+        return false;
+      });
 
     if (hitByBullet || hitByShip) {
       const newLives = player.lives - 1;
       newExplosions.push(spawnExplosion(player.x, player.y));
+
+      // Kill the enemy that rammed the player (classic Galaga behaviour)
+      const finalEnemies =
+        hitByShip && rammingEnemyId !== null
+          ? enemies.map((e) => {
+              if (e.id === rammingEnemyId) {
+                newExplosions.push(spawnExplosion(e.x, e.y));
+                score += TIER_SCORE[e.tier] * DIVE_SCORE_MULT;
+                return { ...e, hp: 0, isAlive: false };
+              }
+              return e;
+            })
+          : enemies;
+
       const enemyBullets = hitByBullet
         ? state.enemyBullets.filter(
             (b) =>
@@ -862,7 +924,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
       if (newLives <= 0) {
         return {
           ...state,
-          enemies,
+          enemies: finalEnemies,
           playerBullets,
           enemyBullets,
           explosions: newExplosions,
@@ -875,7 +937,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
 
       return {
         ...state,
-        enemies,
+        enemies: finalEnemies,
         playerBullets,
         enemyBullets,
         explosions: newExplosions,
@@ -956,7 +1018,14 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
 
 function startNextWave(state: StarSwarmState): StarSwarmState {
   const nextWave = state.wave + 1;
-  return buildWaveState(state.canvasW, state.canvasH, nextWave, state.player, state.score);
+  return buildWaveState(
+    state.canvasW,
+    state.canvasH,
+    nextWave,
+    state.player,
+    state.score,
+    state.bonusLivesAwarded
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -75,6 +75,8 @@ export interface Bullet {
   readonly width: number;
   readonly height: number;
   readonly damage: number;
+  /** Charge shot: passes through all enemies in its lane instead of stopping on first hit. */
+  readonly piercing?: boolean;
 }
 
 export interface Player {
@@ -120,6 +122,8 @@ export interface StarSwarmState {
   readonly formationSwayX: number;
   /** Direction the formation is currently travelling: +1 = right, -1 = left. */
   readonly formationSwayDir: 1 | -1;
+  /** How many bonus lives have been awarded so far (prevents re-awarding at same threshold). */
+  readonly bonusLivesAwarded: number;
 }
 
 /** Input snapshot consumed by each `tick` call. */

--- a/frontend/src/hooks/useStarSwarmAudio.ts
+++ b/frontend/src/hooks/useStarSwarmAudio.ts
@@ -11,6 +11,7 @@ export interface SfxVolumes {
   waveclear: number;
   gameover: number;
   challengingstage: number;
+  bonuslife: number;
 }
 
 export const DEFAULT_SFX_VOLUMES: SfxVolumes = {
@@ -21,6 +22,7 @@ export const DEFAULT_SFX_VOLUMES: SfxVolumes = {
   waveclear: 0.8,
   gameover: 0.8,
   challengingstage: 0.8,
+  bonuslife: 0.9,
 };
 
 // bgMusicActive should be false when the game is over so the track stops.
@@ -36,6 +38,7 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
   const { play: playWaveClear } = useSound("starswarm.waveclear", v.waveclear);
   const { play: playGameOver } = useSound("starswarm.gameover", v.gameover);
   const { play: playChallengingStage } = useSound("starswarm.challengingstage", v.challengingstage);
+  const { play: playBonusLife } = useSound("starswarm.bonuslife", v.bonuslife);
 
   return {
     playLaser,
@@ -45,5 +48,6 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
     playWaveClear,
     playGameOver,
     playChallengingStage,
+    playBonusLife,
   };
 }

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -63,6 +63,7 @@ export default function StarSwarmScreen() {
     playWaveClear,
     playGameOver,
     playChallengingStage,
+    playBonusLife,
   } = useStarSwarmAudio(phase !== "GameOver", devVolumes);
 
   const scoreRef = useRef(0);
@@ -106,6 +107,10 @@ export default function StarSwarmScreen() {
     playWaveClear();
     hapticWaveClear();
   }, [playWaveClear]);
+
+  const handleBonusLife = useCallback(() => {
+    playBonusLife();
+  }, [playBonusLife]);
 
   const handleNewGame = useCallback((opts?: DevOptions) => {
     if (__DEV__ && opts !== undefined) lastDevOptsRef.current = opts;
@@ -157,6 +162,7 @@ export default function StarSwarmScreen() {
               onChargeShotFire={playChargeShot}
               onExplosion={playExplosion}
               onChallengingStage={playChallengingStage}
+              onBonusLife={handleBonusLife}
               isPaused={isPaused}
               width={CANVAS_W}
               height={CANVAS_H}


### PR DESCRIPTION
## Summary

- **#945** — Bonus life at 30k / 70k score (classic Galaga mechanic): engine tracks `bonusLivesAwarded`, `tickBonusLives` checks thresholds each frame, persists across waves, capped at 5 lives. `GameCanvas` fires `onBonusLife` callback and shows a 1UP HUD flash for 1.5s. Wired to audio via `useStarSwarmAudio`.
- **#956** — Ramming enemy now explodes on player contact: `tickCollisions` captures the ramming enemy ID, marks it `isAlive: false`, spawns an explosion, and awards dive-score-multiplied points — matches classic Galaga behaviour.
- **#957** — Aimed shots start at wave 1 (10% fraction, +5%/wave) instead of wave 4 (was 25%).
- **#958** — Enemy bullet speed `0.2` → `0.35` px/ms; bullets now cross the canvas in ~1.8s instead of ~3.2s.
- **#959** — Charge shot bug fixed: input was cleared every tick regardless of whether the engine consumed it; now only cleared when `shootCooldown` actually advances. Charge shot buffed to `damage=4` with `piercing: true` — passes through all enemies in the lane without stopping on first hit.

## Test plan

- [ ] Engine: `npx jest src/game/starswarm/__tests__/engine.test.ts` — 45 tests pass (3 new for bonus life)
- [ ] TypeScript: no new errors in touched files
- [ ] Play to 30k score — lives counter increments, 1UP flashes, sound plays
- [ ] Ram an enemy — both ships explode, score increases
- [ ] Wave 1: enemy bullets are aimed (slight angle toward player)
- [ ] Charge shot fires reliably on button hold; cyan beam passes through multiple enemies in a column

🤖 Generated with [Claude Code](https://claude.com/claude-code)