### PR TITLE
fix(starswarm): auto-pause on app background / tab switch (#1072)

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -60,6 +60,7 @@ interface Props {
   onBonusLife?: () => void;
   onPowerUpCollect?: (type: PowerUpType) => void;
   isPaused?: boolean;
+  onPause?: () => void;
   width: number;
   height: number;
   scale: number;

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -149,6 +149,7 @@ interface Props {
   onChallengingPerfect?: () => void;
   onPowerUpCollect?: (type: PowerUpType) => void;
   isPaused?: boolean;
+  onPause?: () => void;
   width: number;
   height: number;
   scale: number;
@@ -172,6 +173,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       onChallengingPerfect,
       onPowerUpCollect,
       isPaused = false,
+      onPause,
       width,
       height,
       scale,
@@ -207,6 +209,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const onChallengingStageRef = useRef(onChallengingStage);
     const onChallengingPerfectRef = useRef(onChallengingPerfect);
     const onPowerUpCollectRef = useRef(onPowerUpCollect);
+    const onPauseRef = useRef(onPause);
     const prevActivePowerUpRef = useRef<string | null>(null);
     const triggerPowerUpRef = useRef<PowerUpType | null>(null);
     const isPausedRef = useRef(isPaused);
@@ -254,6 +257,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     useEffect(() => {
       onPowerUpCollectRef.current = onPowerUpCollect;
     }, [onPowerUpCollect]);
+    useEffect(() => {
+      onPauseRef.current = onPause;
+    }, [onPause]);
     useEffect(() => {
       onExplosionRef.current = onExplosion;
     }, [onExplosion]);
@@ -798,7 +804,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       }
 
       function handleVisibilityChange() {
-        if (!document.hidden) lastFrameTimeRef.current = 0;
+        if (!document.hidden) {
+          lastFrameTimeRef.current = 0;
+        } else if (stateRef.current.phase === "Playing" && !isPausedRef.current) {
+          onPauseRef.current?.();
+        }
       }
       document.addEventListener("visibilitychange", handleVisibilityChange);
       id = requestAnimationFrame(loop);

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AppState,
+  AppStateStatus,
   LayoutChangeEvent,
   Modal,
   Pressable,
@@ -166,6 +168,15 @@ export default function StarSwarmScreen() {
     setIsPaused(false);
   }, []);
 
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next: AppStateStatus) => {
+      if ((next === "background" || next === "inactive") && phase === "Playing") {
+        handlePause();
+      }
+    });
+    return () => sub.remove();
+  }, [phase, handlePause]);
+
   const dynamicStyles = getStyles(colors);
 
   const scale =
@@ -203,6 +214,7 @@ export default function StarSwarmScreen() {
               onChallengingPerfect={handleChallengingPerfect}
               onBonusLife={handleBonusLife}
               isPaused={isPaused}
+              onPause={handlePause}
               width={CANVAS_W}
               height={CANVAS_H}
               scale={scale}


### PR DESCRIPTION
## Summary

- **Mobile (iOS/Android):** `StarSwarmScreen` adds an `AppState` listener that calls `handlePause()` when the app transitions to `background` or `inactive` while in the `Playing` phase. No-op when paused or in `GameOver`.
- **Web:** Extended the existing `visibilitychange` handler in `GameCanvas.web.tsx` to call `onPause()` when the tab becomes hidden and the game is in `Playing` phase (previously it only reset the frame timestamp on tab restore). The `onPause` prop is now threaded through both `GameCanvas.tsx` and `GameCanvas.web.tsx`.
- The player must tap the existing "Tap to Resume" overlay to resume — they are not auto-resumed on return.

Closes #1072

## Test plan

- [ ] On iOS/Android: background the app during a `Playing` game → pause overlay appears on return; tap to resume works with no frame-delta spike
- [ ] On iOS/Android: backgrounding when already paused or in `GameOver` has no effect
- [ ] On web: switch to another tab during a `Playing` game → pause overlay appears when switching back; tap to resume works
- [ ] Manual pause (tap top zone) still works normally
- [ ] All 149 starswarm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)