### PR TITLE
fix(HomeScreen,httpClient): key props on game cards + cascade localhost guard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "check-i18n": "node scripts/check-i18n-strings.js",
     "process-assets": "python scripts/remove_backgrounds.py",
     "extract-vertices": "python scripts/extract_vertices.py",
-    "bundlesize": "bundlesize"
+    "bundlesize": "bundlesize",
+    "check-build-env": "node scripts/check-build-env.js"
   },
   "jest": {
     "preset": "jest-expo",

--- a/frontend/scripts/check-build-env.js
+++ b/frontend/scripts/check-build-env.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Build-time guard: asserts EXPO_PUBLIC_API_URL is set and non-localhost
+ * for production exports. Run before `expo export` in any CI/CD pipeline
+ * that targets production or staging. See issue #1095.
+ */
+
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function isLocalhost(url) {
+  try {
+    const { hostname } = new URL(url);
+    return LOCALHOST_HOSTNAMES.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+const raw = process.env.EXPO_PUBLIC_API_URL;
+const appEnv = process.env.APP_ENV ?? process.env.NODE_ENV ?? "development";
+const isProduction = appEnv === "production" || appEnv === "staging";
+
+if (!isProduction) {
+  process.exit(0);
+}
+
+const errors = [];
+
+if (!raw) {
+  errors.push("EXPO_PUBLIC_API_URL is not set. Expo bakes this into the bundle at export time.");
+}
+
+if (raw && isLocalhost(raw)) {
+  errors.push(`EXPO_PUBLIC_API_URL resolves to localhost (${raw}). Set it to the production API URL.`);
+}
+
+if (process.env.EXPO_PUBLIC_TEST_HOOKS === "1") {
+  errors.push("EXPO_PUBLIC_TEST_HOOKS=1 is set in a production/staging build. Remove it from Render env vars.");
+}
+
+if (errors.length > 0) {
+  console.error("[check-build-env] Build env validation FAILED:");
+  for (const e of errors) {
+    console.error(`  - ${e}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[check-build-env] OK — EXPO_PUBLIC_API_URL=${raw}, APP_ENV=${appEnv}`);

--- a/frontend/scripts/check-build-env.js
+++ b/frontend/scripts/check-build-env.js
@@ -31,11 +31,15 @@ if (!raw) {
 }
 
 if (raw && isLocalhost(raw)) {
-  errors.push(`EXPO_PUBLIC_API_URL resolves to localhost (${raw}). Set it to the production API URL.`);
+  errors.push(
+    `EXPO_PUBLIC_API_URL resolves to localhost (${raw}). Set it to the production API URL.`
+  );
 }
 
 if (process.env.EXPO_PUBLIC_TEST_HOOKS === "1") {
-  errors.push("EXPO_PUBLIC_TEST_HOOKS=1 is set in a production/staging build. Remove it from Render env vars.");
+  errors.push(
+    "EXPO_PUBLIC_TEST_HOOKS=1 is set in a production/staging build. Remove it from Render env vars."
+  );
 }
 
 if (errors.length > 0) {

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -54,17 +54,24 @@ function resolveBaseUrl(): string {
   if (raw) {
     const resolved = raw.startsWith("http") ? raw : `https://${raw}`;
     const isTestBuild = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
-    if (!__DEV__ && !isTestBuild && isLocalhost(resolved)) {
-      const msg =
-        "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build. " +
-        "This means the env var was set to a local address at bundle time. " +
-        "Set EXPO_PUBLIC_API_URL to the production API URL on the Render service.";
+    if (!__DEV__ && isLocalhost(resolved)) {
+      const msg = isTestBuild
+        ? "EXPO_PUBLIC_TEST_HOOKS=1 is set and EXPO_PUBLIC_API_URL resolves to localhost. " +
+          "If this is a production or staging build, remove EXPO_PUBLIC_TEST_HOOKS from the Render service env vars."
+        : "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build. " +
+          "This means the env var was set to a local address at bundle time. " +
+          "Set EXPO_PUBLIC_API_URL to the production API URL on the Render service.";
       Sentry.captureMessage(msg, {
-        level: "fatal",
-        tags: { subsystem: "httpClient", issue: "localhost-in-prod" },
-        extra: { raw },
+        level: isTestBuild ? "warning" : "fatal",
+        tags: {
+          subsystem: "httpClient",
+          issue: isTestBuild ? "test-hooks-localhost" : "localhost-in-prod",
+        },
+        extra: { raw, isTestBuild },
       });
-      throw new Error(msg);
+      if (!isTestBuild) {
+        throw new Error(msg);
+      }
     }
     return resolved;
   }

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -239,14 +239,18 @@ export default function HomeScreen() {
         ]}
       >
         {numColumns === 1
-          ? games.map((item, index) => renderCard({ item, index }))
+          ? games.map((item, index) => (
+              <React.Fragment key={item.key}>{renderCard({ item, index })}</React.Fragment>
+            ))
           : Array.from({ length: Math.ceil(games.length / numColumns) }, (_, rowIndex) => (
               <View key={rowIndex} style={styles.row}>
                 {games
                   .slice(rowIndex * numColumns, rowIndex * numColumns + numColumns)
-                  .map((item, colIndex) =>
-                    renderCard({ item, index: rowIndex * numColumns + colIndex })
-                  )}
+                  .map((item, colIndex) => (
+                    <React.Fragment key={item.key}>
+                      {renderCard({ item, index: rowIndex * numColumns + colIndex })}
+                    </React.Fragment>
+                  ))}
               </View>
             ))}
       </ScrollView>


### PR DESCRIPTION
## Summary
- **#1096** — Both `.map()` call sites in `HomeScreen.tsx` (single-column and multi-column) now wrap `renderCard()` in `<React.Fragment key={item.key}>`, eliminating the React key-prop warning across iOS and web
- **#1095** — `httpClient.ts` localhost guard extended to fire a Sentry `warning` when `EXPO_PUBLIC_TEST_HOOKS=1` is set alongside a localhost URL, surfacing accidental test-hook leakage at startup rather than per-request
- **#1095** — New `scripts/check-build-env.js` (+ `check-build-env` npm script): build-time validator that exits 1 if `APP_ENV=production|staging` and `EXPO_PUBLIC_API_URL` is missing/localhost or `EXPO_PUBLIC_TEST_HOOKS=1` is set — run before `expo export` in CI

Closes #1095, #1096

## Test plan
- [ ] Navigate to HomeScreen on iOS simulator — no key-prop `console.error` in logs
- [ ] Navigate to HomeScreen on web — no key-prop warning in Chrome console
- [ ] `APP_ENV=production node scripts/check-build-env.js` exits 1 with a clear error when `EXPO_PUBLIC_API_URL` is unset
- [ ] `APP_ENV=production EXPO_PUBLIC_API_URL=https://api.example.com node scripts/check-build-env.js` exits 0
- [ ] `APP_ENV=production EXPO_PUBLIC_TEST_HOOKS=1 EXPO_PUBLIC_API_URL=https://api.example.com node scripts/check-build-env.js` exits 1
- [ ] Sentry event volume for both issues drops to zero after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)