### PR TITLE
feat(starswarm): Enemy behavior — collision redesign, Elite phases, straggler aggression, HP pips

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -62,6 +62,32 @@ const EXPLOSION_DRAW_SIZE = 48;
 const DT_CAP_MS = 33;
 const INVINCIBLE_BLINK_INTERVAL = 120; // ms
 
+const C = {
+  bg: "#000010",
+  star: "#ffffff",
+  bulletEnemy: "#ff4422",
+  bulletPlayer: "#00ffcc",
+  enemyGrunt: "#8888ff",
+  enemyElite: "#ff88ff",
+  enemyBoss: "#ffff44",
+  hitFlash: "#ff2200",
+  pipFilled: "#ffffff",
+  pipEmpty: "rgba(255,255,255,0.2)",
+  player: "#00ffcc",
+  superTint: "#ffee00",
+  powerUp: "#ffee00",
+  explosionHot: "#ffcc00",
+  explosionCool: "#ff4400",
+  hudText: "#ffffff",
+  lives: "#00ffcc",
+  powerBarBg: "rgba(255,255,255,0.18)",
+  powerBarFill: "#ffee00",
+  waveClear: "#00ffcc",
+  challengingStage: "#ffdd00",
+  gameOverText: "#ff4422",
+  gameOverOverlay: "rgba(0,0,0,0.65)",
+} as const;
+
 interface Images {
   playerShip: HTMLImageElement | null;
   enemyGrunt: HTMLImageElement | null;
@@ -303,13 +329,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       ctx.scale(s, s);
 
       // Background
-      ctx.fillStyle = "#000010";
+      ctx.fillStyle = C.bg;
       ctx.fillRect(0, 0, width, height);
 
       // Starfield
       for (const star of sf.stars) {
         ctx.globalAlpha = star.opacity;
-        ctx.fillStyle = "#ffffff";
+        ctx.fillStyle = C.star;
         ctx.beginPath();
         ctx.arc(star.x, star.y, star.r, 0, Math.PI * 2);
         ctx.fill();
@@ -317,7 +343,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       ctx.globalAlpha = 1;
 
       // Enemy bullets
-      ctx.fillStyle = "#ff4422";
+      ctx.fillStyle = C.bulletEnemy;
       for (const b of state.enemyBullets) {
         ctx.fillRect(b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
       }
@@ -328,7 +354,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         if (img) {
           ctx.drawImage(img, b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
         } else {
-          ctx.fillStyle = "#00ffcc";
+          ctx.fillStyle = C.bulletPlayer;
           ctx.fillRect(b.x - b.width / 2, b.y - b.height / 2, b.width, b.height);
         }
       }
@@ -352,7 +378,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           );
         } else {
           ctx.fillStyle =
-            enemy.tier === "Grunt" ? "#8888ff" : enemy.tier === "Elite" ? "#ff88ff" : "#ffff44";
+            enemy.tier === "Grunt" ? C.enemyGrunt : enemy.tier === "Elite" ? C.enemyElite : C.enemyBoss;
           ctx.fillRect(
             enemy.x - enemy.width / 2,
             enemy.y - enemy.height / 2,
@@ -362,7 +388,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         }
         if (enemy.hitFlashTimer > 0) {
           ctx.globalAlpha = 0.55;
-          ctx.fillStyle = "#ff2200";
+          ctx.fillStyle = C.hitFlash;
           ctx.fillRect(
             enemy.x - enemy.width / 2,
             enemy.y - enemy.height / 2,
@@ -382,7 +408,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           const rowX = enemy.x - rowW / 2;
           const rowY = enemy.y - enemy.height / 2 - 8;
           for (let p = 0; p < totalPips; p++) {
-            ctx.fillStyle = p < enemy.hp ? "#ffffff" : "rgba(255,255,255,0.2)";
+            ctx.fillStyle = p < enemy.hp ? C.pipFilled : C.pipEmpty;
             ctx.fillRect(rowX + p * (pipW + pipGap), rowY, pipW, pipH);
           }
         }
@@ -403,7 +429,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             player.height
           );
         } else {
-          ctx.fillStyle = "#00ffcc";
+          ctx.fillStyle = C.player;
           ctx.beginPath();
           ctx.moveTo(player.x, player.y - player.height / 2);
           ctx.lineTo(player.x - player.width / 2, player.y + player.height / 2);
@@ -414,7 +440,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         // Super-state electric tint
         if (state.activePowerUp !== null) {
           ctx.globalAlpha = 0.45;
-          ctx.fillStyle = "#ffee00";
+          ctx.fillStyle = C.superTint;
           ctx.fillRect(
             player.x - player.width / 2,
             player.y - player.height / 2,
@@ -426,7 +452,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       }
 
       // Power-ups — falling lightning bolt
-      ctx.fillStyle = "#ffee00";
+      ctx.fillStyle = C.powerUp;
       for (const pu of state.powerUps) {
         const lx = pu.x - pu.width / 2;
         const ly = pu.y - pu.height / 2;
@@ -458,7 +484,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         } else {
           const progress = exp.frame / 20;
           ctx.globalAlpha = 1 - progress;
-          ctx.fillStyle = progress < 0.4 ? "#ffcc00" : "#ff4400";
+          ctx.fillStyle = progress < 0.4 ? C.explosionHot : C.explosionCool;
           ctx.beginPath();
           ctx.arc(exp.x, exp.y, 6 + progress * 18, 0, Math.PI * 2);
           ctx.fill();
@@ -469,7 +495,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       // HUD
       ctx.font = "bold 13px 'Courier New', monospace";
       ctx.textBaseline = "top";
-      ctx.fillStyle = "#ffffff";
+      ctx.fillStyle = C.hudText;
       ctx.textAlign = "left";
       ctx.fillText(`${t("hud.score")} ${state.score}`, 10, 8);
       ctx.textAlign = "center";
@@ -479,16 +505,16 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
       // Lives — small cyan rectangles at bottom-left
       for (let i = 0; i < player.lives; i++) {
-        ctx.fillStyle = "#00ffcc";
+        ctx.fillStyle = C.lives;
         ctx.fillRect(10 + i * 16, height - 18, 10, 14);
       }
 
       // Power-up countdown bar — above lives
       if (state.activePowerUp !== null) {
         const ratio = state.activePowerUp.remainingMs / POWERUP_DURATION;
-        ctx.fillStyle = "rgba(255,255,255,0.18)";
+        ctx.fillStyle = C.powerBarBg;
         ctx.fillRect(10, height - 26, 60, 4);
-        ctx.fillStyle = "#ffee00";
+        ctx.fillStyle = C.powerBarFill;
         ctx.fillRect(10, height - 26, 60 * ratio, 4);
       }
 
@@ -498,27 +524,27 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
       if (state.phase === "WaveClear") {
         ctx.font = "bold 22px 'Courier New', monospace";
-        ctx.fillStyle = "#00ffcc";
+        ctx.fillStyle = C.waveClear;
         ctx.fillText(t("phase.waveClear"), width / 2, height / 2);
       }
 
       if (state.phase === "ChallengingStage") {
         ctx.font = "bold 20px 'Courier New', monospace";
-        ctx.fillStyle = "#ffdd00";
+        ctx.fillStyle = C.challengingStage;
         ctx.fillText(t("phase.challengingStage"), width / 2, height / 2 - 18);
         ctx.font = "14px 'Courier New', monospace";
-        ctx.fillStyle = "#ffffff";
+        ctx.fillStyle = C.hudText;
         ctx.fillText(t("phase.hits", { count: state.challengingHits }), width / 2, height / 2 + 12);
       }
 
       if (state.phase === "GameOver") {
-        ctx.fillStyle = "rgba(0,0,0,0.65)";
+        ctx.fillStyle = C.gameOverOverlay;
         ctx.fillRect(0, 0, width, height);
         ctx.font = "bold 28px 'Courier New', monospace";
-        ctx.fillStyle = "#ff4422";
+        ctx.fillStyle = C.gameOverText;
         ctx.fillText(t("phase.gameOver"), width / 2, height / 2 - 22);
         ctx.font = "16px 'Courier New', monospace";
-        ctx.fillStyle = "#ffffff";
+        ctx.fillStyle = C.hudText;
         ctx.fillText(`${t("hud.score")} ${state.score}`, width / 2, height / 2 + 18);
       }
 

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -297,7 +297,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       if (!resetTick) return;
       const opts = devOptionsRef.current;
       infiniteLivesRef.current = opts?.infiniteLives ?? false;
-      stateRef.current = initStarSwarm(width, height, opts?.wave ?? 1, 42, opts?.stragglerEnabled ?? false);
+      stateRef.current = initStarSwarm(
+        width,
+        height,
+        opts?.wave ?? 1,
+        42,
+        opts?.stragglerEnabled ?? false
+      );
       sfRef.current = initStarfield(width, height);
       lastFrameTimeRef.current = 0;
       inputRef.current.playerX = width / 2;
@@ -378,7 +384,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           );
         } else {
           ctx.fillStyle =
-            enemy.tier === "Grunt" ? C.enemyGrunt : enemy.tier === "Elite" ? C.enemyElite : C.enemyBoss;
+            enemy.tier === "Grunt"
+              ? C.enemyGrunt
+              : enemy.tier === "Elite"
+                ? C.enemyElite
+                : C.enemyBoss;
           ctx.fillRect(
             enemy.x - enemy.width / 2,
             enemy.y - enemy.height / 2,

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -75,6 +75,7 @@ interface Images {
 export interface DevOptions {
   wave?: number;
   infiniteLives?: boolean;
+  stragglerEnabled?: boolean;
 }
 
 export interface GameCanvasHandle {
@@ -270,7 +271,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       if (!resetTick) return;
       const opts = devOptionsRef.current;
       infiniteLivesRef.current = opts?.infiniteLives ?? false;
-      stateRef.current = initStarSwarm(width, height, opts?.wave ?? 1);
+      stateRef.current = initStarSwarm(width, height, opts?.wave ?? 1, 42, opts?.stragglerEnabled ?? false);
       sfRef.current = initStarfield(width, height);
       lastFrameTimeRef.current = 0;
       inputRef.current.playerX = width / 2;
@@ -360,8 +361,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           );
         }
         if (enemy.hitFlashTimer > 0) {
-          ctx.globalAlpha = 0.7;
-          ctx.fillStyle = "#ffffff";
+          ctx.globalAlpha = 0.55;
+          ctx.fillStyle = "#ff2200";
           ctx.fillRect(
             enemy.x - enemy.width / 2,
             enemy.y - enemy.height / 2,
@@ -369,6 +370,21 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             enemy.height
           );
           ctx.globalAlpha = 1;
+        }
+
+        // HP pips — Elite (2) and Boss (4); Grunt always has 1 HP so pips are omitted
+        if (enemy.tier !== "Grunt") {
+          const totalPips = enemy.tier === "Elite" ? 2 : 4;
+          const pipW = 4;
+          const pipH = 4;
+          const pipGap = 2;
+          const rowW = totalPips * pipW + (totalPips - 1) * pipGap;
+          const rowX = enemy.x - rowW / 2;
+          const rowY = enemy.y - enemy.height / 2 - 8;
+          for (let p = 0; p < totalPips; p++) {
+            ctx.fillStyle = p < enemy.hp ? "#ffffff" : "rgba(255,255,255,0.2)";
+            ctx.fillRect(rowX + p * (pipW + pipGap), rowY, pipW, pipH);
+          }
         }
       }
 

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1576,11 +1576,23 @@ describe("#1030 Elite phase system & Boss passive start", () => {
     expect(s.bossThresholdCrossed).toBe(false);
 
     // Force an Elite to dive
-    const eliteIdx = s.enemies.findIndex((e) => e.isAlive && e.tier === "Elite" && e.phase === "Formation");
+    const eliteIdx = s.enemies.findIndex(
+      (e) => e.isAlive && e.tier === "Elite" && e.phase === "Formation"
+    );
     if (eliteIdx === -1) throw new Error("no elite in formation");
-    s = { ...s, enemies: s.enemies.map((e, i) =>
-      i === eliteIdx ? { ...e, phase: "Wiggling" as const, wiggleTimer: WIGGLE_DURATION, diveTargetX: s.player.x } : e
-    )};
+    s = {
+      ...s,
+      enemies: s.enemies.map((e, i) =>
+        i === eliteIdx
+          ? {
+              ...e,
+              phase: "Wiggling" as const,
+              wiggleTimer: WIGGLE_DURATION,
+              diveTargetX: s.player.x,
+            }
+          : e
+      ),
+    };
 
     const eliteId = s.enemies[eliteIdx]!.id;
     const maxY60 = CANVAS_H * 0.6;
@@ -1588,7 +1600,8 @@ describe("#1030 Elite phase system & Boss passive start", () => {
     for (let i = 0; i < 500; i++) {
       s = tick(s, 16, NO_INPUT);
       const elite = s.enemies.find((e) => e.id === eliteId);
-      if (!elite || !elite.isAlive || elite.phase === "Returning" || elite.phase === "Formation") break;
+      if (!elite || !elite.isAlive || elite.phase === "Returning" || elite.phase === "Formation")
+        break;
       if (elite.phase === "Diving") {
         expect(elite.y).toBeLessThan(maxY60 + 5); // allow 1-frame overshoot tolerance
       }
@@ -1713,9 +1726,7 @@ describe("#1031 Straggler aggression", () => {
     };
     s = tick(s, 16, NO_INPUT);
     // Formation enemies should still be in Formation (no straggler kick)
-    const wiggling = s.enemies.filter(
-      (e) => e.isAlive && e.phase === "Wiggling"
-    );
+    const wiggling = s.enemies.filter((e) => e.isAlive && e.phase === "Wiggling");
     expect(wiggling.length).toBe(0);
   });
 

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -695,13 +695,14 @@ describe("Enemy bullet cap (#972)", () => {
     s = advanceMs(s, 8000);
     expect(s.phase).toBe("Playing");
 
-    // Start with 0 enemy bullets and force an immediate shot
+    // Force the first non-Boss formation enemy to fire immediately
+    // (Bosses are passive until bossThresholdCrossed, so use a Grunt or Elite)
+    const targetIdx = s.enemies.findIndex((e) => e.phase === "Formation" && e.tier !== "Boss");
+    if (targetIdx === -1) return;
     s = {
       ...s,
       enemyBullets: [],
-      enemies: s.enemies.map((e, i) =>
-        i === 0 && e.phase === "Formation" ? { ...e, shootTimer: 0 } : e
-      ),
+      enemies: s.enemies.map((e, i) => (i === targetIdx ? { ...e, shootTimer: 0 } : e)),
     };
 
     s = tick(s, 16, NO_INPUT);
@@ -1195,6 +1196,7 @@ describe("Boss burst-fire (#979)", () => {
     if (bossIdx === -1) throw new Error("no boss in formation");
     s = {
       ...s,
+      bossThresholdCrossed: true, // Boss must be active to fire
       enemyBullets: [],
       enemies: s.enemies.map((e, i) =>
         i === bossIdx ? { ...e, shootTimer: 0, burstShotsLeft: 0 } : e
@@ -1217,9 +1219,10 @@ describe("Boss burst-fire (#979)", () => {
       (e) => e.isAlive && e.tier === "Boss" && e.phase === "Formation"
     );
     if (bossIdx === -1) throw new Error("no boss in formation");
-    // Force last shot in burst
+    // Force last shot in burst (Boss must be active to fire)
     s = {
       ...s,
+      bossThresholdCrossed: true,
       enemyBullets: [],
       enemies: s.enemies.map((e, i) =>
         i === bossIdx ? { ...e, shootTimer: 0, burstShotsLeft: 1 } : e
@@ -1420,5 +1423,329 @@ describe("Power-up engine (#980)", () => {
     expect(s.powerUps.length).toBe(1);
     expect(s.powerUps[0]!.x).toBe(CANVAS_W / 2);
     expect(s.powerUps[0]!.despawnTimer).toBeGreaterThan(6000); // canvas-height-derived (~8950ms at CANVAS_H=640)
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1029 — Grunt & Boss collision redesign
+// ---------------------------------------------------------------------------
+
+describe("#1029 Grunt & Boss collision redesign", () => {
+  it("Grunt never enters Circling phase", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    for (let i = 0; i < 3000; i++) {
+      s = tick(s, 16, NO_INPUT);
+      if (s.phase !== "Playing") break;
+      const gruntCircling = s.enemies.some(
+        (e) => e.isAlive && e.tier === "Grunt" && e.phase === "Circling"
+      );
+      expect(gruntCircling).toBe(false);
+    }
+  });
+
+  it("Grunt returns to Formation after dive without entering Circling", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = resetToFormation({ ...s, nextDiveTimer: 1 });
+    s = tick(s, 16, NO_INPUT);
+
+    const wiggling = s.enemies.find((e) => e.phase === "Wiggling" && e.tier === "Grunt");
+    if (!wiggling) return; // wave may have no Grunts in formation — skip
+    const id = wiggling.id;
+
+    // Wait for the full dive + return cycle
+    s = advanceMs(s, WIGGLE_DURATION + 4000, NO_INPUT);
+    const after = s.enemies.find((e) => e.id === id);
+    if (!after || !after.isAlive) return;
+    expect(after.phase === "Circling").toBe(false);
+  });
+
+  it("Boss never body-collides with player", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, bossThresholdCrossed: true, player: { ...s.player, invincibleTimer: 0 } };
+
+    const bossId = s.enemies.find((e) => e.isAlive && e.tier === "Boss")?.id;
+    if (!bossId) throw new Error("no boss");
+
+    // Teleport Boss directly onto the player and give it a diving phase
+    const { player } = s;
+    s = {
+      ...s,
+      player: { ...player, lives: 3, invincibleTimer: 0 },
+      enemies: s.enemies.map((e) =>
+        e.id === bossId
+          ? {
+              ...e,
+              phase: "Diving" as const,
+              x: player.x,
+              y: player.y,
+              path: {
+                p0: { x: player.x, y: player.y },
+                p1: { x: player.x, y: player.y + 10 },
+                p2: { x: player.x, y: player.y + 20 },
+                p3: { x: player.x, y: player.y + 30 },
+              },
+              pathT: 0,
+              pathDuration: 1000,
+            }
+          : e
+      ),
+    };
+
+    s = tick(s, 16, NO_INPUT);
+    // Player should NOT have lost a life despite Boss being on same position
+    expect(s.player.lives).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1030 — Elite phase system & Boss passive start
+// ---------------------------------------------------------------------------
+
+describe("#1030 Elite phase system & Boss passive start", () => {
+  it("bossThresholdCrossed initialises to false", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    expect(s.bossThresholdCrossed).toBe(false);
+  });
+
+  it("bossThresholdCrossed flips to true once ≤35% non-boss enemies remain and stays true", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.bossThresholdCrossed).toBe(false);
+
+    const target = Math.floor(s.startingNonBossCount * 0.3);
+    let killed = 0;
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) => {
+        if (e.tier !== "Boss" && e.isAlive && killed < s.startingNonBossCount - target) {
+          killed++;
+          return { ...e, isAlive: false, hp: 0 };
+        }
+        return e;
+      }),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.bossThresholdCrossed).toBe(true);
+
+    // Stays true after further ticks
+    s = advanceMs(s, 1000, NO_INPUT);
+    expect(s.bossThresholdCrossed).toBe(true);
+  });
+
+  it("Boss does not fire while bossThresholdCrossed is false", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.bossThresholdCrossed).toBe(false);
+
+    const bossIdx = s.enemies.findIndex((e) => e.isAlive && e.tier === "Boss");
+    if (bossIdx === -1) throw new Error("no boss");
+    s = {
+      ...s,
+      enemyBullets: [],
+      enemies: s.enemies.map((e, i) =>
+        i === bossIdx ? { ...e, shootTimer: 0, burstShotsLeft: 0 } : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    // Boss should not fire while passive
+    expect(s.enemyBullets.length).toBe(0);
+  });
+
+  it("Boss does not dive while bossThresholdCrossed is false", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.bossThresholdCrossed).toBe(false);
+
+    const bossIds = new Set(s.enemies.filter((e) => e.tier === "Boss").map((e) => e.id));
+    s = { ...s, nextDiveTimer: 1 };
+    s = tick(s, 16, NO_INPUT);
+    const bossActed = s.enemies.some(
+      (e) => bossIds.has(e.id) && (e.phase === "Wiggling" || e.phase === "Diving")
+    );
+    expect(bossActed).toBe(false);
+  });
+
+  it("Elite Phase 1 dive stays above 60% canvas height", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.bossThresholdCrossed).toBe(false);
+
+    // Force an Elite to dive
+    const eliteIdx = s.enemies.findIndex((e) => e.isAlive && e.tier === "Elite" && e.phase === "Formation");
+    if (eliteIdx === -1) throw new Error("no elite in formation");
+    s = { ...s, enemies: s.enemies.map((e, i) =>
+      i === eliteIdx ? { ...e, phase: "Wiggling" as const, wiggleTimer: WIGGLE_DURATION, diveTargetX: s.player.x } : e
+    )};
+
+    const eliteId = s.enemies[eliteIdx]!.id;
+    const maxY60 = CANVAS_H * 0.6;
+
+    for (let i = 0; i < 500; i++) {
+      s = tick(s, 16, NO_INPUT);
+      const elite = s.enemies.find((e) => e.id === eliteId);
+      if (!elite || !elite.isAlive || elite.phase === "Returning" || elite.phase === "Formation") break;
+      if (elite.phase === "Diving") {
+        expect(elite.y).toBeLessThan(maxY60 + 5); // allow 1-frame overshoot tolerance
+      }
+    }
+  });
+
+  it("Elite Phase 1 has no body collision", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    expect(s.bossThresholdCrossed).toBe(false);
+    s = { ...s, player: { ...s.player, lives: 3, invincibleTimer: 0 } };
+
+    const eliteId = s.enemies.find((e) => e.isAlive && e.tier === "Elite")?.id;
+    if (!eliteId) throw new Error("no elite");
+    const { player } = s;
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) =>
+        e.id === eliteId
+          ? {
+              ...e,
+              phase: "Diving" as const,
+              x: player.x,
+              y: player.y,
+              path: {
+                p0: { x: player.x, y: player.y },
+                p1: { x: player.x, y: player.y + 5 },
+                p2: { x: player.x, y: player.y + 10 },
+                p3: { x: player.x, y: player.y + 15 },
+              },
+              pathT: 0,
+              pathDuration: 1000,
+            }
+          : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.player.lives).toBe(3);
+  });
+
+  it("Elite Phase 2 (bossThresholdCrossed=true) can body-collide", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    s = { ...s, bossThresholdCrossed: true, player: { ...s.player, lives: 3, invincibleTimer: 0 } };
+
+    const eliteId = s.enemies.find((e) => e.isAlive && e.tier === "Elite")?.id;
+    if (!eliteId) throw new Error("no elite");
+    const { player } = s;
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) =>
+        e.id === eliteId
+          ? {
+              ...e,
+              phase: "Diving" as const,
+              x: player.x,
+              y: player.y,
+              path: {
+                p0: { x: player.x, y: player.y },
+                p1: { x: player.x, y: player.y + 5 },
+                p2: { x: player.x, y: player.y + 10 },
+                p3: { x: player.x, y: player.y + 15 },
+              },
+              pathT: 0,
+              pathDuration: 1000,
+            }
+          : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.player.lives).toBeLessThan(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1031 — Straggler aggression
+// ---------------------------------------------------------------------------
+
+describe("#1031 Straggler aggression", () => {
+  it("stragglerEnabled is false by default", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    expect(s.stragglerEnabled).toBe(false);
+  });
+
+  it("stragglerEnabled=true passed through initStarSwarm", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+    expect(s.stragglerEnabled).toBe(true);
+  });
+
+  it("when ≤3 enemies remain and stragglerEnabled, Formation enemies immediately wiggle", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    // Kill all but 2 enemies
+    const alive = s.enemies.filter((e) => e.isAlive);
+    const toKill = alive.slice(2);
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) =>
+        toKill.some((k) => k.id === e.id) ? { ...e, isAlive: false, hp: 0 } : e
+      ),
+    };
+
+    s = tick(s, 16, NO_INPUT);
+    const formationCount = s.enemies.filter((e) => e.isAlive && e.phase === "Formation").length;
+    expect(formationCount).toBe(0); // all should have entered Wiggling
+  });
+
+  it("straggler does not trigger when stragglerEnabled=false", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, false);
+    s = advanceMs(s, 8000);
+    expect(s.phase).toBe("Playing");
+
+    const alive = s.enemies.filter((e) => e.isAlive);
+    const toKill = alive.slice(2);
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) =>
+        toKill.some((k) => k.id === e.id) ? { ...e, isAlive: false, hp: 0 } : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    // Formation enemies should still be in Formation (no straggler kick)
+    const wiggling = s.enemies.filter(
+      (e) => e.isAlive && e.phase === "Wiggling"
+    );
+    expect(wiggling.length).toBe(0);
+  });
+
+  it("straggler does not apply during ChallengingStage", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, true);
+    expect(s.phase).toBe("ChallengingStage");
+    s = advanceMs(s, 500, NO_INPUT);
+    // Kill all but 2
+    const alive = s.enemies.filter((e) => e.isAlive);
+    const toKill = alive.slice(2);
+    s = {
+      ...s,
+      enemies: s.enemies.map((e) =>
+        toKill.some((k) => k.id === e.id) ? { ...e, isAlive: false, hp: 0 } : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    // Phase should move to WaveClear (all dead or exited), not get stuck
+    // Key assertion: no straggler-forced Wiggling in challenge stage
+    const wiggling = s.enemies.filter((e) => e.isAlive && e.phase === "Wiggling");
+    expect(wiggling.length).toBe(0);
+  });
+
+  it("stragglerEnabled carries over to next wave", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+    s = advanceMs(s, 8000);
+    s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
+    s = tick(s, 16, NO_INPUT); // WaveClear
+    s = advanceMs(s, 3000);
+    expect(s.wave).toBe(2);
+    expect(s.stragglerEnabled).toBe(true);
   });
 });

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -972,9 +972,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
         .map((e, i) => ({ e, i }))
         .filter(
           ({ e }) =>
-            e.isAlive &&
-            e.phase === "Formation" &&
-            (e.tier !== "Boss" || bossThresholdCrossed)
+            e.isAlive && e.phase === "Formation" && (e.tier !== "Boss" || bossThresholdCrossed)
         );
       // Only launch enough new divers to reach the cap; Wiggling enemies are NOT counted (#975)
       const currentDivers = state.enemies.filter((e) => e.isAlive && e.phase === "Diving").length;

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -270,9 +270,18 @@ function returnPath(ex: number, ey: number, fx: number, fy: number): CubicBezier
 }
 
 // #977: wide Bézier arc for Diving phase — sweeps outward before descending
-function divePath(enemy: Enemy, targetX: number, canvasH: number): CubicBezier {
+// shallow=true produces an Elite Phase-1 dive that stays above 60% canvas height
+function divePath(enemy: Enemy, targetX: number, canvasH: number, shallow = false): CubicBezier {
   const sweepDir = enemy.formationX < CANVAS_W / 2 ? -1 : 1;
-  const jitter = (rng() - 0.5) * 40; // ±20px horizontal scatter on P2
+  const jitter = (rng() - 0.5) * 40;
+  if (shallow) {
+    return {
+      p0: { x: enemy.x, y: enemy.y },
+      p1: { x: enemy.formationX + sweepDir * 50, y: enemy.formationY + 50 },
+      p2: { x: targetX + jitter, y: canvasH * 0.4 },
+      p3: { x: targetX, y: canvasH * 0.55 },
+    };
+  }
   return {
     p0: { x: enemy.x, y: enemy.y },
     p1: { x: enemy.formationX + sweepDir * 80, y: enemy.formationY + 80 },
@@ -416,7 +425,8 @@ export function initStarSwarm(
   canvasW: number,
   canvasH: number,
   wave = 1,
-  seed = 42
+  seed = 42,
+  stragglerEnabled = false
 ): StarSwarmState {
   seedRng(seed);
   _resetIds();
@@ -431,7 +441,7 @@ export function initStarSwarm(
     shootCooldown: 0,
   };
 
-  return buildWaveState(canvasW, canvasH, wave, player, 0);
+  return buildWaveState(canvasW, canvasH, wave, player, 0, 0, stragglerEnabled);
 }
 
 function buildWaveState(
@@ -440,7 +450,8 @@ function buildWaveState(
   wave: number,
   player: Player,
   score: number,
-  bonusLivesAwarded = 0
+  bonusLivesAwarded = 0,
+  stragglerEnabled = false
 ): StarSwarmState {
   let enemies: Enemy[];
   let phase: StarSwarmState["phase"];
@@ -493,6 +504,8 @@ function buildWaveState(
     killsSinceLastDrop: 0,
     dropJitterTarget,
     activePowerUp: null,
+    bossThresholdCrossed: false,
+    stragglerEnabled,
   };
 }
 
@@ -597,7 +610,8 @@ function tickSingleEnemy(
   playerX: number,
   canvasH: number,
   shouldDive: boolean,
-  wave: number
+  wave: number,
+  bossThresholdCrossed: boolean
 ): EnemyTickResult {
   if (!enemy.isAlive) return { enemy, bullet: null };
 
@@ -605,11 +619,11 @@ function tickSingleEnemy(
     case "SwoopIn":
       return tickSwoopIn(enemy, dtMs);
     case "Formation":
-      return tickFormation(enemy, dtMs, playerX, shouldDive, wave);
+      return tickFormation(enemy, dtMs, playerX, shouldDive, wave, bossThresholdCrossed);
     case "Wiggling":
-      return tickWiggling(enemy, dtMs, canvasH);
+      return tickWiggling(enemy, dtMs, canvasH, bossThresholdCrossed);
     case "Diving":
-      return tickDiving(enemy, dtMs, canvasH, playerX);
+      return tickDiving(enemy, dtMs, canvasH, playerX, bossThresholdCrossed);
     case "Circling":
       return tickCircling(enemy, dtMs, playerX);
     case "Returning":
@@ -649,8 +663,14 @@ function tickFormation(
   dtMs: number,
   playerX: number,
   shouldDive: boolean,
-  wave: number
+  wave: number,
+  bossThresholdCrossed: boolean
 ): EnemyTickResult {
+  // Boss is passive until threshold crossed: no firing, no diving
+  if (enemy.tier === "Boss" && !bossThresholdCrossed) {
+    return { enemy, bullet: null };
+  }
+
   // #975: transition to Wiggling (not directly to Diving) — gives player a reaction window
   if (shouldDive) {
     return {
@@ -658,7 +678,7 @@ function tickFormation(
         ...enemy,
         phase: "Wiggling",
         wiggleTimer: WIGGLE_DURATION,
-        diveTargetX: playerX, // capture player X at trigger time
+        diveTargetX: playerX,
       },
       bullet: null,
     };
@@ -675,11 +695,17 @@ function tickFormation(
     return { enemy: e, bullet };
   }
 
+  // Elites always fire aimed shots; Grunts use wave-scaled probabilistic aim
+  const vx =
+    enemy.tier === "Elite"
+      ? Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5
+      : aimedBulletVx(enemy.x, playerX, wave);
+
   const bullet: Bullet = {
     id: nextId(),
     x: enemy.x,
     y: enemy.y + enemy.height / 2,
-    vx: aimedBulletVx(enemy.x, playerX, wave),
+    vx,
     vy: BULLET_E_VY,
     owner: "enemy",
     width: BULLET_E_W,
@@ -719,11 +745,18 @@ function bossBurstFire(enemy: Enemy, playerX: number): EnemyTickResult {
 }
 
 // #975: oscillate ±WIGGLE_AMPLITUDE px for WIGGLE_DURATION ms, then launch Bézier dive
-function tickWiggling(enemy: Enemy, dtMs: number, canvasH: number): EnemyTickResult {
+function tickWiggling(
+  enemy: Enemy,
+  dtMs: number,
+  canvasH: number,
+  bossThresholdCrossed: boolean
+): EnemyTickResult {
   const newTimer = enemy.wiggleTimer - dtMs;
 
   if (newTimer <= 0) {
-    const path = divePath(enemy, enemy.diveTargetX, canvasH);
+    // Elite Phase 1 uses a shallow dive arc (stays above 60% canvas height)
+    const shallow = enemy.tier === "Elite" && !bossThresholdCrossed;
+    const path = divePath(enemy, enemy.diveTargetX, canvasH, shallow);
     const duration = enemy.tier === "Boss" ? BOSS_DIVE_PATH_DURATION : DIVE_PATH_DURATION;
     return {
       enemy: {
@@ -749,8 +782,17 @@ function tickWiggling(enemy: Enemy, dtMs: number, canvasH: number): EnemyTickRes
   };
 }
 
-// #977: Bézier arc dive — advances pathT each tick, transitions to Circling at 85% canvas height
-function tickDiving(enemy: Enemy, dtMs: number, canvasH: number, playerX: number): EnemyTickResult {
+// #977/#1029/#1030: Bézier arc dive
+// - Grunts: skip Circling; go directly to Returning at 85%
+// - Elites Phase 1 (bossThresholdCrossed=false): shallow arc, Returning at 60%, no body collision
+// - Elites Phase 2 + Bosses: Circling at 85% (existing behaviour)
+function tickDiving(
+  enemy: Enemy,
+  dtMs: number,
+  canvasH: number,
+  playerX: number,
+  bossThresholdCrossed: boolean
+): EnemyTickResult {
   const newT = enemy.pathT + dtMs / enemy.pathDuration;
   const pos = evalCubic(enemy.path!, Math.min(newT, 1));
 
@@ -782,8 +824,31 @@ function tickDiving(enemy: Enemy, dtMs: number, canvasH: number, playerX: number
     }
   }
 
-  // Transition to Circling when past 85% canvas height or path complete
-  if (pos.y > canvasH * 0.85 || newT >= 1) {
+  const isElitePhase1 = enemy.tier === "Elite" && !bossThresholdCrossed;
+  const depthThreshold = isElitePhase1 ? canvasH * 0.6 : canvasH * 0.85;
+  const pathDone = pos.y > depthThreshold || newT >= 1;
+
+  if (pathDone) {
+    if (enemy.tier === "Grunt" || isElitePhase1) {
+      // No circling: return directly to formation
+      const path = returnPath(pos.x, pos.y, enemy.formationX, enemy.formationY);
+      return {
+        enemy: {
+          ...enemy,
+          phase: "Returning",
+          x: pos.x,
+          y: pos.y,
+          pathT: 0,
+          path,
+          pathDuration: RETURN_DURATION,
+          shootTimer: nextShootTimer,
+          burstShotsLeft: nextBurstShotsLeft,
+        },
+        bullet,
+      };
+    }
+
+    // Elite Phase 2 + Boss → Circling
     return {
       enemy: {
         ...enemy,
@@ -887,6 +952,13 @@ function tickReturning(enemy: Enemy, dtMs: number): EnemyTickResult {
 }
 
 function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
+  // #1030: bossThresholdCrossed latches true once ≤35% non-boss enemies remain
+  const aliveNonBoss = state.enemies.filter((e) => e.isAlive && e.tier !== "Boss").length;
+  const bossThresholdCrossed =
+    state.bossThresholdCrossed ||
+    state.startingNonBossCount === 0 ||
+    aliveNonBoss / state.startingNonBossCount <= BOSS_DIVE_THRESHOLD;
+
   // #926 Dive AI: pick up to maxDivers(wave) formation enemies to send diving
   let nextDiveTimer = state.nextDiveTimer;
   const diveIndices = new Set<number>();
@@ -895,15 +967,14 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     nextDiveTimer -= dtMs;
     if (nextDiveTimer <= 0) {
       nextDiveTimer = diveInterval(state.wave);
-      // #978: Boss only eligible once ≤BOSS_DIVE_THRESHOLD of non-boss enemies remain
-      const aliveNonBoss = state.enemies.filter((e) => e.isAlive && e.tier !== "Boss").length;
-      const bossUnlocked =
-        state.startingNonBossCount === 0 ||
-        aliveNonBoss / state.startingNonBossCount <= BOSS_DIVE_THRESHOLD;
+      // #978/#1030: Boss only eligible once bossThresholdCrossed
       const candidates = state.enemies
         .map((e, i) => ({ e, i }))
         .filter(
-          ({ e }) => e.isAlive && e.phase === "Formation" && (e.tier !== "Boss" || bossUnlocked)
+          ({ e }) =>
+            e.isAlive &&
+            e.phase === "Formation" &&
+            (e.tier !== "Boss" || bossThresholdCrossed)
         );
       // Only launch enough new divers to reach the cap; Wiggling enemies are NOT counted (#975)
       const currentDivers = state.enemies.filter((e) => e.isAlive && e.phase === "Diving").length;
@@ -937,7 +1008,8 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
       state.player.x,
       state.canvasH,
       shouldDive,
-      state.wave
+      state.wave,
+      bossThresholdCrossed
     );
     let e = result.enemy;
     // Apply sway offset to enemies holding Formation position
@@ -965,6 +1037,24 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     );
   }
 
+  // #1031: straggler aggression — when ≤3 enemies survive in a Playing wave,
+  // all Formation enemies immediately start wiggling
+  if (state.stragglerEnabled && state.phase === "Playing") {
+    const aliveCount = enemies.filter((e) => e.isAlive).length;
+    if (aliveCount > 0 && aliveCount <= 3) {
+      enemies = enemies.map((e) => {
+        if (!e.isAlive || e.phase !== "Formation") return e;
+        return {
+          ...e,
+          phase: "Wiggling" as const,
+          wiggleTimer: WIGGLE_DURATION,
+          diveTargetX: state.player.x,
+          shootTimer: Math.min(e.shootTimer, SHOOT_INTERVAL_BASE / 2),
+        };
+      });
+    }
+  }
+
   return {
     ...state,
     enemies,
@@ -972,6 +1062,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     nextDiveTimer,
     formationSwayX: swayX,
     formationSwayDir: swayDir,
+    bossThresholdCrossed,
   };
 }
 
@@ -1105,13 +1196,16 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
       collideCircleAABB(player.x, player.y, PLAYER_HURT_RADIUS, b.x, b.y, b.width, b.height)
     );
 
-    // #956: capture the ramming enemy so we can destroy it on collision
+    // #956/#1029/#1030: capture the ramming enemy so we can destroy it on collision
+    // Bosses never body-collide; Elite Phase 1 (bossThresholdCrossed=false) also exempt
     let rammingEnemyId: number | null = null;
     const hitByShip =
       !hitByBullet &&
       enemies.some((e) => {
         if (
           e.isAlive &&
+          e.tier !== "Boss" &&
+          !(e.tier === "Elite" && !state.bossThresholdCrossed) &&
           (e.phase === "Diving" || e.phase === "Circling") &&
           collideCircleAABB(player.x, player.y, PLAYER_HURT_RADIUS, e.x, e.y, e.width, e.height)
         ) {
@@ -1275,7 +1369,8 @@ function startNextWave(state: StarSwarmState): StarSwarmState {
     nextWave,
     state.player,
     state.score,
-    state.bonusLivesAwarded
+    state.bonusLivesAwarded,
+    state.stragglerEnabled
   );
 }
 

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -152,6 +152,10 @@ export interface StarSwarmState {
   readonly dropJitterTarget: number;
   /** Non-null while the lightning super state is active. */
   readonly activePowerUp: { readonly remainingMs: number } | null;
+  /** True once ≤35% non-boss enemies remain; latches true and never resets mid-wave. */
+  readonly bossThresholdCrossed: boolean;
+  /** When true, ≤3 surviving enemies immediately break formation and go fully aggressive. */
+  readonly stragglerEnabled: boolean;
 }
 
 /** Input snapshot consumed by each `tick` call. */


### PR DESCRIPTION
## Summary

Implements the enemy behavior epic sub-issues in a single cohesive PR:

- **#1029** — Grunts skip `Circling` entirely and return to formation after one dive pass. Bosses removed from body-collision ramming check.
- **#1030** — `bossThresholdCrossed` flag (latches `true` once ≤35% non-boss enemies remain) gates Boss combat entry (no firing, no diving while passive) and splits Elites into Phase 1 (shallow dive, always-aimed, no body collision) vs Phase 2 (full depth, circling, collision).
- **#1031** — Straggler aggression: when ≤3 enemies survive in a Playing wave and `stragglerEnabled=true`, all Formation enemies immediately enter `Wiggling`. `DevOptions.stragglerEnabled` stub allows independent testing without the difficulty-tier PR.
- **#1036** — HP pip indicators above Elite (2 pips) and Boss (4 pips) sprites; hollow pips track lost HP. Non-lethal hit overlay changed from white flash to reddish tint. Canvas palette extracted to `C` token object (design-token compliance).

## Files changed

| File | What changed |
|---|---|
| `types.ts` | Added `bossThresholdCrossed`, `stragglerEnabled` to `StarSwarmState` |
| `engine.ts` | All behavior changes + new `divePath(shallow)` variant |
| `GameCanvas.web.tsx` | HP pip rendering, reddish hit tint, `DevOptions.stragglerEnabled`, color token extraction |
| `engine.test.ts` | 16 new tests; 3 Boss-firing tests updated for passive-start rule |

## Test plan

- [x] 1956 tests passing, zero regressions
- [x] Grunt never enters `Circling` (loop test over 3000 ticks)
- [x] Boss body-collision exemption verified
- [x] `bossThresholdCrossed` initialises false, latches true, stays true
- [x] Boss passive: no fire, no dive while threshold not crossed
- [x] Elite Phase 1 y-position stays < 60% canvas height
- [x] Elite Phase 1 no body collision; Phase 2 collision active
- [x] Straggler aggression triggers only with flag enabled, only in Playing phase, carries across waves

Closes #1029, #1030, #1031, #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)