### PR TITLE
fix(storage): strip transient events and capture raw payload on corrupt load (#1094)

### DIFF
--- a/frontend/src/game/blackjack/__tests__/storage.test.ts
+++ b/frontend/src/game/blackjack/__tests__/storage.test.ts
@@ -55,6 +55,16 @@ describe("blackjack storage", () => {
     expect(await AsyncStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
+  // #1094: rawPayload must be included in the Sentry extra so engineers can
+  // see what the malformed JSON looked like without unfiltering PII fields.
+  it("includes rawPayload in Sentry extra for corrupt payload (#1094)", async () => {
+    const corrupt = "truncated{json";
+    await AsyncStorage.setItem(STORAGE_KEY, corrupt);
+    await loadGame();
+    const call = (Sentry.captureMessage as jest.Mock).mock.calls[0];
+    expect(call[1].extra.rawPayload).toBe(corrupt);
+  });
+
   it("clearGame removes the saved state", async () => {
     await saveGame(newGame());
     await clearGame();

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -21,8 +21,9 @@ export async function saveGame(state: EngineState): Promise<void> {
 }
 
 export async function loadGame(): Promise<EngineState | null> {
+  let raw: string | null = null;
   try {
-    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    raw = await AsyncStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as EngineState;
     // Minimum viability check — only discard if the core fields are missing.
@@ -78,7 +79,7 @@ export async function loadGame(): Promise<EngineState | null> {
     Sentry.captureMessage("blackjack.storage: corrupt game payload, discarding", {
       level: "warning",
       tags: { subsystem: "blackjack.storage", op: "load" },
-      extra: { error: String(e), key: STORAGE_KEY },
+      extra: { error: String(e), key: STORAGE_KEY, rawPayload: raw?.slice(0, 500) },
     });
     await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
     return null;

--- a/frontend/src/game/twenty48/__tests__/storage.test.ts
+++ b/frontend/src/game/twenty48/__tests__/storage.test.ts
@@ -76,6 +76,16 @@ describe("twenty48 storage", () => {
     expect(await AsyncStorage.getItem(GAME_KEY)).toBeNull();
   });
 
+  // #1094: rawPayload must be included in the Sentry extra so engineers can
+  // see what the malformed JSON looked like without unfiltering PII fields.
+  it("includes rawPayload in Sentry extra for corrupt payload (#1094)", async () => {
+    const corrupt = "truncated{json";
+    await AsyncStorage.setItem(GAME_KEY, corrupt);
+    await loadGame();
+    const call = (Sentry.captureMessage as jest.Mock).mock.calls[0];
+    expect(call[1].extra.rawPayload).toBe(corrupt);
+  });
+
   it("returns null when saved data has a different shape", async () => {
     await AsyncStorage.setItem("twenty48_game_v2", JSON.stringify({ foo: "bar" }));
     const loaded = await loadGame();
@@ -91,6 +101,16 @@ describe("twenty48 storage", () => {
     expect(loaded!.scoreDelta).toBe(0);
     expect(loaded!.startedAt).toBeNull();
     expect(loaded!.accumulatedMs).toBe(0);
+  });
+
+  // Events are transient — they must not survive a save/load round-trip so
+  // sounds don't replay and the screen doesn't re-emit stale game events on reload.
+  it("strips transient events on load even if saveGame received them", async () => {
+    const withEvents: Twenty48State = { ...sample, events: ["win2048"] };
+    await saveGame(withEvents);
+    const loaded = await loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.events).toBeUndefined();
   });
 
   it("clearGame removes the saved state", async () => {

--- a/frontend/src/game/twenty48/storage.ts
+++ b/frontend/src/game/twenty48/storage.ts
@@ -32,8 +32,9 @@ export async function saveGame(state: Twenty48State): Promise<void> {
 }
 
 export async function loadGame(): Promise<Twenty48State | null> {
+  let raw: string | null = null;
   try {
-    const raw = await AsyncStorage.getItem(GAME_KEY);
+    raw = await AsyncStorage.getItem(GAME_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Twenty48State;
     // Minimum viability check — only discard if the core fields are missing.
@@ -83,6 +84,10 @@ export async function loadGame(): Promise<Twenty48State | null> {
     // subsequent spawns/merges don't collide with surviving tiles (#698).
     const maxId = parsed.tiles.reduce((m, t) => (t.id > m ? t.id : m), 0);
     seedNextTileId(maxId + 1);
+    // Events are transient (one-shot per move) and must never be replayed on
+    // reload. Strip any that slipped into storage from saves written before
+    // Twenty48Screen stripped them at the call site.
+    parsed.events = undefined;
     return parsed;
   } catch (e) {
     // Corrupt payload: recovery is complete (we remove the bad entry and
@@ -92,7 +97,7 @@ export async function loadGame(): Promise<Twenty48State | null> {
     Sentry.captureMessage("twenty48.storage: corrupt game payload, discarding", {
       level: "warning",
       tags: { subsystem: "twenty48.storage", op: "load" },
-      extra: { error: String(e), key: GAME_KEY },
+      extra: { error: String(e), key: GAME_KEY, rawPayload: raw?.slice(0, 500) },
     });
     // Remove corrupted entry so it doesn't fail on every subsequent load.
     await AsyncStorage.removeItem(GAME_KEY).catch(() => {});

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -206,7 +206,7 @@ export default function Twenty48Screen({ navigation }: Props) {
         return;
       }
       setState(next);
-      saveGame(next);
+      saveGame({ ...next, events: undefined });
       moveCountRef.current += 1;
       syncMarkStarted();
       // Track all-time best tile and first win per session.


### PR DESCRIPTION
## Summary
- `Twenty48Screen.executeMove` now calls `saveGame({ ...next, events: undefined })` — matches the existing blackjack pattern and stops `win2048`/`gameOver` events being replayed as sounds on next app launch
- `twenty48/storage.loadGame` strips `events` before returning, cleaning up any existing prod saves that already have events persisted
- Both `blackjack/storage` and `twenty48/storage` declare `raw` outside the `try` block so the `catch` can include `rawPayload: raw?.slice(0, 500)` in the Sentry extra — unblocks the `error:[Filtered]` diagnostic that's been hiding the exact parse failure shape

## Test plan
- [x] `twenty48 storage — strips transient events on load even if saveGame received them`
- [x] `twenty48 storage — includes rawPayload in Sentry extra for corrupt payload (#1094)`
- [x] `blackjack storage — includes rawPayload in Sentry extra for corrupt payload (#1094)`
- [x] Full suite (1999 tests) passes

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)