### PR TITLE
fix: replace "Gaming App" placeholder with "BC Arcade" across all locales, tests, and docs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -50,7 +50,7 @@ if _sentry_dsn:
 # App
 # ---------------------------------------------------------------------------
 
-app = FastAPI(title="Gaming App API")
+app = FastAPI(title="BC Arcade API")
 app.include_router(cascade_router, prefix="/cascade")
 app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")

--- a/backend/perf/locustfile.py
+++ b/backend/perf/locustfile.py
@@ -1,5 +1,5 @@
 """
-Gaming App — Locust performance test entry point.
+BC Arcade — Locust performance test entry point.
 
 User classes:
 

--- a/backend/zap-baseline.yaml
+++ b/backend/zap-baseline.yaml
@@ -1,9 +1,9 @@
 # OWASP ZAP Baseline Scan Configuration
-# Tuned for the Gaming App JSON API (no HTML pages to crawl).
+# Tuned for the BC Arcade JSON API (no HTML pages to crawl).
 # Referenced by deploy.yml via called-deploy-render.yml zap-target-url parameter.
 env:
   contexts:
-    - name: "Gaming App API"
+    - name: "BC Arcade API"
       urls:
         - "https://dev-games-api.buffingchi.com"
       includePaths:
@@ -25,7 +25,7 @@ jobs:
 
   - type: activeScan
     parameters:
-      context: "Gaming App API"
+      context: "BC Arcade API"
       maxRuleDurationInMins: 5
       maxScanDurationInMins: 20
       addQueryParam: false

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gaming App — Privacy Policy</title>
+    <title>BC Arcade — Privacy Policy</title>
     <style>
       body {
         font-family:
@@ -29,11 +29,11 @@
   </head>
   <body>
     <h1>Privacy Policy</h1>
-    <p><strong>Gaming App</strong> — Last updated: April 3, 2026</p>
+    <p><strong>BC Arcade</strong> — Last updated: April 3, 2026</p>
 
     <h2>Overview</h2>
     <p>
-      Gaming App is a collection of classic and casual games including Yacht,
+      BC Arcade is a collection of classic and casual games including Yacht,
       Blackjack, 2048, Cascade, and Ludo. Your privacy is important to us. This
       policy explains what data the app does and does not collect.
     </p>

--- a/e2e/maestro/home-screen-android.yaml
+++ b/e2e/maestro/home-screen-android.yaml
@@ -2,7 +2,7 @@ appId: com.buffingchi.games
 ---
 - launchApp
 - assertVisible:
-    text: "Gaming App"
+    text: "BC Arcade"
     timeout: 15000
 - assertVisible:
     text: "Choose a game"

--- a/e2e/maestro/home-screen-ios.yaml
+++ b/e2e/maestro/home-screen-ios.yaml
@@ -2,7 +2,7 @@ appId: com.buffingchi.games
 ---
 - launchApp
 - assertVisible:
-    text: "Gaming App"
+    text: "BC Arcade"
     timeout: 15000
 - assertVisible:
     text: "Choose a game"

--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -35,7 +35,7 @@ async function assertNoA11yViolations(
 test.describe("Accessibility — Home screen", () => {
   test("no critical/serious axe violations on Home", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
 
     await assertNoA11yViolations(
       new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21aa"]),

--- a/e2e/tests/blackjack-errors.spec.ts
+++ b/e2e/tests/blackjack-errors.spec.ts
@@ -36,7 +36,7 @@ test.describe("Blackjack — error paths and guardrails", () => {
     await gotoBlackjack(page);
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });
@@ -50,7 +50,7 @@ test.describe("Blackjack — error paths and guardrails", () => {
 
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });
@@ -163,7 +163,7 @@ test.describe("Blackjack — error paths and guardrails", () => {
       .getByRole("button", { name: "Return to home screen", exact: true })
       .click();
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/blackjack-full-game.spec.ts
+++ b/e2e/tests/blackjack-full-game.spec.ts
@@ -28,7 +28,7 @@ test.describe("Blackjack — full happy-path game journey", () => {
     page,
   }) => {
     const bj = new BlackjackPage(page);
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
     await page.getByRole("button", { name: "Play Blackjack" }).click();
     await expect(bj.dealButton()).toBeVisible();
   });
@@ -141,7 +141,7 @@ test.describe("Blackjack — full happy-path game journey", () => {
     await expect(page.getByText("Next Hand")).toBeVisible();
     await page.getByRole("button", { name: /quit/i }).click();
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/blackjack-persistence.spec.ts
+++ b/e2e/tests/blackjack-persistence.spec.ts
@@ -63,7 +63,7 @@ test.describe("Blackjack — state persistence", () => {
 
     // Navigate back to Home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
 

--- a/e2e/tests/cascade-flow.spec.ts
+++ b/e2e/tests/cascade-flow.spec.ts
@@ -29,7 +29,7 @@ test.describe("Cascade — navigation and smoke tests", () => {
 
   test("navigates from Home to Cascade screen", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Play Cascade" }).click();
 
@@ -108,7 +108,7 @@ test.describe("Cascade — navigation and smoke tests", () => {
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 5000,
     });
   });

--- a/e2e/tests/lobby-responsive.spec.ts
+++ b/e2e/tests/lobby-responsive.spec.ts
@@ -76,7 +76,7 @@ test.describe("Lobby — responsive layout", () => {
   test("AppHeader visible on home screen", async ({ page }) => {
     await page.goto("/");
     await expect(
-      page.getByRole("heading", { name: "Gaming App", exact: true }),
+      page.getByRole("heading", { name: "BC Arcade", exact: true }),
     ).toBeVisible({
       timeout: 10000,
     });

--- a/e2e/tests/starswarm-flow.spec.ts
+++ b/e2e/tests/starswarm-flow.spec.ts
@@ -127,7 +127,7 @@ test.describe("Star Swarm — navigation and smoke tests", () => {
 
     await page.goto("/");
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 5_000,
     });
   });

--- a/e2e/tests/twenty48-full-game.spec.ts
+++ b/e2e/tests/twenty48-full-game.spec.ts
@@ -26,7 +26,7 @@ test.describe("2048 — full happy-path game journey", () => {
   });
 
   test("navigates from Home to 2048 on Play 2048 click", async ({ page }) => {
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
     await page.getByRole("button", { name: "Play 2048" }).click();
     await expect(page.getByLabel("Game board")).toBeVisible();
   });
@@ -144,7 +144,7 @@ test.describe("2048 — full happy-path game journey", () => {
     await gotoTwenty48(page);
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/twenty48-game-over.spec.ts
+++ b/e2e/tests/twenty48-game-over.spec.ts
@@ -126,7 +126,7 @@ test.describe("2048 — game-over detection and flow", () => {
       .getByRole("button", { name: "Quit and return to home screen" })
       .click();
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/twenty48-persistence.spec.ts
+++ b/e2e/tests/twenty48-persistence.spec.ts
@@ -66,7 +66,7 @@ test.describe("2048 — state persistence", () => {
 
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await page.getByText("Gaming App").first().waitFor();
+    await page.getByText("BC Arcade").first().waitFor();
 
     // Return to 2048
     await page.getByRole("button", { name: "Play 2048" }).click();

--- a/e2e/tests/twenty48-win-flow.spec.ts
+++ b/e2e/tests/twenty48-win-flow.spec.ts
@@ -166,7 +166,7 @@ test.describe("2048 — win-state + keep-playing flow", () => {
       .first()
       .click();
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/yacht-errors.spec.ts
+++ b/e2e/tests/yacht-errors.spec.ts
@@ -28,7 +28,7 @@ test.describe("Yacht — error paths and navigation", () => {
     // Navigate home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
 
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
   });
 
   test("cannot roll a 4th time in the same turn", async ({ page }) => {
@@ -308,7 +308,7 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
     await page.getByRole("button", { name: /dismiss/i }).click();
 
     // After dismiss the user lands on HomeScreen
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/yacht-full-game.spec.ts
+++ b/e2e/tests/yacht-full-game.spec.ts
@@ -39,7 +39,7 @@ test.describe("Yacht — full 13-round game journey", () => {
   });
 
   test("navigates from Home to Game on Play Yacht click", async ({ page }) => {
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
     await page.getByRole("button", { name: "Play Yacht" }).click();
     await expect(page.getByText("Round 1 / 13")).toBeVisible();
   });
@@ -152,7 +152,7 @@ test.describe("Yacht — full 13-round game journey", () => {
     await page.getByRole("button", { name: /dismiss/i }).click();
 
     // Dismiss now navigates back to HomeScreen rather than hiding the modal in-place.
-    await expect(page.getByText("Gaming App").first()).toBeVisible({
+    await expect(page.getByText("BC Arcade").first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/e2e/tests/yacht-persistence.spec.ts
+++ b/e2e/tests/yacht-persistence.spec.ts
@@ -50,7 +50,7 @@ test.describe("Yacht — localStorage persistence (#183)", () => {
 
     // Go back to Home via URL (Lobby tab pop-to-root not reliable on web)
     await page.goto("/");
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
 
     // Return to Yacht — should resume on Round 2
     await page.getByRole("button", { name: "Play Yacht" }).click();
@@ -74,7 +74,7 @@ test.describe("Yacht — localStorage persistence (#183)", () => {
 
     // Hard reload (simulates app restart while game is in progress)
     await page.reload();
-    await expect(page.getByText("Gaming App").first()).toBeVisible();
+    await expect(page.getByText("BC Arcade").first()).toBeVisible();
 
     await page.getByRole("button", { name: "Play Yacht" }).click();
     await expect(page.getByText("Round 2 / 13")).toBeVisible();

--- a/frontend/scripts/translate.js
+++ b/frontend/scripts/translate.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * OpenAI-powered translation script for the Gaming App i18n workflow.
+ * OpenAI-powered translation script for the BC Arcade i18n workflow.
  *
  * Usage:
  *   node scripts/translate.js --locale fr-CA --namespace common [--model gpt-4o] [--dry-run] [--force]

--- a/frontend/src/components/shared/AppHeader.tsx
+++ b/frontend/src/components/shared/AppHeader.tsx
@@ -395,6 +395,8 @@ const styles = StyleSheet.create({
   logo: {
     width: 40,
     height: 40,
+    borderRadius: 8,
+    backgroundColor: "#1a0a2e",
   },
   backButton: {
     width: 80,

--- a/frontend/src/i18n/glossary.js
+++ b/frontend/src/i18n/glossary.js
@@ -1,5 +1,5 @@
 /**
- * Term glossary for the Gaming App i18n workflow.
+ * Term glossary for the BC Arcade i18n workflow.
  *
  * Used by scripts/translate.js — injected into OpenAI system prompts
  * so protected terms are never translated or modified.
@@ -38,7 +38,7 @@ export const glossary = {
     notes: "Two words, both capitalized.",
   },
 
-  "Gaming App": {
+  "BC Arcade": {
     category: "brand",
     doNotTranslate: true,
     reason: "The app name. Translating would break app store identity.",

--- a/frontend/src/i18n/locales/_meta/common.meta.json
+++ b/frontend/src/i18n/locales/_meta/common.meta.json
@@ -5,7 +5,7 @@
     "tone": "neutral",
     "characterLimit": 20,
     "placeholders": [],
-    "doNotTranslate": ["Gaming App"],
+    "doNotTranslate": ["BC Arcade"],
     "notes": "Do not translate the app name."
   },
   "app.subtitle": {

--- a/frontend/src/i18n/locales/ar/common.json
+++ b/frontend/src/i18n/locales/ar/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "اختر لعبة",
   "nav.back": "← رجوع",
   "nav.backLabel": "العودة إلى الشاشة الرئيسية",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Wähle ein Spiel",
   "nav.back": "← Zurück",
   "nav.backLabel": "Zurück zum Startbildschirm",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Choose a game",
   "nav.back": "← Back",
   "nav.backLabel": "Go back to home screen",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Elige un juego",
   "nav.back": "← Atrás",
   "nav.backLabel": "Volver a la pantalla principal",

--- a/frontend/src/i18n/locales/fr-CA/common.json
+++ b/frontend/src/i18n/locales/fr-CA/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Choisissez un jeu",
   "nav.back": "← Retour",
   "nav.backLabel": "Revenir à l'écran d'accueil",

--- a/frontend/src/i18n/locales/he/common.json
+++ b/frontend/src/i18n/locales/he/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "בחרו משחק",
   "nav.back": "← חזור",
   "nav.backLabel": "חזרה למסך הבית",

--- a/frontend/src/i18n/locales/hi/common.json
+++ b/frontend/src/i18n/locales/hi/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "कोई गेम चुनें",
   "nav.back": "← वापस",
   "nav.backLabel": "होम स्क्रीन पर जाएं",

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "ゲームを選ぼう！",
   "nav.back": "← 戻る",
   "nav.backLabel": "ホーム画面に戻る",

--- a/frontend/src/i18n/locales/ko/common.json
+++ b/frontend/src/i18n/locales/ko/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "게임을 선택하세요",
   "nav.back": "← 뒤로",
   "nav.backLabel": "홈 화면으로 돌아가기",

--- a/frontend/src/i18n/locales/nl/common.json
+++ b/frontend/src/i18n/locales/nl/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Kies een spel",
   "nav.back": "← Terug",
   "nav.backLabel": "Ga terug naar startscherm",

--- a/frontend/src/i18n/locales/pt/common.json
+++ b/frontend/src/i18n/locales/pt/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Escolha um jogo",
   "nav.back": "← Voltar",
   "nav.backLabel": "Voltar para a tela inicial",

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "Выберите игру",
   "nav.back": "← Назад",
   "nav.backLabel": "Вернуться на главный экран",

--- a/frontend/src/i18n/locales/zh/common.json
+++ b/frontend/src/i18n/locales/zh/common.json
@@ -1,5 +1,5 @@
 {
-  "app.title": "Gaming App",
+  "app.title": "BC Arcade",
   "app.subtitle": "选择一个游戏",
   "nav.back": "← 返回",
   "nav.backLabel": "返回主界面",


### PR DESCRIPTION
- Update app.title i18n key in all 13 locale common.json files
- Rename glossary entry and update doNotTranslate term in common.meta.json
- Update all 14 Playwright E2E spec files and 2 Maestro YAML fixtures
- Add backgroundColor + borderRadius to AppHeader logo style to eliminate
  the transparent-halo artifact on the cream light-theme background
- Update remaining stray references in backend main.py, zap-baseline.yaml,
  locustfile.py, translate.js comment, and docs/privacy-policy.html

Fixes #1010

https://claude.ai/code/session_0149ja7yKgFUqLH9tiYqFdit