### PR TITLE
feat(freecell): align FreeCell screen to design system (#995)

### DIFF
--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -38,6 +38,8 @@ export default function FoundationPile({
   const { colors } = useTheme();
   const { t } = useTranslation("freecell");
   const hasDrop = dropId !== undefined && onDrop !== undefined;
+  const RED_SUITS = new Set(["hearts", "diamonds"]);
+  const suitSymbolColor = RED_SUITS.has(suit) ? "#ff716c" : colors.textFilled;
 
   const inner = (() => {
     if (pile.length > 0) {
@@ -72,7 +74,7 @@ export default function FoundationPile({
       },
     ];
     const content = (
-      <Text style={[styles.suit, { color: colors.textMuted }]}>{SUIT_SYMBOL[suit]}</Text>
+      <Text style={[styles.suit, { color: suitSymbolColor }]}>{SUIT_SYMBOL[suit]}</Text>
     );
 
     if (onPress) {
@@ -99,7 +101,7 @@ export default function FoundationPile({
       <DropTarget
         id={dropId!}
         onDrop={onDrop!}
-        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 6 }}
         dimStyle={{ opacity: 0.4 }}
       >
         {inner}
@@ -113,12 +115,13 @@ const styles = StyleSheet.create({
   empty: {
     width: CARD_WIDTH,
     height: CARD_HEIGHT,
-    borderRadius: 8,
+    borderRadius: 6,
     alignItems: "center",
     justifyContent: "center",
   },
   suit: {
-    fontSize: 24,
-    lineHeight: 28,
+    fontSize: 18,
+    lineHeight: 22,
+    opacity: 0.75,
   },
 });

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
+import { useTheme } from "../../theme/ThemeContext";
+
 import { SUITS } from "../../game/freecell/types";
 import { validateMove } from "../../game/freecell/engine";
 import type { FreeCellState, Move } from "../../game/freecell/types";
@@ -13,8 +15,8 @@ import { DragContainer } from "../../game/_shared/drag/DragContainer";
 import type { DragSource, DragCard } from "../../game/_shared/drag/DragContext";
 
 const TABLEAU_COLS = 8;
-const COL_GAP = 4;
-const SLOT_GAP = 6;
+const COL_GAP = 2;
+const SLOT_GAP = 4;
 const ROW_GAP = 8;
 
 const BOARD_WIDTH = TABLEAU_COLS * CARD_WIDTH + (TABLEAU_COLS - 1) * COL_GAP;
@@ -31,6 +33,7 @@ export interface FreeCellBoardProps {
 
 export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   const { t } = useTranslation("freecell");
+  const { colors } = useTheme();
   const [selection, setSelection] = useState<Selection>(null);
 
   function tryMove(move: Move) {
@@ -224,7 +227,18 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
           accessibilityRole="none"
           accessibilityLabel={t("a11y.boardRegion")}
         >
-          <View style={styles.topRow}>
+          <View
+            style={[
+              styles.topRow,
+              {
+                borderBottomWidth: 1,
+                borderBottomColor: colors.border,
+                paddingTop: 6,
+                paddingHorizontal: 4,
+                paddingBottom: 8,
+              },
+            ]}
+          >
             <View style={styles.slotGroup}>
               {state.freeCells.map((card, i) => (
                 <FreeCellSlot

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
 import SharedPlayingCard from "../shared/PlayingCard";
 import { rankLabel } from "../../game/_shared/decks/cardId";
 import type { CanonicalSuit } from "../../game/_shared/decks/types";
@@ -81,7 +82,7 @@ export default function FreeCellSlot({
         <DropTarget
           id={dropId!}
           onDrop={onDrop!}
-          highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+          highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 6 }}
           dimStyle={{ opacity: 0.4 }}
         >
           {draggable}
@@ -102,15 +103,23 @@ export default function FreeCellSlot({
     },
   ];
 
+  const freeLabel = (
+    <Text style={[styles.freeLabel, { color: colors.textFilled }]}>free</Text>
+  );
+
   const emptyEl = handlePress ? (
     <Pressable
       onPress={handlePress}
       style={slotStyle}
       accessibilityRole="button"
       accessibilityLabel={emptyLabel}
-    />
+    >
+      {freeLabel}
+    </Pressable>
   ) : (
-    <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel} />
+    <View style={slotStyle} accessibilityRole="image" accessibilityLabel={emptyLabel}>
+      {freeLabel}
+    </View>
   );
 
   if (hasDrop) {
@@ -118,7 +127,7 @@ export default function FreeCellSlot({
       <DropTarget
         id={dropId!}
         onDrop={onDrop!}
-        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 8 }}
+        highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 6 }}
         dimStyle={{ opacity: 0.4 }}
       >
         {emptyEl}
@@ -132,7 +141,15 @@ const styles = StyleSheet.create({
   empty: {
     width: CARD_WIDTH,
     height: CARD_HEIGHT,
-    borderRadius: 8,
+    borderRadius: 6,
     borderStyle: "dashed",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  freeLabel: {
+    fontFamily: typography.label,
+    fontSize: 8,
+    letterSpacing: 1,
+    textTransform: "uppercase",
   },
 });

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -12,7 +12,7 @@ import { DraggableCard } from "../../game/_shared/drag/DraggableCard";
 import { DropTarget } from "../../game/_shared/drag/DropTarget";
 import type { DropHandler } from "../../game/_shared/drag/DragContext";
 
-const FACE_UP_OFFSET = 24;
+const FACE_UP_OFFSET = 36;
 
 export interface TableauColumnProps {
   readonly pile: readonly Card[];
@@ -38,7 +38,7 @@ export default function TableauColumn({
   const { colors } = useTheme();
   const { t } = useTranslation("freecell");
 
-  const highlightStyle: ViewStyle = { borderColor: colors.accent, borderWidth: 2, borderRadius: 8 };
+  const highlightStyle: ViewStyle = { borderColor: colors.accent, borderWidth: 2, borderRadius: 6 };
   const dimStyle: ViewStyle = { opacity: 0.4 };
   const hasDrop = dropId !== undefined && onDrop !== undefined;
 
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
   empty: {
     width: CARD_WIDTH,
     height: CARD_HEIGHT,
-    borderRadius: 8,
+    borderRadius: 6,
     borderWidth: 1,
     borderStyle: "dashed",
   },

--- a/frontend/src/components/shared/PlayingCard.tsx
+++ b/frontend/src/components/shared/PlayingCard.tsx
@@ -56,12 +56,12 @@ export default function PlayingCard({
       width={width}
       height={height}
       faceDown={faceDown}
-      cardBg={colors.surface}
+      cardBg="#fff"
       cardBgBack={colors.surfaceAlt}
       border={hintHighlighted ? colors.bonus : highlighted ? colors.accent : colors.border}
       borderHighlight={colors.accent}
-      textColor={colors.text}
-      redSuitColor={colors.error}
+      textColor="#0e0e13"
+      redSuitColor="#ff716c"
     />
   );
 
@@ -69,7 +69,18 @@ export default function PlayingCard({
   // than by lowering the wrapper's opacity. In overlapping hand layouts (e.g.
   // Hearts) translucent cards let the card underneath bleed through — the
   // overlay keeps the card itself opaque. Radius matches CardFace.
-  const wrapperStyle = [{ width, height }, rotateStyle];
+  const wrapperStyle = [
+    {
+      width,
+      height,
+      shadowColor: "#000",
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.2,
+      shadowRadius: 4,
+      elevation: 2,
+    },
+    rotateStyle,
+  ];
   const disabledOverlay = disabled ? (
     <View
       pointerEvents="none"
@@ -79,7 +90,7 @@ export default function PlayingCard({
         left: 0,
         width,
         height,
-        borderRadius: 8,
+        borderRadius: 6,
         backgroundColor: "rgba(0,0,0,0.5)",
       }}
     />

--- a/frontend/src/game/_shared/decks/classic/ClassicCardFace.tsx
+++ b/frontend/src/game/_shared/decks/classic/ClassicCardFace.tsx
@@ -18,7 +18,7 @@ export default function ClassicCardFace({
   textColor,
   redSuitColor,
 }: CardFaceProps) {
-  const r = 8; // border radius
+  const r = 6; // border radius
 
   if (faceDown) {
     return (

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -29,12 +29,12 @@ import { clearGame, loadGame, saveGame } from "../game/freecell/storage";
 import { useGameEvents } from "../game/_shared/useGameEvents";
 import { useSound } from "../game/_shared/useSound";
 
-// 8 columns × 40px + 7 gaps × 4px
+// 8 columns × 40px + 7 gaps × 2px
 const TABLEAU_COLS = 8;
-const COL_GAP = 4;
+const COL_GAP = 2;
 const BOARD_WIDTH = TABLEAU_COLS * CARD_WIDTH + (TABLEAU_COLS - 1) * COL_GAP;
-// Top row (free cells + foundations) + gap + tableau worst case (12 cards stacked at 24px offset)
-const BOARD_HEIGHT = CARD_HEIGHT * 2 + 8 + 12 * 24 + CARD_HEIGHT;
+// Top row (free cells + foundations) + gap + tableau worst case (12 cards stacked at 36px offset)
+const BOARD_HEIGHT = CARD_HEIGHT * 2 + 8 + 12 * 36 + CARD_HEIGHT;
 
 export default function FreeCellScreen() {
   const { t } = useTranslation("freecell");
@@ -204,6 +204,9 @@ export default function FreeCellScreen() {
       {state !== null && (
         <View style={styles.body} onLayout={onOuterLayout}>
           <View style={styles.hudRow} accessibilityRole="summary">
+            <Text style={[styles.hudTitle, { color: colors.text }]}>
+              {t("freecell:game.title")}
+            </Text>
             <Text
               style={[styles.hudText, { color: colors.textMuted }]}
               accessibilityLabel={t("freecell:score.moves", { moves: state.moveCount })}
@@ -405,13 +408,19 @@ const styles = StyleSheet.create({
   },
   hudRow: {
     flexDirection: "row",
-    justifyContent: "flex-end",
+    justifyContent: "space-between",
     paddingHorizontal: 4,
     paddingVertical: 8,
   },
-  hudText: {
+  hudTitle: {
     fontFamily: typography.heading,
-    fontSize: 16,
+    fontSize: 14,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+  hudText: {
+    fontFamily: typography.body,
+    fontSize: 12,
     letterSpacing: 0.5,
   },
   boardWrap: {


### PR DESCRIPTION
## Summary
- Cards now use white face (`#fff`), dark text (`#0e0e13`), salmon red suits (`#ff716c`), and a drop shadow on the wrapper
- Border radius tightened 8→6 on cards, empty slots, and drop-target highlights
- Free cell empty slots show a "FREE" micro-label (Manrope 8px, uppercase, `colors.textFilled`)
- Foundation suit symbols: 24→18px at 0.75 opacity, suit-coloured (red for ♥♦, dark for ♣♠)
- Tableau card offset increased 24→36px for better card stack visibility
- Slot gap 6→4px, column gap 4→2px for a tighter top-row layout
- Top-row separator line (1px `colors.border`) added below free cells + foundations
- HUD redesigned: game title left (Space Grotesk 14/700), move count right (Manrope 12px)
- `BOARD_HEIGHT` updated from `12*24` to `12*36` to match new offset

## Test plan
- [x] 1899 frontend unit tests pass (no regressions)
- [x] TypeScript noEmit: no new errors in modified files
- [x] ESLint: clean on all 7 modified files
- [ ] Visual smoke test on device / Expo Web (card face colours, shadows, FREE label, foundation symbols, HUD layout)

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)