### PR TITLE
test(DraggableCard): add missing unit tests for tap, double-fire, and drag-hide

### DIFF
--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -11,6 +11,7 @@ type AnyProps = Record<string, any>;
 export interface DraggableCardProps {
   children: React.ReactNode;
   style?: object;
+  testID?: string;
   /** Tap fallback — same behavior as the old onPress. */
   onTap?: () => void;
   /** The card(s) that will be dragged. For a tableau run, pass all cards
@@ -25,6 +26,7 @@ export interface DraggableCardProps {
 export function DraggableCard({
   children,
   style,
+  testID,
   onTap,
   dragCards,
   dragSource,
@@ -112,7 +114,7 @@ export function DraggableCard({
   const innerEl = onTap ? React.cloneElement(child, { onPress: onTap }) : child;
 
   return (
-    <Animated.View ref={viewRef} style={[style, beingDragged && { opacity: 0 }]}>
+    <Animated.View ref={viewRef} testID={testID} style={[style, beingDragged && { opacity: 0 }]}>
       <GestureDetector gesture={gesture}>{innerEl}</GestureDetector>
     </Animated.View>
   );

--- a/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
@@ -7,9 +7,7 @@ import { DragProvider, useDragContext } from "../DragContext";
 import type { DragCard, DragSource } from "../DragContext";
 import { DraggableCard } from "../DraggableCard";
 
-const dragCards: DragCard[] = [
-  { suit: "spades", rank: 1, faceDown: false, width: 60, height: 90 },
-];
+const dragCards: DragCard[] = [{ suit: "spades", rank: 1, faceDown: false, width: 60, height: 90 }];
 const dragSource: DragSource = {
   game: "solitaire",
   type: "tableau",
@@ -26,13 +24,7 @@ function wrap(children: React.ReactNode) {
 }
 
 /** Renders a button that calls startDrag for the given source/cards. */
-function DragTrigger({
-  source,
-  cards,
-}: {
-  source: DragSource;
-  cards: DragCard[];
-}) {
+function DragTrigger({ source, cards }: { source: DragSource; cards: DragCard[] }) {
   const { startDrag } = useDragContext();
   return (
     <Text

--- a/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
@@ -3,11 +3,19 @@ import { Text } from "react-native";
 import { render, fireEvent } from "@testing-library/react-native";
 
 import { ThemeProvider } from "../../../../theme/ThemeContext";
-import { DragProvider } from "../DragContext";
+import { DragProvider, useDragContext } from "../DragContext";
+import type { DragCard, DragSource } from "../DragContext";
 import { DraggableCard } from "../DraggableCard";
 
-const dragCards = [{ suit: "spades" as const, rank: 1, faceDown: false, width: 60, height: 90 }];
-const dragSource = { game: "solitaire" as const, type: "tableau" as const, col: 0, fromIndex: 0 };
+const dragCards: DragCard[] = [
+  { suit: "spades", rank: 1, faceDown: false, width: 60, height: 90 },
+];
+const dragSource: DragSource = {
+  game: "solitaire",
+  type: "tableau",
+  col: 0,
+  fromIndex: 0,
+};
 
 function wrap(children: React.ReactNode) {
   return (
@@ -17,8 +25,28 @@ function wrap(children: React.ReactNode) {
   );
 }
 
+/** Renders a button that calls startDrag for the given source/cards. */
+function DragTrigger({
+  source,
+  cards,
+}: {
+  source: DragSource;
+  cards: DragCard[];
+}) {
+  const { startDrag } = useDragContext();
+  return (
+    <Text
+      accessibilityRole="button"
+      accessibilityLabel="trigger"
+      onPress={() => startDrag(source, cards)}
+    >
+      Trigger
+    </Text>
+  );
+}
+
 describe("DraggableCard", () => {
-  it("fires onTap when the card is pressed", () => {
+  it("fires onTap when a draggable card is pressed", () => {
     const onTap = jest.fn();
     const { getByRole } = render(
       wrap(
@@ -31,8 +59,41 @@ describe("DraggableCard", () => {
     expect(onTap).toHaveBeenCalledTimes(1);
   });
 
+  it("fires onTap exactly once per press — not double-fired via both gesture and onPress", () => {
+    // Regression: the old Simultaneous composition wired onTap to both the RNGH
+    // tap gesture (runOnJS) and the native onPress clone, risking two calls per touch.
+    const onTap = jest.fn();
+    const { getByRole } = render(
+      wrap(
+        <DraggableCard onTap={onTap} dragCards={dragCards} dragSource={dragSource}>
+          <Text accessibilityRole="button">A♠</Text>
+        </DraggableCard>
+      )
+    );
+    fireEvent.press(getByRole("button"));
+    fireEvent.press(getByRole("button"));
+    expect(onTap).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onTap when a non-draggable card is pressed", () => {
+    const onTap = jest.fn();
+    const { getByRole } = render(
+      wrap(
+        <DraggableCard
+          onTap={onTap}
+          dragCards={dragCards}
+          dragSource={dragSource}
+          draggable={false}
+        >
+          <Text accessibilityRole="button">K♦</Text>
+        </DraggableCard>
+      )
+    );
+    fireEvent.press(getByRole("button"));
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+
   it("does not fire onTap when draggable=false and no onTap is provided", () => {
-    // Renders without error when neither drag nor tap handler is configured.
     const { getByText } = render(
       wrap(
         <DraggableCard dragCards={dragCards} dragSource={dragSource} draggable={false}>
@@ -43,7 +104,7 @@ describe("DraggableCard", () => {
     expect(getByText("A♠")).toBeTruthy();
   });
 
-  it("does not fire onTap when the card has no onTap prop", () => {
+  it("does not throw when pressed with no onTap prop", () => {
     const { getByRole } = render(
       wrap(
         <DraggableCard dragCards={dragCards} dragSource={dragSource}>
@@ -51,7 +112,23 @@ describe("DraggableCard", () => {
         </DraggableCard>
       )
     );
-    // Should not throw when pressed without an onTap handler.
     expect(() => fireEvent.press(getByRole("button"))).not.toThrow();
+  });
+
+  it("hides the card (opacity 0) while it is the active drag source", () => {
+    const { getByLabelText, getByTestId } = render(
+      <DragProvider>
+        <ThemeProvider>
+          <DragTrigger source={dragSource} cards={dragCards} />
+          <DraggableCard testID="card" dragCards={dragCards} dragSource={dragSource}>
+            <Text>A♠</Text>
+          </DraggableCard>
+        </ThemeProvider>
+      </DragProvider>
+    );
+
+    expect(getByTestId("card")).not.toHaveStyle({ opacity: 0 });
+    fireEvent.press(getByLabelText("trigger"));
+    expect(getByTestId("card")).toHaveStyle({ opacity: 0 });
   });
 });


### PR DESCRIPTION
Follow-up to #1115 — test commit landed after the merge.

## What's here

- `draggable=false` + `onTap`: face-down card tap was completely untested
- Explicit single-fire assertion: names the double-fire regression that the old `Simultaneous` + `onPress` clone could have triggered (one call from RNGH tap worklet, one from native `onPress`)
- `beingDragged` opacity: first coverage of the `opacity: 0` hiding logic; requires the `testID` prop added to `DraggableCard` in this commit

## Test plan

- [ ] `npx jest src/game/_shared/drag/__tests__/DraggableCard.test.tsx` — 6 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)