### PR TITLE
fix(#1006): center FreeCell board, scale up, align slots with tableau

### DIFF
--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -16,7 +16,6 @@ import type { DragSource, DragCard } from "../../game/_shared/drag/DragContext";
 
 const TABLEAU_COLS = 8;
 const COL_GAP = 2;
-const SLOT_GAP = 4;
 const ROW_GAP = 8;
 
 const BOARD_WIDTH = TABLEAU_COLS * CARD_WIDTH + (TABLEAU_COLS - 1) * COL_GAP;
@@ -234,41 +233,36 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 borderBottomWidth: 1,
                 borderBottomColor: colors.border,
                 paddingTop: 6,
-                paddingHorizontal: 4,
                 paddingBottom: 8,
               },
             ]}
           >
-            <View style={styles.slotGroup}>
-              {state.freeCells.map((card, i) => (
-                <FreeCellSlot
-                  key={i}
-                  card={card}
-                  cellIndex={i}
-                  selected={selection?.kind === "freecell" && selection.cell === i}
-                  hintSource={
-                    (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
-                    (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
-                  }
-                  onPress={handleFreeCellPress}
-                  dropId={`freecell-slot-${i}`}
-                  onDrop={(source) => handleDropToFreeCell(source, i)}
-                />
-              ))}
-            </View>
-            <View style={styles.slotGroup}>
-              {SUITS.map((suit) => (
-                <FoundationPile
-                  key={suit}
-                  pile={state.foundations[suit]}
-                  suit={suit}
-                  selected={false}
-                  onPress={() => handleFoundationPress()}
-                  dropId={`freecell-foundation-${suit}`}
-                  onDrop={(source) => handleDropToFoundation(source)}
-                />
-              ))}
-            </View>
+            {state.freeCells.map((card, i) => (
+              <FreeCellSlot
+                key={i}
+                card={card}
+                cellIndex={i}
+                selected={selection?.kind === "freecell" && selection.cell === i}
+                hintSource={
+                  (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
+                  (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
+                }
+                onPress={handleFreeCellPress}
+                dropId={`freecell-slot-${i}`}
+                onDrop={(source) => handleDropToFreeCell(source, i)}
+              />
+            ))}
+            {SUITS.map((suit) => (
+              <FoundationPile
+                key={suit}
+                pile={state.foundations[suit]}
+                suit={suit}
+                selected={false}
+                onPress={() => handleFoundationPress()}
+                dropId={`freecell-foundation-${suit}`}
+                onDrop={(source) => handleDropToFoundation(source)}
+              />
+            ))}
           </View>
 
           <View style={styles.tableau}>
@@ -312,12 +306,8 @@ const styles = StyleSheet.create({
   },
   topRow: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    gap: COL_GAP,
     width: BOARD_WIDTH,
-  },
-  slotGroup: {
-    flexDirection: "row",
-    gap: SLOT_GAP,
   },
   tableau: {
     flexDirection: "row",

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -152,7 +152,7 @@ export default function FreeCellScreen() {
 
   const undoDisabled = state === null || state.undoStack.length === 0 || state.isComplete;
   const hintDisabled = state === null || state.isComplete;
-  const scale = outerWidth > 0 ? Math.min(1, outerWidth / BOARD_WIDTH) : 1;
+  const scale = outerWidth > 0 ? outerWidth / BOARD_WIDTH : 1;
 
   return (
     <GameShell
@@ -425,12 +425,12 @@ const styles = StyleSheet.create({
   },
   boardWrap: {
     alignSelf: "stretch",
-    alignItems: "flex-start",
+    alignItems: "center",
     overflow: "hidden",
   },
   board: {
-    alignSelf: "flex-start",
-    transformOrigin: "top left",
+    alignSelf: "center",
+    transformOrigin: "top center",
   } as ViewStyle,
   modalOverlay: {
     flex: 1,


### PR DESCRIPTION
Closes #1006

## Summary

- **Scale-up**: removes the `Math.min(1, …)` cap in `FreeCellScreen.tsx` so the board fills all available horizontal space (not just shrinks on narrow screens)
- **Centering**: changes `boardWrap` / `board` alignment to `center` and `transformOrigin` to `top center` so the board sits symmetrically on wider screens instead of hugging the left edge
- **Slot alignment**: replaces the two-group `space-between` top row with a single flat 8-slot row using the same `COL_GAP = 2` as the tableau, so free cells (positions 0–3) and foundations (positions 4–7) land exactly above their corresponding tableau columns

## Test plan

- [ ] Wide screen (>348 px): board fills width symmetrically, no dead space on right
- [ ] Narrow screen (<348 px): board still shrinks proportionally (scale-down path unchanged)
- [ ] Free cell and foundation slot centers align visually with tableau column centers
- [ ] Drag-and-drop to free cells, foundations, and tableau still works
- [ ] Game logic (moves, undo, hint, win) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)