### PR TITLE
feat(freecell): auto-complete when all remaining moves are to foundation (#1113)

### DIFF
--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -16,6 +16,8 @@
 import {
   applyHint,
   applyMove,
+  autoComplete,
+  canAutoComplete,
   createSeededRng,
   dealGame,
   getHintMoves,
@@ -759,5 +761,144 @@ describe("applyHint", () => {
       toCol: 1,
     });
     expect(afterMove.hint).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canAutoComplete
+// ---------------------------------------------------------------------------
+
+describe("canAutoComplete", () => {
+  function fullFoundations(): Foundations {
+    const thirteen = (suit: Suit) =>
+      ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const).map((r) => c(suit, r));
+    return {
+      spades: thirteen("spades"),
+      hearts: thirteen("hearts"),
+      diamonds: thirteen("diamonds"),
+      clubs: thirteen("clubs"),
+    };
+  }
+
+  it("returns false when the game is already complete", () => {
+    const state = mkState({ foundations: fullFoundations(), isComplete: true });
+    expect(canAutoComplete(state)).toBe(false);
+  });
+
+  it("returns true when all remaining cards are directly playable to foundations", () => {
+    // All suits at rank 12 (Queen) in foundations; Kings on tableau top
+    const foundations: Foundations = {
+      spades: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("spades", r)),
+      hearts: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("hearts", r)),
+      diamonds: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("diamonds", r)),
+      clubs: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("clubs", r)),
+    };
+    const state = mkState({
+      foundations,
+      tableau: [
+        [c("spades", 13)],
+        [c("hearts", 13)],
+        [c("diamonds", 13)],
+        [c("clubs", 13)],
+        [], [], [], [],
+      ],
+    });
+    expect(canAutoComplete(state)).toBe(true);
+  });
+
+  it("returns true when freecell cards are the next needed for all foundations", () => {
+    // foundations at rank 12; all four kings are split between freecells and tableau
+    const f12 = (suit: Suit) =>
+      ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((r) => c(suit, r));
+    const foundations: Foundations = {
+      spades: f12("spades"),
+      hearts: f12("hearts"),
+      diamonds: f12("diamonds"),
+      clubs: f12("clubs"),
+    };
+    const state = mkState({
+      foundations,
+      freeCells: [c("spades", 13), c("hearts", 13), null, null],
+      tableau: [[c("diamonds", 13)], [c("clubs", 13)], [], [], [], [], [], []],
+    });
+    expect(canAutoComplete(state)).toBe(true);
+  });
+
+  it("returns false when a card is buried under a card that cannot yet be placed", () => {
+    // foundations empty; 3♠ sits on top of 2♠ — 2♠ needs A♠ first but A♠ is buried
+    const state = mkState({
+      tableau: [
+        [c("spades", 3), c("spades", 2)],  // 2♠ on top but A♠ missing
+        [], [], [], [], [], [], [],
+      ],
+    });
+    expect(canAutoComplete(state)).toBe(false);
+  });
+
+  it("returns false when tableau still needs rearrangement", () => {
+    // Aces buried mid-column
+    const state = mkState({
+      tableau: [
+        [c("hearts", 5), c("spades", 1)],
+        [], [], [], [], [], [], [],
+      ],
+    });
+    expect(canAutoComplete(state)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autoComplete (single step)
+// ---------------------------------------------------------------------------
+
+describe("autoComplete", () => {
+  it("moves a freecell ace to the foundation", () => {
+    const state = mkState({ freeCells: [c("spades", 1), null, null, null] });
+    const next = autoComplete(state);
+    expect(next.foundations.spades).toHaveLength(1);
+    expect(next.foundations.spades[0]).toEqual(c("spades", 1));
+    expect(next.freeCells[0]).toBeNull();
+  });
+
+  it("prefers freecell over tableau when both are playable", () => {
+    const foundations: Foundations = {
+      spades: [c("spades", 1)],
+      hearts: [],
+      diamonds: [],
+      clubs: [],
+    };
+    const state = mkState({
+      foundations,
+      freeCells: [c("spades", 2), null, null, null],
+      tableau: [[c("hearts", 1)], [], [], [], [], [], [], []],
+    });
+    const next = autoComplete(state);
+    expect(next.foundations.spades).toHaveLength(2);
+    expect(next.freeCells[0]).toBeNull();
+  });
+
+  it("moves a tableau card to the foundation when freecells are empty", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], [], []],
+    });
+    const next = autoComplete(state);
+    expect(next.foundations.spades).toHaveLength(1);
+    expect(next.tableau[0]).toHaveLength(0);
+  });
+
+  it("returns the same state when no card can be placed on the foundation", () => {
+    const state = mkState({
+      tableau: [[c("spades", 5)], [], [], [], [], [], [], []],
+    });
+    expect(autoComplete(state)).toBe(state);
+  });
+
+  it("increments moveCount by 1 per step", () => {
+    const state = mkState({
+      tableau: [[c("clubs", 1)], [], [], [], [], [], [], []],
+      moveCount: 7,
+    });
+    const next = autoComplete(state);
+    expect(next.moveCount).toBe(8);
   });
 });

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -788,10 +788,10 @@ describe("canAutoComplete", () => {
   it("returns true when all remaining cards are directly playable to foundations", () => {
     // All suits at rank 12 (Queen) in foundations; Kings on tableau top
     const foundations: Foundations = {
-      spades: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("spades", r)),
-      hearts: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("hearts", r)),
-      diamonds: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("diamonds", r)),
-      clubs: ([1,2,3,4,5,6,7,8,9,10,11,12] as const).map((r) => c("clubs", r)),
+      spades: ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((r) => c("spades", r)),
+      hearts: ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((r) => c("hearts", r)),
+      diamonds: ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((r) => c("diamonds", r)),
+      clubs: ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((r) => c("clubs", r)),
     };
     const state = mkState({
       foundations,
@@ -800,7 +800,10 @@ describe("canAutoComplete", () => {
         [c("hearts", 13)],
         [c("diamonds", 13)],
         [c("clubs", 13)],
-        [], [], [], [],
+        [],
+        [],
+        [],
+        [],
       ],
     });
     expect(canAutoComplete(state)).toBe(true);
@@ -828,8 +831,14 @@ describe("canAutoComplete", () => {
     // foundations empty; 3♠ sits on top of 2♠ — 2♠ needs A♠ first but A♠ is buried
     const state = mkState({
       tableau: [
-        [c("spades", 3), c("spades", 2)],  // 2♠ on top but A♠ missing
-        [], [], [], [], [], [], [],
+        [c("spades", 3), c("spades", 2)], // 2♠ on top but A♠ missing
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
       ],
     });
     expect(canAutoComplete(state)).toBe(false);
@@ -838,10 +847,7 @@ describe("canAutoComplete", () => {
   it("returns false when tableau still needs rearrangement", () => {
     // Aces buried mid-column
     const state = mkState({
-      tableau: [
-        [c("hearts", 5), c("spades", 1)],
-        [], [], [], [], [], [], [],
-      ],
+      tableau: [[c("hearts", 5), c("spades", 1)], [], [], [], [], [], [], []],
     });
     expect(canAutoComplete(state)).toBe(false);
   });

--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -486,6 +486,76 @@ export function applyHint(state: FreeCellState): FreeCellState {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-complete
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when every remaining card can reach the foundation using only
+ * direct foundation plays (no rearrangement). Uses a greedy simulation:
+ * repeatedly move any available top card / free-cell card to the foundation
+ * until no more progress is possible, then check if all 52 cards arrived.
+ */
+export function canAutoComplete(state: FreeCellState): boolean {
+  if (state.isComplete) return false;
+
+  const counts: Record<Suit, number> = {
+    spades: state.foundations.spades.length,
+    hearts: state.foundations.hearts.length,
+    diamonds: state.foundations.diamonds.length,
+    clubs: state.foundations.clubs.length,
+  };
+  const columns: Card[][] = state.tableau.map((col) => [...col]);
+  const cells: (Card | null)[] = [...state.freeCells];
+
+  let moved = true;
+  while (moved) {
+    moved = false;
+    for (let i = 0; i < cells.length; i++) {
+      const card = cells[i];
+      if (card != null && card.rank === counts[card.suit] + 1) {
+        counts[card.suit]++;
+        cells[i] = null;
+        moved = true;
+      }
+    }
+    for (const col of columns) {
+      const card = col[col.length - 1];
+      if (card !== undefined && card.rank === counts[card.suit] + 1) {
+        counts[card.suit]++;
+        col.pop();
+        moved = true;
+      }
+    }
+  }
+
+  return (
+    counts.spades + counts.hearts + counts.diamonds + counts.clubs === DECK_SIZE
+  );
+}
+
+/**
+ * Executes one step of the auto-complete sequence: moves the next available
+ * card to the foundation. Free-cell cards are preferred over tableau cards.
+ * Returns `state` unchanged if no foundation move is currently available.
+ */
+export function autoComplete(state: FreeCellState): FreeCellState {
+  for (let cell = 0; cell < FREE_CELL_COUNT; cell++) {
+    const card = state.freeCells[cell];
+    if (card != null && canStackOnFoundation(card, state.foundations[card.suit])) {
+      return applyMove(state, { type: "freecell-to-foundation", fromCell: cell });
+    }
+  }
+  for (let col = 0; col < TABLEAU_COLUMNS; col++) {
+    const pile = state.tableau[col] ?? [];
+    const card = topOf(pile);
+    if (card !== undefined && canStackOnFoundation(card, state.foundations[card.suit])) {
+      return applyMove(state, { type: "tableau-to-foundation", fromCol: col });
+    }
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
 // Undo
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -528,9 +528,7 @@ export function canAutoComplete(state: FreeCellState): boolean {
     }
   }
 
-  return (
-    counts.spades + counts.hearts + counts.diamonds + counts.clubs === DECK_SIZE
-  );
+  return counts.spades + counts.hearts + counts.diamonds + counts.clubs === DECK_SIZE;
 }
 
 /**

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -23,11 +23,21 @@ import FreeCellBoard from "../components/freecell/FreeCellBoard";
 import { CARD_WIDTH, CARD_HEIGHT } from "../components/freecell/FreeCellSlot";
 import { FreeCellFoundationAnimation } from "../components/freecell/FreeCellFoundationAnimation";
 import { FreeCellGameWinAnimation } from "../components/freecell/FreeCellGameWinAnimation";
-import { dealGame, applyMove, undoMove, applyHint, getHintMoves } from "../game/freecell/engine";
+import {
+  dealGame,
+  applyMove,
+  undoMove,
+  applyHint,
+  getHintMoves,
+  canAutoComplete,
+  autoComplete,
+} from "../game/freecell/engine";
 import type { FreeCellState, Move } from "../game/freecell/types";
 import { clearGame, loadGame, saveGame } from "../game/freecell/storage";
 import { useGameEvents } from "../game/_shared/useGameEvents";
 import { useSound } from "../game/_shared/useSound";
+
+const AUTO_STEP_MS = 120;
 
 // 8 columns × 40px + 7 gaps × 2px
 const TABLEAU_COLS = 8;
@@ -48,6 +58,10 @@ export default function FreeCellScreen() {
 
   const flashOpacity = useRef(new Animated.Value(0)).current;
   const hasLoadedRef = useRef(false);
+  const isMountedRef = useRef(true);
+  const autoCompletingRef = useRef(false);
+  const autoStepTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [autoCompleting, setAutoCompleting] = useState(false);
 
   const [showFoundation, setShowFoundation] = useState(false);
   const [showGameWin, setShowGameWin] = useState(false);
@@ -59,19 +73,52 @@ export default function FreeCellScreen() {
   const { play: playGameWin } = useSound("freecell.gameWin");
   const { play: playInvalidMove } = useSound("freecell.invalidMove");
 
+  const startAutoComplete = useCallback((fromState: FreeCellState) => {
+    if (autoCompletingRef.current) return;
+    if (!canAutoComplete(fromState)) return;
+    autoCompletingRef.current = true;
+    setAutoCompleting(true);
+
+    const step = (current: FreeCellState) => {
+      if (!isMountedRef.current) return;
+      const next = autoComplete(current);
+      if (next === current || next.isComplete) {
+        setState(next === current ? current : next);
+        autoCompletingRef.current = false;
+        setAutoCompleting(false);
+        return;
+      }
+      setState(next);
+      autoStepTimeoutRef.current = setTimeout(() => step(next), AUTO_STEP_MS);
+    };
+
+    autoStepTimeoutRef.current = setTimeout(() => step(fromState), AUTO_STEP_MS);
+  }, []);
+
+  // Track mount status for async safety
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (autoStepTimeoutRef.current !== null) clearTimeout(autoStepTimeoutRef.current);
+    };
+  }, []);
+
   // Mount: resume saved game or deal fresh
   useEffect(() => {
     let alive = true;
     loadGame().then((saved) => {
       if (!alive) return;
       hasLoadedRef.current = true;
-      setState(saved ?? dealGame());
+      const initial = saved ?? dealGame();
+      setState(initial);
       setLoading(false);
+      startAutoComplete(initial);
     });
     return () => {
       alive = false;
     };
-  }, []);
+  }, [startAutoComplete]);
 
   // Persist on every state change once the mount load has resolved
   useEffect(() => {
@@ -114,7 +161,7 @@ export default function FreeCellScreen() {
 
   const handleMove = useCallback(
     (move: Move) => {
-      if (state === null) return;
+      if (state === null || autoCompletingRef.current) return;
       const next = applyMove(state, move);
       if (next === state) {
         flashInvalid();
@@ -122,8 +169,9 @@ export default function FreeCellScreen() {
         return;
       }
       setState(next);
+      startAutoComplete(next);
     },
-    [state, flashInvalid, playInvalidMove]
+    [state, flashInvalid, playInvalidMove, startAutoComplete]
   );
 
   const handleUndo = useCallback(() => {
@@ -150,8 +198,9 @@ export default function FreeCellScreen() {
     setOuterWidth(Math.floor(e.nativeEvent.layout.width));
   }, []);
 
-  const undoDisabled = state === null || state.undoStack.length === 0 || state.isComplete;
-  const hintDisabled = state === null || state.isComplete;
+  const undoDisabled =
+    state === null || state.undoStack.length === 0 || state.isComplete || autoCompleting;
+  const hintDisabled = state === null || state.isComplete || autoCompleting;
   const scale = outerWidth > 0 ? outerWidth / BOARD_WIDTH : 1;
 
   return (


### PR DESCRIPTION
## Summary

- Adds `canAutoComplete` to the FreeCell engine — greedy simulation that checks whether every card in the tableau and free cells can reach the foundations without any rearrangement
- Adds `autoComplete` to advance one card per call (free-cell cards preferred over tableau)
- `FreeCellScreen` runs a 120 ms/step timer loop that triggers automatically after every move and on initial game load; Hint and Undo buttons are disabled while it runs

## How it works

`canAutoComplete` simulates moving top cards and free-cell cards to their foundations in round-robin passes until no more progress is possible, then checks whether the total count reaches 52. `autoComplete` picks the first legal foundation move and delegates to `applyMove`, so the full undo/event/sound pipeline fires normally for each step.

## Test plan

- [ ] Play a game to near-completion; once no more rearrangement is needed, observe the cards animating to foundations automatically
- [ ] Hint and Undo buttons are greyed out while auto-complete is running
- [ ] Auto-complete does NOT trigger mid-game when tableau rearrangement is still required
- [ ] Loading a saved game that is already auto-completable triggers the sequence immediately
- [ ] Navigating away mid-sequence does not cause errors (timer is cleared on unmount)
- [ ] All 2009 engine unit tests pass

Closes #1113

https://claude.ai/code/session_01MA4uqce8HE6SVdjsd5wq2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA4uqce8HE6SVdjsd5wq2b)_