### PR TITLE
fix(twenty48): replace flaky RNG restoration test with deterministic getRng() check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       # See wcmchenry3-stack/.github#45.
       backend-url: "https://gaming-app-api-dev.onrender.com"
       health-path: "/health"
-      probe-path: "/yacht/state"
+      probe-path: "/games/me"
       probe-expected-status: "400"
     secrets: inherit
 

--- a/frontend/src/game/twenty48/__tests__/engine.test.ts
+++ b/frontend/src/game/twenty48/__tests__/engine.test.ts
@@ -11,6 +11,7 @@ import {
   slideAndMerge,
   isGameOver,
   setRng,
+  getRng,
   createSeededRng,
   SIZE,
   Direction,
@@ -456,15 +457,7 @@ describe("seedable RNG (setRng + createSeededRng)", () => {
   });
 
   it("setRng(Math.random) after afterEach restores non-determinism", () => {
-    // Sanity: back on default, two games should almost always differ.
-    const a = newGame();
-    const b = newGame();
-    // Not guaranteed to differ, but across 16 cells with random placement
-    // the odds of a full match are vanishingly small.
-    const flatA = a.board.flat();
-    const flatB = b.board.flat();
-    const anyDiff = flatA.some((v, i) => v !== flatB[i]);
-    expect(anyDiff).toBe(true);
+    expect(getRng()).toBe(Math.random);
   });
 });
 

--- a/frontend/src/game/twenty48/engine.ts
+++ b/frontend/src/game/twenty48/engine.ts
@@ -160,6 +160,10 @@ export function setRng(fn: RandomSource): void {
   _rng = fn;
 }
 
+export function getRng(): RandomSource {
+  return _rng;
+}
+
 /**
  * LCG deterministic RNG — for testing only.
  */


### PR DESCRIPTION
## Summary

- The twenty48 `engine.test.ts` test `setRng(Math.random) after afterEach restores non-determinism` compared two randomly generated boards to verify the RNG was restored — near-impossible to fail but not truly impossible, and it did fail in CI on PR #965
- Added a `getRng()` export to `engine.ts` so the test can assert reference equality (`getRng() === Math.random`) directly — fully deterministic, zero false positives

## Test plan

- [ ] `test-frontend` CI job passes on this PR
- [ ] PR #965 (dev → main) re-runs and passes after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)