### PR TITLE
fix(drag): replace Gesture.Race with Simultaneous to fix iOS tap and drag

### DIFF
--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -63,11 +63,17 @@ export function DraggableCard({
     startDrag(dragSource, dragCards);
   }, [dragSource, dragCards, startDrag]);
 
+  // Tracks whether the pan actually activated so onFinalize knows whether
+  // snap-back is needed. Shared value so worklets can read/write it without
+  // crossing the JS thread.
+  const panActivated = useSharedValue(false);
+
   const pan = Gesture.Pan()
     .minDistance(8)
     .enabled(draggable)
     .onStart(() => {
       "worklet";
+      panActivated.value = true;
       // Convert window position to container-local coordinates.
       const localX = cachedPageX.value - containerOffsetX.value;
       const localY = cachedPageY.value - containerOffsetY.value;
@@ -88,15 +94,22 @@ export function DraggableCard({
     })
     .onFinalize((_e, success) => {
       "worklet";
-      if (!success) runOnJS(snapBackAndClear)();
+      if (!success && panActivated.value) runOnJS(snapBackAndClear)();
+      panActivated.value = false;
     });
 
-  const tap = Gesture.Tap().onEnd(() => {
-    "worklet";
-    if (onTap) runOnJS(onTap)();
-  });
+  // maxDistance matches pan's minDistance so the two don't overlap: a touch
+  // that moves < 8 px is a tap; >= 8 px activates pan and fails the tap.
+  // Gesture.Simultaneous instead of Race avoids the iOS quirk where the pan
+  // recognizer's pending state blocks the tap from ever firing.
+  const tap = Gesture.Tap()
+    .maxDistance(8)
+    .onEnd((_e, success) => {
+      "worklet";
+      if (success && onTap) runOnJS(onTap)();
+    });
 
-  const gesture = draggable ? Gesture.Race(pan, tap) : tap;
+  const gesture = draggable ? Gesture.Simultaneous(pan, tap) : tap;
 
   // Hide this card when it (or a card above it in the same run) is being dragged —
   // the DragOverlay renders the visual at the finger position instead.


### PR DESCRIPTION
## Summary

- Fixes **#985** — Klondike Solitaire iOS: both drag-and-drop and tap-to-move broken
- Fixes **#986** — FreeCell iOS: drag-and-drop not working

**Root cause:** `Gesture.Race(pan, tap)` in `DraggableCard` behaves differently on iOS. The iOS native Pan recognizer enters a tracking state immediately on touch-down and holds it while waiting for `minDistance(8)`. While tracking, iOS gesture coordination blocks the Tap from firing — breaking tap-to-move in Solitaire and preventing pan activation in FreeCell.

**Fix (single file: `frontend/src/game/_shared/drag/DraggableCard.tsx`):**
- Switch `Gesture.Race(pan, tap)` → `Gesture.Simultaneous(pan, tap)` so both recognizers run independently and the iOS tracking state no longer blocks the tap
- Add `tap.maxDistance(8)` (matching pan's `minDistance`) so a touch that moves ≥8px fails the tap cleanly — no overlap zone
- Guard the tap `onEnd` callback with the `success` flag so it can't fire mid-drag
- Add `panActivated` shared value so `onFinalize` only calls `snapBackAndClear` when the pan actually activated, avoiding spurious snap-back animations on every tap

## Test plan

- [ ] Tap-to-move works in Klondike Solitaire on iOS simulator
- [ ] Drag-and-drop works in Klondike Solitaire on iOS simulator
- [ ] Tap-to-move works in FreeCell on iOS simulator
- [ ] Drag-and-drop works in FreeCell on iOS simulator
- [ ] Both interaction modes still work on Android and web (no regression)
- [ ] All 162 existing drag/solitaire/freecell Jest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)