### PR TITLE
Fix FreeCell hint: show destination alongside source

### DIFF
--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -22,6 +22,7 @@ export interface FoundationPileProps {
   readonly pile: readonly Card[];
   readonly suit: Suit;
   readonly selected?: boolean;
+  readonly hintDestination?: boolean;
   readonly onPress?: (suit: Suit) => void;
   readonly dropId?: string;
   readonly onDrop?: DropHandler;
@@ -31,6 +32,7 @@ export default function FoundationPile({
   pile,
   suit,
   selected = false,
+  hintDestination = false,
   onPress,
   dropId,
   onDrop,
@@ -57,6 +59,7 @@ export default function FoundationPile({
             width={CARD_WIDTH}
             height={CARD_HEIGHT}
             highlighted={selected}
+            hintHighlighted={hintDestination}
             onPress={onPress ? () => onPress(suit) : undefined}
             accessibilityLabel={label}
           />
@@ -68,8 +71,8 @@ export default function FoundationPile({
     const pileStyle = [
       styles.empty,
       {
-        borderColor: selected ? colors.accent : colors.border,
-        borderWidth: selected ? 2 : 1,
+        borderColor: hintDestination ? colors.bonus : selected ? colors.accent : colors.border,
+        borderWidth: hintDestination || selected ? 2 : 1,
         backgroundColor: colors.background,
       },
     ];

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -218,6 +218,25 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     [state]
   );
 
+  const hint = state.hint;
+  const hintDestFoundationSuit: string | undefined = (() => {
+    if (!hint) return undefined;
+    if (hint.type === "tableau-to-foundation") {
+      const col = state.tableau[hint.fromCol];
+      return col && col.length > 0 ? col[col.length - 1].suit : undefined;
+    }
+    if (hint.type === "freecell-to-foundation") {
+      return state.freeCells[hint.fromCell]?.suit ?? undefined;
+    }
+    return undefined;
+  })();
+  const hintDestFreeCellIndex: number | undefined =
+    hint?.type === "tableau-to-freecell" ? hint.toCell : undefined;
+  const hintDestTableauCol: number | undefined =
+    hint?.type === "tableau-to-tableau" || hint?.type === "freecell-to-tableau"
+      ? hint.toCol
+      : undefined;
+
   return (
     <DragProvider getLegalDropIds={getLegalDropIds}>
       <DragContainer>
@@ -247,6 +266,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                   (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
                   (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
                 }
+                hintDestination={hintDestFreeCellIndex === i}
                 onPress={handleFreeCellPress}
                 dropId={`freecell-slot-${i}`}
                 onDrop={(source) => handleDropToFreeCell(source, i)}
@@ -258,6 +278,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 pile={state.foundations[suit]}
                 suit={suit}
                 selected={false}
+                hintDestination={hintDestFoundationSuit === suit}
                 onPress={() => handleFoundationPress()}
                 dropId={`freecell-foundation-${suit}`}
                 onDrop={(source) => handleDropToFoundation(source)}
@@ -286,6 +307,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                       : pile.length - 1
                     : undefined
                 }
+                hintDestination={hintDestTableauCol === col}
                 onCardPress={handleTableauCardPress}
                 onEmptyPress={handleTableauEmptyPress}
                 dropId={`freecell-tableau-${col}`}

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -20,6 +20,7 @@ export interface FreeCellSlotProps {
   readonly cellIndex: number;
   readonly selected?: boolean;
   readonly hintSource?: boolean;
+  readonly hintDestination?: boolean;
   readonly onPress?: (cellIndex: number) => void;
   readonly dropId?: string;
   readonly onDrop?: DropHandler;
@@ -30,6 +31,7 @@ export default function FreeCellSlot({
   cellIndex,
   selected = false,
   hintSource = false,
+  hintDestination = false,
   onPress,
   dropId,
   onDrop,
@@ -97,8 +99,8 @@ export default function FreeCellSlot({
   const slotStyle = [
     styles.empty,
     {
-      borderColor: selected ? colors.accent : colors.border,
-      borderWidth: selected ? 2 : 1,
+      borderColor: hintDestination ? colors.bonus : selected ? colors.accent : colors.border,
+      borderWidth: hintDestination || selected ? 2 : 1,
       backgroundColor: colors.background,
     },
   ];

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -19,6 +19,7 @@ export interface TableauColumnProps {
   readonly colIndex: number;
   readonly selectedIndex?: number;
   readonly hintIndex?: number;
+  readonly hintDestination?: boolean;
   readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
   readonly onEmptyPress?: (colIndex: number) => void;
   readonly dropId?: string;
@@ -30,6 +31,7 @@ export default function TableauColumn({
   colIndex,
   selectedIndex,
   hintIndex,
+  hintDestination = false,
   onCardPress,
   onEmptyPress,
   dropId,
@@ -46,7 +48,14 @@ export default function TableauColumn({
     const empty = (
       <Pressable
         onPress={onEmptyPress ? () => onEmptyPress(colIndex) : undefined}
-        style={[styles.empty, { borderColor: colors.border, backgroundColor: colors.background }]}
+        style={[
+          styles.empty,
+          {
+            borderColor: hintDestination ? colors.bonus : colors.border,
+            borderWidth: hintDestination ? 2 : 1,
+            backgroundColor: colors.background,
+          },
+        ]}
         accessibilityRole="button"
         accessibilityLabel={t("pile.tableau.empty", { col: colIndex + 1 })}
       />
@@ -78,6 +87,7 @@ export default function TableauColumn({
   const cards = pile.map((card, cardIndex) => {
     const isSelected = selectedIndex !== undefined && cardIndex >= selectedIndex;
     const isHint = hintIndex !== undefined && cardIndex >= hintIndex;
+    const isHintDest = hintDestination && cardIndex === pile.length - 1;
     const rl = rankLabel(card.rank);
     const suitName = t(`suit.${card.suit}` as const);
     const label = isSelected
@@ -107,7 +117,7 @@ export default function TableauColumn({
           width={CARD_WIDTH}
           height={CARD_HEIGHT}
           highlighted={isSelected}
-          hintHighlighted={isHint}
+          hintHighlighted={isHint || isHintDest}
           accessibilityLabel={label}
         />
       </DraggableCard>

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.hint.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.hint.test.tsx
@@ -23,16 +23,7 @@ const BONUS_COLOR = "#4ade80";
 
 const BASE: FreeCellState = {
   _v: 1,
-  tableau: [
-    [{ suit: "clubs", rank: 2 }],
-    [{ suit: "hearts", rank: 3 }],
-    [],
-    [],
-    [],
-    [],
-    [],
-    [],
-  ],
+  tableau: [[{ suit: "clubs", rank: 2 }], [{ suit: "hearts", rank: 3 }], [], [], [], [], [], []],
   freeCells: [{ suit: "spades", rank: 1 }, null, null, null],
   foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
   undoStack: [],

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.hint.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.hint.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Tests for FreeCell hint destination highlighting (#1109).
+ *
+ * All five move types must highlight BOTH source and destination.
+ * Sources are already covered by existing FreeCellBoard.test.tsx;
+ * these tests focus on destination highlighting.
+ *
+ * Board layout used across most cases:
+ *   Col 0: [2♣]   Col 1: [3♥]   Cols 2–7: empty
+ *   freeCells[0]: A♠   freeCells[1–3]: null
+ *   All foundations empty
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../theme/ThemeContext";
+import FreeCellBoard from "../FreeCellBoard";
+import type { FreeCellState } from "../../../game/freecell/types";
+
+// Dark theme default: colors.bonus === "#4ade80"
+const BONUS_COLOR = "#4ade80";
+
+const BASE: FreeCellState = {
+  _v: 1,
+  tableau: [
+    [{ suit: "clubs", rank: 2 }],
+    [{ suit: "hearts", rank: 3 }],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+  ],
+  freeCells: [{ suit: "spades", rank: 1 }, null, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+function withHint(hint: FreeCellState["hint"]): FreeCellState {
+  return { ...BASE, hint };
+}
+
+function renderBoard(state: FreeCellState) {
+  return render(
+    <ThemeProvider>
+      <FreeCellBoard state={state} onMove={jest.fn()} />
+    </ThemeProvider>
+  );
+}
+
+// ── No hint ──────────────────────────────────────────────────────────────────
+
+describe("hint destination — no hint active", () => {
+  it("empty free cell slots have normal border (not bonus)", () => {
+    const { getByLabelText } = renderBoard(BASE);
+    const slot = getByLabelText("Empty free cell 2");
+    expect(slot).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("empty foundation slots have normal border (not bonus)", () => {
+    const { getByLabelText } = renderBoard(BASE);
+    const foundation = getByLabelText("Empty Spades foundation");
+    expect(foundation).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("empty tableau columns have normal border (not bonus)", () => {
+    const { getByLabelText } = renderBoard(BASE);
+    const col = getByLabelText("Empty tableau column 3");
+    expect(col).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});
+
+// ── tableau-to-freecell ───────────────────────────────────────────────────────
+
+describe("hint destination — tableau-to-freecell", () => {
+  it("destination free cell slot gets bonus border", () => {
+    const state = withHint({ type: "tableau-to-freecell", fromCol: 0, toCell: 1 });
+    const { getByLabelText } = renderBoard(state);
+    // toCell: 1 → "Empty free cell 2" (1-indexed)
+    expect(getByLabelText("Empty free cell 2")).toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("non-destination free cell slots do not get bonus border", () => {
+    const state = withHint({ type: "tableau-to-freecell", fromCol: 0, toCell: 1 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty free cell 3")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+    expect(getByLabelText("Empty free cell 4")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});
+
+// ── tableau-to-foundation ─────────────────────────────────────────────────────
+
+describe("hint destination — tableau-to-foundation", () => {
+  it("destination foundation slot gets bonus border (derived from top card suit)", () => {
+    // Top of col 0 is 2♣ → clubs foundation
+    const state = withHint({ type: "tableau-to-foundation", fromCol: 0 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty Clubs foundation")).toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("non-matching foundations do not get bonus border", () => {
+    const state = withHint({ type: "tableau-to-foundation", fromCol: 0 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty Spades foundation")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+    expect(getByLabelText("Empty Hearts foundation")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});
+
+// ── freecell-to-foundation ────────────────────────────────────────────────────
+
+describe("hint destination — freecell-to-foundation", () => {
+  it("destination foundation slot gets bonus border (derived from freecell card suit)", () => {
+    // freeCells[0] is A♠ → spades foundation
+    const state = withHint({ type: "freecell-to-foundation", fromCell: 0 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty Spades foundation")).toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("non-matching foundations do not get bonus border", () => {
+    const state = withHint({ type: "freecell-to-foundation", fromCell: 0 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty Clubs foundation")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});
+
+// ── freecell-to-tableau ───────────────────────────────────────────────────────
+
+describe("hint destination — freecell-to-tableau", () => {
+  it("destination empty tableau column gets bonus border", () => {
+    // toCol: 2 → "Empty tableau column 3" (1-indexed)
+    const state = withHint({ type: "freecell-to-tableau", fromCell: 0, toCol: 2 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty tableau column 3")).toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+
+  it("non-destination empty columns do not get bonus border", () => {
+    const state = withHint({ type: "freecell-to-tableau", fromCell: 0, toCol: 2 });
+    const { getByLabelText } = renderBoard(state);
+    expect(getByLabelText("Empty tableau column 4")).not.toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});
+
+// ── tableau-to-tableau ────────────────────────────────────────────────────────
+
+describe("hint destination — tableau-to-tableau", () => {
+  it("renders without error when destination column is non-empty", () => {
+    // 2♣ → 3♥ (fromCol 0 → toCol 1)
+    const state = withHint({
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    });
+    expect(() => renderBoard(state)).not.toThrow();
+  });
+
+  it("destination empty column gets bonus border", () => {
+    // K♦ → empty col 3
+    const stateWithKing: FreeCellState = {
+      ...BASE,
+      tableau: [
+        [{ suit: "diamonds", rank: 13 }],
+        [{ suit: "hearts", rank: 3 }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      hint: { type: "tableau-to-tableau", fromCol: 0, fromIndex: 0, toCol: 2 },
+    };
+    const { getByLabelText } = renderBoard(stateWithKing);
+    expect(getByLabelText("Empty tableau column 3")).toHaveStyle({ borderColor: BONUS_COLOR });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1109

The Hint button was only highlighting the card(s) to pick up (source). The destination — foundation pile, free cell slot, or tableau column — received no visual indicator, leaving the player to guess where the card goes.

- Added `hintDestination?: boolean` prop to `FoundationPile`, `FreeCellSlot`, and `TableauColumn`
- `FreeCellBoard` derives the correct target from `state.hint` for all five move types and passes it through
- Destinations render with the same `colors.bonus` (gold) border as source cards

| Move type | Source (existing) | Destination (new) |
|---|---|---|
| `tableau-to-tableau` | source cards gold | top card of dest column gold |
| `tableau-to-freecell` | source cards gold | dest free cell slot gold border |
| `tableau-to-foundation` | source cards gold | dest foundation gold border |
| `freecell-to-tableau` | source card gold | dest column top card / empty slot gold |
| `freecell-to-foundation` | source card gold | dest foundation gold border |

The "No moves left" banner path is unchanged.

## Test plan

- [ ] Tap Hint in a real game — both the card to move and where to put it glow gold
- [ ] All five move types covered above
- [ ] Tapping Hint when no moves remain still shows the "No moves left" banner
- [ ] Gold border disappears after making any move (hint is cleared by engine on each move)
- [ ] New `FreeCellBoard.hint.test.tsx` — 13 tests covering all destination types and the no-hint baseline; all pass

https://claude.ai/code/session_01MA4uqce8HE6SVdjsd5wq2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA4uqce8HE6SVdjsd5wq2b)_