### PR TITLE
feat(starswarm): relative touch input — ship offset above thumb (#973)

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -42,6 +42,9 @@ export default function Controls({
 
   const playerXRef = useRef(CANVAS_W / 2);
   const activeDragRef = useRef(false);
+  // Ship X captured at each touch-start — used to compute delta from gesture start,
+  // avoiding cumulative drift from per-event changeX accumulation.
+  const shipXAtDragStartRef = useRef(CANVAS_W / 2);
 
   const [isCharging, setIsCharging] = useState(false);
   const [isOnCooldown, setIsOnCooldown] = useState(false);
@@ -77,11 +80,16 @@ export default function Controls({
     .minDistance(0)
     .onBegin((e) => {
       activeDragRef.current = e.y > dragZoneY;
+      if (activeDragRef.current) {
+        // Capture ship X at gesture start so we use total translation (not
+        // per-event changeX accumulation) — avoids drift over long gestures.
+        shipXAtDragStartRef.current = playerXRef.current;
+      }
     })
     .onChange((e) => {
       if (!activeDragRef.current) return;
-      const logicalDx = e.changeX / scale;
-      const newX = clamp(playerXRef.current + logicalDx, 0, CANVAS_W);
+      // newX = shipX_at_touch_start + (currentTouchX - touchStartX)
+      const newX = clamp(shipXAtDragStartRef.current + e.translationX / scale, 0, CANVAS_W);
       playerXRef.current = newX;
       canvasRef.current?.setPlayerX(newX);
     })


### PR DESCRIPTION
Closes #973. Part of epic #982.

## Summary

Switches the pan gesture from per-event `changeX` accumulation to the explicit formula from the GDD:

```
newX = shipX_at_touch_start + (currentTouchX - touchStartX)
```

- `shipXAtDragStartRef` is captured in `onBegin` each time a drag begins — no snap to finger's absolute X on new touch
- `onChange` now uses `e.translationX` (RNGH's total displacement from gesture start) divided by scale, added to the captured start position
- Eliminates cumulative drift that can develop from accumulating `changeX` across hundreds of incremental events in a long gesture
- Drag-zone activation threshold, keyboard arrow-key controls, pause/game-over tap handling, and web canvas behaviour all unchanged

## Test plan

- [ ] On device/simulator: drag ship left and right — movement tracks finger delta, no teleport on new touch
- [ ] Lift finger and re-place elsewhere — ship stays put, then moves from new position
- [ ] Keyboard ArrowLeft/Right still moves ship on web
- [ ] Pause tap (top zone), game-over new-game button unaffected
- [ ] All 1843 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)