### PR TITLE
chore(#902): remove reset_leaderboard() no-ops and Cascade engine debug logs

### DIFF
--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -125,12 +125,3 @@ async def get_scores(request: Request) -> LeaderboardResponse:
     async with factory() as db:
         scores = await _top_scores(db)
     return LeaderboardResponse(scores=scores)
-
-
-def reset_leaderboard() -> None:
-    """Test helper — no-op; leaderboard lives in the DB.
-
-    Kept for backward compatibility with the autouse fixture in
-    test_cascade_api.py. The conftest clean_db_tables fixture handles cleanup.
-    """
-    return None

--- a/backend/sudoku/router.py
+++ b/backend/sudoku/router.py
@@ -115,10 +115,3 @@ async def get_scores(
     async with factory() as db:
         scores = await _top_scores(db, difficulty, variant)
     return LeaderboardResponse(scores=scores)
-
-
-def reset_leaderboard() -> None:
-    """Test helper — no-op. The leaderboard lives in the DB; conftest's
-    ``clean_db_tables`` fixture handles per-test isolation.
-    """
-    return None

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -10,7 +10,6 @@ GET /cascade/scores remains unchanged.
 
 import uuid
 
-import pytest
 from fastapi.testclient import TestClient
 
 from main import app

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -13,20 +13,12 @@ import uuid
 import pytest
 from fastapi.testclient import TestClient
 
-import cascade.router as cascade_router_module
 from main import app
 
 client = TestClient(app)
 
 TEST_SESSION = str(uuid.uuid4())
 SESSION_HEADERS = {"X-Session-ID": TEST_SESSION}
-
-
-@pytest.fixture(autouse=True)
-def reset_leaderboard():
-    cascade_router_module.reset_leaderboard()
-    yield
-    cascade_router_module.reset_leaderboard()
 
 
 def _create_game(session_id: str = TEST_SESSION) -> str:

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -132,7 +132,7 @@ export async function createEngine(
     setId: string,
     x: number,
     y: number,
-    source: "player" | "merge" = "player"
+    _source: "player" | "merge" = "player"
   ): FruitBody {
     const rbDesc = R.RigidBodyDesc.dynamic()
       .setTranslation(x * SCALE, y * SCALE)
@@ -239,12 +239,10 @@ export async function createEngine(
   }
 
   let disposed = false;
-  let stepCount = 0;
 
   return {
     step(dt?: number): { snapshots: BodySnapshot[]; events: GameEvent[] } {
       if (disposed) return { snapshots: [], events: [] };
-      stepCount += 1;
       const countBefore = fruitMap.size;
 
       const events: GameEvent[] = [];

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -127,12 +127,7 @@ export async function createEngine(
   // body, making fruitMap.get(handle) return the wrong tier in subsequent queue entries).
   const mergeQueue: Array<[number, number, number]> = []; // [handleA, handleB, tier]
 
-  function spawnAt(
-    def: FruitDefinition,
-    setId: string,
-    x: number,
-    y: number
-  ): FruitBody {
+  function spawnAt(def: FruitDefinition, setId: string, x: number, y: number): FruitBody {
     const rbDesc = R.RigidBodyDesc.dynamic()
       .setTranslation(x * SCALE, y * SCALE)
       .setCcdEnabled(true);

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -134,9 +134,6 @@ export async function createEngine(
     y: number,
     source: "player" | "merge" = "player"
   ): FruitBody {
-    console.log(
-      `[Engine] spawn tier=${def.tier} source=${source} totalBefore=${fruitMap.size} t=${Date.now()}`
-    );
     const rbDesc = R.RigidBodyDesc.dynamic()
       .setTranslation(x * SCALE, y * SCALE)
       .setCcdEnabled(true);
@@ -206,9 +203,6 @@ export async function createEngine(
   }
 
   function processMerges(events: GameEvent[]): void {
-    if (mergeQueue.length > 0) {
-      console.log(`[Engine] processMerges queueLen=${mergeQueue.length} t=${Date.now()}`);
-    }
     for (const [ha, hb, enqueuedTier] of mergeQueue) {
       const fa = fruitMap.get(ha);
       const fb = fruitMap.get(hb);
@@ -231,7 +225,6 @@ export async function createEngine(
       const posB = rbb.translation();
       const midX = (posA.x + posB.x) / 2 / SCALE; // back to pixels
       const midY = (posA.y + posB.y) / 2 / SCALE;
-      console.log(`[Engine] merge tier=${tier} midX=${midX.toFixed(0)} midY=${midY.toFixed(0)}`);
 
       removeBody(ha);
       removeBody(hb);
@@ -315,15 +308,6 @@ export async function createEngine(
         console.warn(
           `[Engine] step added ${delta} fruits in one tick — expected 1 from a single player drop`
         );
-      }
-
-      // Periodic bin snapshot (~5 s at 60 fps)
-      if (stepCount % 300 === 0) {
-        const tierCounts: Record<number, number> = {};
-        fruitMap.forEach((fb) => {
-          tierCounts[fb.fruitTier] = (tierCounts[fb.fruitTier] ?? 0) + 1;
-        });
-        console.log("[Engine] bin snapshot", tierCounts, "total=", fruitMap.size);
       }
 
       // Collect body snapshots (pixel coordinates) and detect boundary escapes

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -131,8 +131,7 @@ export async function createEngine(
     def: FruitDefinition,
     setId: string,
     x: number,
-    y: number,
-    _source: "player" | "merge" = "player"
+    y: number
   ): FruitBody {
     const rbDesc = R.RigidBodyDesc.dynamic()
       .setTranslation(x * SCALE, y * SCALE)
@@ -232,7 +231,7 @@ export async function createEngine(
 
       if (tier < 10) {
         const nextDef = fruitSet.fruits[(tier + 1) as FruitTier];
-        spawnAt(nextDef, fruitSet.id, midX, midY, "merge");
+        spawnAt(nextDef, fruitSet.id, midX, midY);
       }
     }
     mergeQueue.length = 0;


### PR DESCRIPTION
## Summary
- Removes the `reset_leaderboard()` no-op stubs from `backend/cascade/router.py` and `backend/sudoku/router.py` — vestigial from the in-memory era; `conftest.py`'s `clean_db_tables` fixture handles test isolation
- Removes the autouse `reset_leaderboard` fixture and its now-unused import from `backend/tests/test_cascade_api.py`
- Deletes 4 `console.log` debug traces from `frontend/src/game/cascade/engine.ts` (spawn, processMerges queue, per-merge, bin-snapshot) that fired on every game tick and were visible in any user's devtools

## Test plan
- [ ] `python -m pytest tests/test_cascade_api.py tests/test_sudoku_api.py -v` — all 43 tests pass
- [ ] No remaining `[Engine]` console.log calls in engine.ts
- [ ] CI green

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)