### PR TITLE
fix(starswarm): elite dive always fires on entry and shield no longer grants charge laser

### DIFF
--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -711,7 +711,7 @@ function tickPlayer(state: StarSwarmState, dtMs: number, input: StarSwarmInput):
 
   const player: Player = { ...p, x: newX, invincibleTimer, shootCooldown };
 
-  const isSuper = state.activePowerUp !== null;
+  const isSuper = state.activePowerUp?.type === "lightning";
 
   if (shootCooldown === 0 && input.fire) {
     const bullet: Bullet = {
@@ -919,7 +919,7 @@ function tickWiggling(
         pathDuration: duration,
         vel: { x: 0, y: 0 },
         burstShotsLeft: 0,
-        shootTimer: rng() * DIVE_SHOOT_INTERVAL,
+        shootTimer: 0,
       },
       bullet: null,
     };


### PR DESCRIPTION
## Summary

- **#1069** — Set `shootTimer: 0` on Phase-1 dive entry so elite enemies fire immediately instead of waiting up to 1500 ms (which often exceeds the 1800 ms dive duration).
- **#1071** — Change `isSuper` check from `activePowerUp !== null` to `activePowerUp?.type === "lightning"` so the shield is purely defensive and no longer activates the charge laser / 4× damage / faster fire rate.

## Changes

`frontend/src/game/starswarm/engine.ts`
- Line 714: `const isSuper = state.activePowerUp?.type === "lightning";`
- Line 922: `shootTimer: 0,`

## Test plan

- [ ] All 135 existing engine tests pass (`npx jest engine.test.ts`)
- [ ] In-game: Phase-1 elite dives immediately fire a bullet on entry
- [ ] In-game: Shield power-up does NOT grant charge beam or boosted fire rate
- [ ] In-game: Lightning power-up still grants charge beam and boosted fire rate

Closes #1069
Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)