### PR TITLE
fix(starswarm): bonus life race condition, slow-mo window, repeating threshold (#1078 #1079)

### DIFF
--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -814,17 +814,11 @@ describe("Dive/circle shooting", () => {
 // ---------------------------------------------------------------------------
 
 describe("Bonus lives", () => {
-  it("awards +1 life when score crosses 30,000", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
-    s = advanceMs(s, 8000); // reach Playing
-    const startLives = s.player.lives;
-    // Inject score just below threshold, then cross it via a kill
-    s = { ...s, score: 29_999 };
-    // Force enemy to be in formation at a known position and kill it with a bullet
+  function killEnemy(s: StarSwarmState, bulletId: number): StarSwarmState {
     const enemy = s.enemies.find((e) => e.isAlive);
-    if (!enemy) throw new Error("no enemy");
+    if (!enemy) throw new Error("no alive enemy");
     const bullet: Bullet = {
-      id: 99999,
+      id: bulletId,
       x: enemy.x,
       y: enemy.y,
       vx: 0,
@@ -834,44 +828,77 @@ describe("Bonus lives", () => {
       height: enemy.height,
       damage: 10,
     };
-    s = { ...s, playerBullets: [bullet] };
-    s = tick(s, 16, NO_INPUT);
+    return tick({ ...s, playerBullets: [bullet] }, 16, NO_INPUT);
+  }
+
+  it("awards +1 life when score crosses the Ensign threshold (30k)", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    s = advanceMs(s, 8000); // reach Playing
+    const startLives = s.player.lives;
+    s = { ...s, score: 29_999 };
+    s = killEnemy(s, 99999);
     expect(s.player.lives).toBe(startLives + 1);
     expect(s.bonusLivesAwarded).toBe(1);
   });
 
-  it("does not re-award bonus life on the same threshold", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+  it("does not re-award bonus life on the same multiple", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     s = { ...s, score: 29_999, bonusLivesAwarded: 0 };
-    const enemy = s.enemies.find((e) => e.isAlive);
-    if (!enemy) throw new Error("no enemy");
-    const bullet: Bullet = {
-      id: 99998,
-      x: enemy.x,
-      y: enemy.y,
-      vx: 0,
-      vy: 0,
-      owner: "player",
-      width: enemy.width,
-      height: enemy.height,
-      damage: 10,
-    };
-    s = tick({ ...s, playerBullets: [bullet] }, 16, NO_INPUT);
+    s = killEnemy(s, 99998);
     const livesAfterFirst = s.player.lives;
-    // Tick again from same score — threshold already crossed, bonusLivesAwarded=1
+    // Tick again from same score — multiple already counted, bonusLivesAwarded=1
     s = tick(s, 16, NO_INPUT);
     expect(s.player.lives).toBe(livesAfterFirst);
   });
 
   it("caps lives at MAX_LIVES (5)", () => {
-    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
     s = advanceMs(s, 8000);
     s = { ...s, score: 29_999, player: { ...s.player, lives: 5 } };
+    s = killEnemy(s, 99997);
+    expect(s.player.lives).toBe(5);
+  });
+
+  // #1079: repeating threshold
+  it("awards a second bonus life at 60k on Ensign", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    s = advanceMs(s, 8000);
+    // Already awarded 1 life at 30k — now cross 60k
+    s = { ...s, score: 59_999, bonusLivesAwarded: 1, player: { ...s.player, lives: 3 } };
+    s = killEnemy(s, 88881);
+    expect(s.player.lives).toBe(4);
+    expect(s.bonusLivesAwarded).toBe(2);
+  });
+
+  it("threshold scales by difficulty: Lieutenant (2×) awards life at 60k not 30k", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Lieutenant");
+    s = advanceMs(s, 8000);
+    // Score crosses 30k — no life yet (threshold is 60k for Lieutenant)
+    s = { ...s, score: 29_999, bonusLivesAwarded: 0 };
+    s = killEnemy(s, 88882);
+    const livesAt30k = s.player.lives;
+    const awardedAt30k = s.bonusLivesAwarded;
+    expect(awardedAt30k).toBe(0); // no life at 30k
+
+    // Now cross 60k
+    s = { ...s, score: 59_999, bonusLivesAwarded: 0 };
+    s = killEnemy(s, 88883);
+    expect(s.bonusLivesAwarded).toBe(1);
+    expect(s.player.lives).toBe(livesAt30k + 1);
+  });
+
+  // #1078: race condition — same-tick lethal hit + threshold crossing
+  it("player survives when bonus life threshold is crossed in the same tick as a lethal hit", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    s = advanceMs(s, 8000);
+    // Player at 1 life, score just below threshold
+    s = { ...s, score: 29_999, player: { ...s.player, lives: 1, invincibleTimer: 0 } };
     const enemy = s.enemies.find((e) => e.isAlive);
-    if (!enemy) throw new Error("no enemy");
-    const bullet: Bullet = {
-      id: 99997,
+    if (!enemy) throw new Error("no alive enemy");
+    // Kill bullet at enemy position
+    const killBullet: Bullet = {
+      id: 77771,
       x: enemy.x,
       y: enemy.y,
       vx: 0,
@@ -881,8 +908,44 @@ describe("Bonus lives", () => {
       height: enemy.height,
       damage: 10,
     };
-    s = tick({ ...s, playerBullets: [bullet] }, 16, NO_INPUT);
-    expect(s.player.lives).toBe(5);
+    // Enemy bullet on top of player (lethal hit same tick)
+    const enemyBullet: Bullet = {
+      id: 77772,
+      x: s.player.x,
+      y: s.player.y,
+      vx: 0,
+      vy: 0,
+      owner: "enemy",
+      width: 8,
+      height: 8,
+      damage: 1,
+    };
+    s = tick({ ...s, playerBullets: [killBullet], enemyBullets: [enemyBullet] }, 16, NO_INPUT);
+    // Bonus life awarded before lethal hit resolves — player should survive
+    expect(s.phase).not.toBe("GameOver");
+    expect(s.player.lives).toBeGreaterThan(0);
+  });
+
+  // #1078: slow-mo timer and invincibility
+  it("sets bonusLifeSlowMoTimer and invincibleTimer after bonus life award", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    s = advanceMs(s, 8000);
+    s = { ...s, score: 29_999 };
+    s = killEnemy(s, 88884);
+    expect(s.bonusLifeSlowMoTimer).toBeGreaterThan(0);
+    expect(s.player.invincibleTimer).toBeGreaterThan(0);
+  });
+
+  it("bonusLifeSlowMoTimer decrements over time and does not go negative", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1, 42, "Ensign");
+    s = advanceMs(s, 8000);
+    s = { ...s, score: 29_999 };
+    s = killEnemy(s, 88885);
+    const timerAfterAward = s.bonusLifeSlowMoTimer;
+    expect(timerAfterAward).toBeGreaterThan(0);
+    // Advance enough to exhaust the timer
+    s = advanceMs(s, 1000);
+    expect(s.bonusLifeSlowMoTimer).toBe(0);
   });
 });
 

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -98,9 +98,12 @@ const MAX_SWAY = 40; // max offset from center in px
 const AIMED_SHOT_WAVE_START = 1;
 const AIMED_SHOT_FRACTION = 0.1; // 10% aimed at wave 1, +5% per wave, cap 60%
 
-// #945 Bonus lives
-const BONUS_LIFE_THRESHOLDS = [30_000, 70_000];
+// #945 Bonus lives (#1078 #1079)
+const BONUS_LIFE_BASE = 30_000;
 const MAX_LIVES = 5;
+const BONUS_LIFE_SLOW_MO_SCALE = 0.35; // #1078: time scale during slow-mo window
+const BONUS_LIFE_SLOW_MO_DURATION = 800; // ms of slow-mo after bonus life
+const BONUS_LIFE_INVINCIBLE_MS = 600; // ms of invincibility after bonus life
 
 // #980: power-up entity
 const POWERUP_W = 24;
@@ -202,6 +205,11 @@ export function difficultyParamScale(tier: DifficultyTier): number {
 /** Human-readable display label for a difficulty tier. */
 export function difficultyLabel(tier: DifficultyTier): string {
   return DIFFICULTY_LABEL[tier];
+}
+
+/** Points per bonus life at the given difficulty (scales with score multiplier). */
+function bonusLifeThreshold(difficulty: DifficultyTier): number {
+  return BONUS_LIFE_BASE * difficultyMultiplier(difficulty);
 }
 const TIER_SIZE: Record<EnemyTier, { w: number; h: number }> = {
   Grunt: { w: 24, h: 24 },
@@ -636,6 +644,7 @@ function buildWaveState(
     formationSwayX: 0,
     formationSwayDir: 1,
     bonusLivesAwarded,
+    bonusLifeSlowMoTimer: 0,
     startingNonBossCount,
     killsSinceLastDrop: 0,
     dropJitterTarget,
@@ -662,14 +671,20 @@ export function tick(state: StarSwarmState, dtMs: number, input: StarSwarmInput)
     return { ...state, phaseTimer: timer };
   }
 
-  let s = tickPlayer(state, dtMs, input);
-  s = tickEnemies(s, dtMs);
-  s = tickBullets(s, dtMs);
-  s = tickPowerUps(s, dtMs);
-  s = tickBuddyShips(s, dtMs);
-  s = tickCollisions(s);
-  s = tickBonusLives(state, s);
-  s = tickExplosions(s, dtMs);
+  // #1078: decrement slow-mo timer with real time; scale all gameplay by BONUS_LIFE_SLOW_MO_SCALE
+  const slowMoActive = state.bonusLifeSlowMoTimer > 0;
+  const bonusLifeSlowMoTimer = Math.max(0, state.bonusLifeSlowMoTimer - dtMs);
+  const scaledDt = slowMoActive ? dtMs * BONUS_LIFE_SLOW_MO_SCALE : dtMs;
+
+  let s: StarSwarmState = { ...state, bonusLifeSlowMoTimer };
+  s = tickPlayer(s, scaledDt, input);
+  s = tickEnemies(s, scaledDt);
+  s = tickBullets(s, scaledDt);
+  s = tickPowerUps(s, scaledDt);
+  s = tickBuddyShips(s, scaledDt);
+  s = tickCollisions(s); // score updated by kills here
+  s = tickBonusLives(state, s); // #1078: after score updated; un-GameOvers if bonus life rescues player
+  s = tickExplosions(s, scaledDt);
   s = checkPhaseTransitions(s);
   return s;
 }
@@ -678,24 +693,33 @@ export function tick(state: StarSwarmState, dtMs: number, input: StarSwarmInput)
 // Bonus lives (#945)
 // ---------------------------------------------------------------------------
 
-function tickBonusLives(prev: StarSwarmState, next: StarSwarmState): StarSwarmState {
-  if (next.phase === "GameOver") return next;
+// #1078 #1079: repeating threshold scaled by difficulty; slow-mo + invincibility on award
+// No early exit on GameOver — if the threshold was just crossed in the same tick the player died,
+// the bonus life is still awarded and GameOver is reverted (race condition fix).
+function tickBonusLives(_prev: StarSwarmState, next: StarSwarmState): StarSwarmState {
+  const threshold = bonusLifeThreshold(next.difficulty);
+  const livesEarnable = Math.floor(next.score / threshold);
+  const livesToAward = Math.max(0, livesEarnable - next.bonusLivesAwarded);
 
-  let { player, bonusLivesAwarded } = next;
+  if (livesToAward === 0 || next.player.lives >= MAX_LIVES) return next;
 
-  for (const [i, threshold] of BONUS_LIFE_THRESHOLDS.entries()) {
-    if (
-      next.score >= threshold &&
-      prev.score < threshold &&
-      bonusLivesAwarded < i + 1 &&
-      player.lives < MAX_LIVES
-    ) {
-      player = { ...player, lives: player.lives + 1 };
-      bonusLivesAwarded++;
-    }
-  }
+  const awarded = Math.min(livesToAward, MAX_LIVES - next.player.lives);
+  const newLives = next.player.lives + awarded;
 
-  return { ...next, player, bonusLivesAwarded };
+  // #1078: if the bonus life rescued the player from a same-tick lethal hit, revert GameOver
+  const phase = next.phase === "GameOver" && newLives > 0 ? "Playing" : next.phase;
+
+  return {
+    ...next,
+    phase,
+    player: {
+      ...next.player,
+      lives: newLives,
+      invincibleTimer: Math.max(next.player.invincibleTimer, BONUS_LIFE_INVINCIBLE_MS),
+    },
+    bonusLivesAwarded: next.bonusLivesAwarded + awarded,
+    bonusLifeSlowMoTimer: BONUS_LIFE_SLOW_MO_DURATION,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -178,8 +178,10 @@ export interface StarSwarmState {
   readonly formationSwayX: number;
   /** Direction the formation is currently travelling: +1 = right, -1 = left. */
   readonly formationSwayDir: 1 | -1;
-  /** How many bonus lives have been awarded so far (prevents re-awarding at same threshold). */
+  /** How many bonus lives have been awarded so far (prevents re-awarding at same multiple). */
   readonly bonusLivesAwarded: number;
+  /** ms remaining for the slow-motion window after a bonus life is awarded (#1078); 0 when inactive. */
+  readonly bonusLifeSlowMoTimer: number;
   /** Non-Boss enemy count at wave start; used for Boss dive eligibility (#978). */
   readonly startingNonBossCount: number;
   /** Enemy kills since last power-up drop (Playing phase only). */


### PR DESCRIPTION
## Summary

- **Race condition fix (#1078):** `tickBonusLives` no longer exits early when `phase === "GameOver"`. If a player's kill crosses the bonus life threshold in the same tick they take a lethal hit, the life is awarded and GameOver is reverted — player survives at 1 life with invincibility frames.
- **Slow-mo window (#1078):** 800 ms at 35% time-scale applied to all gameplay sub-ticks after a bonus life is awarded; starfield scrolls at full speed (updated outside the engine).
- **Invincibility (#1078):** 600 ms `invincibleTimer` granted on bonus life award (reuses existing machinery).
- **Repeating threshold (#1079):** Replaces the fixed `[30_000, 70_000]` array with repeating multiples of `BONUS_LIFE_BASE × difficultyMultiplier`. Harder difficulties scale the threshold proportionally so roughly the same number of kills earns a life at every tier.

## Files changed

| File | What changed |
|---|---|
| `src/game/starswarm/types.ts` | Added `bonusLifeSlowMoTimer: number` to `StarSwarmState` |
| `src/game/starswarm/engine.ts` | New constants; `bonusLifeThreshold()` helper; rewrote `tickBonusLives()`; applied `scaledDt` in `tick()`; added `bonusLifeSlowMoTimer` to initial state |
| `src/game/starswarm/__tests__/engine.test.ts` | Updated 3 existing tests to use Ensign difficulty; added 5 new tests |

## Test plan

- [x] All 140 starswarm engine tests pass
- [x] No new TypeScript errors introduced
- [x] Race condition: player at 1 life, score at 29,999, enemy kill + enemy bullet same tick → survives
- [x] Slow-mo timer set to 800 ms after award, decrements to 0 over time
- [x] Invincibility timer set after award
- [x] Second life at 60k on Ensign; no life at 30k on Lieutenant (2× threshold = 60k)
- [x] Cap at MAX_LIVES (5) preserved

Closes #1078, #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)