### PR TITLE
feat(#980, #981): lightning power-up — engine, UI, and audio

### DIFF
--- a/e2e/tests/starswarm-flow.spec.ts
+++ b/e2e/tests/starswarm-flow.spec.ts
@@ -44,9 +44,7 @@ test.describe("Star Swarm — navigation and smoke tests", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test("charge shot button is accessible during active play", async ({
-    page,
-  }) => {
+  test("charge-shot button is absent from active play UI", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: "Play Star Swarm" }).click();
     await expect(
@@ -54,7 +52,7 @@ test.describe("Star Swarm — navigation and smoke tests", () => {
     ).toBeVisible({ timeout: 10_000 });
     await expect(
       page.getByRole("button", { name: /Charge shot/i }),
-    ).toBeVisible({ timeout: 5_000 });
+    ).not.toBeAttached();
   });
 
   test("drag interaction on canvas does not crash the game", async ({

--- a/e2e/tests/starswarm-game-over.spec.ts
+++ b/e2e/tests/starswarm-game-over.spec.ts
@@ -45,7 +45,7 @@ test.describe("Star Swarm — game-over state and score API", () => {
     });
   });
 
-  test("charge shot button visible before game over (active play)", async ({
+  test("charge-shot button is absent during active play (#981 removal)", async ({
     page,
   }) => {
     await page.goto("/");
@@ -54,13 +54,15 @@ test.describe("Star Swarm — game-over state and score API", () => {
       page.getByRole("img", { name: /Star Swarm game/i }),
     ).toBeVisible({ timeout: 10_000 });
 
-    // During SwoopIn / Playing phase the charge shot button should be present
+    // Charge-shot button was removed in #981 — power-up now grants super state
     await expect(
       page.getByRole("button", { name: /Charge shot/i }),
-    ).toBeVisible({ timeout: 5_000 });
+    ).not.toBeAttached();
   });
 
-  test("score submission POST request is correctly shaped", async ({ page }) => {
+  test("score submission POST request is correctly shaped", async ({
+    page,
+  }) => {
     const capturedBodies: unknown[] = [];
 
     await page.route(`${API_BASE}/starswarm/score`, async (route) => {

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -1,15 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Animated, Platform, Pressable, StyleSheet, Text, View } from "react-native";
+import React, { useCallback, useEffect, useRef } from "react";
+import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import * as Haptics from "expo-haptics";
 import { useTranslation } from "react-i18next";
 import type { GameCanvasHandle } from "./GameCanvas";
 import type { GamePhase } from "../../game/starswarm/types";
-import { CANVAS_W, CANVAS_H, CHARGE_SHOOT_COOLDOWN } from "../../game/starswarm/engine";
+import { CANVAS_W, CANVAS_H } from "../../game/starswarm/engine";
 
 const DRAG_ZONE_Y_RATIO = 0.6; // bottom 40% is the drag zone
-const CHARGE_BTN_SIZE = 56;
-const CHARGE_BTN_HIT_SLOP = 12;
 
 interface Props {
   canvasRef: React.RefObject<GameCanvasHandle | null>;
@@ -45,25 +43,6 @@ export default function Controls({
   // Ship X captured at each touch-start — used to compute delta from gesture start,
   // avoiding cumulative drift from per-event changeX accumulation.
   const shipXAtDragStartRef = useRef(CANVAS_W / 2);
-
-  const [isCharging, setIsCharging] = useState(false);
-  const [isOnCooldown, setIsOnCooldown] = useState(false);
-  const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pulseAnim = useRef(new Animated.Value(1)).current;
-
-  useEffect(() => {
-    if (isCharging) {
-      Animated.loop(
-        Animated.sequence([
-          Animated.timing(pulseAnim, { toValue: 1.22, duration: 280, useNativeDriver: true }),
-          Animated.timing(pulseAnim, { toValue: 1, duration: 280, useNativeDriver: true }),
-        ])
-      ).start();
-    } else {
-      pulseAnim.stopAnimation();
-      Animated.spring(pulseAnim, { toValue: 1, useNativeDriver: true, bounciness: 0 }).start();
-    }
-  }, [isCharging, pulseAnim]);
 
   const resetPlayerX = useCallback(() => {
     playerXRef.current = CANVAS_W / 2;
@@ -143,51 +122,10 @@ export default function Controls({
   }, [canvasRef]);
 
   const isGameOver = phase === "GameOver";
-  const gameActive = !isGameOver && !isPaused;
 
   return (
     <GestureDetector gesture={panGesture}>
       <View style={[styles.overlay, { width: displayW, height: displayH }]}>
-        {/* Charge shot button — bottom-right corner, only during active play */}
-        {gameActive && (
-          <Animated.View
-            style={[
-              styles.chargeBtnWrap,
-              {
-                bottom: Platform.OS === "web" ? 20 : 28,
-                right: 12,
-                transform: [{ scale: pulseAnim }],
-              },
-            ]}
-          >
-            <Pressable
-              style={[
-                styles.chargeBtn,
-                isCharging && styles.chargeBtnActive,
-                isOnCooldown && !isCharging && styles.chargeBtnCooldown,
-              ]}
-              hitSlop={CHARGE_BTN_HIT_SLOP}
-              accessibilityLabel={t("controls.chargeShotLabel")}
-              accessibilityRole="button"
-              onPressIn={() => setIsCharging(true)}
-              onPressOut={() => {
-                setIsCharging(false);
-                setIsOnCooldown(true);
-                canvasRef.current?.setChargeShot(true);
-                if (cooldownTimerRef.current) clearTimeout(cooldownTimerRef.current);
-                cooldownTimerRef.current = setTimeout(
-                  () => setIsOnCooldown(false),
-                  CHARGE_SHOOT_COOLDOWN
-                );
-              }}
-            >
-              <Text style={styles.chargeBtnIcon} aria-hidden>
-                ⚡
-              </Text>
-            </Pressable>
-          </Animated.View>
-        )}
-
         {/* Pause overlay */}
         {isPaused && !isGameOver && (
           <Pressable
@@ -239,31 +177,6 @@ const styles = StyleSheet.create({
     position: "absolute",
     top: 0,
     left: 0,
-  },
-  chargeBtnWrap: {
-    position: "absolute",
-    width: CHARGE_BTN_SIZE,
-    height: CHARGE_BTN_SIZE,
-  },
-  chargeBtn: {
-    width: CHARGE_BTN_SIZE,
-    height: CHARGE_BTN_SIZE,
-    borderRadius: CHARGE_BTN_SIZE / 2,
-    backgroundColor: "rgba(0, 200, 255, 0.18)",
-    borderWidth: 2,
-    borderColor: "rgba(0, 200, 255, 0.55)",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  chargeBtnActive: {
-    backgroundColor: "rgba(0, 200, 255, 0.42)",
-    borderColor: "#00ffcc",
-  },
-  chargeBtnCooldown: {
-    opacity: 0.35,
-  },
-  chargeBtnIcon: {
-    fontSize: 26,
   },
   pauseOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -1,9 +1,17 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { Canvas, Circle, Fill, Group, Image as SkiaImage, Rect } from "@shopify/react-native-skia";
+import {
+  Canvas,
+  Circle,
+  Fill,
+  Group,
+  Image as SkiaImage,
+  Path,
+  Rect,
+} from "@shopify/react-native-skia";
 import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
-import { initStarSwarm, tick, BULLET_C_W } from "../../game/starswarm/engine";
+import { initStarSwarm, tick, BULLET_C_W, POWERUP_DURATION } from "../../game/starswarm/engine";
 import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
 import type { StarfieldState } from "../../game/starswarm/starfield";
 import { useStarSwarmImages } from "../../game/starswarm/assets";
@@ -21,7 +29,6 @@ export interface DevOptions {
 export interface GameCanvasHandle {
   setPlayerX: (x: number) => void;
   setFire: (fire: boolean) => void;
-  setChargeShot: (fire: boolean) => void;
 }
 
 interface Props {
@@ -31,10 +38,10 @@ interface Props {
   onPlayerHit?: () => void;
   onWaveClear?: () => void;
   onLaserFire?: () => void;
-  onChargeShotFire?: () => void;
   onExplosion?: () => void;
   onChallengingStage?: () => void;
   onBonusLife?: () => void;
+  onPowerUpCollect?: () => void;
   isPaused?: boolean;
   width: number;
   height: number;
@@ -60,10 +67,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onPlayerHit,
       onWaveClear,
       onLaserFire,
-      onChargeShotFire,
       onExplosion,
       onChallengingStage,
       onBonusLife,
+      onPowerUpCollect,
       isPaused = false,
       width,
       height,
@@ -78,7 +85,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
     const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
-    const inputRef = useRef({ playerX: width / 2, fire: true, chargeShot: false });
+    const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
     // Assign during render (not via effect) so the reset effect always reads the
     // latest devOptions even though devOptions is not in its dependency array.
@@ -94,10 +101,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onPlayerHitRef = useRef(onPlayerHit);
     const onWaveClearRef = useRef(onWaveClear);
     const onLaserFireRef = useRef(onLaserFire);
-    const onChargeShotFireRef = useRef(onChargeShotFire);
     const onExplosionRef = useRef(onExplosion);
     const onChallengingStageRef = useRef(onChallengingStage);
     const onBonusLifeRef = useRef(onBonusLife);
+    const onPowerUpCollectRef = useRef(onPowerUpCollect);
+    const prevActivePowerUpRef = useRef(false); // tracks whether buff was active last frame
     const prevBonusLivesRef = useRef(gameRef.current.bonusLivesAwarded);
     const bonusFlashEndRef = useRef(0); // ms timestamp when 1UP flash expires
 
@@ -122,9 +130,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onLaserFireRef.current = onLaserFire;
     }, [onLaserFire]);
     useEffect(() => {
-      onChargeShotFireRef.current = onChargeShotFire;
-    }, [onChargeShotFire]);
-    useEffect(() => {
       onExplosionRef.current = onExplosion;
     }, [onExplosion]);
     useEffect(() => {
@@ -133,6 +138,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onBonusLifeRef.current = onBonusLife;
     }, [onBonusLife]);
+    useEffect(() => {
+      onPowerUpCollectRef.current = onPowerUpCollect;
+    }, [onPowerUpCollect]);
 
     const [renderState, setRenderState] = useState<RenderState>({
       game: gameRef.current,
@@ -147,9 +155,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         setFire(fire) {
           inputRef.current.fire = fire;
-        },
-        setChargeShot(fire) {
-          inputRef.current.chargeShot = fire;
         },
       }),
       []
@@ -166,7 +171,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       lastFrameTimeRef.current = 0;
       inputRef.current.playerX = width / 2;
       inputRef.current.fire = true;
-      inputRef.current.chargeShot = false;
       prevScoreRef.current = 0;
       prevLivesRef.current = gameRef.current.player.lives;
       prevPhaseRef.current = gameRef.current.phase;
@@ -187,12 +191,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         const prev = gameRef.current;
         if (prev.phase !== "GameOver" && !isPausedRef.current) {
           try {
-            const chargeShotRequested = inputRef.current.chargeShot;
             const prevCooldown = prev.player.shootCooldown;
             const next = tick(prev, dtMs, {
               playerX: inputRef.current.playerX,
               fire: inputRef.current.fire,
-              chargeShot: inputRef.current.chargeShot,
             });
 
             // Dev: when infinite lives is on, intercept any lives decrement and
@@ -206,22 +208,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
               };
             }
 
-            // Only clear chargeShot when the engine actually consumed it (cooldown advanced)
-            if (chargeShotRequested && applied.player.shootCooldown > prevCooldown) {
-              inputRef.current.chargeShot = false;
-            }
-
             gameRef.current = applied;
             if (applied.score !== prevScoreRef.current) {
               prevScoreRef.current = applied.score;
               onScoreChangeRef.current?.(applied.score);
             }
             if (applied.player.shootCooldown > prevCooldown) {
-              if (chargeShotRequested) {
-                onChargeShotFireRef.current?.();
-              } else {
-                onLaserFireRef.current?.();
-              }
+              onLaserFireRef.current?.();
             }
             if (applied.explosions.length > prev.explosions.length) {
               onExplosionRef.current?.();
@@ -235,6 +228,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
               bonusFlashEndRef.current = Date.now() + 1500;
             }
             prevBonusLivesRef.current = applied.bonusLivesAwarded;
+            const isNowActive = applied.activePowerUp !== null;
+            if (!prevActivePowerUpRef.current && isNowActive) {
+              onPowerUpCollectRef.current?.();
+            }
+            prevActivePowerUpRef.current = isNowActive;
             if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
               onWaveClearRef.current?.();
             }
@@ -405,6 +403,33 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                 />
               ))}
 
+            {/* Super-state electric tint on player ship */}
+            {!blink && state.activePowerUp !== null && (
+              <Rect
+                x={player.x - player.width / 2}
+                y={player.y - player.height / 2}
+                width={player.width}
+                height={player.height}
+                color="rgba(255,238,0,0.45)"
+              />
+            )}
+
+            {/* Power-ups — falling lightning bolt */}
+            {state.powerUps.map((pu) => {
+              const lx = pu.x - pu.width / 2;
+              const ly = pu.y - pu.height / 2;
+              const pw = pu.width;
+              const ph = pu.height;
+              const boltPath =
+                `M${lx + pw * 0.625},${ly} ` +
+                `L${lx + pw * 0.125},${ly + ph * 0.542} ` +
+                `L${lx + pw * 0.458},${ly + ph * 0.542} ` +
+                `L${lx + pw * 0.375},${ly + ph} ` +
+                `L${lx + pw * 0.875},${ly + ph * 0.458} ` +
+                `L${lx + pw * 0.542},${ly + ph * 0.458} Z`;
+              return <Path key={pu.id} path={boltPath} color="#ffee00" />;
+            })}
+
             {/* Explosions */}
             {state.explosions.map((exp) => {
               const frameImg = images.explosionFrames[exp.frame] ?? null;
@@ -449,6 +474,16 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             {Array.from({ length: player.lives }, (_, i) => (
               <View key={i} style={styles.lifeIndicator} />
             ))}
+            {state.activePowerUp !== null && (
+              <View style={styles.powerUpBarWrap}>
+                <View
+                  style={[
+                    styles.powerUpBar,
+                    { width: 60 * (state.activePowerUp.remainingMs / POWERUP_DURATION) },
+                  ]}
+                />
+              </View>
+            )}
           </View>
 
           {showBonusFlash && (
@@ -522,6 +557,21 @@ const styles = StyleSheet.create({
     width: 10,
     height: 14,
     backgroundColor: "#00ffcc",
+  },
+  powerUpBarWrap: {
+    position: "absolute",
+    bottom: 20,
+    left: 0,
+    width: 60,
+    height: 4,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    borderRadius: 2,
+    overflow: "hidden",
+  },
+  powerUpBar: {
+    height: 4,
+    backgroundColor: "#ffee00",
+    borderRadius: 2,
   },
   phaseOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -3,7 +3,7 @@ import { View } from "react-native";
 import { Asset } from "expo-asset";
 import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
-import { initStarSwarm, tick } from "../../game/starswarm/engine";
+import { initStarSwarm, tick, POWERUP_DURATION } from "../../game/starswarm/engine";
 import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
 import type { StarfieldState } from "../../game/starswarm/starfield";
 import type { StarSwarmState } from "../../game/starswarm/types";
@@ -80,7 +80,6 @@ export interface DevOptions {
 export interface GameCanvasHandle {
   setPlayerX: (x: number) => void;
   setFire: (fire: boolean) => void;
-  setChargeShot: (fire: boolean) => void;
 }
 
 interface Props {
@@ -90,9 +89,9 @@ interface Props {
   onPlayerHit?: () => void;
   onWaveClear?: () => void;
   onLaserFire?: () => void;
-  onChargeShotFire?: () => void;
   onExplosion?: () => void;
   onChallengingStage?: () => void;
+  onPowerUpCollect?: () => void;
   isPaused?: boolean;
   width: number;
   height: number;
@@ -110,9 +109,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onPlayerHit,
       onWaveClear,
       onLaserFire,
-      onChargeShotFire,
       onExplosion,
       onChallengingStage,
+      onPowerUpCollect,
       isPaused = false,
       width,
       height,
@@ -132,7 +131,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const scaleRef = useRef(scale);
     const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
-    const inputRef = useRef({ playerX: width / 2, fire: true, chargeShot: false });
+    const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
     const devOptionsRef = useRef<DevOptions | undefined>(devOptions);
     devOptionsRef.current = devOptions;
@@ -143,9 +142,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onPlayerHitRef = useRef(onPlayerHit);
     const onWaveClearRef = useRef(onWaveClear);
     const onLaserFireRef = useRef(onLaserFire);
-    const onChargeShotFireRef = useRef(onChargeShotFire);
     const onExplosionRef = useRef(onExplosion);
     const onChallengingStageRef = useRef(onChallengingStage);
+    const onPowerUpCollectRef = useRef(onPowerUpCollect);
+    const prevActivePowerUpRef = useRef(false);
     const isPausedRef = useRef(isPaused);
     const prevScoreRef = useRef(0);
     const prevLivesRef = useRef(stateRef.current.player.lives);
@@ -182,8 +182,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onLaserFireRef.current = onLaserFire;
     }, [onLaserFire]);
     useEffect(() => {
-      onChargeShotFireRef.current = onChargeShotFire;
-    }, [onChargeShotFire]);
+      onPowerUpCollectRef.current = onPowerUpCollect;
+    }, [onPowerUpCollect]);
     useEffect(() => {
       onExplosionRef.current = onExplosion;
     }, [onExplosion]);
@@ -262,9 +262,6 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         setFire(fire) {
           inputRef.current.fire = fire;
         },
-        setChargeShot(fire) {
-          inputRef.current.chargeShot = fire;
-        },
       }),
       []
     );
@@ -278,10 +275,10 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       lastFrameTimeRef.current = 0;
       inputRef.current.playerX = width / 2;
       inputRef.current.fire = true;
-      inputRef.current.chargeShot = false;
       prevScoreRef.current = 0;
       prevLivesRef.current = stateRef.current.player.lives;
       prevPhaseRef.current = stateRef.current.phase;
+      prevActivePowerUpRef.current = false;
     }, [resetTick, width, height]);
 
     const draw = useCallback(() => {
@@ -398,6 +395,36 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           ctx.closePath();
           ctx.fill();
         }
+        // Super-state electric tint
+        if (state.activePowerUp !== null) {
+          ctx.globalAlpha = 0.45;
+          ctx.fillStyle = "#ffee00";
+          ctx.fillRect(
+            player.x - player.width / 2,
+            player.y - player.height / 2,
+            player.width,
+            player.height
+          );
+          ctx.globalAlpha = 1;
+        }
+      }
+
+      // Power-ups — falling lightning bolt
+      ctx.fillStyle = "#ffee00";
+      for (const pu of state.powerUps) {
+        const lx = pu.x - pu.width / 2;
+        const ly = pu.y - pu.height / 2;
+        const pw = pu.width;
+        const ph = pu.height;
+        ctx.beginPath();
+        ctx.moveTo(lx + pw * 0.625, ly);
+        ctx.lineTo(lx + pw * 0.125, ly + ph * 0.542);
+        ctx.lineTo(lx + pw * 0.458, ly + ph * 0.542);
+        ctx.lineTo(lx + pw * 0.375, ly + ph);
+        ctx.lineTo(lx + pw * 0.875, ly + ph * 0.458);
+        ctx.lineTo(lx + pw * 0.542, ly + ph * 0.458);
+        ctx.closePath();
+        ctx.fill();
       }
 
       // Explosions
@@ -438,6 +465,15 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       for (let i = 0; i < player.lives; i++) {
         ctx.fillStyle = "#00ffcc";
         ctx.fillRect(10 + i * 16, height - 18, 10, 14);
+      }
+
+      // Power-up countdown bar — above lives
+      if (state.activePowerUp !== null) {
+        const ratio = state.activePowerUp.remainingMs / POWERUP_DURATION;
+        ctx.fillStyle = "rgba(255,255,255,0.18)";
+        ctx.fillRect(10, height - 26, 60, 4);
+        ctx.fillStyle = "#ffee00";
+        ctx.fillRect(10, height - 26, 60 * ratio, 4);
       }
 
       // Phase overlays
@@ -490,14 +526,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         const prev = stateRef.current;
         if (prev.phase !== "GameOver" && !isPausedRef.current) {
           try {
-            const chargeShotRequested = inputRef.current.chargeShot;
             const prevCooldown = prev.player.shootCooldown;
             const next = tick(prev, dtMs, {
               playerX: inputRef.current.playerX,
               fire: inputRef.current.fire,
-              chargeShot: inputRef.current.chargeShot,
             });
-            if (inputRef.current.chargeShot) inputRef.current.chargeShot = false;
             let applied = next;
             if (infiniteLivesRef.current && next.player.lives < prevLivesRef.current) {
               applied = {
@@ -512,12 +545,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
               onScoreChangeRef.current?.(applied.score);
             }
             if (applied.player.shootCooldown > prevCooldown) {
-              if (chargeShotRequested) {
-                onChargeShotFireRef.current?.();
-              } else {
-                onLaserFireRef.current?.();
-              }
+              onLaserFireRef.current?.();
             }
+            const isNowActive = applied.activePowerUp !== null;
+            if (!prevActivePowerUpRef.current && isNowActive) {
+              onPowerUpCollectRef.current?.();
+            }
+            prevActivePowerUpRef.current = isNowActive;
             if (applied.explosions.length > prev.explosions.length) {
               onExplosionRef.current?.();
             }

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -12,6 +12,8 @@ import {
   BOSS_DIVE_THRESHOLD,
   BURST_INTERVAL,
   BURST_PAUSE_BASE,
+  POWERUP_DURATION,
+  triggerKills,
   seedRng,
   _resetIds,
   CANVAS_W,
@@ -19,8 +21,8 @@ import {
 } from "../engine";
 import type { Bullet, StarSwarmInput, StarSwarmState } from "../types";
 
-const NO_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: false, chargeShot: false };
-const FIRE_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: true, chargeShot: false };
+const NO_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: false };
+const FIRE_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: true };
 
 function advanceMs(state: StarSwarmState, ms: number, input = NO_INPUT): StarSwarmState {
   const step = 16;
@@ -199,7 +201,7 @@ describe("Collision: player bullets vs enemies", () => {
     const target = s.enemies.find((e) => e.isAlive && e.tier === "Grunt");
     if (!target) return; // no grunt on this wave config, skip
 
-    const aim: StarSwarmInput = { playerX: target.x, fire: true, chargeShot: false };
+    const aim: StarSwarmInput = { playerX: target.x, fire: true };
     s = advanceMs(s, 3000, aim);
     expect(s.score).toBeGreaterThan(scoreBefore);
   });
@@ -211,7 +213,7 @@ describe("Collision: player bullets vs enemies", () => {
     const target = s.enemies.find((e) => e.isAlive);
     if (!target) return;
 
-    const aim: StarSwarmInput = { playerX: target.x, fire: true, chargeShot: false };
+    const aim: StarSwarmInput = { playerX: target.x, fire: true };
     s = tick(s, 16, aim); // fire one bullet
     const bulletsBefore = s.playerBullets.length;
 
@@ -1233,5 +1235,158 @@ describe("Boss burst-fire (#979)", () => {
   it("burstShotsLeft is 0 for all enemies at wave start", () => {
     const s = initStarSwarm(CANVAS_W, CANVAS_H);
     expect(s.enemies.every((e) => e.burstShotsLeft === 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lightning power-up engine (#980)
+// ---------------------------------------------------------------------------
+
+describe("Power-up engine (#980)", () => {
+  it("triggerKills returns 12 at wave 1 and caps at 20", () => {
+    expect(triggerKills(1)).toBe(12);
+    expect(triggerKills(2)).toBe(13);
+    expect(triggerKills(8)).toBe(20);
+    expect(triggerKills(100)).toBe(20);
+  });
+
+  it("killsSinceLastDrop and dropJitterTarget initialised at wave start", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    expect(s.killsSinceLastDrop).toBe(0);
+    expect(s.dropJitterTarget).toBeGreaterThan(0);
+  });
+
+  it("activePowerUp is null at wave start", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    expect(s.activePowerUp).toBeNull();
+  });
+
+  it("kill counter only increments during Playing phase", () => {
+    // ChallengingStage wave — kills should NOT increment counter
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
+    expect(s.phase).toBe("ChallengingStage");
+    const target = s.enemies.find((e) => e.isAlive);
+    if (!target) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 88001,
+      x: target.x,
+      y: target.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: target.width,
+      height: target.height,
+      damage: 10,
+    };
+    s = { ...s, playerBullets: [bullet] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.killsSinceLastDrop).toBe(0);
+  });
+
+  it("power-up spawns when killsSinceLastDrop reaches dropJitterTarget during Playing", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+    // Force counter to be one kill away from the target
+    s = { ...s, killsSinceLastDrop: s.dropJitterTarget - 1, powerUps: [] };
+    const target = s.enemies.find((e) => e.isAlive);
+    if (!target) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 88002,
+      x: target.x,
+      y: target.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: target.width,
+      height: target.height,
+      damage: 10,
+    };
+    s = { ...s, playerBullets: [bullet] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.powerUps.length).toBe(1);
+    expect(s.killsSinceLastDrop).toBe(0); // reset after spawn
+  });
+
+  it("does not spawn a second power-up if one is already on screen", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const existing = {
+      id: 9999,
+      x: 100,
+      y: 100,
+      vy: 0.08,
+      width: 24,
+      height: 24,
+      despawnTimer: 5000,
+    };
+    s = { ...s, killsSinceLastDrop: s.dropJitterTarget - 1, powerUps: [existing] };
+    const target = s.enemies.find((e) => e.isAlive);
+    if (!target) throw new Error("no enemy");
+    const bullet: Bullet = {
+      id: 88003,
+      x: target.x,
+      y: target.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: target.width,
+      height: target.height,
+      damage: 10,
+    };
+    s = { ...s, playerBullets: [bullet] };
+    s = tick(s, 16, NO_INPUT);
+    // Still 1 (the existing one, not spawning a second)
+    expect(s.powerUps.length).toBe(1);
+  });
+
+  it("collecting power-up sets activePowerUp with POWERUP_DURATION remainingMs", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    // Place a power-up directly on the player
+    const pu = {
+      id: 8001,
+      x: s.player.x,
+      y: s.player.y,
+      vy: 0,
+      width: 24,
+      height: 24,
+      despawnTimer: 6000,
+    };
+    s = { ...s, powerUps: [pu] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.activePowerUp).not.toBeNull();
+    expect(s.activePowerUp!.remainingMs).toBeGreaterThan(POWERUP_DURATION - 50);
+    expect(s.powerUps.length).toBe(0); // removed on collection
+  });
+
+  it("super state applies damage=4, piercing=true, fast cooldown to player bullets", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, activePowerUp: { remainingMs: 3000 }, player: { ...s.player, shootCooldown: 0 } };
+    s = tick(s, 16, FIRE_INPUT);
+    const bullet = s.playerBullets[s.playerBullets.length - 1];
+    expect(bullet).toBeDefined();
+    expect(bullet!.damage).toBe(4);
+    expect(bullet!.piercing).toBe(true);
+    // Cooldown should be the super cooldown (70ms), well below normal 280ms
+    expect(s.player.shootCooldown).toBeGreaterThan(0);
+    expect(s.player.shootCooldown).toBeLessThan(280);
+  });
+
+  it("activePowerUp expires after POWERUP_DURATION ms", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, activePowerUp: { remainingMs: 100 } };
+    s = advanceMs(s, 200, NO_INPUT);
+    expect(s.activePowerUp).toBeNull();
+  });
+
+  it("Challenging Stage spawns one power-up at wave start (X = canvasW/2)", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
+    expect(s.phase).toBe("ChallengingStage");
+    expect(s.powerUps.length).toBe(1);
+    expect(s.powerUps[0]!.x).toBe(CANVAS_W / 2);
+    expect(s.powerUps[0]!.despawnTimer).toBeGreaterThan(6000); // 8000ms
   });
 });

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -4,6 +4,7 @@ import type {
   Bullet,
   Explosion,
   Player,
+  PowerUp,
   Vec2,
   CubicBezier,
   EnemyTier,
@@ -27,9 +28,8 @@ const BULLET_P_W = 5;
 const BULLET_P_H = 14;
 const BULLET_P_VY = -0.56; // px/ms upward
 
-export const BULLET_C_W = 12; // charge shot — wider
+export const BULLET_C_W = 12; // super-state bullet — wider
 const BULLET_C_H = 22;
-export const CHARGE_SHOOT_COOLDOWN = 900; // ms; longer cooldown than auto-fire
 
 const BULLET_E_W = 5;
 const BULLET_E_H = 10;
@@ -97,6 +97,16 @@ const AIMED_SHOT_FRACTION = 0.1; // 10% aimed at wave 1, +5% per wave, cap 60%
 // #945 Bonus lives
 const BONUS_LIFE_THRESHOLDS = [30_000, 70_000];
 const MAX_LIVES = 5;
+
+// #980: power-up entity
+const POWERUP_W = 24;
+const POWERUP_H = 24;
+const POWERUP_VY = 0.08; // px/ms fall speed
+const POWERUP_DESPAWN = 6000; // ms before auto-despawn
+const CHALLENGING_POWERUP_DESPAWN = 8000; // ms (longer despawn during Challenging Stage)
+export const POWERUP_DURATION = 5000; // ms of super state
+const SUPER_SHOOT_COOLDOWN = 70; // ms (4× fire rate during super)
+const SUPER_DAMAGE = 4;
 
 // #974: small circle around the player sprite centre — forgiveness hitbox
 export const PLAYER_HURT_RADIUS = 7; // px
@@ -369,6 +379,11 @@ function isChallengingWave(wave: number): boolean {
   return wave % 3 === 0;
 }
 
+// #980: kills needed to trigger a power-up drop (before jitter is applied)
+export function triggerKills(wave: number): number {
+  return Math.min(12 + Math.floor((wave - 1) * 1.5), 20);
+}
+
 // #926: how many enemies may dive simultaneously at a given wave
 export function maxDivers(wave: number): number {
   if (wave <= 2) return 1;
@@ -441,6 +456,18 @@ function buildWaveState(
 
   const startingNonBossCount = enemies.filter((e) => e.tier !== "Boss").length;
 
+  const challengingPowerUp: PowerUp = {
+    id: nextId(),
+    x: canvasW / 2,
+    y: POWERUP_H / 2,
+    vy: POWERUP_VY,
+    width: POWERUP_W,
+    height: POWERUP_H,
+    despawnTimer: CHALLENGING_POWERUP_DESPAWN,
+  };
+  const powerUps: PowerUp[] = isChallengingWave(wave) ? [challengingPowerUp] : [];
+  const dropJitterTarget = triggerKills(wave) + Math.floor(rng() * 5) - 2;
+
   return {
     phase,
     wave,
@@ -450,6 +477,7 @@ function buildWaveState(
     playerBullets: [],
     enemyBullets: [],
     explosions: [],
+    powerUps,
     phaseTimer: 0,
     canvasW,
     canvasH,
@@ -459,6 +487,9 @@ function buildWaveState(
     formationSwayDir: 1,
     bonusLivesAwarded,
     startingNonBossCount,
+    killsSinceLastDrop: 0,
+    dropJitterTarget,
+    activePowerUp: null,
   };
 }
 
@@ -478,6 +509,7 @@ export function tick(state: StarSwarmState, dtMs: number, input: StarSwarmInput)
   let s = tickPlayer(state, dtMs, input);
   s = tickEnemies(s, dtMs);
   s = tickBullets(s, dtMs);
+  s = tickPowerUps(s, dtMs);
   s = tickCollisions(s);
   s = tickBonusLives(state, s);
   s = tickExplosions(s, dtMs);
@@ -522,44 +554,26 @@ function tickPlayer(state: StarSwarmState, dtMs: number, input: StarSwarmInput):
 
   const player: Player = { ...p, x: newX, invincibleTimer, shootCooldown };
 
-  if (shootCooldown === 0) {
-    if (input.chargeShot) {
-      const bullet: Bullet = {
-        id: nextId(),
-        x: newX,
-        y: p.y - p.height / 2,
-        vx: 0,
-        vy: BULLET_P_VY,
-        owner: "player",
-        width: BULLET_C_W,
-        height: BULLET_C_H,
-        damage: 4,
-        piercing: true,
-      };
-      return {
-        ...state,
-        player: { ...player, shootCooldown: CHARGE_SHOOT_COOLDOWN },
-        playerBullets: [...state.playerBullets, bullet],
-      };
-    }
-    if (input.fire) {
-      const bullet: Bullet = {
-        id: nextId(),
-        x: newX,
-        y: p.y - p.height / 2,
-        vx: 0,
-        vy: BULLET_P_VY,
-        owner: "player",
-        width: BULLET_P_W,
-        height: BULLET_P_H,
-        damage: 1,
-      };
-      return {
-        ...state,
-        player: { ...player, shootCooldown: PLAYER_SHOOT_COOLDOWN },
-        playerBullets: [...state.playerBullets, bullet],
-      };
-    }
+  const isSuper = state.activePowerUp !== null;
+
+  if (shootCooldown === 0 && input.fire) {
+    const bullet: Bullet = {
+      id: nextId(),
+      x: newX,
+      y: p.y - p.height / 2,
+      vx: 0,
+      vy: BULLET_P_VY,
+      owner: "player",
+      width: isSuper ? BULLET_C_W : BULLET_P_W,
+      height: isSuper ? BULLET_C_H : BULLET_P_H,
+      damage: isSuper ? SUPER_DAMAGE : 1,
+      piercing: isSuper ? true : undefined,
+    };
+    return {
+      ...state,
+      player: { ...player, shootCooldown: isSuper ? SUPER_SHOOT_COOLDOWN : PLAYER_SHOOT_COOLDOWN },
+      playerBullets: [...state.playerBullets, bullet],
+    };
   }
 
   return { ...state, player };
@@ -959,6 +973,24 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
 }
 
 // ---------------------------------------------------------------------------
+// Power-ups (#980)
+// ---------------------------------------------------------------------------
+
+function tickPowerUps(state: StarSwarmState, dtMs: number): StarSwarmState {
+  const powerUps = state.powerUps
+    .map((pu) => ({ ...pu, y: pu.y + pu.vy * dtMs, despawnTimer: pu.despawnTimer - dtMs }))
+    .filter((pu) => pu.despawnTimer > 0 && pu.y - pu.height / 2 < state.canvasH);
+
+  let activePowerUp = state.activePowerUp;
+  if (activePowerUp !== null) {
+    const newMs = activePowerUp.remainingMs - dtMs;
+    activePowerUp = newMs <= 0 ? null : { remainingMs: newMs };
+  }
+
+  return { ...state, powerUps, activePowerUp };
+}
+
+// ---------------------------------------------------------------------------
 // Bullets
 // ---------------------------------------------------------------------------
 
@@ -988,6 +1020,9 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
   const { player } = state;
   let { score, challengingHits } = state;
   const newExplosions: Explosion[] = [...state.explosions];
+  let killsSinceLastDrop = state.killsSinceLastDrop;
+  let dropJitterTarget = state.dropJitterTarget;
+  let powerUps: PowerUp[] = [...state.powerUps];
 
   // ── Player bullets ↔ enemies ──────────────────────────────────────────────
   const hitBulletIds = new Set<number>(); // non-piercing bullets consumed this tick
@@ -1015,6 +1050,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         const bonus = state.phase === "ChallengingStage" ? 1 : mult;
         score += base * bonus;
         if (state.phase === "ChallengingStage") challengingHits += 1;
+        if (state.phase === "Playing") killsSinceLastDrop++;
         return { ...enemy, hp: 0, isAlive: false, hitFlashTimer: 0 };
       }
 
@@ -1026,6 +1062,38 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
 
   // Piercing bullets are removed by the off-screen filter in tickBullets, not here
   const playerBullets = state.playerBullets.filter((b) => !hitBulletIds.has(b.id));
+
+  // ── Power-up drop check (Playing only, max 1 on screen) ────────────────────
+  if (
+    state.phase === "Playing" &&
+    killsSinceLastDrop >= dropJitterTarget &&
+    powerUps.length === 0
+  ) {
+    const spawnX = POWERUP_W / 2 + rng() * (state.canvasW - POWERUP_W);
+    powerUps = [
+      {
+        id: nextId(),
+        x: spawnX,
+        y: POWERUP_H / 2,
+        vy: POWERUP_VY,
+        width: POWERUP_W,
+        height: POWERUP_H,
+        despawnTimer: POWERUP_DESPAWN,
+      },
+    ];
+    killsSinceLastDrop = 0;
+    dropJitterTarget = triggerKills(state.wave) + Math.floor(rng() * 5) - 2;
+  }
+
+  // ── Player ↔ power-up collection ────────────────────────────────────────
+  let activePowerUp = state.activePowerUp;
+  const collectedIdx = powerUps.findIndex((pu) =>
+    aabb(player.x, player.y, player.width, player.height, pu.x, pu.y, pu.width, pu.height)
+  );
+  if (collectedIdx !== -1) {
+    powerUps = powerUps.filter((_, i) => i !== collectedIdx);
+    activePowerUp = { remainingMs: POWERUP_DURATION };
+  }
 
   // ── Enemy contact ↔ player (bullets + #925 diving/circling ships) ──────────
   // #974: player uses a small forgiveness circle (PLAYER_HURT_RADIUS) instead of full AABB
@@ -1091,6 +1159,10 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
           explosions: newExplosions,
           score,
           challengingHits,
+          powerUps,
+          killsSinceLastDrop,
+          dropJitterTarget,
+          activePowerUp,
           player: { ...player, lives: 0 },
           phase: "GameOver",
         };
@@ -1104,12 +1176,27 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         explosions: newExplosions,
         score,
         challengingHits,
+        powerUps,
+        killsSinceLastDrop,
+        dropJitterTarget,
+        activePowerUp,
         player: { ...player, lives: newLives, invincibleTimer: PLAYER_INVINCIBLE_MS },
       };
     }
   }
 
-  return { ...state, enemies, playerBullets, score, challengingHits, explosions: newExplosions };
+  return {
+    ...state,
+    enemies,
+    playerBullets,
+    score,
+    challengingHits,
+    explosions: newExplosions,
+    powerUps,
+    killsSinceLastDrop,
+    dropJitterTarget,
+    activePowerUp,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -108,6 +108,18 @@ export interface Explosion {
   readonly frameTimer: number;
 }
 
+export interface PowerUp {
+  readonly id: number;
+  readonly x: number;
+  readonly y: number;
+  /** Fall speed in px/ms. */
+  readonly vy: number;
+  readonly width: number;
+  readonly height: number;
+  /** ms until auto-despawn (if not collected). */
+  readonly despawnTimer: number;
+}
+
 export interface StarSwarmState {
   readonly phase: GamePhase;
   readonly wave: number;
@@ -117,6 +129,7 @@ export interface StarSwarmState {
   readonly playerBullets: readonly Bullet[];
   readonly enemyBullets: readonly Bullet[];
   readonly explosions: readonly Explosion[];
+  readonly powerUps: readonly PowerUp[];
   /** General-purpose countdown timer (WaveClear pause, etc.). */
   readonly phaseTimer: number;
   readonly canvasW: number;
@@ -133,6 +146,12 @@ export interface StarSwarmState {
   readonly bonusLivesAwarded: number;
   /** Non-Boss enemy count at wave start; used for Boss dive eligibility (#978). */
   readonly startingNonBossCount: number;
+  /** Enemy kills since last power-up drop (Playing phase only). */
+  readonly killsSinceLastDrop: number;
+  /** Kill count target to trigger the next drop (includes ±2 jitter). */
+  readonly dropJitterTarget: number;
+  /** Non-null while the lightning super state is active. */
+  readonly activePowerUp: { readonly remainingMs: number } | null;
 }
 
 /** Input snapshot consumed by each `tick` call. */
@@ -141,6 +160,4 @@ export interface StarSwarmInput {
   readonly playerX: number;
   /** true while auto-fire is active. */
   readonly fire: boolean;
-  /** One-shot: fire a charge bullet this tick (Controls resets to false after one frame). */
-  readonly chargeShot: boolean;
 }

--- a/frontend/src/hooks/useStarSwarmAudio.ts
+++ b/frontend/src/hooks/useStarSwarmAudio.ts
@@ -5,7 +5,7 @@ const BG_KEYS = ["starswarm.bg1", "starswarm.bg2", "starswarm.bg3", "starswarm.b
 
 export interface SfxVolumes {
   laser: number;
-  chargeshot: number;
+  powerupcollect: number;
   explosion: number;
   playerhit: number;
   waveclear: number;
@@ -16,7 +16,7 @@ export interface SfxVolumes {
 
 export const DEFAULT_SFX_VOLUMES: SfxVolumes = {
   laser: 0,
-  chargeshot: 0.6,
+  powerupcollect: 0.8,
   explosion: 0.45,
   playerhit: 0.7,
   waveclear: 0.8,
@@ -32,7 +32,7 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
   const v = { ...DEFAULT_SFX_VOLUMES, ...volumes };
 
   const { play: playLaser } = useSound("starswarm.laser", v.laser);
-  const { play: playChargeShot } = useSound("starswarm.chargeshot", v.chargeshot);
+  const { play: playPowerUpCollect } = useSound("starswarm.powerupcollect", v.powerupcollect);
   const { play: playExplosion } = useSound("starswarm.explosion", v.explosion);
   const { play: playPlayerHit } = useSound("starswarm.playerhit", v.playerhit);
   const { play: playWaveClear } = useSound("starswarm.waveclear", v.waveclear);
@@ -42,7 +42,7 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
 
   return {
     playLaser,
-    playChargeShot,
+    playPowerUpCollect,
     playExplosion,
     playPlayerHit,
     playWaveClear,

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -57,7 +57,7 @@ export default function StarSwarmScreen() {
 
   const {
     playLaser,
-    playChargeShot,
+    playPowerUpCollect,
     playExplosion,
     playPlayerHit,
     playWaveClear,
@@ -159,7 +159,7 @@ export default function StarSwarmScreen() {
               onPlayerHit={handlePlayerHit}
               onWaveClear={handleWaveClear}
               onLaserFire={playLaser}
-              onChargeShotFire={playChargeShot}
+              onPowerUpCollect={playPowerUpCollect}
               onExplosion={playExplosion}
               onChallengingStage={playChallengingStage}
               onBonusLife={handleBonusLife}
@@ -231,7 +231,7 @@ export default function StarSwarmScreen() {
                   {(
                     [
                       ["Laser", "laser"],
-                      ["Charge shot", "chargeshot"],
+                      ["Power-up", "powerupcollect"],
                       ["Explosion", "explosion"],
                       ["Player hit", "playerhit"],
                       ["Wave clear", "waveclear"],


### PR DESCRIPTION
## Summary
- **Engine (#980):** `PowerUp` entity (24×24, vy=0.08) falls from top; collected by player AABB to activate 5 s super state (damage 4, piercing bullets, 70 ms cooldown). Kill-count trigger `triggerKills(wave)` with ±2 jitter controls drop rate; max 1 power-up on screen at a time. Challenging Stage spawns one guaranteed at wave start (8 s despawn vs 6 s normal).
- **UI (#981):** Yellow lightning bolt rendered on power-ups (Skia SVG path + Canvas 2D polygon). Player gets yellow tint while super active. HUD countdown bar (60 px wide, `#ffee00`) shows remaining duration. Charge-shot button removed from `Controls`; `onChargeShotFire` → `onPowerUpCollect` in both GameCanvas variants.
- **Audio:** `chargeshot` SFX key replaced by `powerupcollect` (0.8 vol default) in `useStarSwarmAudio`; dev panel mixer updated.
- **Tests:** 97 starswarm engine tests pass (9 new power-up tests + existing suite).

## Test plan
- [ ] Web: power-up falls, player collects it, ship turns yellow, shooting fires wide piercing beams at rapid rate
- [ ] Web: countdown bar depletes to zero then reverts to normal fire
- [ ] Web: Challenging Stage wave shows power-up at spawn
- [ ] Web: max 1 power-up on screen (kill spree doesn't stack multiple)
- [ ] Mobile: same as above — Skia bolt renders, haptics still fire on hit/death/wave-clear
- [ ] No charge-shot button visible anywhere
- [ ] Dev panel sound mixer shows "Power-up" row (not "Charge shot")
- [ ] `npx jest --no-coverage --testPathPattern="starswarm"` → 97 tests pass

Closes #980, #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)