### PR TITLE
fix(DraggableCard): pan-only in GestureDetector, native onPress for tap

### DIFF
--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { Platform } from "react-native";
 import Animated, { useAnimatedRef, measure as rnMeasure } from "react-native-reanimated";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useSharedValue, runOnJS } from "react-native-reanimated";
@@ -93,7 +92,11 @@ export function DraggableCard({
       panActivated.value = false;
     });
 
-  // maxDistance matches pan's minDistance: touch that moves < 8 px is a tap; >= 8 px is a drag.
+  // For non-draggable (face-down) cards, RNGH tap works correctly and is unchanged.
+  // For draggable cards, pan-only in GestureDetector: when pan fails (< 8 px movement),
+  // the touch is released and the native onPress cloned onto the child below handles tap.
+  // This avoids the Simultaneous/requireExternalGestureToFail iOS UIGestureRecognizer
+  // deadlock that kept both tap and drag broken (#1101, #1102).
   const tap = Gesture.Tap()
     .maxDistance(8)
     .onEnd((_e, success) => {
@@ -101,14 +104,7 @@ export function DraggableCard({
       if (success && onTap) runOnJS(onTap)();
     });
 
-  // iOS RNGH 2.30.0: Gesture.Race blocked tap because the native recogniser
-  // kept tap in "possible" while pan was also possible, preventing tap from
-  // ever activating. requireExternalGestureToFail(pan) declares the direction
-  // explicitly — tap waits for pan to fail before it can fire, letting pan run
-  // freely without the recogniser deadlock that bare Simultaneous caused.
-  const gesture = draggable
-    ? Gesture.Simultaneous(pan, Platform.OS === "ios" ? tap.requireExternalGestureToFail(pan) : tap)
-    : tap;
+  const gesture = draggable ? pan : tap;
 
   const beingDragged = dragState !== null && isCardInDragStack(dragState.source, dragSource);
 


### PR DESCRIPTION
Fixes #1101, #1102

## Summary

- Removes the `Gesture.Simultaneous(pan, tap.requireExternalGestureToFail(pan))` iOS-specific composition that held the `UIGestureRecognizer` group in the "possible" state, preventing both drag (`pan.onStart`) and tap (`onTap`) from ever activating
- For **draggable cards**: `GestureDetector` now receives only `pan`. When pan fails (<8 px movement), the touch is released and the native `onPress` already cloned onto the child (line 112) fires `onTap` — no RNGH tap gesture needed on this path
- For **non-draggable (face-down) cards**: RNGH `tap` was never broken; this path is unchanged
- Removes the `Platform` import and all iOS-specific gesture branching — the fix is cross-platform

## How it works

The industry-standard RNGH pattern (also documented in the research that informed these issues) is: **RNGH pan-only + native `onPress` for tap**. `DraggableCard` already cloned `onPress: onTap` onto every child at line 112 — the only blocker was that `GestureDetector` with the `Simultaneous` composition was intercepting the touch before the native `Pressable` could see it.

## Test plan

- [ ] **Unit**: `DraggableCard.test.tsx` — all 3 tests pass (`fireEvent.press` exercises the native `onPress` path that is now the tap route for draggable cards)
- [ ] **iOS device/simulator**: tap a face-up card in Klondike → card should be selected; drag a face-up card → drag overlay should appear and drop should register
- [ ] **iOS device/simulator**: tap a face-down card → flip/no-op should fire (RNGH tap path, unchanged)
- [ ] **Android**: both tap and drag should be unaffected (no platform-specific logic remains)
- [ ] **Web**: same — no platform-specific logic remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)