### PR TITLE
fix(freecell): lower cardPlace and supermove sound volume (#987)

### DIFF
--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -53,8 +53,8 @@ export default function FreeCellScreen() {
   const [showGameWin, setShowGameWin] = useState(false);
   const [showNoMovesBanner, setShowNoMovesBanner] = useState(false);
 
-  const { play: playCardPlace } = useSound("freecell.cardPlace");
-  const { play: playSupermove } = useSound("freecell.supermove");
+  const { play: playCardPlace } = useSound("freecell.cardPlace", 0.4);
+  const { play: playSupermove } = useSound("freecell.supermove", 0.5);
   const { play: playFoundationComplete } = useSound("freecell.foundationComplete");
   const { play: playGameWin } = useSound("freecell.gameWin");
   const { play: playInvalidMove } = useSound("freecell.invalidMove");


### PR DESCRIPTION
## Summary
- Reduces `freecell.cardPlace` volume to `0.4` (was `1.0`) — most frequent sound, was jarring on rapid moves
- Reduces `freecell.supermove` volume to `0.5` (was `1.0`) — can fire repeatedly during multi-card moves
- Foundation complete, game win, and invalid move sounds unchanged (not flagged in #987)

Closes #987

## Test plan
- [ ] Play FreeCell on device/simulator; card placement sounds are noticeably quieter
- [ ] Supermove (moving a run of cards) sounds at moderate volume
- [ ] Foundation complete / game win / invalid move sounds play at full volume unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)