### PR TITLE
feat(starswarm): difficulty tiers — #1037

### DIFF
--- a/backend/starswarm/router.py
+++ b/backend/starswarm/router.py
@@ -28,12 +28,14 @@ class ScoreRequest(BaseModel):
     player_id: str = Field(..., min_length=1, max_length=64)
     score: int = Field(..., ge=0)
     wave_reached: int = Field(..., ge=1)
+    difficulty_tier: str = Field(default="LieutenantJG", max_length=32)
 
 
 class LeaderboardEntry(BaseModel):
     player_id: str
     score: int
     wave_reached: int
+    difficulty_tier: str
     timestamp: str
     rank: int
 
@@ -79,6 +81,7 @@ async def _top10(db: AsyncSession) -> list[LeaderboardEntry]:
                 player_id=str(meta.get("player_name") or "anon"),
                 score=int(g.final_score or 0),
                 wave_reached=int(meta.get("wave_reached") or 1),
+                difficulty_tier=str(meta.get("difficulty_tier") or "LieutenantJG"),
                 timestamp=g.completed_at.isoformat() if g.completed_at else "",
                 rank=i + 1,
             )
@@ -98,7 +101,11 @@ async def submit_score(request: Request, body: ScoreRequest) -> LeaderboardRespo
             final_score=body.score,
             outcome="completed",
             completed_at=datetime.now(timezone.utc),
-            game_metadata={"player_name": body.player_id, "wave_reached": body.wave_reached},
+            game_metadata={
+                "player_name": body.player_id,
+                "wave_reached": body.wave_reached,
+                "difficulty_tier": body.difficulty_tier,
+            },
         )
         db.add(game)
         await db.commit()

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -17,11 +17,13 @@ import {
   applyPowerUp,
   BULLET_C_W,
   POWERUP_DURATION,
+  difficultyLabel,
+  difficultyMultiplier,
 } from "../../game/starswarm/engine";
 import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
 import type { StarfieldState } from "../../game/starswarm/starfield";
 import { useStarSwarmImages } from "../../game/starswarm/assets";
-import type { StarSwarmState, PowerUpType } from "../../game/starswarm/types";
+import type { StarSwarmState, PowerUpType, DifficultyTier } from "../../game/starswarm/types";
 
 const EXPLOSION_DRAW_SIZE = 48;
 const DT_CAP_MS = 33;
@@ -33,6 +35,8 @@ export interface DevOptions {
   stragglerEnabled?: boolean;
   /** Suppress straggler aggression for easier wave-end testing (#1039). */
   pauseStraggler?: boolean;
+  /** Override difficulty tier for this game (#1037). */
+  difficulty?: DifficultyTier;
 }
 
 export interface GameCanvasHandle {
@@ -59,6 +63,8 @@ interface Props {
   scale: number;
   /** Increments each time a new game is requested — triggers an internal reset. */
   resetTick?: number;
+  /** Active difficulty tier — passed from the pre-game selector (#1037). */
+  difficulty?: DifficultyTier;
   /** Dev options applied on each reset (wave, infiniteLives). Passed as prop so reset
    *  is reactive and doesn't depend on the imperative ref being non-null. */
   devOptions?: DevOptions;
@@ -87,6 +93,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       height,
       scale,
       resetTick,
+      difficulty: difficultyProp = "LieutenantJG",
       devOptions,
     },
     ref
@@ -94,7 +101,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const { t } = useTranslation("starswarm");
     const images = useStarSwarmImages();
 
-    const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height));
+    const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height, 1, 42, difficultyProp));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
@@ -102,6 +109,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     // latest devOptions even though devOptions is not in its dependency array.
     const devOptionsRef = useRef<DevOptions | undefined>(devOptions);
     devOptionsRef.current = devOptions;
+    const difficultyRef = useRef<DifficultyTier>(difficultyProp);
+    difficultyRef.current = difficultyProp;
     const lastFrameTimeRef = useRef(0);
     const prevScoreRef = useRef(0);
     const prevLivesRef = useRef(gameRef.current.player.lives);
@@ -186,7 +195,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         height,
         opts?.wave ?? 1,
         42,
-        opts?.stragglerEnabled ?? false
+        opts?.difficulty ?? difficultyRef.current
       );
       sfRef.current = initStarfield(width, height);
       lastFrameTimeRef.current = 0;
@@ -600,6 +609,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             <Text style={styles.hudText}>{`${t("hud.best")} ${hs}`}</Text>
             <Text style={styles.hudText}>{`${t("hud.wave")} ${state.wave}`}</Text>
           </View>
+          <View style={styles.hudDifficulty}>
+            <Text style={styles.hudDifficultyText}>
+              {`${difficultyLabel(state.difficulty)} ×${difficultyMultiplier(state.difficulty)}`}
+            </Text>
+          </View>
 
           <View style={styles.hudBottom}>
             {Array.from({ length: player.lives }, (_, i) => (
@@ -756,5 +770,15 @@ const styles = StyleSheet.create({
     textShadowColor: "#ff8800",
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 8,
+  },
+  hudDifficulty: {
+    alignSelf: "center",
+    marginTop: 2,
+  },
+  hudDifficultyText: {
+    color: "#aaffee",
+    fontSize: 10,
+    fontWeight: "bold",
+    textAlign: "center",
   },
 });

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -3,10 +3,17 @@ import { View } from "react-native";
 import { Asset } from "expo-asset";
 import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
-import { initStarSwarm, tick, applyPowerUp, POWERUP_DURATION } from "../../game/starswarm/engine";
+import {
+  initStarSwarm,
+  tick,
+  applyPowerUp,
+  POWERUP_DURATION,
+  difficultyLabel,
+  difficultyMultiplier,
+} from "../../game/starswarm/engine";
 import { initStarfield, tickStarfield } from "../../game/starswarm/starfield";
 import type { StarfieldState } from "../../game/starswarm/starfield";
-import type { StarSwarmState, PowerUpType } from "../../game/starswarm/types";
+import type { StarSwarmState, PowerUpType, DifficultyTier } from "../../game/starswarm/types";
 
 import playerShipSrc from "../../../assets/starswarm/player-ship.webp";
 import enemyGruntSrc from "../../../assets/starswarm/enemy-grunt.webp";
@@ -86,6 +93,7 @@ const C = {
   explosionHot: "#ffcc00",
   explosionCool: "#ff4400",
   hudText: "#ffffff",
+  hudDiff: "#aaffee",
   lives: "#00ffcc",
   powerBarBg: "rgba(255,255,255,0.18)",
   powerBarFill: "#ffee00",
@@ -110,6 +118,8 @@ export interface DevOptions {
   infiniteLives?: boolean;
   stragglerEnabled?: boolean;
   pauseStraggler?: boolean;
+  /** Override difficulty tier for this game (#1037). */
+  difficulty?: DifficultyTier;
 }
 
 export interface GameCanvasHandle {
@@ -133,6 +143,8 @@ interface Props {
   height: number;
   scale: number;
   resetTick?: number;
+  /** Active difficulty tier — passed from the pre-game selector (#1037). */
+  difficulty?: DifficultyTier;
   devOptions?: DevOptions;
 }
 
@@ -153,6 +165,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       height,
       scale,
       resetTick,
+      difficulty: difficultyProp = "LieutenantJG",
       devOptions,
     },
     ref
@@ -165,7 +178,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const scaleRef = useRef(scale);
-    const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height));
+    const difficultyRef = useRef<DifficultyTier>(difficultyProp);
+    const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height, 1, 42, difficultyProp));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
@@ -200,6 +214,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       scaleRef.current = scale;
     }, [scale]);
+    useEffect(() => {
+      difficultyRef.current = difficultyProp;
+    }, [difficultyProp]);
     useEffect(() => {
       highScoreRef.current = highScore;
     }, [highScore]);
@@ -315,7 +332,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         height,
         opts?.wave ?? 1,
         42,
-        opts?.stragglerEnabled ?? false
+        opts?.difficulty ?? difficultyRef.current
       );
       sfRef.current = initStarfield(width, height);
       lastFrameTimeRef.current = 0;
@@ -589,6 +606,16 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       ctx.fillText(`${t("hud.best")} ${hs}`, width / 2, 8);
       ctx.textAlign = "right";
       ctx.fillText(`${t("hud.wave")} ${state.wave}`, width - 10, 8);
+
+      // Difficulty tier — centered below score row
+      ctx.font = "bold 10px 'Courier New', monospace";
+      ctx.textAlign = "center";
+      ctx.fillStyle = C.hudDiff;
+      ctx.fillText(
+        `${difficultyLabel(state.difficulty)} ×${difficultyMultiplier(state.difficulty)}`,
+        width / 2,
+        26
+      );
 
       // Lives — small cyan rectangles at bottom-left
       for (let i = 0; i < player.lives; i++) {

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -19,8 +19,12 @@ import {
   CANVAS_W,
   CANVAS_H,
   applyPowerUp,
+  DIFFICULTY_TIERS,
+  difficultyMultiplier,
+  difficultyParamScale,
+  difficultyLabel,
 } from "../engine";
-import type { Bullet, StarSwarmInput, StarSwarmState } from "../types";
+import type { Bullet, DifficultyTier, StarSwarmInput, StarSwarmState } from "../types";
 
 const NO_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: false };
 const FIRE_INPUT: StarSwarmInput = { playerX: CANVAS_W / 2, fire: true };
@@ -329,8 +333,8 @@ describe("Collision: enemy bullets vs player", () => {
 // ---------------------------------------------------------------------------
 
 describe("Scoring", () => {
-  it("Grunt is worth 100 points", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+  it("Grunt is worth 100 points (Ensign ×1 baseline)", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     const grunt = s.enemies.find((e) => e.isAlive && e.tier === "Grunt");
     if (!grunt) return;
@@ -353,8 +357,8 @@ describe("Scoring", () => {
     expect(s.score - scoreBeforeKill).toBe(100);
   });
 
-  it("Elite is worth 200 points", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+  it("Elite is worth 200 points (Ensign ×1 baseline)", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     // Elite has 2 HP — need to hit twice
     const elite = s.enemies.find((e) => e.isAlive && e.tier === "Elite");
@@ -563,8 +567,8 @@ describe("Boss HP (#970)", () => {
     }
   });
 
-  it("Boss is still worth 400 points on kill", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+  it("Boss is still worth 400 points on kill (Ensign ×1 baseline)", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     const bossId = s.enemies.find((e) => e.isAlive && e.tier === "Boss")?.id;
     if (!bossId) throw new Error("no boss");
@@ -1695,18 +1699,18 @@ describe("#1030 Elite phase system & Boss passive start", () => {
 // ---------------------------------------------------------------------------
 
 describe("#1031 Straggler aggression", () => {
-  it("stragglerEnabled is false by default", () => {
-    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+  it("stragglerEnabled is false on Ensign difficulty", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     expect(s.stragglerEnabled).toBe(false);
   });
 
-  it("stragglerEnabled=true passed through initStarSwarm", () => {
-    const s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+  it("stragglerEnabled is true on LieutenantJG (default) difficulty", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
     expect(s.stragglerEnabled).toBe(true);
   });
 
   it("when ≤3 enemies remain and stragglerEnabled, Formation enemies immediately wiggle", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "LieutenantJG");
     s = advanceMs(s, 8000);
     expect(s.phase).toBe("Playing");
 
@@ -1725,8 +1729,8 @@ describe("#1031 Straggler aggression", () => {
     expect(formationCount).toBe(0); // all should have entered Wiggling
   });
 
-  it("straggler does not trigger when stragglerEnabled=false", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, false);
+  it("straggler does not trigger on Ensign difficulty", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     expect(s.phase).toBe("Playing");
 
@@ -1745,7 +1749,7 @@ describe("#1031 Straggler aggression", () => {
   });
 
   it("straggler does not apply during ChallengingStage", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, true);
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "LieutenantJG");
     expect(s.phase).toBe("ChallengingStage");
     s = advanceMs(s, 500, NO_INPUT);
     // Kill all but 2
@@ -1765,7 +1769,7 @@ describe("#1031 Straggler aggression", () => {
   });
 
   it("stragglerEnabled carries over to next wave", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, true);
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "LieutenantJG");
     s = advanceMs(s, 8000);
     s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
     s = tick(s, 16, NO_INPUT); // WaveClear
@@ -2010,5 +2014,119 @@ describe("#1035 Buddy Ship", () => {
     // At some point during the 4000ms window bullets were generated; final count may be lower
     // due to off-screen removal. We just verify buddy removed cleanly.
     expect(bulletsAfter).toBeGreaterThanOrEqual(0); // always true — buddy removal is the key check
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1037 — Difficulty tiers
+// ---------------------------------------------------------------------------
+
+describe("#1037 Difficulty tiers", () => {
+  it("DIFFICULTY_TIERS has 10 entries ordered Ensign→FleetAdmiral", () => {
+    expect(DIFFICULTY_TIERS.length).toBe(10);
+    expect(DIFFICULTY_TIERS[0]).toBe("Ensign");
+    expect(DIFFICULTY_TIERS[9]).toBe("FleetAdmiral");
+  });
+
+  it("difficultyMultiplier returns 1 for Ensign and 10 for FleetAdmiral", () => {
+    expect(difficultyMultiplier("Ensign")).toBe(1);
+    expect(difficultyMultiplier("FleetAdmiral")).toBe(10);
+  });
+
+  it("difficultyMultiplier returns a positive number for every tier", () => {
+    for (const tier of DIFFICULTY_TIERS) {
+      expect(difficultyMultiplier(tier)).toBeGreaterThan(0);
+    }
+  });
+
+  it("difficultyParamScale returns 0.7 for Ensign and 3.0 for FleetAdmiral", () => {
+    expect(difficultyParamScale("Ensign")).toBeCloseTo(0.7);
+    expect(difficultyParamScale("FleetAdmiral")).toBeCloseTo(3.0);
+  });
+
+  it("difficultyLabel returns a non-empty string for every tier", () => {
+    for (const tier of DIFFICULTY_TIERS) {
+      expect(difficultyLabel(tier).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("initStarSwarm stores difficulty in state", () => {
+    const tiers: DifficultyTier[] = ["Ensign", "Captain", "FleetAdmiral"];
+    for (const tier of tiers) {
+      const s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, tier);
+      expect(s.difficulty).toBe(tier);
+    }
+  });
+
+  it("Ensign disables straggler; all other tiers enable it", () => {
+    const ensign = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    expect(ensign.stragglerEnabled).toBe(false);
+    for (const tier of DIFFICULTY_TIERS.filter((t) => t !== "Ensign")) {
+      const s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, tier);
+      expect(s.stragglerEnabled).toBe(true);
+    }
+  });
+
+  it("score multiplier is applied: FleetAdmiral kill worth 10× base", () => {
+    let base = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    let hard = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "FleetAdmiral");
+    base = advanceMs(base, 8000);
+    hard = advanceMs(hard, 8000);
+    expect(base.phase).toBe("Playing");
+    expect(hard.phase).toBe("Playing");
+
+    const gruntBase = base.enemies.find((e) => e.isAlive && e.tier === "Grunt");
+    const gruntHard = hard.enemies.find((e) => e.isAlive && e.tier === "Grunt");
+    if (!gruntBase || !gruntHard) throw new Error("no grunt found");
+
+    const kill = (s: StarSwarmState, id: number): StarSwarmState => {
+      const e = s.enemies.find((en) => en.id === id)!;
+      const b: Bullet = {
+        id: 55500 + id,
+        x: e.x,
+        y: e.y,
+        vx: 0,
+        vy: 0,
+        owner: "player",
+        width: e.width,
+        height: e.height,
+        damage: 999,
+      };
+      return tick({ ...s, playerBullets: [b] }, 16, NO_INPUT);
+    };
+
+    const scoreBase = kill(base, gruntBase.id).score;
+    const scoreHard = kill(hard, gruntHard.id).score;
+    expect(scoreHard).toBe(scoreBase * 10);
+  });
+
+  it("difficulty carries over to next wave", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Admiral");
+    s = advanceMs(s, 8000);
+    s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
+    s = tick(s, 16, NO_INPUT);
+    s = advanceMs(s, 3000);
+    expect(s.wave).toBe(2);
+    expect(s.difficulty).toBe("Admiral");
+  });
+
+  it("wave clear bonus is multiplied by difficulty", () => {
+    let base = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    let hard = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Captain"); // ×4
+    base = advanceMs(base, 8000);
+    hard = advanceMs(hard, 8000);
+
+    // Kill all enemies to trigger wave clear bonus
+    const wipeAll = (s: StarSwarmState): StarSwarmState => ({
+      ...s,
+      enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })),
+    });
+    base = tick(wipeAll(base), 16, NO_INPUT);
+    hard = tick(wipeAll(hard), 16, NO_INPUT);
+
+    // Both should be in WaveClear and hard score should be ≥ 4× base score
+    expect(base.phase).toBe("WaveClear");
+    expect(hard.phase).toBe("WaveClear");
+    expect(hard.score).toBeGreaterThanOrEqual(base.score * 4);
   });
 });

--- a/frontend/src/game/starswarm/api.ts
+++ b/frontend/src/game/starswarm/api.ts
@@ -1,0 +1,26 @@
+import { createGameClient } from "../_shared/httpClient";
+
+export interface LeaderboardEntry {
+  player_id: string;
+  score: number;
+  wave_reached: number;
+  difficulty_tier: string;
+  timestamp: string;
+  rank: number;
+}
+
+export interface LeaderboardResponse {
+  scores: LeaderboardEntry[];
+}
+
+const request = createGameClient({ apiTag: "starswarm" });
+
+export const starSwarmApi = {
+  submitScore: (score: number, wave_reached: number, difficulty_tier: string) =>
+    request<LeaderboardResponse>("/starswarm/score", {
+      method: "POST",
+      body: JSON.stringify({ player_id: "player", score, wave_reached, difficulty_tier }),
+    }),
+
+  getLeaderboard: () => request<LeaderboardResponse>("/starswarm/leaderboard"),
+};

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -11,6 +11,7 @@ import type {
   CubicBezier,
   EnemyTier,
   StarSwarmInput,
+  DifficultyTier,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -128,6 +129,79 @@ export const PLAYER_HURT_RADIUS = 7; // px
 
 const TIER_SCORE: Record<EnemyTier, number> = { Grunt: 100, Elite: 200, Boss: 400 };
 const TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 2, Boss: 4 };
+
+// ---------------------------------------------------------------------------
+// Difficulty tier system (#1037)
+// ---------------------------------------------------------------------------
+
+const DIFFICULTY_SCORE_MULT: Record<DifficultyTier, number> = {
+  Ensign: 1,
+  LieutenantJG: 1.5,
+  Lieutenant: 2,
+  LieutenantCommander: 2.5,
+  Commander: 3,
+  Captain: 4,
+  RearAdmiral: 5,
+  ViceAdmiral: 6,
+  Admiral: 8,
+  FleetAdmiral: 10,
+};
+
+// Scales AI aggression: dive interval floor, bullet cap, aimed-shot cap, sway speed.
+const DIFFICULTY_PARAM_SCALE: Record<DifficultyTier, number> = {
+  Ensign: 0.7,
+  LieutenantJG: 1.0,
+  Lieutenant: 1.15,
+  LieutenantCommander: 1.3,
+  Commander: 1.5,
+  Captain: 1.7,
+  RearAdmiral: 1.9,
+  ViceAdmiral: 2.15,
+  Admiral: 2.5,
+  FleetAdmiral: 3.0,
+};
+
+const DIFFICULTY_LABEL: Record<DifficultyTier, string> = {
+  Ensign: "Ensign",
+  LieutenantJG: "Lieutenant J.G.",
+  Lieutenant: "Lieutenant",
+  LieutenantCommander: "Lieutenant Cmdr",
+  Commander: "Commander",
+  Captain: "Captain",
+  RearAdmiral: "Rear Admiral",
+  ViceAdmiral: "Vice Admiral",
+  Admiral: "Admiral",
+  FleetAdmiral: "Fleet Admiral",
+};
+
+/** All tiers from easiest to hardest — use for UI selector ordering. */
+export const DIFFICULTY_TIERS: readonly DifficultyTier[] = [
+  "Ensign",
+  "LieutenantJG",
+  "Lieutenant",
+  "LieutenantCommander",
+  "Commander",
+  "Captain",
+  "RearAdmiral",
+  "ViceAdmiral",
+  "Admiral",
+  "FleetAdmiral",
+];
+
+/** Score multiplier applied to every point award for this tier. */
+export function difficultyMultiplier(tier: DifficultyTier): number {
+  return DIFFICULTY_SCORE_MULT[tier];
+}
+
+/** AI parameter scale factor (dive rate, bullet density, aimed-shot fraction). */
+export function difficultyParamScale(tier: DifficultyTier): number {
+  return DIFFICULTY_PARAM_SCALE[tier];
+}
+
+/** Human-readable display label for a difficulty tier. */
+export function difficultyLabel(tier: DifficultyTier): string {
+  return DIFFICULTY_LABEL[tier];
+}
 const TIER_SIZE: Record<EnemyTier, { w: number; h: number }> = {
   Grunt: { w: 24, h: 24 },
   Elite: { w: 28, h: 28 },
@@ -432,8 +506,11 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
 // Wave helpers
 // ---------------------------------------------------------------------------
 
-function diveInterval(wave: number): number {
-  return Math.max(DIVE_INTERVAL_MIN, DIVE_INTERVAL_BASE * Math.pow(0.88, wave - 1));
+function diveInterval(wave: number, paramScale = 1): number {
+  const base = DIVE_INTERVAL_BASE * Math.pow(0.88, wave - 1);
+  // Higher difficulty → lower floor → more frequent dives
+  const floor = Math.max(300, Math.round(DIVE_INTERVAL_MIN / paramScale));
+  return Math.max(floor, base);
 }
 
 function isChallengingWave(wave: number): boolean {
@@ -453,15 +530,16 @@ export function maxDivers(wave: number): number {
   return 4;
 }
 
-// #972: max enemy bullets on screen — 3 at wave 1, +1 every 2 waves
-export function bulletCap(wave: number): number {
-  return 3 + Math.floor((wave - 1) / 2);
+// #972: max enemy bullets on screen — 3 at wave 1, +1 every 2 waves; scaled by difficulty
+export function bulletCap(wave: number, paramScale = 1): number {
+  return Math.min(24, Math.round((3 + Math.floor((wave - 1) / 2)) * paramScale));
 }
 
-// #924: compute vx for an enemy bullet — non-zero only at wave 4+
-function aimedBulletVx(enemyX: number, playerX: number, wave: number): number {
+// #924: compute vx for an enemy bullet — non-zero only at wave 4+; cap raised by difficulty
+function aimedBulletVx(enemyX: number, playerX: number, wave: number, paramScale = 1): number {
   if (wave < AIMED_SHOT_WAVE_START) return 0;
-  const fraction = Math.min(0.6, AIMED_SHOT_FRACTION + (wave - AIMED_SHOT_WAVE_START) * 0.05);
+  const cap = Math.min(0.9, 0.6 * paramScale);
+  const fraction = Math.min(cap, AIMED_SHOT_FRACTION + (wave - AIMED_SHOT_WAVE_START) * 0.05);
   if (rng() > fraction) return 0;
   return Math.sign(playerX - enemyX) * BULLET_E_VY * 0.5;
 }
@@ -475,7 +553,7 @@ export function initStarSwarm(
   canvasH: number,
   wave = 1,
   seed = 42,
-  stragglerEnabled = false
+  difficulty: DifficultyTier = "LieutenantJG"
 ): StarSwarmState {
   seedRng(seed);
   _resetIds();
@@ -490,7 +568,7 @@ export function initStarSwarm(
     shootCooldown: 0,
   };
 
-  return buildWaveState(canvasW, canvasH, wave, player, 0, 0, stragglerEnabled);
+  return buildWaveState(canvasW, canvasH, wave, player, 0, 0, difficulty);
 }
 
 function buildWaveState(
@@ -500,7 +578,7 @@ function buildWaveState(
   player: Player,
   score: number,
   bonusLivesAwarded = 0,
-  stragglerEnabled = false
+  difficulty: DifficultyTier = "LieutenantJG"
 ): StarSwarmState {
   let enemies: Enemy[];
   let phase: StarSwarmState["phase"];
@@ -532,6 +610,9 @@ function buildWaveState(
   };
   const powerUps: PowerUp[] = isChallengingWave(wave) ? [challengingPowerUp] : [];
   const dropJitterTarget = triggerKills(wave) + Math.floor(rng() * 5) - 2;
+  const paramScale = difficultyParamScale(difficulty);
+  // Ensign gets gentler AI; every tier above gets straggler aggression
+  const stragglerEnabled = difficulty !== "Ensign";
 
   return {
     phase,
@@ -548,7 +629,7 @@ function buildWaveState(
     canvasW,
     canvasH,
     challengingHits: 0,
-    nextDiveTimer: diveInterval(wave),
+    nextDiveTimer: diveInterval(wave, paramScale),
     formationSwayX: 0,
     formationSwayDir: 1,
     bonusLivesAwarded,
@@ -560,6 +641,7 @@ function buildWaveState(
     stragglerEnabled,
     pauseStraggler: false,
     bombFlashTimer: 0,
+    difficulty,
   };
 }
 
@@ -666,7 +748,8 @@ function tickSingleEnemy(
   canvasH: number,
   shouldDive: boolean,
   wave: number,
-  bossThresholdCrossed: boolean
+  bossThresholdCrossed: boolean,
+  paramScale = 1
 ): EnemyTickResult {
   if (!enemy.isAlive) return { enemy, bullet: null };
 
@@ -674,7 +757,15 @@ function tickSingleEnemy(
     case "SwoopIn":
       return tickSwoopIn(enemy, dtMs);
     case "Formation":
-      return tickFormation(enemy, dtMs, playerX, shouldDive, wave, bossThresholdCrossed);
+      return tickFormation(
+        enemy,
+        dtMs,
+        playerX,
+        shouldDive,
+        wave,
+        bossThresholdCrossed,
+        paramScale
+      );
     case "Wiggling":
       return tickWiggling(enemy, dtMs, canvasH, bossThresholdCrossed);
     case "Diving":
@@ -719,7 +810,8 @@ function tickFormation(
   playerX: number,
   shouldDive: boolean,
   wave: number,
-  bossThresholdCrossed: boolean
+  bossThresholdCrossed: boolean,
+  paramScale = 1
 ): EnemyTickResult {
   // Boss is passive until threshold crossed: no firing, no diving
   if (enemy.tier === "Boss" && !bossThresholdCrossed) {
@@ -754,7 +846,7 @@ function tickFormation(
   const vx =
     enemy.tier === "Elite"
       ? Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5
-      : aimedBulletVx(enemy.x, playerX, wave);
+      : aimedBulletVx(enemy.x, playerX, wave, paramScale);
 
   const bullet: Bullet = {
     id: nextId(),
@@ -1021,7 +1113,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
   if (state.phase === "Playing") {
     nextDiveTimer -= dtMs;
     if (nextDiveTimer <= 0) {
-      nextDiveTimer = diveInterval(state.wave);
+      nextDiveTimer = diveInterval(state.wave, difficultyParamScale(state.difficulty));
       // #978/#1030: Boss only eligible once bossThresholdCrossed
       const candidates = state.enemies
         .map((e, i) => ({ e, i }))
@@ -1041,7 +1133,8 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
   }
 
   // #923 Formation sway: advance offset, bounce at ±MAX_SWAY
-  const swaySpeed = SWAY_SPEED_BASE + (state.wave - 1) * SWAY_SPEED_PER_WAVE;
+  const _ps = difficultyParamScale(state.difficulty);
+  const swaySpeed = (SWAY_SPEED_BASE + (state.wave - 1) * SWAY_SPEED_PER_WAVE) * _ps;
   let swayX = state.formationSwayX + state.formationSwayDir * swaySpeed * dtMs;
   let swayDir = state.formationSwayDir;
   if (swayX >= MAX_SWAY) {
@@ -1062,7 +1155,8 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
       state.canvasH,
       shouldDive,
       state.wave,
-      bossThresholdCrossed
+      bossThresholdCrossed,
+      _ps
     );
     let e = result.enemy;
     // Apply sway offset to enemies holding Formation position
@@ -1076,7 +1170,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     if (e.isAlive && e.hitFlashTimer > 0) {
       e = { ...e, hitFlashTimer: Math.max(0, e.hitFlashTimer - dtMs) };
     }
-    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave)) {
+    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave, _ps)) {
       newEnemyBullets.push(result.bullet);
     }
     return e;
@@ -1246,6 +1340,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
   let killsSinceLastDrop = state.killsSinceLastDrop;
   let dropJitterTarget = state.dropJitterTarget;
   let powerUps: PowerUp[] = [...state.powerUps];
+  const scoreMult = difficultyMultiplier(state.difficulty);
 
   // ── Player bullets ↔ enemies ──────────────────────────────────────────────
   const hitBulletIds = new Set<number>(); // non-piercing bullets consumed this tick
@@ -1271,7 +1366,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         const base = TIER_SCORE[enemy.tier];
         const mult = enemy.phase === "Diving" || enemy.phase === "Circling" ? DIVE_SCORE_MULT : 1;
         const bonus = state.phase === "ChallengingStage" ? 1 : mult;
-        score += base * bonus;
+        score += Math.round(base * bonus * scoreMult);
         if (state.phase === "ChallengingStage") challengingHits += 1;
         if (state.phase === "Playing") killsSinceLastDrop++;
         return { ...enemy, hp: 0, isAlive: false, hitFlashTimer: 0 };
@@ -1341,7 +1436,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         const newHp = e.hp - 1;
         if (newHp <= 0) {
           newExplosions.push(spawnExplosion(e.x, e.y));
-          score += TIER_SCORE[e.tier]; // no dive multiplier for bomb kills
+          score += Math.round(TIER_SCORE[e.tier] * scoreMult); // no dive multiplier for bomb kills
           if (state.phase === "Playing") killsSinceLastDrop++;
           return { ...e, hp: 0, isAlive: false, hitFlashTimer: 0 };
         }
@@ -1434,7 +1529,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
             ? enemies.map((e) => {
                 if (e.id === rammingEnemyId) {
                   newExplosions.push(spawnExplosion(e.x, e.y));
-                  score += TIER_SCORE[e.tier] * DIVE_SCORE_MULT;
+                  score += Math.round(TIER_SCORE[e.tier] * DIVE_SCORE_MULT * scoreMult);
                   return { ...e, hp: 0, isAlive: false };
                 }
                 return e;
@@ -1550,10 +1645,11 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
     // Enemies exit when their path completes (they reach formationY which is off-screen bottom)
     const anyAlive = liveEnemies.length > 0;
     if (!anyAlive) {
-      const waveClearBonus = state.wave * WAVE_CLEAR_BONUS_BASE;
+      const sm = difficultyMultiplier(state.difficulty);
+      const waveClearBonus = Math.round(state.wave * WAVE_CLEAR_BONUS_BASE * sm);
       return {
         ...state,
-        score: state.score + waveClearBonus + state.challengingHits * 50,
+        score: state.score + waveClearBonus + Math.round(state.challengingHits * 50 * sm),
         phase: "WaveClear",
         phaseTimer: CHALLENGING_CLEAR_PAUSE,
       };
@@ -1564,7 +1660,8 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
   // Playing → WaveClear once all enemies dead
   if (state.phase === "Playing") {
     if (liveEnemies.length === 0) {
-      const waveClearBonus = state.wave * WAVE_CLEAR_BONUS_BASE;
+      const sm = difficultyMultiplier(state.difficulty);
+      const waveClearBonus = Math.round(state.wave * WAVE_CLEAR_BONUS_BASE * sm);
       return {
         ...state,
         score: state.score + waveClearBonus,
@@ -1587,7 +1684,7 @@ function startNextWave(state: StarSwarmState): StarSwarmState {
     state.player,
     state.score,
     state.bonusLivesAwarded,
-    state.stragglerEnabled
+    state.difficulty
   );
 }
 
@@ -1600,6 +1697,7 @@ export function applyPowerUp(state: StarSwarmState, type: PowerUpType): StarSwar
 
   if (type === "bomb") {
     const newExplosions: Explosion[] = [...state.explosions];
+    const sm = difficultyMultiplier(state.difficulty);
     let score = state.score;
     let killsSinceLastDrop = state.killsSinceLastDrop;
     const enemies = state.enemies.map((e) => {
@@ -1613,7 +1711,7 @@ export function applyPowerUp(state: StarSwarmState, type: PowerUpType): StarSwar
           frame: 0,
           frameTimer: EXPLOSION_FRAME_MS,
         });
-        score += TIER_SCORE[e.tier];
+        score += Math.round(TIER_SCORE[e.tier] * sm);
         killsSinceLastDrop++;
         return { ...e, hp: 0, isAlive: false, hitFlashTimer: 0 };
       }

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -2,6 +2,19 @@ export type EnemyTier = "Grunt" | "Elite" | "Boss";
 
 export type PowerUpType = "lightning" | "shield" | "buddy" | "bomb";
 
+/** Starfleet difficulty tiers (#1037) — ordered easiest to hardest. */
+export type DifficultyTier =
+  | "Ensign"
+  | "LieutenantJG"
+  | "Lieutenant"
+  | "LieutenantCommander"
+  | "Commander"
+  | "Captain"
+  | "RearAdmiral"
+  | "ViceAdmiral"
+  | "Admiral"
+  | "FleetAdmiral";
+
 /** Five-state AI machine + SwoopIn entry animation. */
 export type EnemyPhase =
   | "SwoopIn" // following Bézier path onto screen into formation slot
@@ -190,6 +203,8 @@ export interface StarSwarmState {
   readonly pauseStraggler: boolean;
   /** ms remaining for the Smart Bomb full-screen flash overlay; 0 when inactive (#1034). */
   readonly bombFlashTimer: number;
+  /** Active difficulty tier; drives score multiplier and AI param scaling (#1037). */
+  readonly difficulty: DifficultyTier;
 }
 
 /** Input snapshot consumed by each `tick` call. */

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -16,5 +16,7 @@
   "controls.tapToResume": "Tap to resume",
   "controls.resumeLabel": "Resume game",
   "controls.newGame": "NEW GAME",
-  "controls.newGameLabel": "Start a new game"
+  "controls.newGameLabel": "Start a new game",
+  "difficulty.selectTitle": "Select Difficulty",
+  "difficulty.start": "Start Game"
 }

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -23,8 +23,14 @@ import Controls, {
   hapticPlayerDeath,
   hapticWaveClear,
 } from "../components/starswarm/Controls";
-import { CANVAS_W, CANVAS_H } from "../game/starswarm/engine";
-import type { GamePhase, PowerUpType } from "../game/starswarm/types";
+import {
+  CANVAS_W,
+  CANVAS_H,
+  DIFFICULTY_TIERS,
+  difficultyLabel,
+  difficultyMultiplier,
+} from "../game/starswarm/engine";
+import type { GamePhase, PowerUpType, DifficultyTier } from "../game/starswarm/types";
 import { useStarSwarmAudio, DEFAULT_SFX_VOLUMES } from "../hooks/useStarSwarmAudio";
 import type { SfxVolumes } from "../hooks/useStarSwarmAudio";
 
@@ -48,7 +54,12 @@ export default function StarSwarmScreen() {
   const [devInfiniteLives, setDevInfiniteLives] = useState(false);
   const [devStragglerEnabled, setDevStragglerEnabled] = useState(true);
   const [devPauseStraggler, setDevPauseStraggler] = useState(false);
+  const [devDifficulty, setDevDifficulty] = useState<DifficultyTier>("LieutenantJG");
   const [devVolumes, setDevVolumes] = useState<SfxVolumes>(DEFAULT_SFX_VOLUMES);
+
+  // Pre-game difficulty selector — shown before each new game
+  const [difficulty, setDifficulty] = useState<DifficultyTier>("LieutenantJG");
+  const [showDifficultyPicker, setShowDifficultyPicker] = useState(true);
 
   const adjustVolume = useCallback((key: keyof SfxVolumes, delta: number) => {
     setDevVolumes((v) => ({
@@ -126,6 +137,20 @@ export default function StarSwarmScreen() {
     setResetTick((t) => t + 1);
   }, []);
 
+  // Show difficulty picker — triggered by header "New Game" and Controls "New Game"
+  const handleRequestNewGame = useCallback(() => {
+    setShowDifficultyPicker(true);
+  }, []);
+
+  // Confirm difficulty selection and start the game
+  const handleConfirmDifficulty = useCallback(() => {
+    setShowDifficultyPicker(false);
+    scoreRef.current = 0;
+    setPhase("SwoopIn");
+    setIsPaused(false);
+    setResetTick((t) => t + 1);
+  }, []);
+
   const handlePause = useCallback(() => {
     setIsPaused(true);
   }, []);
@@ -147,7 +172,7 @@ export default function StarSwarmScreen() {
       title={t("game.title")}
       requireBack
       onBack={() => navigation.popToTop()}
-      onNewGame={handleNewGame}
+      onNewGame={handleRequestNewGame}
       style={{
         paddingBottom: Math.max(insets.bottom, 8),
         paddingLeft: Math.max(insets.left, 0),
@@ -173,6 +198,7 @@ export default function StarSwarmScreen() {
               width={CANVAS_W}
               height={CANVAS_H}
               scale={scale}
+              difficulty={difficulty}
               resetTick={resetTick}
               devOptions={lastDevOptsRef.current}
             />
@@ -183,7 +209,7 @@ export default function StarSwarmScreen() {
               isPaused={isPaused}
               onPause={handlePause}
               onResume={handleResume}
-              onNewGame={handleNewGame}
+              onNewGame={handleRequestNewGame}
             />
             {__DEV__ && (
               <Pressable style={dynamicStyles.devButton} onPress={() => setDevPanelOpen(true)}>
@@ -192,6 +218,57 @@ export default function StarSwarmScreen() {
             )}
           </View>
         )}
+        {showDifficultyPicker && scale > 0 && (
+          <Modal
+            visible
+            transparent
+            animationType="fade"
+            onRequestClose={handleConfirmDifficulty}
+            accessibilityViewIsModal
+          >
+            <View style={styles.pickerOverlay}>
+              <View style={dynamicStyles.pickerPanel}>
+                <Text style={dynamicStyles.pickerTitle}>{t("difficulty.selectTitle")}</Text>
+                <ScrollView
+                  showsVerticalScrollIndicator={false}
+                  style={styles.pickerScroll}
+                  contentContainerStyle={styles.pickerScrollContent}
+                >
+                  {DIFFICULTY_TIERS.map((tier) => (
+                    <Pressable
+                      key={tier}
+                      style={[
+                        styles.pickerRow,
+                        difficulty === tier && dynamicStyles.pickerRowSelected,
+                      ]}
+                      onPress={() => setDifficulty(tier)}
+                      accessibilityRole="radio"
+                      accessibilityState={{ checked: difficulty === tier }}
+                      accessibilityLabel={`${difficultyLabel(tier)} ×${difficultyMultiplier(tier)}`}
+                    >
+                      <Text
+                        style={[
+                          styles.pickerTierName,
+                          difficulty === tier && dynamicStyles.pickerTierNameSelected,
+                        ]}
+                      >
+                        {difficultyLabel(tier)}
+                      </Text>
+                      <Text style={styles.pickerTierMult}>{`×${difficultyMultiplier(tier)}`}</Text>
+                    </Pressable>
+                  ))}
+                </ScrollView>
+                <Pressable
+                  style={[styles.devActionBtn, dynamicStyles.devPrimary, styles.pickerStartBtn]}
+                  onPress={handleConfirmDifficulty}
+                >
+                  <Text style={styles.devPrimaryText}>{t("difficulty.start")}</Text>
+                </Pressable>
+              </View>
+            </View>
+          </Modal>
+        )}
+
         {__DEV__ && (
           <Modal
             visible={devPanelOpen}
@@ -241,6 +318,36 @@ export default function StarSwarmScreen() {
                     <Text style={dynamicStyles.devLabel}>Pause straggler</Text>
                     <Switch value={devPauseStraggler} onValueChange={setDevPauseStraggler} />
                   </View>
+
+                  <Text style={dynamicStyles.devSectionHeader}>── Difficulty Tier ──</Text>
+
+                  <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    style={styles.devTierScroll}
+                    contentContainerStyle={styles.devTierScrollContent}
+                  >
+                    {DIFFICULTY_TIERS.map((tier) => (
+                      <Pressable
+                        key={tier}
+                        style={[
+                          styles.devTierBtn,
+                          devDifficulty === tier && styles.devTierBtnActive,
+                        ]}
+                        onPress={() => setDevDifficulty(tier)}
+                        accessibilityLabel={`Dev difficulty ${difficultyLabel(tier)}`}
+                      >
+                        <Text
+                          style={[
+                            styles.devTierText,
+                            devDifficulty === tier && styles.devTierTextActive,
+                          ]}
+                        >
+                          {difficultyLabel(tier)}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </ScrollView>
 
                   <Text style={dynamicStyles.devSectionHeader}>── Power-ups ──</Text>
 
@@ -302,6 +409,7 @@ export default function StarSwarmScreen() {
                         infiniteLives: devInfiniteLives,
                         stragglerEnabled: devStragglerEnabled,
                         pauseStraggler: devPauseStraggler,
+                        difficulty: devDifficulty,
                       });
                     }}
                   >
@@ -403,6 +511,70 @@ const baseStyles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "700",
   },
+  devTierScroll: {
+    marginVertical: 2,
+  },
+  devTierScrollContent: {
+    gap: 6,
+    paddingVertical: 2,
+  },
+  devTierBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: "rgba(255,255,255,0.07)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.15)",
+  },
+  devTierBtnActive: {
+    backgroundColor: "rgba(255,128,0,0.3)",
+    borderColor: "rgba(255,128,0,0.8)",
+  },
+  devTierText: {
+    color: "rgba(255,255,255,0.55)",
+    fontSize: 9,
+    fontWeight: "700",
+  },
+  devTierTextActive: {
+    color: "#ff8000",
+  },
+  pickerOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,10,0.88)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pickerScroll: {
+    maxHeight: 320,
+  },
+  pickerScrollContent: {
+    gap: 6,
+    paddingVertical: 4,
+  },
+  pickerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.1)",
+    backgroundColor: "rgba(255,255,255,0.05)",
+  },
+  pickerTierName: {
+    color: "rgba(255,255,255,0.75)",
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  pickerTierMult: {
+    color: "rgba(255,238,0,0.8)",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  pickerStartBtn: {
+    marginTop: 12,
+  },
 });
 
 // Create dynamic styles based on theme tokens to comply with design-tokens policy
@@ -450,6 +622,31 @@ const getStyles = (colors: ReturnType<typeof useTheme>["colors"]) =>
     },
     devPrimary: {
       backgroundColor: "rgba(255,128,0,1)",
+    },
+    pickerPanel: {
+      backgroundColor: colors.surfaceHigh,
+      borderRadius: 14,
+      padding: 24,
+      width: 300,
+      maxHeight: "80%",
+      borderWidth: 1,
+      borderColor: "rgba(0,255,200,0.3)",
+    },
+    pickerTitle: {
+      color: "#00ffcc",
+      fontSize: 15,
+      fontWeight: "700",
+      letterSpacing: 1.5,
+      textAlign: "center",
+      textTransform: "uppercase",
+      marginBottom: 14,
+    },
+    pickerRowSelected: {
+      backgroundColor: "rgba(0,255,200,0.12)",
+      borderColor: "rgba(0,255,200,0.55)",
+    },
+    pickerTierNameSelected: {
+      color: "#ffffff",
     },
   });
 


### PR DESCRIPTION
## Summary

- **10 Starfleet-ranked difficulty tiers** (Ensign → Fleet Admiral) selectable before each game
- **Score multipliers** ×1–×10 applied to all point awards (enemy kills, wave-clear bonus, bomb)
- **AI param scaling** 0.7–3.0: dive interval, bullet cap, aimed-shot fraction, formation sway speed
- **Straggler aggression** derived from tier (disabled on Ensign only)
- **Pre-game difficulty picker modal** shown before every new game; dev panel tier override
- **HUD**: tier name + multiplier displayed on both native and web canvases
- **Backend**: `difficulty_tier` persisted in score submissions and returned in leaderboard
- **starswarm API client** (`api.ts`) for score submission and leaderboard fetch
- **128 engine tests** all passing; updated straggler tests use tier strings; added `#1037` block

## Closes
Closes #1037

## Test plan
- [ ] Select each difficulty tier in the picker and verify HUD shows correct label + multiplier
- [ ] Kill a Grunt on Ensign (×1) → 100 pts; on FleetAdmiral (×10) → 1000 pts
- [ ] Wave-clear bonus scales with multiplier
- [ ] Straggler AI disabled on Ensign, enabled on LieutenantJG+
- [ ] Backend leaderboard returns `difficulty_tier` field
- [ ] Dev panel tier selector overrides difficulty for that game session
- [ ] `npx jest src/game/starswarm/__tests__/engine.test.ts` → 128/128 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)