### PR TITLE
fix(starswarm): buddy ship aims at live enemy centroid at fire time (#1070)

### DIFF
--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -1275,8 +1275,15 @@ function tickBuddyShips(state: StarSwarmState, dtMs: number): StarSwarmState {
       const bulletCount =
         BUDDY_BULLET_COUNT_MIN +
         Math.floor(Math.random() * (BUDDY_BULLET_COUNT_MAX - BUDDY_BULLET_COUNT_MIN + 1));
-      const dx = buddy.targetX - pos.x;
-      const dy = buddy.targetY - pos.y;
+      const aliveEnemies = state.enemies.filter((e) => e.isAlive);
+      let aimX = pos.x;
+      let aimY = pos.y + 1;
+      if (aliveEnemies.length > 0) {
+        aimX = aliveEnemies.reduce((s, e) => s + e.x, 0) / aliveEnemies.length;
+        aimY = aliveEnemies.reduce((s, e) => s + e.y, 0) / aliveEnemies.length;
+      }
+      const dx = aimX - pos.x;
+      const dy = aimY - pos.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
       const baseDirX = dist > 1 ? dx / dist : 0;
       const baseDirY = dist > 1 ? dy / dist : 1;


### PR DESCRIPTION
## Summary
- At fire time (`BUDDY_FIRE_AT_T = 0.45`), the buddy ship was aiming using `buddy.targetX/Y`, which is also the Bézier path's p2 control point — so the ship is near that point and `dx/dy ≈ 0`, triggering the straight-down fallback
- Now computes the live centroid of all alive enemies at the moment the burst fires and aims at that instead
- Falls back to straight down only if no enemies remain alive

## Test plan
- [ ] All 144 existing starswarm engine tests pass
- [ ] Play Star Swarm, collect a buddy ship power-up, verify the spread burst fans toward where enemies actually are rather than always shooting straight down
- [ ] Verify edge case: if all enemies are dead when buddy fires, burst still goes straight down (harmless)

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)