### PR TITLE
fix(starswarm): powerup despawn timer too short to reach player (#1004)

### DIFF
--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1360,6 +1360,38 @@ describe("Power-up engine (#980)", () => {
     expect(s.powerUps.length).toBe(0); // removed on collection
   });
 
+  it("spawned powerup despawnTimer exceeds travel time to player (regression #1004)", () => {
+    // Pre-fix: POWERUP_DESPAWN=6000ms → 480px travel → despawned 76px above ship.
+    // Fix: despawnTimer is now canvas-height-derived so the powerup always reaches the ship.
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000); // reach Playing phase
+    expect(s.phase).toBe("Playing");
+    // Force a kill-triggered drop on the next tick
+    s = { ...s, killsSinceLastDrop: s.dropJitterTarget - 1, powerUps: [] };
+    const target = s.enemies.find((e) => e.isAlive);
+    if (!target) throw new Error("no alive enemy");
+    const killBullet: Bullet = {
+      id: 99001,
+      x: target.x,
+      y: target.y,
+      vx: 0,
+      vy: 0,
+      owner: "player",
+      width: target.width,
+      height: target.height,
+      damage: 999,
+    };
+    s = { ...s, playerBullets: [killBullet] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.powerUps.length).toBe(1);
+    const pu = s.powerUps[0]!;
+    // Physics: player sits at canvasH - 72 (PLAYER_Y_FROM_BOTTOM), powerup spawns at y≈12.
+    // Verify the despawn timer outlasts the fall so collection can happen.
+    const playerY = CANVAS_H - 72;
+    const msToReachPlayer = (playerY - pu.y) / 0.08; // POWERUP_VY = 0.08 px/ms
+    expect(pu.despawnTimer).toBeGreaterThan(msToReachPlayer);
+  });
+
   it("super state applies damage=4, piercing=true, fast cooldown to player bullets", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H);
     s = advanceMs(s, 8000);
@@ -1387,6 +1419,6 @@ describe("Power-up engine (#980)", () => {
     expect(s.phase).toBe("ChallengingStage");
     expect(s.powerUps.length).toBe(1);
     expect(s.powerUps[0]!.x).toBe(CANVAS_W / 2);
-    expect(s.powerUps[0]!.despawnTimer).toBeGreaterThan(6000); // 8000ms
+    expect(s.powerUps[0]!.despawnTimer).toBeGreaterThan(6000); // canvas-height-derived (~8950ms at CANVAS_H=640)
   });
 });

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -102,9 +102,12 @@ const MAX_LIVES = 5;
 const POWERUP_W = 24;
 const POWERUP_H = 24;
 const POWERUP_VY = 0.08; // px/ms fall speed
-const POWERUP_DESPAWN = 6000; // ms before auto-despawn
-const CHALLENGING_POWERUP_DESPAWN = 8000; // ms (longer despawn during Challenging Stage)
 export const POWERUP_DURATION = 5000; // ms of super state
+// Time for a powerup to fall from spawn (y = POWERUP_H/2) to just past the player, plus a
+// 2-second collection window. Computed per-canvas so it works at any screen height.
+function powerUpDespawnMs(canvasH: number): number {
+  return Math.ceil((canvasH - PLAYER_Y_FROM_BOTTOM - POWERUP_H / 2) / POWERUP_VY) + 2000;
+}
 const SUPER_SHOOT_COOLDOWN = 70; // ms (4× fire rate during super)
 const SUPER_DAMAGE = 4;
 
@@ -463,7 +466,7 @@ function buildWaveState(
     vy: POWERUP_VY,
     width: POWERUP_W,
     height: POWERUP_H,
-    despawnTimer: CHALLENGING_POWERUP_DESPAWN,
+    despawnTimer: powerUpDespawnMs(canvasH),
   };
   const powerUps: PowerUp[] = isChallengingWave(wave) ? [challengingPowerUp] : [];
   const dropJitterTarget = triggerKills(wave) + Math.floor(rng() * 5) - 2;
@@ -1078,7 +1081,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         vy: POWERUP_VY,
         width: POWERUP_W,
         height: POWERUP_H,
-        despawnTimer: POWERUP_DESPAWN,
+        despawnTimer: powerUpDespawnMs(state.canvasH),
       },
     ];
     killsSinceLastDrop = 0;


### PR DESCRIPTION
## Summary
- **Root cause**: `POWERUP_DESPAWN = 6000ms` at `POWERUP_VY = 0.08 px/ms` only carried a powerup **480 px** from spawn (y = 12). On a 640-px canvas the player sits at y = 568, requiring **6 950 ms** of fall time — 950 ms more than the timer allowed. The powerup disappeared 76 px above the ship.
- **Fix**: Replace both `POWERUP_DESPAWN` and `CHALLENGING_POWERUP_DESPAWN` constants with `powerUpDespawnMs(canvasH)`, which computes fall time from spawn to player plus a 2-second collection buffer. Works at any screen height.
- **Regression test**: forces a kill-drop spawn and asserts `despawnTimer > msToReachPlayer`. Would have caught this with the old constant (6 000 ≤ 6 950 → fail).

## Test plan
- [x] 98 StarSwarm engine tests pass (1 new regression test added)
- [x] Old `POWERUP_DESPAWN = 6000` verified to fail the new assertion
- [x] New `powerUpDespawnMs(640) = 8950` verified to pass
- [ ] Manual smoke: play StarSwarm, verify lightning powerup can be collected at ship level

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)