### PR TITLE
style(freecell): prettier-format FreeCellSlot.tsx

### DIFF
--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -103,9 +103,7 @@ export default function FreeCellSlot({
     },
   ];
 
-  const freeLabel = (
-    <Text style={[styles.freeLabel, { color: colors.textFilled }]}>free</Text>
-  );
+  const freeLabel = <Text style={[styles.freeLabel, { color: colors.textFilled }]}>free</Text>;
 
   const emptyEl = handlePress ? (
     <Pressable


### PR DESCRIPTION
## Summary
- Runs `prettier --write` on `FreeCellSlot.tsx` to fix the `lint-frontend` CI failure introduced by PR #1001

## Test plan
- [x] `npx prettier --check src/components/freecell/FreeCellSlot.tsx` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)