### PR TITLE
feat(mahjong): stronger selection feedback — lift, glow, highlight, smart hints (#1075)

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -16,9 +16,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Canvas, Fill, Group, ImageSVG, Rect, useSVG } from "@shopify/react-native-skia";
 import { useTranslation } from "react-i18next";
-import { hasFreePairs, isFreeTile } from "../../game/mahjong/engine";
+import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine";
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
+import {
+  MAHJONG_TILE_FACE_SELECTED,
+  MAHJONG_GLOW_BG,
+} from "../../theme/theme.constants";
 
 // ---------------------------------------------------------------------------
 // Layout constants
@@ -48,6 +52,7 @@ function tileY(row: number, layer: number): number {
 
 const BG = "#1a3a1a";
 const TILE_FACE = "#f5f0e8";
+const TILE_FACE_SELECTED = MAHJONG_TILE_FACE_SELECTED;
 const TILE_FACE_LOCKED = "#d0c8b8";
 const BORDER_NORMAL = "#8b7355";
 const BORDER_SELECTED = "#ffd700";
@@ -290,33 +295,73 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
           const y = tileY(tile.row, tile.layer);
           const isSelected = tile.id === selectedId;
           const isFree = freeTiles.has(tile.id);
-          const borderColor = isSelected
-            ? BORDER_SELECTED
-            : isFree && hasSelection
-              ? BORDER_HINT
-              : BORDER_NORMAL;
-          const faceColor = isFree ? TILE_FACE : TILE_FACE_LOCKED;
           const fw = TILE_W - SIDE_W;
           const fh = TILE_H - SIDE_W;
+
+          // Lift selected tile upward/outward for a "picked up" cue.
+          const liftX = isSelected ? 4 : 0;
+          const liftY = isSelected ? -5 : 0;
+          // 2 px border on selected for visibility at small tile sizes.
+          const borderInset = isSelected ? 2 : 1;
+
+          // Hints only on tiles that actually match the selection.
+          const isHint =
+            isFree && hasSelection && state.selected !== null && tilesMatch(tile, state.selected);
+          const borderColor = isSelected ? BORDER_SELECTED : isHint ? BORDER_HINT : BORDER_NORMAL;
+          const faceColor = isSelected ? TILE_FACE_SELECTED : isFree ? TILE_FACE : TILE_FACE_LOCKED;
 
           return (
             <Group key={tile.id}>
               {/* Drop shadow */}
-              <Rect x={x + SIDE_W + 2} y={y + SIDE_W + 2} width={fw} height={fh} color={SHADOW} />
+              <Rect
+                x={x + SIDE_W + 2 + liftX}
+                y={y + SIDE_W + 2 + liftY}
+                width={fw}
+                height={fh}
+                color={SHADOW}
+              />
+              {/* Gold glow behind selected tile */}
+              {isSelected && (
+                <Rect
+                  x={x + liftX - 3}
+                  y={y + liftY - 3}
+                  width={fw + 6}
+                  height={fh + 6}
+                  color={MAHJONG_GLOW_BG}
+                />
+              )}
               {/* Right 3-D side */}
-              <Rect x={x + fw} y={y + SIDE_W} width={SIDE_W} height={fh} color={SIDE_R} />
+              <Rect
+                x={x + fw + liftX}
+                y={y + SIDE_W + liftY}
+                width={SIDE_W}
+                height={fh}
+                color={SIDE_R}
+              />
               {/* Bottom 3-D side */}
-              <Rect x={x + SIDE_W} y={y + fh} width={fw} height={SIDE_W} color={SIDE_B} />
+              <Rect
+                x={x + SIDE_W + liftX}
+                y={y + fh + liftY}
+                width={fw}
+                height={SIDE_W}
+                color={SIDE_B}
+              />
               {/* Border */}
-              <Rect x={x} y={y} width={fw} height={fh} color={borderColor} />
+              <Rect x={x + liftX} y={y + liftY} width={fw} height={fh} color={borderColor} />
               {/* Face */}
-              <Rect x={x + 1} y={y + 1} width={fw - 2} height={fh - 2} color={faceColor} />
+              <Rect
+                x={x + borderInset + liftX}
+                y={y + borderInset + liftY}
+                width={fw - 2 * borderInset}
+                height={fh - 2 * borderInset}
+                color={faceColor}
+              />
               {/* SVG face art */}
               <TileFaceLayer
                 svg={tileSvgs[tile.faceId - 1] ?? null}
                 suit={tile.suit}
-                x={x + 2}
-                y={y + 2}
+                x={x + 2 + liftX}
+                y={y + 2 + liftY}
                 w={fw - 4}
                 h={fh - 4}
                 opacity={isFree ? 1 : 0.35}

--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -19,10 +19,7 @@ import { useTranslation } from "react-i18next";
 import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine";
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
-import {
-  MAHJONG_TILE_FACE_SELECTED,
-  MAHJONG_GLOW_BG,
-} from "../../theme/theme.constants";
+import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_BG } from "../../theme/theme.constants";
 
 // ---------------------------------------------------------------------------
 // Layout constants

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -13,9 +13,14 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Asset } from "expo-asset";
 import { useTranslation } from "react-i18next";
-import { hasFreePairs, isFreeTile } from "../../game/mahjong/engine";
+import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine";
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
+import {
+  MAHJONG_TILE_FACE_SELECTED,
+  MAHJONG_GLOW_BG,
+  MAHJONG_GLOW_SHADOW,
+} from "../../theme/theme.constants";
 
 // ---------------------------------------------------------------------------
 // Layout constants (mirror GameCanvas.tsx exactly)
@@ -45,6 +50,7 @@ function tileY(row: number, layer: number): number {
 
 const BG = "#1a3a1a";
 const TILE_FACE = "#f5f0e8";
+const TILE_FACE_SELECTED = MAHJONG_TILE_FACE_SELECTED;
 const TILE_FACE_LOCKED = "#d0c8b8";
 const BORDER_NORMAL = "#8b7355";
 const BORDER_SELECTED = "#ffd700";
@@ -112,33 +118,52 @@ function drawBoard(
     const fw = TILE_W - SIDE_W;
     const fh = TILE_H - SIDE_W;
 
-    const borderColor = isSelected
-      ? BORDER_SELECTED
-      : isFree && hasSelection
-        ? BORDER_HINT
-        : BORDER_NORMAL;
-    const faceColor = isFree ? TILE_FACE : TILE_FACE_LOCKED;
+    // Lift selected tile upward/outward for a "picked up" cue.
+    const liftX = isSelected ? 4 : 0;
+    const liftY = isSelected ? -5 : 0;
+    // 2 px border on selected for visibility at small tile sizes.
+    const borderInset = isSelected ? 2 : 1;
+
+    // Hints only on tiles that actually match the selection, not all free tiles.
+    const isHint =
+      isFree && hasSelection && state.selected !== null && tilesMatch(tile, state.selected);
+    const borderColor = isSelected ? BORDER_SELECTED : isHint ? BORDER_HINT : BORDER_NORMAL;
+    const faceColor = isSelected ? TILE_FACE_SELECTED : isFree ? TILE_FACE : TILE_FACE_LOCKED;
     const suitColor = SUIT_COLOR[tile.suit] ?? "#888888";
 
     // Drop shadow
     ctx.fillStyle = "rgba(0,0,0,0.35)";
-    ctx.fillRect(x + SIDE_W + 2, y + SIDE_W + 2, fw, fh);
+    ctx.fillRect(x + SIDE_W + 2 + liftX, y + SIDE_W + 2 + liftY, fw, fh);
 
     // Right 3-D side
     ctx.fillStyle = SIDE_R;
-    ctx.fillRect(x + fw, y + SIDE_W, SIDE_W, fh);
+    ctx.fillRect(x + fw + liftX, y + SIDE_W + liftY, SIDE_W, fh);
 
     // Bottom 3-D side
     ctx.fillStyle = SIDE_B;
-    ctx.fillRect(x + SIDE_W, y + fh, fw, SIDE_W);
+    ctx.fillRect(x + SIDE_W + liftX, y + fh + liftY, fw, SIDE_W);
+
+    // Gold glow behind selected tile — applied to the border rect only.
+    if (isSelected) {
+      ctx.shadowColor = MAHJONG_GLOW_SHADOW;
+      ctx.shadowBlur = 10;
+    }
 
     // Border
     ctx.fillStyle = borderColor;
-    ctx.fillRect(x, y, fw, fh);
+    ctx.fillRect(x + liftX, y + liftY, fw, fh);
+
+    // Clear glow before drawing face so inner fills stay crisp.
+    ctx.shadowBlur = 0;
 
     // Face
     ctx.fillStyle = faceColor;
-    ctx.fillRect(x + 1, y + 1, fw - 2, fh - 2);
+    ctx.fillRect(
+      x + borderInset + liftX,
+      y + borderInset + liftY,
+      fw - 2 * borderInset,
+      fh - 2 * borderInset
+    );
 
     // SVG face art — fall back to suit-color rect while image is loading.
     // SVGs with width="100%" have naturalWidth=0 even when loaded; check for
@@ -146,10 +171,10 @@ function drawBoard(
     const img = tileImages[tile.faceId - 1];
     ctx.globalAlpha = isFree ? 1 : 0.35;
     if (img !== null) {
-      ctx.drawImage(img, x + 2, y + 2, fw - 4, fh - 4);
+      ctx.drawImage(img, x + 2 + liftX, y + 2 + liftY, fw - 4, fh - 4);
     } else {
       ctx.fillStyle = suitColor;
-      ctx.fillRect(x + 8, y + 10, fw - 16, fh - 20);
+      ctx.fillRect(x + 8 + liftX, y + 10 + liftY, fw - 16, fh - 20);
     }
 
     ctx.restore();

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -16,11 +16,7 @@ import { useTranslation } from "react-i18next";
 import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine";
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
-import {
-  MAHJONG_TILE_FACE_SELECTED,
-  MAHJONG_GLOW_BG,
-  MAHJONG_GLOW_SHADOW,
-} from "../../theme/theme.constants";
+import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_SHADOW } from "../../theme/theme.constants";
 
 // ---------------------------------------------------------------------------
 // Layout constants (mirror GameCanvas.tsx exactly)

--- a/frontend/src/theme/theme.constants.ts
+++ b/frontend/src/theme/theme.constants.ts
@@ -33,3 +33,12 @@ export const DEV_SURFACE_SUBTLE = "rgba(255,255,255,0.08)";
 
 /** Slightly more opaque white surface for dev-panel step buttons. */
 export const DEV_SURFACE_DIM = "rgba(255,255,255,0.1)";
+
+/** Mahjong tile face when selected — soft yellow highlight. */
+export const MAHJONG_TILE_FACE_SELECTED = "#fff8c0";
+
+/** Mahjong selected tile glow — subtle gold background. */
+export const MAHJONG_GLOW_BG = "rgba(255,215,0,0.35)";
+
+/** Mahjong selected tile glow — stronger gold shadow effect. */
+export const MAHJONG_GLOW_SHADOW = "rgba(255,215,0,0.7)";


### PR DESCRIPTION
## Summary

- **Lift effect**: selected tile offsets +4px right / -5px up, simulating picking it up off the board
- **Gold glow**: `shadowBlur=10` on web canvas; translucent gold rect (token `MAHJONG_GLOW_BG`) behind tile on native Skia
- **Warm-yellow face**: token `MAHJONG_TILE_FACE_SELECTED` (`#fff8c0`) for selected tile instead of cream
- **2 px border**: inset increases from 1→2 px on selected so the gold border is visible at small tile sizes
- **Smart hints**: cyan hint highlights now only appear on tiles that `tilesMatch()` the selected tile — removes the noisy "all free tiles go cyan" behavior

New color values extracted to `theme.constants.ts` as `MAHJONG_TILE_FACE_SELECTED`, `MAHJONG_GLOW_BG`, and `MAHJONG_GLOW_SHADOW` (design-token policy compliance).

Both `GameCanvas.tsx` (Skia/native) and `GameCanvas.web.tsx` (Canvas 2D/web) updated in sync.

## Test plan

- [ ] All 97 mahjong tests pass
- [ ] Select a tile — immediately obvious (gold glow + lift + yellow face)
- [ ] Only matching tiles get cyan hint, not all free tiles
- [ ] Deselecting (tap same tile) cleanly returns it to normal appearance
- [ ] Works on both web and native renderers

Closes #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)