### PR TITLE
fix(hearts): show "You win!" instead of "You wins!" when player wins

### DIFF
--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} سيطر على الجولة! +26 للآخرين.",
   "hand_end.next": "الجولة التالية",
   "game_over.title": "النهاية",
+  "game_over.you_win": "أنت فزت!",
   "game_over.winner": "{{label}} فاز!",
   "game_over.submit": "أرسل النتيجة",
   "game_over.name_placeholder": "أدخل اسمك",

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} hat den Mond geschossen! +26 für alle anderen.",
   "hand_end.next": "Nächste Runde",
   "game_over.title": "Spielende",
+  "game_over.you_win": "Du gewinnst!",
   "game_over.winner": "{{label}} gewinnt!",
   "game_over.submit": "Punkte senden",
   "game_over.name_placeholder": "Dein Name hier",

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -54,6 +54,7 @@
 
   "game_over.title": "Game Over",
   "game_over.winner": "{{label}} wins!",
+  "game_over.you_win": "You win!",
   "game_over.submit": "Submit Score",
   "game_over.name_placeholder": "Enter your name",
   "game_over.submitting": "Submitting…",

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "¡{{label}} hizo luna! +26 a los demás.",
   "hand_end.next": "Siguiente Mano",
   "game_over.title": "Fin del Juego",
+  "game_over.you_win": "¡Tú ganas!",
   "game_over.winner": "¡{{label}} gana!",
   "game_over.submit": "Enviar puntaje",
   "game_over.name_placeholder": "Escribe tu nombre",

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} a raflé la mise! +26 aux autres.",
   "hand_end.next": "Prochaine manche",
   "game_over.title": "Fin de partie",
+  "game_over.you_win": "Vous gagnez!",
   "game_over.winner": "{{label}} gagne!",
   "game_over.submit": "Envoyer score",
   "game_over.name_placeholder": "Entrez votre nom",

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} לקח את הכל! +26 לכל השאר.",
   "hand_end.next": "יד הבאה",
   "game_over.title": "סיום משחק",
+  "game_over.you_win": "ניצחת!",
   "game_over.winner": "{{label}} ניצח/ה!",
   "game_over.submit": "שלח ניקוד",
   "game_over.name_placeholder": "הכנס את שמך",

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} ने चांद मारा! +26 बाकी सभी को।",
   "hand_end.next": "अगला हाथ",
   "game_over.title": "खेल खत्म",
+  "game_over.you_win": "आप जीते!",
   "game_over.winner": "{{label}} जीता!",
   "game_over.submit": "स्कोर भेजें",
   "game_over.name_placeholder": "अपना नाम लिखें",

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}}が月を射抜いた！他全員に+26点！",
   "hand_end.next": "次の手札",
   "game_over.title": "ゲーム終了",
+  "game_over.you_win": "あなたの勝利！",
   "game_over.winner": "{{label}}の勝利！",
   "game_over.submit": "スコア送信",
   "game_over.name_placeholder": "名前を入力してください",

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}}이(가) 올킬 성공! +26점 추가!",
   "hand_end.next": "다음 라운드",
   "game_over.title": "게임 종료",
+  "game_over.you_win": "내가 승리!",
   "game_over.winner": "{{label}} 승리!",
   "game_over.submit": "점수 제출",
   "game_over.name_placeholder": "이름을 입력하세요",

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} ging voor de volle maan! +26 voor de rest.",
   "hand_end.next": "Volgende Beurt",
   "game_over.title": "Einde Spel",
+  "game_over.you_win": "Jij wint!",
   "game_over.winner": "{{label}} wint!",
   "game_over.submit": "Score indienen",
   "game_over.name_placeholder": "Voer je naam in",

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} fez a limpa! +26 para os outros.",
   "hand_end.next": "Próxima Rodada",
   "game_over.title": "Fim de Jogo",
+  "game_over.you_win": "Você venceu!",
   "game_over.winner": "{{label}} venceu!",
   "game_over.submit": "Enviar Pontos",
   "game_over.name_placeholder": "Digite seu nome",

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}} собрал всё! +26 остальным.",
   "hand_end.next": "Следующий раунд",
   "game_over.title": "Игра окончена",
+  "game_over.you_win": "Вы победили!",
   "game_over.winner": "{{label}} победил!",
   "game_over.submit": "Отправить",
   "game_over.name_placeholder": "Введите имя",

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -38,6 +38,7 @@
   "hand_end.moon": "{{label}}收全红心！其他人+26分。",
   "hand_end.next": "下一局",
   "game_over.title": "游戏结束",
+  "game_over.you_win": "你获胜！",
   "game_over.winner": "{{label}}获胜！",
   "game_over.submit": "提交分数",
   "game_over.name_placeholder": "输入你的名字",

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -513,7 +513,9 @@ export default function HeartsScreen() {
                 {t("game_over.title")}
               </Text>
               <Text style={[styles.winnerText, { color: colors.accent }]}>
-                {t("game_over.winner", { label: playerLabels[gameState.winnerIndex ?? 0] ?? "" })}
+                {gameState.winnerIndex === 0
+                  ? t("game_over.you_win")
+                  : t("game_over.winner", { label: playerLabels[gameState.winnerIndex ?? 0] ?? "" })}
               </Text>
               <HeartsScoreboard
                 playerLabels={playerLabels}

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -515,7 +515,9 @@ export default function HeartsScreen() {
               <Text style={[styles.winnerText, { color: colors.accent }]}>
                 {gameState.winnerIndex === 0
                   ? t("game_over.you_win")
-                  : t("game_over.winner", { label: playerLabels[gameState.winnerIndex ?? 0] ?? "" })}
+                  : t("game_over.winner", {
+                      label: playerLabels[gameState.winnerIndex ?? 0] ?? "",
+                    })}
               </Text>
               <HeartsScoreboard
                 playerLabels={playerLabels}


### PR DESCRIPTION
Adds a dedicated game_over.you_win i18n key used when winnerIndex === 0,
avoiding the verb-agreement error that occurred when the "You" label was
substituted into the third-person "{{label}} wins!" template. The same
fix is applied across all 13 supported locales, correcting equivalent
conjugation issues in German, Spanish, French, Arabic, Russian, and others.

Closes #1067

https://claude.ai/code/session_01SX3QJtiz55yZxZcvDW11aB