### PR TITLE
feat(starswarm): Challenging Stage PERFECT bonus + score submission (#1022 #1040)

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -48,13 +48,15 @@ export interface GameCanvasHandle {
 
 interface Props {
   highScore?: number;
-  onGameOver?: (finalScore: number) => void;
+  onGameOver?: (finalScore: number, wave: number) => void;
   onScoreChange?: (score: number) => void;
   onPlayerHit?: () => void;
   onWaveClear?: () => void;
   onLaserFire?: () => void;
   onExplosion?: () => void;
   onChallengingStage?: () => void;
+  /** Called once when all enemies in a Challenging Stage are hit (#1022). */
+  onChallengingPerfect?: () => void;
   onBonusLife?: () => void;
   onPowerUpCollect?: (type: PowerUpType) => void;
   isPaused?: boolean;
@@ -86,6 +88,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onLaserFire,
       onExplosion,
       onChallengingStage,
+      onChallengingPerfect,
       onBonusLife,
       onPowerUpCollect,
       isPaused = false,
@@ -123,6 +126,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onLaserFireRef = useRef(onLaserFire);
     const onExplosionRef = useRef(onExplosion);
     const onChallengingStageRef = useRef(onChallengingStage);
+    const onChallengingPerfectRef = useRef(onChallengingPerfect);
     const onBonusLifeRef = useRef(onBonusLife);
     const onPowerUpCollectRef = useRef(onPowerUpCollect);
     const prevActivePowerUpRef = useRef<string | null>(null); // type of active power-up last frame
@@ -156,6 +160,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onChallengingStageRef.current = onChallengingStage;
     }, [onChallengingStage]);
+    useEffect(() => {
+      onChallengingPerfectRef.current = onChallengingPerfect;
+    }, [onChallengingPerfect]);
     useEffect(() => {
       onBonusLifeRef.current = onBonusLife;
     }, [onBonusLife]);
@@ -276,6 +283,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             prevActivePowerUpRef.current = nowType;
             if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
               onWaveClearRef.current?.();
+              if (applied.challengingPerfect) onChallengingPerfectRef.current?.();
             }
             if (
               applied.phase === "ChallengingStage" &&
@@ -285,7 +293,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             }
             prevPhaseRef.current = applied.phase;
             if (applied.phase === "GameOver") {
-              onGameOverRef.current?.(applied.score);
+              onGameOverRef.current?.(applied.score, applied.wave);
             }
           } catch (e) {
             Sentry.captureException(e, { tags: { subsystem: "starswarm.loop" } });
@@ -644,6 +652,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           {state.phase === "WaveClear" && (
             <View style={styles.phaseOverlay}>
               <Text style={styles.overlayTitle}>{t("phase.waveClear")}</Text>
+              {state.challengingPerfect && (
+                <Text style={styles.perfectBanner}>{t("phase.perfect")}</Text>
+              )}
             </View>
           )}
 
@@ -741,6 +752,16 @@ const styles = StyleSheet.create({
     fontSize: 14,
     textAlign: "center",
     marginTop: 8,
+  },
+  perfectBanner: {
+    color: "#ffdd00",
+    fontSize: 20,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginTop: 6,
+    textShadowColor: "#ff8800",
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 8,
   },
   gameOverOverlay: {
     backgroundColor: "rgba(0,0,0,0.65)",

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -130,13 +130,15 @@ export interface GameCanvasHandle {
 
 interface Props {
   highScore?: number;
-  onGameOver?: (finalScore: number) => void;
+  onGameOver?: (finalScore: number, wave: number) => void;
   onScoreChange?: (score: number) => void;
   onPlayerHit?: () => void;
   onWaveClear?: () => void;
   onLaserFire?: () => void;
   onExplosion?: () => void;
   onChallengingStage?: () => void;
+  /** Called once when all enemies in a Challenging Stage are hit (#1022). */
+  onChallengingPerfect?: () => void;
   onPowerUpCollect?: (type: PowerUpType) => void;
   isPaused?: boolean;
   width: number;
@@ -159,6 +161,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onLaserFire,
       onExplosion,
       onChallengingStage,
+      onChallengingPerfect,
       onPowerUpCollect,
       isPaused = false,
       width,
@@ -194,6 +197,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onLaserFireRef = useRef(onLaserFire);
     const onExplosionRef = useRef(onExplosion);
     const onChallengingStageRef = useRef(onChallengingStage);
+    const onChallengingPerfectRef = useRef(onChallengingPerfect);
     const onPowerUpCollectRef = useRef(onPowerUpCollect);
     const prevActivePowerUpRef = useRef<string | null>(null);
     const triggerPowerUpRef = useRef<PowerUpType | null>(null);
@@ -244,6 +248,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onChallengingStageRef.current = onChallengingStage;
     }, [onChallengingStage]);
+    useEffect(() => {
+      onChallengingPerfectRef.current = onChallengingPerfect;
+    }, [onChallengingPerfect]);
     useEffect(() => {
       const wasPaused = isPausedRef.current;
       isPausedRef.current = isPaused;
@@ -640,6 +647,14 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         ctx.font = "bold 22px 'Courier New', monospace";
         ctx.fillStyle = C.waveClear;
         ctx.fillText(t("phase.waveClear"), width / 2, height / 2);
+        if (state.challengingPerfect) {
+          ctx.font = "bold 18px 'Courier New', monospace";
+          ctx.fillStyle = "#ffdd00";
+          ctx.shadowColor = "#ff8800";
+          ctx.shadowBlur = 8;
+          ctx.fillText(t("phase.perfect"), width / 2, height / 2 + 30);
+          ctx.shadowBlur = 0;
+        }
       }
 
       if (state.phase === "ChallengingStage") {
@@ -727,6 +742,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             prevLivesRef.current = applied.player.lives;
             if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
               onWaveClearRef.current?.();
+              if (applied.challengingPerfect) onChallengingPerfectRef.current?.();
             }
             if (
               applied.phase === "ChallengingStage" &&
@@ -736,7 +752,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             }
             prevPhaseRef.current = applied.phase;
             if (applied.phase === "GameOver") {
-              onGameOverRef.current?.(applied.score);
+              onGameOverRef.current?.(applied.score, applied.wave);
             }
           } catch (e) {
             Sentry.captureException(e, { tags: { subsystem: "starswarm.loop" } });

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -738,10 +738,10 @@ describe("ChallengingStage off-screen cleanup", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
     expect(s.phase).toBe("ChallengingStage");
 
-    // Last enemy (idx 23) starts with pathT = -(23*80/3200) ≈ -0.575
-    // It exits the canvas after (1 + 0.575) * 3200 ≈ 5040 ms.
+    // With 40 enemies, last enemy (idx 39) has delay = 39*80/3200 = 0.975.
+    // It exits the canvas after (1 + 0.975) * 3200 ≈ 6320 ms.
     // Advance past that with no firing so enemies scroll off instead of being shot.
-    s = advanceMs(s, 6000, NO_INPUT);
+    s = advanceMs(s, 7000, NO_INPUT);
     expect(s.phase).toBe("WaveClear");
   });
 
@@ -2128,5 +2128,77 @@ describe("#1037 Difficulty tiers", () => {
     expect(base.phase).toBe("WaveClear");
     expect(hard.phase).toBe("WaveClear");
     expect(hard.score).toBeGreaterThanOrEqual(base.score * 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1022 — Challenging Stage cadence (3, 7, 11, 15), 40 enemies, PERFECT bonus
+// ---------------------------------------------------------------------------
+
+describe("#1022 Challenging Stage cadence & PERFECT bonus", () => {
+  it("waves 3, 7, 11, 15 start as ChallengingStage (classic Galaga cadence)", () => {
+    for (const wave of [3, 7, 11, 15]) {
+      const s = initStarSwarm(CANVAS_W, CANVAS_H, wave);
+      expect(s.phase).toBe("ChallengingStage");
+    }
+  });
+
+  it("waves 4, 5, 6, 8, 9, 10 do NOT start as ChallengingStage", () => {
+    for (const wave of [4, 5, 6, 8, 9, 10]) {
+      const s = initStarSwarm(CANVAS_W, CANVAS_H, wave);
+      expect(s.phase).not.toBe("ChallengingStage");
+    }
+  });
+
+  it("ChallengingStage spawns exactly 40 enemies", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
+    expect(s.phase).toBe("ChallengingStage");
+    expect(s.enemies.length).toBe(40);
+  });
+
+  it("challengingPerfect is false at ChallengingStage start", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
+    expect(s.challengingPerfect).toBe(false);
+  });
+
+  it("challengingPerfect is true on WaveClear when all 40 enemies were hit", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
+    // Force all 40 hits and kill every enemy in one tick
+    s = {
+      ...s,
+      challengingHits: 40,
+      enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.phase).toBe("WaveClear");
+    expect(s.challengingPerfect).toBe(true);
+  });
+
+  it("challengingPerfect is false on WaveClear when enemies scroll off without being shot", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
+    // 40 enemies; last one (idx 39) exits at ≈6320ms — advance past with no firing
+    s = advanceMs(s, 7000, NO_INPUT);
+    expect(s.phase).toBe("WaveClear");
+    expect(s.challengingPerfect).toBe(false);
+  });
+
+  it("PERFECT clears add 10,000 pts bonus at Ensign ×1 (plus 40×50 hit bonus)", () => {
+    // Zero-hit path: enemies scroll off — only waveClearBonus (wave 3 × 500 × 1 = 1500)
+    let noPerfect = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
+    noPerfect = advanceMs(noPerfect, 7000, NO_INPUT);
+    expect(noPerfect.phase).toBe("WaveClear");
+
+    // Full-hit path: all 40 hit + perfect → 1500 + 2000 + 10000 = 13500
+    let perfect = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
+    perfect = {
+      ...perfect,
+      challengingHits: 40,
+      enemies: perfect.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })),
+    };
+    perfect = tick(perfect, 16, NO_INPUT);
+    expect(perfect.phase).toBe("WaveClear");
+
+    // Δ = 40 hits × 50 + 10,000 perfect bonus = 12,000
+    expect(perfect.score - noPerfect.score).toBe(40 * 50 + 10_000);
   });
 });

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -73,6 +73,8 @@ const DIVE_INTERVAL_MIN = 900; // floor regardless of wave
 
 const WAVE_CLEAR_PAUSE = 1600; // ms
 const CHALLENGING_CLEAR_PAUSE = 2200; // ms
+const CHALLENGING_ENEMY_COUNT = 40; // classic 40-enemy Challenging Stage (#1022)
+const PERFECT_BONUS = 10_000; // flat bonus for hitting all challenge enemies (#1022)
 
 const SHOOT_INTERVAL_BASE = 2600; // ms base
 const SHOOT_INTERVAL_JITTER = 1400; // ms random addend
@@ -513,8 +515,11 @@ function diveInterval(wave: number, paramScale = 1): number {
   return Math.max(floor, base);
 }
 
+// Classic Galaga cadence: wave 3, then every 4th wave (3, 7, 11, 15 …) (#1022)
 function isChallengingWave(wave: number): boolean {
-  return wave % 3 === 0;
+  if (wave === 3) return true;
+  if (wave < 3) return false;
+  return (wave - 3) % 4 === 0;
 }
 
 // #980: kills needed to trigger a power-up drop (before jitter is applied)
@@ -584,9 +589,8 @@ function buildWaveState(
   let phase: StarSwarmState["phase"];
 
   if (isChallengingWave(wave)) {
-    const total = FORMATION_COLS * 3;
-    enemies = Array.from({ length: total }, (_, i) =>
-      makeChallengeEnemy(i, total, canvasW, canvasH)
+    enemies = Array.from({ length: CHALLENGING_ENEMY_COUNT }, (_, i) =>
+      makeChallengeEnemy(i, CHALLENGING_ENEMY_COUNT, canvasW, canvasH)
     );
     phase = "ChallengingStage";
   } else {
@@ -642,6 +646,7 @@ function buildWaveState(
     pauseStraggler: false,
     bombFlashTimer: 0,
     difficulty,
+    challengingPerfect: false,
   };
 }
 
@@ -1647,11 +1652,14 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
     if (!anyAlive) {
       const sm = difficultyMultiplier(state.difficulty);
       const waveClearBonus = Math.round(state.wave * WAVE_CLEAR_BONUS_BASE * sm);
+      const perfect = state.challengingHits === CHALLENGING_ENEMY_COUNT;
+      const perfectBonus = perfect ? Math.round(PERFECT_BONUS * sm) : 0;
       return {
         ...state,
-        score: state.score + waveClearBonus + Math.round(state.challengingHits * 50 * sm),
+        score: state.score + waveClearBonus + Math.round(state.challengingHits * 50 * sm) + perfectBonus,
         phase: "WaveClear",
         phaseTimer: CHALLENGING_CLEAR_PAUSE,
+        challengingPerfect: perfect,
       };
     }
     return state;

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -1656,7 +1656,8 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
       const perfectBonus = perfect ? Math.round(PERFECT_BONUS * sm) : 0;
       return {
         ...state,
-        score: state.score + waveClearBonus + Math.round(state.challengingHits * 50 * sm) + perfectBonus,
+        score:
+          state.score + waveClearBonus + Math.round(state.challengingHits * 50 * sm) + perfectBonus,
         phase: "WaveClear",
         phaseTimer: CHALLENGING_CLEAR_PAUSE,
         challengingPerfect: perfect,

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -205,6 +205,8 @@ export interface StarSwarmState {
   readonly bombFlashTimer: number;
   /** Active difficulty tier; drives score multiplier and AI param scaling (#1037). */
   readonly difficulty: DifficultyTier;
+  /** True when the player hit all enemies in a Challenging Stage (#1022). */
+  readonly challengingPerfect: boolean;
 }
 
 /** Input snapshot consumed by each `tick` call. */

--- a/frontend/src/hooks/useStarSwarmAudio.ts
+++ b/frontend/src/hooks/useStarSwarmAudio.ts
@@ -17,6 +17,7 @@ export interface SfxVolumes {
   gameover: number;
   challengingstage: number;
   bonuslife: number;
+  perfectbonus: number;
 }
 
 export const DEFAULT_SFX_VOLUMES: SfxVolumes = {
@@ -31,6 +32,7 @@ export const DEFAULT_SFX_VOLUMES: SfxVolumes = {
   gameover: 0.8,
   challengingstage: 0.8,
   bonuslife: 0.9,
+  perfectbonus: 1.0,
 };
 
 // bgMusicActive should be false when the game is over so the track stops.
@@ -50,6 +52,7 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
   const { play: playGameOver } = useSound("starswarm.gameover", v.gameover);
   const { play: playChallengingStage } = useSound("starswarm.challengingstage", v.challengingstage);
   const { play: playBonusLife } = useSound("starswarm.bonuslife", v.bonuslife);
+  const { play: playPerfect } = useSound("blackjack.blackjack", v.perfectbonus);
 
   const playPowerUpCollect = useCallback(
     (type: PowerUpType) => {
@@ -70,5 +73,6 @@ export function useStarSwarmAudio(bgMusicActive: boolean, volumes?: Partial<SfxV
     playGameOver,
     playChallengingStage,
     playBonusLife,
+    playPerfect,
   };
 }

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -18,5 +18,15 @@
   "controls.newGame": "NEW GAME",
   "controls.newGameLabel": "Start a new game",
   "difficulty.selectTitle": "Select Difficulty",
-  "difficulty.start": "Start Game"
+  "difficulty.start": "Start Game",
+  "phase.perfect": "PERFECT!",
+  "leaderboard.title": "Star Swarm — Top Scores",
+  "leaderboard.colRank": "#",
+  "leaderboard.colScore": "Score",
+  "leaderboard.colWave": "Wave",
+  "leaderboard.colDifficulty": "Tier",
+  "leaderboard.colDate": "Date",
+  "leaderboard.empty": "No scores yet — be the first!",
+  "leaderboard.error": "Could not load scores",
+  "leaderboard.retry": "Retry"
 }

--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -1,31 +1,168 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useCallback, useEffect, useState } from "react";
+import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+import { starSwarmApi } from "../game/starswarm/api";
+import type { LeaderboardEntry } from "../game/starswarm/api";
+import { formatDate } from "../utils/formatTimestamp";
 
 export default function LeaderboardScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
-  const { t } = useTranslation("common");
+  const { t } = useTranslation("starswarm");
+
+  const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await starSwarmApi.getLeaderboard();
+      setEntries(data.scores);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    load().finally(() => {
+      if (active) setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [load]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: LeaderboardEntry }) => (
+      <View style={[styles.row, { borderBottomColor: colors.border }]}>
+        <Text style={[styles.colRank, { color: colors.textMuted }]}>{item.rank}</Text>
+        <Text style={[styles.colScore, { color: colors.text }]} numberOfLines={1}>
+          {item.score.toLocaleString()}
+        </Text>
+        <Text style={[styles.colWave, { color: colors.text }]}>{item.wave_reached}</Text>
+        <Text style={[styles.colDifficulty, { color: colors.accent }]} numberOfLines={1}>
+          {item.difficulty_tier}
+        </Text>
+        <Text style={[styles.colDate, { color: colors.textMuted }]}>
+          {formatDate(item.timestamp)}
+        </Text>
+      </View>
+    ),
+    [colors]
+  );
+
+  const header = (
+    <View style={[styles.headerRow, { borderBottomColor: colors.border }]}>
+      <Text style={[styles.colRank, styles.headerCell, { color: colors.textMuted }]}>
+        {t("leaderboard.colRank")}
+      </Text>
+      <Text style={[styles.colScore, styles.headerCell, { color: colors.textMuted }]}>
+        {t("leaderboard.colScore")}
+      </Text>
+      <Text style={[styles.colWave, styles.headerCell, { color: colors.textMuted }]}>
+        {t("leaderboard.colWave")}
+      </Text>
+      <Text style={[styles.colDifficulty, styles.headerCell, { color: colors.textMuted }]}>
+        {t("leaderboard.colDifficulty")}
+      </Text>
+      <Text style={[styles.colDate, styles.headerCell, { color: colors.textMuted }]}>
+        {t("leaderboard.colDate")}
+      </Text>
+    </View>
+  );
+
+  let body: React.ReactNode;
+  if (loading) {
+    body = (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.accent} size="large" accessibilityLabel="Loading" />
+      </View>
+    );
+  } else if (error) {
+    body = (
+      <View style={styles.center}>
+        <Text style={[styles.errorText, { color: colors.error }]}>{t("leaderboard.error")}</Text>
+        <Pressable
+          onPress={() => {
+            setLoading(true);
+            load().finally(() => setLoading(false));
+          }}
+          style={[styles.retryBtn, { borderColor: colors.accent }]}
+          accessibilityRole="button"
+        >
+          <Text style={[styles.retryText, { color: colors.accent }]}>{t("leaderboard.retry")}</Text>
+        </Pressable>
+      </View>
+    );
+  } else {
+    body = (
+      <FlatList
+        data={entries ?? []}
+        keyExtractor={(e) => String(e.rank)}
+        renderItem={renderItem}
+        ListHeaderComponent={header}
+        ListEmptyComponent={
+          <Text style={[styles.empty, { color: colors.textMuted }]}>{t("leaderboard.empty")}</Text>
+        }
+        contentContainerStyle={styles.listContent}
+      />
+    );
+  }
 
   return (
     <View
       style={[
         styles.container,
-        { backgroundColor: colors.background, paddingTop: APP_HEADER_HEIGHT + insets.top },
+        {
+          backgroundColor: colors.background,
+          paddingTop: APP_HEADER_HEIGHT + insets.top,
+          paddingBottom: Math.max(insets.bottom, 16),
+        },
       ]}
     >
-      <AppHeader title={t("nav.ranks")} />
-      <Text style={[styles.icon]}>🏆</Text>
-      <Text style={[styles.subtitle, { color: colors.textMuted }]}>Coming Soon</Text>
+      <AppHeader title={t("leaderboard.title")} />
+      {body}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
-  icon: { fontSize: 48, marginBottom: 16 },
-  subtitle: { fontSize: 16 },
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  errorText: { fontSize: 14, marginBottom: 12, textAlign: "center" },
+  retryBtn: { paddingHorizontal: 20, paddingVertical: 10, borderRadius: 999, borderWidth: 1 },
+  retryText: { fontSize: 13, fontWeight: "700", textTransform: "uppercase", letterSpacing: 0.8 },
+  listContent: { paddingBottom: 32 },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerCell: {
+    fontSize: 10,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 13,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  colRank: { width: 28, fontSize: 12, textAlign: "center" },
+  colScore: { flex: 2, fontSize: 14, fontVariant: ["tabular-nums"], fontWeight: "700" },
+  colWave: { width: 40, fontSize: 13, textAlign: "center" },
+  colDifficulty: { flex: 1, fontSize: 11, fontWeight: "600" },
+  colDate: { width: 72, fontSize: 11, textAlign: "right" },
+  empty: { fontSize: 14, textAlign: "center", paddingVertical: 48, paddingHorizontal: 24 },
 });

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -74,7 +74,8 @@ function formatGameType(raw: string): string {
       return "Yacht";
     case "cascade":
       return "Cascade";
-
+    case "starswarm":
+      return "Star Swarm";
     default:
       return raw;
   }

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -31,6 +31,7 @@ import {
   difficultyMultiplier,
 } from "../game/starswarm/engine";
 import type { GamePhase, PowerUpType, DifficultyTier } from "../game/starswarm/types";
+import { starSwarmApi } from "../game/starswarm/api";
 import { useStarSwarmAudio, DEFAULT_SFX_VOLUMES } from "../hooks/useStarSwarmAudio";
 import type { SfxVolumes } from "../hooks/useStarSwarmAudio";
 
@@ -77,6 +78,7 @@ export default function StarSwarmScreen() {
     playGameOver,
     playChallengingStage,
     playBonusLife,
+    playPerfect,
   } = useStarSwarmAudio(phase !== "GameOver", devVolumes);
 
   const scoreRef = useRef(0);
@@ -98,7 +100,7 @@ export default function StarSwarmScreen() {
   }, []);
 
   const handleGameOver = useCallback(
-    (finalScore: number) => {
+    (finalScore: number, wave: number) => {
       setPhase("GameOver");
       playGameOver();
       hapticPlayerDeath();
@@ -106,9 +108,14 @@ export default function StarSwarmScreen() {
         highScoreRef.current = finalScore;
         setHighScore(finalScore);
       }
+      starSwarmApi.submitScore(finalScore, wave, difficulty).catch(() => {});
     },
-    [playGameOver]
+    [playGameOver, difficulty]
   );
+
+  const handleChallengingPerfect = useCallback(() => {
+    playPerfect();
+  }, [playPerfect]);
 
   const handlePlayerHit = useCallback(() => {
     playPlayerHit();
@@ -193,6 +200,7 @@ export default function StarSwarmScreen() {
               onPowerUpCollect={playPowerUpCollect}
               onExplosion={playExplosion}
               onChallengingStage={playChallengingStage}
+              onChallengingPerfect={handleChallengingPerfect}
               onBonusLife={handleBonusLife}
               isPaused={isPaused}
               width={CANVAS_W}
@@ -378,6 +386,7 @@ export default function StarSwarmScreen() {
                       ["Wave clear", "waveclear"],
                       ["Game over", "gameover"],
                       ["Challenging", "challengingstage"],
+                      ["Perfect bonus", "perfectbonus"],
                     ] as [string, keyof SfxVolumes][]
                   ).map(([label, key]) => (
                     <View key={key} style={styles.devRow}>

--- a/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { render, screen, waitFor } from "@testing-library/react-native";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import LeaderboardScreen from "../LeaderboardScreen";
 
@@ -10,6 +10,18 @@ jest.mock("expo-blur", () => ({
 jest.mock("expo-linear-gradient", () => ({
   LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
+
+const mockGetLeaderboard = jest.fn() as jest.Mock<Promise<{ scores: unknown[] }>>;
+jest.mock("../../game/starswarm/api", () => ({
+  starSwarmApi: {
+    getLeaderboard: () => mockGetLeaderboard(),
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLeaderboard.mockResolvedValue({ scores: [] });
+});
 
 function renderScreen() {
   return render(
@@ -25,8 +37,16 @@ describe("LeaderboardScreen", () => {
     expect(screen.getByRole("header")).toBeTruthy();
   });
 
-  it("renders the coming soon placeholder", () => {
+  it("shows a loading indicator before the API resolves", () => {
+    mockGetLeaderboard.mockImplementation(() => new Promise(() => {}));
     renderScreen();
-    expect(screen.getByText("Coming Soon")).toBeTruthy();
+    expect(screen.getByLabelText("Loading")).toBeTruthy();
+  });
+
+  it("shows empty-state text when there are no scores", async () => {
+    renderScreen();
+    await waitFor(() => {
+      expect(screen.getByText("leaderboard.empty")).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **#1022 Challenging Stage**: classic Galaga cadence (waves 3, 7, 11, 15…); spawns 40 enemies per challenging wave; awards `PERFECT!` banner + 10,000-pt bonus (×difficulty multiplier) when the player hits all 40
- **#1040 Score submission**: `handleGameOver` now calls `starSwarmApi.submitScore(score, wave, difficulty)` fire-and-forget; Star Swarm fully wired into the Leaderboard screen (rank/score/wave/tier/date table) and Profile screen (`formatGameType` returns `"Star Swarm"`)

### Files changed

| File | Change |
|------|--------|
| `engine.ts` | `isChallengingWave` cadence, `CHALLENGING_ENEMY_COUNT=40`, `PERFECT_BONUS=10_000`, `challengingPerfect` state |
| `types.ts` | `challengingPerfect: boolean` field on `StarSwarmState` |
| `GameCanvas.tsx` / `.web.tsx` | `onGameOver(score, wave)`, `onChallengingPerfect`, PERFECT banner render |
| `useStarSwarmAudio.ts` | `playPerfect` (reuses `blackjack.blackjack` fanfare) |
| `StarSwarmScreen.tsx` | `handleGameOver` submits score; `handleChallengingPerfect` plays fanfare; dev mixer row |
| `LeaderboardScreen.tsx` | Full implementation: fetch, loading/error/empty states, rank table |
| `ProfileScreen.tsx` | `"starswarm"` → `"Star Swarm"` in `formatGameType` |
| `starswarm.json` | `phase.perfect` + leaderboard i18n keys |
| `engine.test.ts` | 7 new `#1022` tests; fix off-screen timing comment (24 → 40 enemies) |

## Test plan

- [ ] 135/135 `engine.test.ts` pass
- [ ] Wave 3 shows "CHALLENGING STAGE" banner, 40 enemies fly across
- [ ] Shooting all 40 shows "PERFECT!" banner and `+10,000` is reflected in score
- [ ] Missing enemies: no PERFECT banner, no bonus
- [ ] Game over submits score to backend (`/starswarm/score`)
- [ ] Leaderboard screen loads and shows rank table
- [ ] Profile screen shows "Star Swarm" for `game_type = "starswarm"` entries

Closes #1022, Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)