### PR TITLE
feat(assets): central image registry in _shared/images.ts (#1026)

### DIFF
--- a/docs/ASSETS.md
+++ b/docs/ASSETS.md
@@ -11,13 +11,17 @@ Download and place at `frontend/assets/source-icons/` if you need to re-export a
 
 ## Asset conventions
 
-See `CLAUDE.md` for the full conventions. Summary:
+| Directory | Format | Purpose | Registry |
+|---|---|---|---|
+| `assets/sounds/` | MP3 / OGG | All game audio | `_shared/sounds.ts` |
+| `assets/fruit-icons/` | WebP | Fruit art for React Native UI (menus, pickers) | `_shared/images.ts` → `FRUIT_ICONS` |
+| `assets/fruits-baked/` | PNG | Pre-composited fruit sprites for Skia canvas | `_shared/images.ts` → `FRUIT_BAKED` |
+| `assets/celestial-icons/` | WebP | Cosmos art for React Native UI | `_shared/images.ts` → `COSMOS_ICONS` |
+| `assets/cosmos-baked/` | PNG | Pre-composited cosmos sprites for Skia canvas | `_shared/images.ts` → `COSMOS_BAKED` |
+| `assets/<game>/` | WebP / PNG | Game-specific sprites (e.g. `starswarm/`) | Per-game `assets.ts` |
 
-| Directory | Format | Purpose |
-|---|---|---|
-| `assets/sounds/` | MP3 / OGG | All game audio — registered in `_shared/sounds.ts` |
-| `assets/images/shared/` | WebP | Art reused across ≥2 games (fruit icons, celestial icons) |
-| `assets/images/<game>/` | WebP / PNG | Game-specific sprites |
-| `assets/<game>/` (legacy) | mixed | Existing per-game dirs — migrate on next touch |
+**Why two formats per theme?** `icons` (WebP) are transparent-background images used in React Native `<Image>` components. `baked` (PNG) are pre-composited, clipped sprites for single-call Skia `drawImage` — produced by `scripts/bake_sprites.py`. They are different assets, not duplicates.
 
-New games: add sounds to `_shared/sounds.ts` and images to `assets/images/<game>/`.
+**Adding a new shared image set:** add imports + export object to `_shared/images.ts`; import the registry object wherever needed.
+
+**Adding a new game's sprites:** create `assets/<game>/` and a `src/game/<game>/assets.ts` loader (see `starswarm/assets.ts` as the pattern).

--- a/frontend/src/__tests__/assetTransparency.test.ts
+++ b/frontend/src/__tests__/assetTransparency.test.ts
@@ -74,7 +74,7 @@ const ASSET_DIRS = [
 
 describe("No raw PNGs in icon asset directories", () => {
   const ASSETS_ROOT = path.join(FRONTEND_ROOT, "assets");
-  const EXEMPT_DIRS = new Set(["source-icons"]);
+  const EXEMPT_DIRS = new Set<string>();
 
   const subdirs = fs
     .readdirSync(ASSETS_ROOT, { withFileTypes: true })

--- a/frontend/src/game/_shared/images.ts
+++ b/frontend/src/game/_shared/images.ts
@@ -1,0 +1,123 @@
+// Image asset registry — mirrors the sounds.ts pattern.
+//
+// Two variants per theme:
+//   icons — WebP with transparent background, for React Native <Image> in UI (menus, pickers)
+//   baked — PNG pre-composited + clipped sprites, for Skia canvas rendering
+//
+// Metro resolves imports at bundle time; asset paths must be static literals.
+
+// --- Fruit icons (UI display) ---
+import _cherryIcon from "../../../assets/fruit-icons/cherry.webp";
+import _blueberryIcon from "../../../assets/fruit-icons/blueberry.webp";
+import _lemonIcon from "../../../assets/fruit-icons/lemon.webp";
+import _grapesIcon from "../../../assets/fruit-icons/grapes.webp";
+import _orangeIcon from "../../../assets/fruit-icons/orange.webp";
+import _appleIcon from "../../../assets/fruit-icons/apple.webp";
+import _peachIcon from "../../../assets/fruit-icons/peach.webp";
+import _coconutIcon from "../../../assets/fruit-icons/coconut.webp";
+import _dragonfruitIcon from "../../../assets/fruit-icons/dragonfruit.webp";
+import _pineappleIcon from "../../../assets/fruit-icons/pineapple.webp";
+import _watermelonIcon from "../../../assets/fruit-icons/watermelon.webp";
+import _pumpkinIcon from "../../../assets/fruit-icons/pumpkin.webp";
+
+// --- Fruit baked sprites (Skia canvas) ---
+import _cherryBaked from "../../../assets/fruits-baked/cherry.png";
+import _blueberryBaked from "../../../assets/fruits-baked/blueberry.png";
+import _lemonBaked from "../../../assets/fruits-baked/lemon.png";
+import _grapesBaked from "../../../assets/fruits-baked/grapes.png";
+import _orangeBaked from "../../../assets/fruits-baked/orange.png";
+import _appleBaked from "../../../assets/fruits-baked/apple.png";
+import _peachBaked from "../../../assets/fruits-baked/peach.png";
+import _coconutBaked from "../../../assets/fruits-baked/coconut.png";
+import _dragonfruitBaked from "../../../assets/fruits-baked/dragonfruit.png";
+import _pineappleBaked from "../../../assets/fruits-baked/pineapple.png";
+import _watermelonBaked from "../../../assets/fruits-baked/watermelon.png";
+import _pumpkinBaked from "../../../assets/fruits-baked/pumpkin.png";
+
+// --- Celestial icons (UI display) ---
+import _moonIcon from "../../../assets/celestial-icons/moon.webp";
+import _plutoIcon from "../../../assets/celestial-icons/pluto.webp";
+import _mercuryIcon from "../../../assets/celestial-icons/mercury.webp";
+import _marsIcon from "../../../assets/celestial-icons/mars.webp";
+import _venusIcon from "../../../assets/celestial-icons/venus.webp";
+import _earthIcon from "../../../assets/celestial-icons/earth.webp";
+import _neptuneIcon from "../../../assets/celestial-icons/neptune.webp";
+import _uranusIcon from "../../../assets/celestial-icons/uranus.webp";
+import _saturnIcon from "../../../assets/celestial-icons/saturn.webp";
+import _jupiterIcon from "../../../assets/celestial-icons/jupiter.webp";
+import _sunIcon from "../../../assets/celestial-icons/sun.webp";
+import _milkyWayIcon from "../../../assets/celestial-icons/milkyway.webp";
+
+// --- Cosmos baked sprites (Skia canvas) ---
+import _moonBaked from "../../../assets/cosmos-baked/moon.png";
+import _plutoBaked from "../../../assets/cosmos-baked/pluto.png";
+import _mercuryBaked from "../../../assets/cosmos-baked/mercury.png";
+import _marsBaked from "../../../assets/cosmos-baked/mars.png";
+import _venusBaked from "../../../assets/cosmos-baked/venus.png";
+import _earthBaked from "../../../assets/cosmos-baked/earth.png";
+import _neptuneBaked from "../../../assets/cosmos-baked/neptune.png";
+import _uranusBaked from "../../../assets/cosmos-baked/uranus.png";
+import _saturnBaked from "../../../assets/cosmos-baked/saturn.png";
+import _jupiterBaked from "../../../assets/cosmos-baked/jupiter.png";
+import _sunBaked from "../../../assets/cosmos-baked/sun.png";
+import _milkyWayBaked from "../../../assets/cosmos-baked/milkyway.png";
+
+export const FRUIT_ICONS = {
+  cherry: _cherryIcon,
+  blueberry: _blueberryIcon,
+  lemon: _lemonIcon,
+  grape: _grapesIcon,
+  orange: _orangeIcon,
+  apple: _appleIcon,
+  peach: _peachIcon,
+  coconut: _coconutIcon,
+  dragonfruit: _dragonfruitIcon,
+  pineapple: _pineappleIcon,
+  watermelon: _watermelonIcon,
+  pumpkin: _pumpkinIcon,
+} as const;
+
+export const FRUIT_BAKED = {
+  cherry: _cherryBaked,
+  blueberry: _blueberryBaked,
+  lemon: _lemonBaked,
+  grape: _grapesBaked,
+  orange: _orangeBaked,
+  apple: _appleBaked,
+  peach: _peachBaked,
+  coconut: _coconutBaked,
+  dragonfruit: _dragonfruitBaked,
+  pineapple: _pineappleBaked,
+  watermelon: _watermelonBaked,
+  pumpkin: _pumpkinBaked,
+} as const;
+
+export const COSMOS_ICONS = {
+  moon: _moonIcon,
+  pluto: _plutoIcon,
+  mercury: _mercuryIcon,
+  mars: _marsIcon,
+  venus: _venusIcon,
+  earth: _earthIcon,
+  neptune: _neptuneIcon,
+  uranus: _uranusIcon,
+  saturn: _saturnIcon,
+  jupiter: _jupiterIcon,
+  sun: _sunIcon,
+  milkyWay: _milkyWayIcon,
+} as const;
+
+export const COSMOS_BAKED = {
+  moon: _moonBaked,
+  pluto: _plutoBaked,
+  mercury: _mercuryBaked,
+  mars: _marsBaked,
+  venus: _venusBaked,
+  earth: _earthBaked,
+  neptune: _neptuneBaked,
+  uranus: _uranusBaked,
+  saturn: _saturnBaked,
+  jupiter: _jupiterBaked,
+  sun: _sunBaked,
+  milkyWay: _milkyWayBaked,
+} as const;

--- a/frontend/src/theme/fruitSets.ts
+++ b/frontend/src/theme/fruitSets.ts
@@ -1,55 +1,6 @@
 import { ImageSourcePropType } from "react-native";
 
-import cherryIcon from "../../assets/fruit-icons/cherry.webp";
-import blueberryIcon from "../../assets/fruit-icons/blueberry.webp";
-import lemonIcon from "../../assets/fruit-icons/lemon.webp";
-import grapesIcon from "../../assets/fruit-icons/grapes.webp";
-import orangeIcon from "../../assets/fruit-icons/orange.webp";
-import appleIcon from "../../assets/fruit-icons/apple.webp";
-import peachIcon from "../../assets/fruit-icons/peach.webp";
-import coconutIcon from "../../assets/fruit-icons/coconut.webp";
-import dragonfruitIcon from "../../assets/fruit-icons/dragonfruit.webp";
-import pineappleIcon from "../../assets/fruit-icons/pineapple.webp";
-import watermelonIcon from "../../assets/fruit-icons/watermelon.webp";
-import pumpkinIcon from "../../assets/fruit-icons/pumpkin.webp"; // reserved for future use
-import moonIcon from "../../assets/celestial-icons/moon.webp";
-import plutoIcon from "../../assets/celestial-icons/pluto.webp";
-import mercuryIcon from "../../assets/celestial-icons/mercury.webp";
-import marsIcon from "../../assets/celestial-icons/mars.webp";
-import venusIcon from "../../assets/celestial-icons/venus.webp";
-import earthIcon from "../../assets/celestial-icons/earth.webp";
-import neptuneIcon from "../../assets/celestial-icons/neptune.webp";
-import uranusIcon from "../../assets/celestial-icons/uranus.webp";
-import saturnIcon from "../../assets/celestial-icons/saturn.webp";
-import jupiterIcon from "../../assets/celestial-icons/jupiter.webp";
-import sunIcon from "../../assets/celestial-icons/sun.webp";
-import milkyWayIcon from "../../assets/celestial-icons/milkyway.webp"; // reserved for future use
-
-// Pre-baked game canvas icons — composited, clipped, ready for single drawImage
-import cherryBaked from "../../assets/fruits-baked/cherry.png";
-import blueberryBaked from "../../assets/fruits-baked/blueberry.png";
-import lemonBaked from "../../assets/fruits-baked/lemon.png";
-import grapesBaked from "../../assets/fruits-baked/grapes.png";
-import orangeBaked from "../../assets/fruits-baked/orange.png";
-import appleBaked from "../../assets/fruits-baked/apple.png";
-import peachBaked from "../../assets/fruits-baked/peach.png";
-import coconutBaked from "../../assets/fruits-baked/coconut.png";
-import dragonfruitBaked from "../../assets/fruits-baked/dragonfruit.png";
-import pineappleBaked from "../../assets/fruits-baked/pineapple.png";
-import watermelonBaked from "../../assets/fruits-baked/watermelon.png";
-import pumpkinBaked from "../../assets/fruits-baked/pumpkin.png"; // reserved for future use
-import moonBaked from "../../assets/cosmos-baked/moon.png";
-import plutoBaked from "../../assets/cosmos-baked/pluto.png";
-import mercuryBaked from "../../assets/cosmos-baked/mercury.png";
-import marsBaked from "../../assets/cosmos-baked/mars.png";
-import venusBaked from "../../assets/cosmos-baked/venus.png";
-import earthBaked from "../../assets/cosmos-baked/earth.png";
-import neptuneBaked from "../../assets/cosmos-baked/neptune.png";
-import uranusBaked from "../../assets/cosmos-baked/uranus.png";
-import saturnBaked from "../../assets/cosmos-baked/saturn.png";
-import jupiterBaked from "../../assets/cosmos-baked/jupiter.png";
-import sunBaked from "../../assets/cosmos-baked/sun.png";
-import milkyWayBaked from "../../assets/cosmos-baked/milkyway.png"; // reserved for future use
+import { COSMOS_BAKED, COSMOS_ICONS, FRUIT_BAKED, FRUIT_ICONS } from "../game/_shared/images";
 
 export type FruitTier = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
@@ -107,67 +58,6 @@ const SCORE_VALUES: Record<FruitTier, number> = {
   9: 512,
   10: 1024,
 };
-
-const FRUIT_ICONS = {
-  cherry: cherryIcon,
-  blueberry: blueberryIcon,
-  lemon: lemonIcon,
-  grape: grapesIcon,
-  orange: orangeIcon,
-  apple: appleIcon,
-  peach: peachIcon,
-  coconut: coconutIcon,
-  dragonfruit: dragonfruitIcon,
-  pineapple: pineappleIcon,
-  watermelon: watermelonIcon,
-  pumpkin: pumpkinIcon,
-} as const;
-
-const COSMOS_ICONS = {
-  moon: moonIcon,
-  pluto: plutoIcon,
-  mercury: mercuryIcon,
-  mars: marsIcon,
-  venus: venusIcon,
-  earth: earthIcon,
-  neptune: neptuneIcon,
-  uranus: uranusIcon,
-  saturn: saturnIcon,
-  jupiter: jupiterIcon,
-  sun: sunIcon,
-  milkyWay: milkyWayIcon,
-} as const;
-
-// Baked game-canvas icons (produced by scripts/bake_sprites.py)
-const FRUIT_BAKED = {
-  cherry: cherryBaked,
-  blueberry: blueberryBaked,
-  lemon: lemonBaked,
-  grape: grapesBaked,
-  orange: orangeBaked,
-  apple: appleBaked,
-  peach: peachBaked,
-  coconut: coconutBaked,
-  dragonfruit: dragonfruitBaked,
-  pineapple: pineappleBaked,
-  watermelon: watermelonBaked,
-  pumpkin: pumpkinBaked,
-} as const;
-
-const COSMOS_BAKED = {
-  moon: moonBaked,
-  pluto: plutoBaked,
-  mercury: mercuryBaked,
-  mars: marsBaked,
-  venus: venusBaked,
-  earth: earthBaked,
-  neptune: neptuneBaked,
-  uranus: uranusBaked,
-  saturn: saturnBaked,
-  jupiter: jupiterBaked,
-  sun: sunBaked,
-  milkyWay: milkyWayBaked,
-} as const;
 
 export const FRUIT_SETS: Record<string, FruitSet> = {
   fruits: {

--- a/frontend/src/theme/useFruitImages.ts
+++ b/frontend/src/theme/useFruitImages.ts
@@ -11,31 +11,7 @@
 import { useImage } from "@shopify/react-native-skia";
 import type { SkImage } from "@shopify/react-native-skia";
 
-// --- Baked fruit icons (pre-composited, clipped — for game canvas rendering) ---
-import cherryIcon from "../../assets/fruits-baked/cherry.png";
-import blueberryIcon from "../../assets/fruits-baked/blueberry.png";
-import lemonIcon from "../../assets/fruits-baked/lemon.png";
-import grapesIcon from "../../assets/fruits-baked/grapes.png";
-import orangeIcon from "../../assets/fruits-baked/orange.png";
-import appleIcon from "../../assets/fruits-baked/apple.png";
-import peachIcon from "../../assets/fruits-baked/peach.png";
-import coconutIcon from "../../assets/fruits-baked/coconut.png";
-import dragonfruitIcon from "../../assets/fruits-baked/dragonfruit.png";
-import pineappleIcon from "../../assets/fruits-baked/pineapple.png";
-import watermelonIcon from "../../assets/fruits-baked/watermelon.png";
-
-// --- Baked celestial icons ---
-import moonIcon from "../../assets/cosmos-baked/moon.png";
-import plutoIcon from "../../assets/cosmos-baked/pluto.png";
-import mercuryIcon from "../../assets/cosmos-baked/mercury.png";
-import marsIcon from "../../assets/cosmos-baked/mars.png";
-import venusIcon from "../../assets/cosmos-baked/venus.png";
-import earthIcon from "../../assets/cosmos-baked/earth.png";
-import neptuneIcon from "../../assets/cosmos-baked/neptune.png";
-import uranusIcon from "../../assets/cosmos-baked/uranus.png";
-import saturnIcon from "../../assets/cosmos-baked/saturn.png";
-import jupiterIcon from "../../assets/cosmos-baked/jupiter.png";
-import sunIcon from "../../assets/cosmos-baked/sun.png";
+import { COSMOS_BAKED, FRUIT_BAKED } from "../game/_shared/images";
 
 export interface FruitSetImages {
   /** Images indexed by tier (0–10). null = not yet loaded. */
@@ -46,31 +22,31 @@ export interface FruitSetImages {
 export function useFruitImages(): FruitSetImages {
   // Fruit tier order: cherry, blueberry, lemon, grape, orange, apple,
   //                   peach, coconut, dragonfruit, pineapple, watermelon
-  const cherry = useImage(cherryIcon);
-  const blueberry = useImage(blueberryIcon);
-  const lemon = useImage(lemonIcon);
-  const grape = useImage(grapesIcon);
-  const orange = useImage(orangeIcon);
-  const apple = useImage(appleIcon);
-  const peach = useImage(peachIcon);
-  const coconut = useImage(coconutIcon);
-  const dragonfruit = useImage(dragonfruitIcon);
-  const pineapple = useImage(pineappleIcon);
-  const watermelon = useImage(watermelonIcon);
+  const cherry = useImage(FRUIT_BAKED.cherry);
+  const blueberry = useImage(FRUIT_BAKED.blueberry);
+  const lemon = useImage(FRUIT_BAKED.lemon);
+  const grape = useImage(FRUIT_BAKED.grape);
+  const orange = useImage(FRUIT_BAKED.orange);
+  const apple = useImage(FRUIT_BAKED.apple);
+  const peach = useImage(FRUIT_BAKED.peach);
+  const coconut = useImage(FRUIT_BAKED.coconut);
+  const dragonfruit = useImage(FRUIT_BAKED.dragonfruit);
+  const pineapple = useImage(FRUIT_BAKED.pineapple);
+  const watermelon = useImage(FRUIT_BAKED.watermelon);
 
   // Cosmos tier order: moon, pluto, mercury, mars, venus, earth,
   //                    neptune, uranus, saturn, jupiter, sun
-  const moon = useImage(moonIcon);
-  const pluto = useImage(plutoIcon);
-  const mercury = useImage(mercuryIcon);
-  const mars = useImage(marsIcon);
-  const venus = useImage(venusIcon);
-  const earth = useImage(earthIcon);
-  const neptune = useImage(neptuneIcon);
-  const uranus = useImage(uranusIcon);
-  const saturn = useImage(saturnIcon);
-  const jupiter = useImage(jupiterIcon);
-  const sun = useImage(sunIcon);
+  const moon = useImage(COSMOS_BAKED.moon);
+  const pluto = useImage(COSMOS_BAKED.pluto);
+  const mercury = useImage(COSMOS_BAKED.mercury);
+  const mars = useImage(COSMOS_BAKED.mars);
+  const venus = useImage(COSMOS_BAKED.venus);
+  const earth = useImage(COSMOS_BAKED.earth);
+  const neptune = useImage(COSMOS_BAKED.neptune);
+  const uranus = useImage(COSMOS_BAKED.uranus);
+  const saturn = useImage(COSMOS_BAKED.saturn);
+  const jupiter = useImage(COSMOS_BAKED.jupiter);
+  const sun = useImage(COSMOS_BAKED.sun);
 
   return {
     fruits: [


### PR DESCRIPTION
## Summary

Creates `frontend/src/game/_shared/images.ts` — a single registry for all shared image assets, mirroring the existing `sounds.ts` pattern.

**Before:** `fruitSets.ts` and `useFruitImages.ts` each imported asset files directly — 48 and 22 individual import statements respectively, duplicated across both files.

**After:** all paths live in `images.ts` and both files import the four named registries:

| Export | Format | Source dir | Used for |
|---|---|---|---|
| `FRUIT_ICONS` | WebP | `fruit-icons/` | React Native `<Image>` in UI menus/pickers |
| `FRUIT_BAKED` | PNG | `fruits-baked/` | Skia canvas sprite rendering |
| `COSMOS_ICONS` | WebP | `celestial-icons/` | React Native `<Image>` in UI menus/pickers |
| `COSMOS_BAKED` | PNG | `cosmos-baked/` | Skia canvas sprite rendering |

Also:
- Removes dead `source-icons` entry from `assetTransparency.test.ts` (directory was removed in #1027)
- Expands `docs/ASSETS.md` with the full conventions table and an explanation of the icons vs baked distinction

Closes #1026. Completes epic #1023.

## Test plan

- [ ] Cascade and Twenty48 fruit themes render correctly (fruits + cosmos sets)
- [ ] UI fruit/cosmos pickers display icons correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)