### PR TITLE
feat(yacht): joker fanfare + dev dice-override panel (#983, #984)

### DIFF
--- a/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
+++ b/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
@@ -9,6 +9,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { AnimationOverlay } from "../shared/AnimationOverlay";
+import { BADGE_JOKER_BG, BADGE_YACHT_BG } from "../../theme/theme.constants";
 
 interface Props {
   visible: boolean;
@@ -146,10 +147,10 @@ const styles = StyleSheet.create({
     paddingVertical: 18,
   },
   badgeYacht: {
-    backgroundColor: "rgba(255,215,0,0.95)",
+    backgroundColor: BADGE_YACHT_BG,
   },
   badgeJoker: {
-    backgroundColor: "rgba(138,43,226,0.95)",
+    backgroundColor: BADGE_JOKER_BG,
   },
   badgeText: {
     fontSize: 42,

--- a/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
+++ b/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
@@ -13,6 +13,7 @@ import { AnimationOverlay } from "../shared/AnimationOverlay";
 interface Props {
   visible: boolean;
   onDismiss: () => void;
+  variant?: "yacht" | "joker";
 }
 
 // Die face characters scattered around the badge
@@ -28,7 +29,7 @@ const FACE_OFFSETS = [
   { x: 20, y: 140 },
 ] as const;
 
-export function YachtCelebrationAnimation({ visible, onDismiss }: Props) {
+export function YachtCelebrationAnimation({ visible, onDismiss, variant = "yacht" }: Props) {
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   const badgeScale = useSharedValue(0);
@@ -114,13 +115,19 @@ export function YachtCelebrationAnimation({ visible, onDismiss }: Props) {
             {DIE_FACES[i]}
           </Animated.Text>
         ))}
-        <Animated.View style={[styles.badge, badgeStyle]}>
+        <Animated.View
+          style={[
+            styles.badge,
+            variant === "joker" ? styles.badgeJoker : styles.badgeYacht,
+            badgeStyle,
+          ]}
+        >
           <Text
             style={styles.badgeText}
             accessibilityRole="text"
             accessibilityLiveRegion="assertive"
           >
-            YACHT!
+            {variant === "joker" ? "JOKER!" : "YACHT!"}
           </Text>
         </Animated.View>
       </View>
@@ -134,10 +141,15 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   badge: {
-    backgroundColor: "rgba(255,215,0,0.95)",
     borderRadius: 20,
     paddingHorizontal: 40,
     paddingVertical: 18,
+  },
+  badgeYacht: {
+    backgroundColor: "rgba(255,215,0,0.95)",
+  },
+  badgeJoker: {
+    backgroundColor: "rgba(138,43,226,0.95)",
   },
   badgeText: {
     fontSize: 42,

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -58,6 +58,8 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "yacht.yacht": require("../../../assets/sounds/hearts-moon-shot.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "yacht.joker": require("../../../assets/sounds/hearts-moon-shot.mp3"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   "yacht.straight": require("../../../assets/sounds/yacht-straight.ogg"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "yacht.upperBonus": require("../../../assets/sounds/yacht-upper-bonus.ogg"),

--- a/frontend/src/game/yacht/__tests__/engine.test.ts
+++ b/frontend/src/game/yacht/__tests__/engine.test.ts
@@ -15,6 +15,7 @@ import {
   isInProgress,
   setRng,
   createSeededRng,
+  setDiceOverride,
   Category,
   CATEGORIES,
 } from "../engine";
@@ -803,5 +804,53 @@ describe("score — upperBonus event", () => {
     const withDice = { ...already, dice: [1, 2, 3, 4, 5], rolls_used: 1 };
     const next = score(withDice, "chance");
     expect(next.events ?? []).not.toContainEqual({ type: "upperBonus" });
+  });
+});
+
+describe("score — joker event", () => {
+  function stateWithYachtScored(): GameState {
+    const base = newGame();
+    return computeDerived({ ...base, scores: { ...base.scores, yacht: 50 }, yacht_bonus_count: 0 });
+  }
+
+  it("emits joker event when scoring a second yacht (joker bonus)", () => {
+    const withYachtScored = stateWithYachtScored();
+    const withDice = { ...withYachtScored, dice: [4, 4, 4, 4, 4], rolls_used: 1 };
+    const next = score(withDice, "fours");
+    expect(next.yacht_bonus_count).toBe(1);
+    expect(next.events ?? []).toContainEqual({ type: "joker" });
+  });
+
+  it("does not emit joker event when scoring normally (no joker)", () => {
+    const base = makeGame([1, 2, 3, 4, 5]);
+    const next = score(base, "chance");
+    expect(next.events ?? []).not.toContainEqual({ type: "joker" });
+  });
+});
+
+describe("setDiceOverride", () => {
+  it("applies override values to unheld dice on the next roll then clears", () => {
+    setDiceOverride([6, 6, 6, 6, 6]);
+    const state = newGame();
+    const next = roll(state, [false, false, false, false, false]);
+    expect(next.dice).toEqual([6, 6, 6, 6, 6]);
+    // Override consumed — subsequent roll uses RNG (not all-6)
+    setRng(createSeededRng(42));
+    const next2 = roll({ ...next, rolls_used: 1 }, [false, false, false, false, false]);
+    expect(next2.dice).not.toEqual([6, 6, 6, 6, 6]);
+  });
+
+  it("respects held dice when applying override", () => {
+    setDiceOverride([1, 1, 1, 1, 1]);
+    const base = newGame();
+    // First roll to get a held state
+    setRng(createSeededRng(7));
+    const after1 = roll(base, [false, false, false, false, false]);
+    const die0 = after1.dice[0];
+    // Hold die 0, override rest to 1
+    setDiceOverride([99, 1, 1, 1, 1]);
+    const after2 = roll(after1, [true, false, false, false, false]);
+    expect(after2.dice[0]).toBe(die0); // held — unchanged
+    expect(after2.dice[1]).toBe(1); // override applied
   });
 });

--- a/frontend/src/game/yacht/engine.ts
+++ b/frontend/src/game/yacht/engine.ts
@@ -96,6 +96,12 @@ export function createSeededRng(seed: number): RandomSource {
 // for Playwright/Maestro flows that need deterministic dice against a
 // production-shaped bundle. Call `globalThis.__yacht_setSeed(n)` before
 // the next `newGame()` to pin the roll sequence.
+let _diceOverride: number[] | null = null;
+
+export function setDiceOverride(values: number[]): void {
+  _diceOverride = [...values];
+}
+
 const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
 const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
 if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
@@ -104,6 +110,8 @@ if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
   ) => {
     setRng(createSeededRng(seed));
   };
+  (globalThis as unknown as { __yacht_setDice?: (values: number[]) => void }).__yacht_setDice =
+    setDiceOverride;
 }
 
 // ---------------------------------------------------------------------------
@@ -317,9 +325,11 @@ export function roll(state: GameState, heldInput: readonly boolean[]): GameState
 
   const nextDice = [...state.dice];
   const rolledIndices: number[] = [];
+  const override = _diceOverride;
+  _diceOverride = null;
   for (let i = 0; i < 5; i++) {
     if (!held[i]) {
-      nextDice[i] = 1 + Math.floor(_rng() * 6);
+      nextDice[i] = override != null ? override[i] : 1 + Math.floor(_rng() * 6);
       rolledIndices.push(i);
     }
   }
@@ -399,6 +409,7 @@ export function score(state: GameState, category: Category): GameState {
   // Collect score events for this action.
   const scoreEvents: GameEvent[] = [];
   if (category === "yacht" && scoreValue === 50) scoreEvents.push({ type: "yacht" });
+  if (nextYachtBonusCount > state.yacht_bonus_count) scoreEvents.push({ type: "joker" });
   if (category === "large_straight" && scoreValue > 0) scoreEvents.push({ type: "largeStraight" });
   if (category === "small_straight" && scoreValue > 0) scoreEvents.push({ type: "smallStraight" });
   // upperBonus fires exactly once: when the upper total first reaches ≥ 63.

--- a/frontend/src/game/yacht/types.ts
+++ b/frontend/src/game/yacht/types.ts
@@ -9,6 +9,7 @@ export type GameEvent =
   | { readonly type: "dieHold"; readonly index: number }
   | { readonly type: "dieRelease"; readonly index: number }
   | { readonly type: "yacht" }
+  | { readonly type: "joker" }
   | { readonly type: "largeStraight" }
   | { readonly type: "smallStraight" }
   | { readonly type: "upperBonus" };

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -28,6 +28,14 @@ import GameOverModal from "../components/yacht/GameOverModal";
 import { YachtCelebrationAnimation } from "../components/yacht/YachtCelebrationAnimation";
 import NewGameConfirmModal from "../components/shared/NewGameConfirmModal";
 import { useTheme } from "../theme/ThemeContext";
+import {
+  DEV_ACCENT,
+  DEV_ACCENT_DIM,
+  DEV_ACCENT_BORDER,
+  DEV_OVERLAY_BG,
+  DEV_SURFACE_SUBTLE,
+  DEV_SURFACE_DIM,
+} from "../theme/theme.constants";
 import { GameShell } from "../components/shared/GameShell";
 
 type Props = {
@@ -420,7 +428,7 @@ export default function GameScreen({ navigation, route }: Props) {
                 ))}
 
                 <Pressable
-                  style={[styles.devActionBtn, { backgroundColor: "rgba(255,128,0,1)" }]}
+                  style={[styles.devActionBtn, { backgroundColor: DEV_ACCENT }]}
                   onPress={() => {
                     setDiceOverride([...devDice]);
                     setDevPanelOpen(false);
@@ -430,7 +438,7 @@ export default function GameScreen({ navigation, route }: Props) {
                 </Pressable>
 
                 <Pressable
-                  style={[styles.devActionBtn, { backgroundColor: "rgba(255,255,255,0.08)" }]}
+                  style={[styles.devActionBtn, { backgroundColor: DEV_SURFACE_SUBTLE }]}
                   onPress={() => setDevPanelOpen(false)}
                 >
                   <Text style={[styles.devActionText, { color: colors.textMuted }]}>Close</Text>
@@ -491,7 +499,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 8,
     right: 8,
-    backgroundColor: "rgba(255,128,0,0.85)",
+    backgroundColor: DEV_ACCENT_DIM,
     paddingHorizontal: 6,
     paddingVertical: 2,
     borderRadius: 4,
@@ -505,7 +513,7 @@ const styles = StyleSheet.create({
   },
   devOverlay: {
     flex: 1,
-    backgroundColor: "rgba(0,0,0,0.7)",
+    backgroundColor: DEV_OVERLAY_BG,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -515,13 +523,13 @@ const styles = StyleSheet.create({
     width: 320,
     maxHeight: "85%",
     borderWidth: 1,
-    borderColor: "rgba(255,128,0,0.5)",
+    borderColor: DEV_ACCENT_BORDER,
   },
   devScrollContent: {
     gap: 12,
   },
   devTitle: {
-    color: "rgba(255,128,0,1)",
+    color: DEV_ACCENT,
     fontSize: 14,
     fontWeight: "700",
     letterSpacing: 2,
@@ -549,7 +557,7 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   devStepBtn: {
-    backgroundColor: "rgba(255,255,255,0.1)",
+    backgroundColor: DEV_SURFACE_DIM,
     width: 32,
     height: 32,
     borderRadius: 6,
@@ -569,7 +577,7 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   devPresetBtn: {
-    backgroundColor: "rgba(255,255,255,0.08)",
+    backgroundColor: DEV_SURFACE_SUBTLE,
     borderRadius: 6,
     paddingVertical: 6,
     paddingHorizontal: 10,

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { View, Text, StyleSheet, Pressable } from "react-native";
+import { Modal, ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -13,6 +13,7 @@ import {
   toggleHold as engineToggleHold,
   possibleScores as enginePossibleScores,
   isInProgress,
+  setDiceOverride,
   Category,
 } from "../game/yacht/engine";
 import { saveGame, clearGame } from "../game/yacht/storage";
@@ -43,7 +44,10 @@ export default function GameScreen({ navigation, route }: Props) {
   const [gameKey, setGameKey] = useState(0);
   const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
   const [showYachtCelebration, setShowYachtCelebration] = useState(false);
+  const [showJokerCelebration, setShowJokerCelebration] = useState(false);
   const [rollingIndices, setRollingIndices] = useState<readonly number[]>([]);
+  const [devPanelOpen, setDevPanelOpen] = useState(false);
+  const [devDice, setDevDice] = useState<[number, number, number, number, number]>([3, 3, 3, 3, 3]);
 
   // Keep a ref in sync so startNewGame can log the pre-reset state without
   // closing over a stale copy of gameState (useCallback has [] deps).
@@ -64,6 +68,7 @@ export default function GameScreen({ navigation, route }: Props) {
   const { play: playDiceRoll } = useSound("yacht.diceRoll");
   const { play: playDieHold } = useSound("yacht.dieHold");
   const { play: playYacht } = useSound("yacht.yacht");
+  const { play: playJoker } = useSound("yacht.joker");
   const { play: playStraight } = useSound("yacht.straight");
   const { play: playUpperBonus } = useSound("yacht.upperBonus");
 
@@ -120,6 +125,10 @@ export default function GameScreen({ navigation, route }: Props) {
       yacht: () => {
         playYacht();
         setShowYachtCelebration(true);
+      },
+      joker: () => {
+        playJoker();
+        setShowJokerCelebration(true);
       },
       largeStraight: () => playStraight(),
       smallStraight: () => playStraight(),
@@ -300,6 +309,12 @@ export default function GameScreen({ navigation, route }: Props) {
         onDismiss={() => setShowYachtCelebration(false)}
       />
 
+      <YachtCelebrationAnimation
+        variant="joker"
+        visible={showJokerCelebration}
+        onDismiss={() => setShowJokerCelebration(false)}
+      />
+
       <GameOverModal
         visible={gameState.game_over}
         totalScore={gameState.total_score}
@@ -315,6 +330,116 @@ export default function GameScreen({ navigation, route }: Props) {
         onConfirm={handleConfirmNewGame}
         onCancel={() => setConfirmNewGameVisible(false)}
       />
+
+      {__DEV__ && (
+        <Pressable style={styles.devButton} onPress={() => setDevPanelOpen(true)}>
+          <Text style={styles.devButtonText}>DEV</Text>
+        </Pressable>
+      )}
+
+      {__DEV__ && (
+        <Modal
+          visible={devPanelOpen}
+          transparent
+          animationType="fade"
+          accessibilityViewIsModal
+          onRequestClose={() => setDevPanelOpen(false)}
+        >
+          <View style={styles.devOverlay}>
+            <View style={[styles.devPanel, { backgroundColor: colors.surfaceHigh }]}>
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.devScrollContent}
+              >
+                <Text style={styles.devTitle}>Yacht Dev Panel</Text>
+
+                <Text style={[styles.devSectionHeader, { color: colors.textMuted }]}>
+                  ── Dice Override ──
+                </Text>
+                <Text style={[styles.devHint, { color: colors.textMuted }]}>
+                  Applied on next roll. Held dice are respected.
+                </Text>
+
+                <View style={styles.devDiceRow}>
+                  {devDice.map((val, i) => (
+                    <View key={i} style={styles.devDieCell}>
+                      <Pressable
+                        style={styles.devStepBtn}
+                        onPress={() =>
+                          setDevDice((d) => {
+                            const next = [...d] as typeof d;
+                            next[i] = Math.min(6, d[i] + 1);
+                            return next;
+                          })
+                        }
+                        accessibilityLabel={`Increase die ${i + 1}`}
+                      >
+                        <Text style={styles.devStepText}>+</Text>
+                      </Pressable>
+                      <Text style={styles.devDieValue}>{val}</Text>
+                      <Pressable
+                        style={styles.devStepBtn}
+                        onPress={() =>
+                          setDevDice((d) => {
+                            const next = [...d] as typeof d;
+                            next[i] = Math.max(1, d[i] - 1);
+                            return next;
+                          })
+                        }
+                        accessibilityLabel={`Decrease die ${i + 1}`}
+                      >
+                        <Text style={styles.devStepText}>−</Text>
+                      </Pressable>
+                    </View>
+                  ))}
+                </View>
+
+                <Text style={[styles.devSectionHeader, { color: colors.textMuted }]}>
+                  ── Presets ──
+                </Text>
+
+                {(
+                  [
+                    ["Yacht", [3, 3, 3, 3, 3]],
+                    ["Full House", [2, 2, 2, 5, 5]],
+                    ["Sm. Straight", [1, 2, 3, 4, 6]],
+                    ["Lg. Straight", [1, 2, 3, 4, 5]],
+                    ["All 1s", [1, 1, 1, 1, 1]],
+                    ["All 6s", [6, 6, 6, 6, 6]],
+                  ] as [string, [number, number, number, number, number]][]
+                ).map(([label, preset]) => (
+                  <Pressable
+                    key={label}
+                    style={styles.devPresetBtn}
+                    onPress={() => setDevDice(preset)}
+                  >
+                    <Text style={styles.devPresetText}>
+                      {label} [{preset.join(",")}]
+                    </Text>
+                  </Pressable>
+                ))}
+
+                <Pressable
+                  style={[styles.devActionBtn, { backgroundColor: "rgba(255,128,0,1)" }]}
+                  onPress={() => {
+                    setDiceOverride([...devDice]);
+                    setDevPanelOpen(false);
+                  }}
+                >
+                  <Text style={styles.devActionPrimaryText}>Apply on next roll</Text>
+                </Pressable>
+
+                <Pressable
+                  style={[styles.devActionBtn, { backgroundColor: "rgba(255,255,255,0.08)" }]}
+                  onPress={() => setDevPanelOpen(false)}
+                >
+                  <Text style={[styles.devActionText, { color: colors.textMuted }]}>Close</Text>
+                </Pressable>
+              </ScrollView>
+            </View>
+          </View>
+        </Modal>
+      )}
     </GameShell>
   );
 }
@@ -361,5 +486,111 @@ const styles = StyleSheet.create({
     minHeight: 0,
     marginHorizontal: 12,
     marginBottom: 12,
+  },
+  devButton: {
+    position: "absolute",
+    bottom: 8,
+    right: 8,
+    backgroundColor: "rgba(255,128,0,0.85)",
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    zIndex: 100,
+  },
+  devButtonText: {
+    color: "#fff",
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 1,
+  },
+  devOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.7)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  devPanel: {
+    borderRadius: 12,
+    padding: 24,
+    width: 320,
+    maxHeight: "85%",
+    borderWidth: 1,
+    borderColor: "rgba(255,128,0,0.5)",
+  },
+  devScrollContent: {
+    gap: 12,
+  },
+  devTitle: {
+    color: "rgba(255,128,0,1)",
+    fontSize: 14,
+    fontWeight: "700",
+    letterSpacing: 2,
+    textAlign: "center",
+    textTransform: "uppercase",
+  },
+  devSectionHeader: {
+    fontSize: 10,
+    letterSpacing: 1,
+    textAlign: "center",
+    marginTop: 4,
+  },
+  devHint: {
+    fontSize: 11,
+    textAlign: "center",
+  },
+  devDiceRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 4,
+  },
+  devDieCell: {
+    flex: 1,
+    alignItems: "center",
+    gap: 4,
+  },
+  devStepBtn: {
+    backgroundColor: "rgba(255,255,255,0.1)",
+    width: 32,
+    height: 32,
+    borderRadius: 6,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  devStepText: {
+    color: "#fff",
+    fontSize: 18,
+    lineHeight: 22,
+  },
+  devDieValue: {
+    color: "#fff",
+    fontSize: 20,
+    fontWeight: "700",
+    minWidth: 24,
+    textAlign: "center",
+  },
+  devPresetBtn: {
+    backgroundColor: "rgba(255,255,255,0.08)",
+    borderRadius: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    alignItems: "center",
+  },
+  devPresetText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  devActionBtn: {
+    borderRadius: 8,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  devActionPrimaryText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  devActionText: {
+    fontSize: 13,
   },
 });

--- a/frontend/src/theme/theme.constants.ts
+++ b/frontend/src/theme/theme.constants.ts
@@ -9,3 +9,9 @@
 
 /** Semi-transparent black backdrop behind modal cards. */
 export const MODAL_SCRIM = "rgba(0,0,0,0.5)";
+
+/** Yacht celebration badge — gold, matching the original badge colour. */
+export const BADGE_YACHT_BG = "rgba(255,215,0,0.95)";
+
+/** Joker celebration badge — purple, for the joker variant. */
+export const BADGE_JOKER_BG = "rgba(138,43,226,0.95)";

--- a/frontend/src/theme/theme.constants.ts
+++ b/frontend/src/theme/theme.constants.ts
@@ -15,3 +15,21 @@ export const BADGE_YACHT_BG = "rgba(255,215,0,0.95)";
 
 /** Joker celebration badge — purple, for the joker variant. */
 export const BADGE_JOKER_BG = "rgba(138,43,226,0.95)";
+
+/** Dev-panel accent colour (orange). */
+export const DEV_ACCENT = "rgba(255,128,0,1)";
+
+/** Dev-panel accent colour at reduced opacity — for buttons/badges. */
+export const DEV_ACCENT_DIM = "rgba(255,128,0,0.85)";
+
+/** Dev-panel accent border. */
+export const DEV_ACCENT_BORDER = "rgba(255,128,0,0.5)";
+
+/** Semi-transparent black backdrop for the dev-panel modal. */
+export const DEV_OVERLAY_BG = "rgba(0,0,0,0.7)";
+
+/** Subtle white surface for dev-panel secondary buttons. */
+export const DEV_SURFACE_SUBTLE = "rgba(255,255,255,0.08)";
+
+/** Slightly more opaque white surface for dev-panel step buttons. */
+export const DEV_SURFACE_DIM = "rgba(255,255,255,0.1)";


### PR DESCRIPTION
## Summary
- **#983 — Joker fanfare:** engine emits a `joker` GameEvent when `yacht_bonus_count` increments. `GameScreen` plays `yacht.joker` sound and shows a purple `YachtCelebrationAnimation variant="joker"` displaying "JOKER!" — visually distinct from the gold "YACHT!" banner.
- **#984 — Dev panel:** `setDiceOverride([...])` added to the engine; the next `roll()` substitutes those values for unheld dice, then self-clears. `GameScreen` adds a `DEV` button (guarded by `__DEV__`) that opens a modal with per-die ± steppers, common presets (Yacht, Full House, Small/Large Straight, All 1s/6s), and "Apply on next roll".

Closes #983, #984

## Test plan
- [ ] Score a Yacht (first one) — gold "YACHT!" badge appears as before
- [ ] Score a second Yacht (joker) — purple "JOKER!" badge appears + sound plays
- [ ] Normal scoring produces no joker animation
- [ ] DEV button only visible in dev builds; hidden in production
- [ ] DEV panel: set dice to [3,3,3,3,3], tap Apply, roll → dice show 3s
- [ ] Held dice are respected when override is active
- [ ] Override clears after one roll (subsequent rolls are random again)
- [ ] Presets correctly populate the dice selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)