### PR TITLE
feat(starswarm): foundations — Boss HP 4, bullet cap, maxDivers fix

### DIFF
--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -3,6 +3,8 @@ import {
   tick,
   isSwooping,
   diverCount,
+  maxDivers,
+  bulletCap,
   seedRng,
   _resetIds,
   CANVAS_W,
@@ -505,6 +507,181 @@ describe("Player firing", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Boss HP 4 (#970)
+// ---------------------------------------------------------------------------
+
+describe("Boss HP (#970)", () => {
+  it("Boss starts with 4 HP", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const boss = s.enemies.find((e) => e.isAlive && e.tier === "Boss");
+    if (!boss) throw new Error("no boss");
+    expect(boss.hp).toBe(4);
+  });
+
+  it("Boss requires exactly 4 hits of damage=1 to die", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const bossId = s.enemies.find((e) => e.isAlive && e.tier === "Boss")?.id;
+    if (!bossId) throw new Error("no boss");
+    const getBoss = () => s.enemies.find((e) => e.id === bossId)!;
+
+    for (let hit = 1; hit <= 4; hit++) {
+      const b = getBoss();
+      s = {
+        ...s,
+        playerBullets: [
+          { id: hit, x: b.x, y: b.y, vx: 0, vy: -0.5, owner: "player", width: 5, height: 14, damage: 1 },
+        ],
+      };
+      s = tick(s, 16, NO_INPUT);
+      if (hit < 4) {
+        expect(getBoss().isAlive).toBe(true);
+        expect(getBoss().hp).toBe(4 - hit);
+      } else {
+        expect(getBoss().isAlive).toBe(false);
+      }
+    }
+  });
+
+  it("Boss is still worth 400 points on kill", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const bossId = s.enemies.find((e) => e.isAlive && e.tier === "Boss")?.id;
+    if (!bossId) throw new Error("no boss");
+    const getBoss = () => s.enemies.find((e) => e.id === bossId)!;
+    const scoreBefore = s.score;
+
+    for (let hit = 1; hit <= 4; hit++) {
+      const b = getBoss();
+      s = {
+        ...s,
+        playerBullets: [
+          { id: hit, x: b.x, y: b.y, vx: 0, vy: -0.5, owner: "player", width: 5, height: 14, damage: 1 },
+        ],
+      };
+      s = tick(s, 16, NO_INPUT);
+    }
+
+    expect(s.score - scoreBefore).toBe(400);
+  });
+
+  it("Grunt and Elite HP are unchanged", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.enemies.find((e) => e.isAlive && e.tier === "Grunt")?.hp).toBe(1);
+    expect(s.enemies.find((e) => e.isAlive && e.tier === "Elite")?.hp).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxDivers cap (#969)
+// ---------------------------------------------------------------------------
+
+describe("maxDivers cap (#969)", () => {
+  it("returns 1 for waves 1 and 2", () => {
+    expect(maxDivers(1)).toBe(1);
+    expect(maxDivers(2)).toBe(1);
+  });
+
+  it("returns 2 for waves 3 and 4", () => {
+    expect(maxDivers(3)).toBe(2);
+    expect(maxDivers(4)).toBe(2);
+  });
+
+  it("never exceeds 1 simultaneous Diving enemy on wave 1", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    for (let i = 0; i < 2000; i++) {
+      s = tick(s, 16, NO_INPUT);
+      if (s.phase !== "Playing") break;
+      const divers = s.enemies.filter((e) => e.isAlive && e.phase === "Diving").length;
+      expect(divers).toBeLessThanOrEqual(maxDivers(1));
+    }
+  });
+
+  it("never exceeds 2 simultaneous Diving enemies on wave 4", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 4);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    for (let i = 0; i < 2000; i++) {
+      s = tick(s, 16, NO_INPUT);
+      if (s.phase !== "Playing") break;
+      const divers = s.enemies.filter((e) => e.isAlive && e.phase === "Diving").length;
+      expect(divers).toBeLessThanOrEqual(maxDivers(4));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Enemy bullet cap (#972)
+// ---------------------------------------------------------------------------
+
+describe("Enemy bullet cap (#972)", () => {
+  it("bulletCap returns correct values for each wave pair", () => {
+    expect(bulletCap(1)).toBe(3);
+    expect(bulletCap(2)).toBe(3);
+    expect(bulletCap(3)).toBe(4);
+    expect(bulletCap(5)).toBe(5);
+    expect(bulletCap(7)).toBe(6);
+  });
+
+  it("no new enemy bullet fired when cap is already reached", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    // Fill to the wave-1 cap (3 bullets), placed safely mid-screen
+    const fillerBullets: Bullet[] = Array.from({ length: 3 }, (_, i) => ({
+      id: 10000 + i,
+      x: 100,
+      y: 200 + i * 20,
+      vx: 0,
+      vy: 0.35,
+      owner: "enemy" as const,
+      width: 5,
+      height: 10,
+      damage: 1,
+    }));
+
+    // Force one Formation enemy's shoot timer to fire immediately
+    s = {
+      ...s,
+      enemyBullets: fillerBullets,
+      enemies: s.enemies.map((e, i) =>
+        i === 0 && e.phase === "Formation" ? { ...e, shootTimer: 0 } : e
+      ),
+    };
+
+    s = tick(s, 16, NO_INPUT);
+
+    // The 3 filler bullets are still on-screen (y ≈ 205) — no 4th bullet allowed
+    expect(s.enemyBullets.length).toBeLessThanOrEqual(bulletCap(1));
+  });
+
+  it("enemy fires normally when bullet count is below cap", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    // Start with 0 enemy bullets and force an immediate shot
+    s = {
+      ...s,
+      enemyBullets: [],
+      enemies: s.enemies.map((e, i) =>
+        i === 0 && e.phase === "Formation" ? { ...e, shootTimer: 0 } : e
+      ),
+    };
+
+    s = tick(s, 16, NO_INPUT);
+    expect(s.enemyBullets.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // GameOver is terminal
 // ---------------------------------------------------------------------------
 
@@ -555,10 +732,12 @@ describe("Dive/circle shooting", () => {
     s = advanceMs(s, 8000); // reach Playing
     expect(s.phase).toBe("Playing");
 
-    // Force one enemy into Diving with an expired shoot timer so it fires immediately
+    // Force one enemy into Diving with an expired shoot timer so it fires immediately.
+    // Clear existing enemy bullets so the bullet cap (wave 1 = 3) doesn't suppress the shot.
     const playerX = s.player.x;
     s = {
       ...s,
+      enemyBullets: [],
       enemies: s.enemies.map((e, i) =>
         i === 0 ? { ...e, phase: "Diving" as const, diveTargetX: playerX, shootTimer: 0 } : e
       ),

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -531,7 +531,17 @@ describe("Boss HP (#970)", () => {
       s = {
         ...s,
         playerBullets: [
-          { id: hit, x: b.x, y: b.y, vx: 0, vy: -0.5, owner: "player", width: 5, height: 14, damage: 1 },
+          {
+            id: hit,
+            x: b.x,
+            y: b.y,
+            vx: 0,
+            vy: -0.5,
+            owner: "player",
+            width: 5,
+            height: 14,
+            damage: 1,
+          },
         ],
       };
       s = tick(s, 16, NO_INPUT);
@@ -557,7 +567,17 @@ describe("Boss HP (#970)", () => {
       s = {
         ...s,
         playerBullets: [
-          { id: hit, x: b.x, y: b.y, vx: 0, vy: -0.5, owner: "player", width: 5, height: 14, damage: 1 },
+          {
+            id: hit,
+            x: b.x,
+            y: b.y,
+            vx: 0,
+            vy: -0.5,
+            owner: "player",
+            width: 5,
+            height: 14,
+            damage: 1,
+          },
         ],
       };
       s = tick(s, 16, NO_INPUT);

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -82,7 +82,7 @@ const BONUS_LIFE_THRESHOLDS = [30_000, 70_000];
 const MAX_LIVES = 5;
 
 const TIER_SCORE: Record<EnemyTier, number> = { Grunt: 100, Elite: 200, Boss: 400 };
-const TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 2, Boss: 3 };
+const TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 2, Boss: 4 };
 const TIER_SIZE: Record<EnemyTier, { w: number; h: number }> = {
   Grunt: { w: 24, h: 24 },
   Elite: { w: 28, h: 28 },
@@ -315,11 +315,16 @@ function isChallengingWave(wave: number): boolean {
 }
 
 // #926: how many enemies may dive simultaneously at a given wave
-function maxDivers(wave: number): number {
+export function maxDivers(wave: number): number {
   if (wave <= 2) return 1;
   if (wave <= 4) return 2;
   if (wave <= 6) return 3;
   return 4;
+}
+
+// #972: max enemy bullets on screen — 3 at wave 1, +1 every 2 waves
+export function bulletCap(wave: number): number {
+  return 3 + Math.floor((wave - 1) / 2);
 }
 
 // #924: compute vx for an enemy bullet — non-zero only at wave 4+
@@ -748,8 +753,10 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
       const candidates = state.enemies
         .map((e, i) => ({ e, i }))
         .filter(({ e }) => e.isAlive && e.phase === "Formation");
-      const max = maxDivers(state.wave);
-      for (let k = 0; k < max && candidates.length > 0; k++) {
+      // Only launch enough new divers to reach the cap — don't ignore enemies already diving.
+      const currentDivers = state.enemies.filter((e) => e.isAlive && e.phase === "Diving").length;
+      const allowedNew = Math.max(0, maxDivers(state.wave) - currentDivers);
+      for (let k = 0; k < allowedNew && candidates.length > 0; k++) {
         const pick = Math.floor(rng() * candidates.length);
         diveIndices.add(candidates[pick]!.i);
         candidates.splice(pick, 1);
@@ -785,7 +792,9 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     if (e.isAlive && e.phase === "Formation") {
       e = { ...e, x: e.formationX + swayX };
     }
-    if (result.bullet) newEnemyBullets.push(result.bullet);
+    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave)) {
+      newEnemyBullets.push(result.bullet);
+    }
     return e;
   });
 


### PR DESCRIPTION
Closes #969, #970, #972. Part of epic #982.

## Summary

- **#970 Boss HP 3→4** — `TIER_HP.Boss` bumped to 4. Bosses feel like a genuine escalation threat vs Elites (2 HP). Score and explosion logic unchanged; Boss still awards 400 pts.
- **#972 Enemy bullet cap** — New `bulletCap(wave)` exported function (`3 + floor((wave-1)/2)`). Applied in `tickEnemies` before each bullet push: if `newEnemyBullets.length >= cap`, shot is silently dropped. Wave 1 cap = 3, scaling +1 every 2 waves.
- **#969 maxDivers cap fix** — Bug found and fixed: the dive trigger was selecting `maxDivers(wave)` enemies per interval without checking how many were already Diving, allowing the cap to be exceeded. Fix: compute `currentDivers = enemies in Diving phase`, allow only `max(0, maxDivers - currentDivers)` new divers. `maxDivers` and `bulletCap` are now exported for direct unit testing.

**Root cause (maxDivers):** `tickEnemies` counted from `max = maxDivers(wave)` unconditionally, so if 1 enemy was already diving on wave 1 when the next interval fired, it selected 1 more — giving 2 simultaneous divers against a cap of 1.

## Test plan

- [x] `Boss HP (#970)` — starts at 4 HP, requires 4 hits, worth 400 pts, other tiers unchanged
- [x] `maxDivers cap (#969)` — unit asserts return values; 2000-tick integration confirms cap never exceeded on wave 1 (max 1) and wave 4 (max 2)
- [x] `Enemy bullet cap (#972)` — `bulletCap` formula asserts; cap blocks 4th bullet when 3 already on-screen; normal firing works when below cap
- [x] All 1843 existing tests pass (dive/circle shooting test updated to clear `enemyBullets` before injecting test scenario — cap was correctly suppressing the bullet in that test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)