### PR TITLE
fix(tap): iOS tap-to-select broken in Klondike Solitaire and FreeCell (#1082)

### DIFF
--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -101,13 +101,16 @@ export function DraggableCard({
       if (success && onTap) runOnJS(onTap)();
     });
 
-  // iOS RNGH 2.30.0 regression: Gesture.Simultaneous prevents the pan from exceeding
-  // minDistance on iOS. Use Race on iOS so the faster recognizer wins cleanly.
-  // Android/web keep Simultaneous to avoid the older iOS pan-pending-blocks-tap quirk.
+  // iOS RNGH 2.30.0: Gesture.Race blocked tap because the native recogniser
+  // kept tap in "possible" while pan was also possible, preventing tap from
+  // ever activating. requireExternalGestureToFail(pan) declares the direction
+  // explicitly — tap waits for pan to fail before it can fire, letting pan run
+  // freely without the recogniser deadlock that bare Simultaneous caused.
   const gesture = draggable
-    ? Platform.OS === "ios"
-      ? Gesture.Race(pan, tap)
-      : Gesture.Simultaneous(pan, tap)
+    ? Gesture.Simultaneous(
+        pan,
+        Platform.OS === "ios" ? tap.requireExternalGestureToFail(pan) : tap
+      )
     : tap;
 
   const beingDragged = dragState !== null && isCardInDragStack(dragState.source, dragSource);

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -107,10 +107,7 @@ export function DraggableCard({
   // explicitly — tap waits for pan to fail before it can fire, letting pan run
   // freely without the recogniser deadlock that bare Simultaneous caused.
   const gesture = draggable
-    ? Gesture.Simultaneous(
-        pan,
-        Platform.OS === "ios" ? tap.requireExternalGestureToFail(pan) : tap
-      )
+    ? Gesture.Simultaneous(pan, Platform.OS === "ios" ? tap.requireExternalGestureToFail(pan) : tap)
     : tap;
 
   const beingDragged = dragState !== null && isCardInDragStack(dragState.source, dragSource);

--- a/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Text } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../../theme/ThemeContext";
+import { DragProvider } from "../DragContext";
+import { DraggableCard } from "../DraggableCard";
+
+const dragCards = [{ suit: "spades" as const, rank: 1, faceDown: false, width: 60, height: 90 }];
+const dragSource = { game: "solitaire" as const, type: "tableau" as const, col: 0, fromIndex: 0 };
+
+function wrap(children: React.ReactNode) {
+  return (
+    <DragProvider>
+      <ThemeProvider>{children}</ThemeProvider>
+    </DragProvider>
+  );
+}
+
+describe("DraggableCard", () => {
+  it("fires onTap when the card is pressed", () => {
+    const onTap = jest.fn();
+    const { getByRole } = render(
+      wrap(
+        <DraggableCard onTap={onTap} dragCards={dragCards} dragSource={dragSource}>
+          <Text accessibilityRole="button">A♠</Text>
+        </DraggableCard>
+      )
+    );
+    fireEvent.press(getByRole("button"));
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onTap when draggable=false and no onTap is provided", () => {
+    // Renders without error when neither drag nor tap handler is configured.
+    const { getByText } = render(
+      wrap(
+        <DraggableCard dragCards={dragCards} dragSource={dragSource} draggable={false}>
+          <Text>A♠</Text>
+        </DraggableCard>
+      )
+    );
+    expect(getByText("A♠")).toBeTruthy();
+  });
+
+  it("does not fire onTap when the card has no onTap prop", () => {
+    const { getByRole } = render(
+      wrap(
+        <DraggableCard dragCards={dragCards} dragSource={dragSource}>
+          <Text accessibilityRole="button">A♠</Text>
+        </DraggableCard>
+      )
+    );
+    // Should not throw when pressed without an onTap handler.
+    expect(() => fireEvent.press(getByRole("button"))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #1082 — on iOS, tapping a face-up card in Klondike Solitaire (and FreeCell) produced no visual selection highlight and no card movement, leaving the board completely non-interactive via tap.
- Root cause: `Gesture.Race(pan, tap)` introduced in #1081 to fix drag kept `Gesture.Tap()` blocked in RNGH's "possible" state while the pan recogniser was also possible. The native iOS recogniser coordination in RNGH 2.30.0 prevented tap from ever activating.
- Fix: replace `Gesture.Race(pan, tap)` (iOS) with `Gesture.Simultaneous(pan, tap.requireExternalGestureToFail(pan))`. The explicit `requireExternalGestureToFail` declaration tells the native iOS recogniser that tap is downstream of pan — tap waits for pan to fail, pan runs freely without the deadlock. Drag (pan) and tap now both work independently.
- Adds `DraggableCard.test.tsx` covering the `onTap` callback and the no-handler render path.

## Test plan

- [ ] On iOS device/simulator: tap a face-up tableau card → card shows selection highlight
- [ ] Tap a second valid target → card moves
- [ ] Tap the same card again → deselects
- [ ] Drag a card → drag still works (pan gesture unaffected)
- [ ] Android and web tap behaviour unchanged
- [ ] `npx jest` → 1996 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)