### PR TITLE
chore(cascade): split fruitSets to remove react-native from engine graph (#1059)

### DIFF
--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -1,5 +1,5 @@
 import Matter from "matter-js";
-import { FruitDefinition, FruitSet, FruitTier } from "../../theme/fruitSets";
+import { FruitDefinition, FruitSet, FruitTier } from "../../theme/fruitSets.engine";
 import { getVerticesForFruit } from "./fruitVertices";
 
 // Re-export shared types so imports from './engine' resolve correctly on native

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -1,4 +1,4 @@
-import { FruitDefinition, FruitTier } from "../../theme/fruitSets";
+import { FruitDefinition, FruitTier } from "../../theme/fruitSets.engine";
 import type { GameEvent } from "./types";
 
 // --- Canonical physics world dimensions (px) ---

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -1,4 +1,4 @@
-import { FruitSet } from "../../theme/fruitSets";
+import { FruitDefinition, FruitSet, FruitTier } from "../../theme/fruitSets.engine";
 import { getVerticesForFruit } from "./fruitVertices";
 
 // Re-export all shared types and constants so existing imports from './engine' keep working
@@ -226,7 +226,9 @@ export async function createEngine(
 
       if (tier < 10) {
         const nextDef = fruitSet.fruits[(tier + 1) as FruitTier];
-        spawnAt(nextDef, fruitSet.id, midX, midY);
+        if (nextDef !== undefined) {
+          spawnAt(nextDef, fruitSet.id, midX, midY);
+        }
       }
     }
     mergeQueue.length = 0;

--- a/frontend/src/game/cascade/fruitQueue.ts
+++ b/frontend/src/game/cascade/fruitQueue.ts
@@ -1,4 +1,4 @@
-import { FruitTier } from "../../theme/fruitSets";
+import { FruitTier } from "../../theme/fruitSets.engine";
 import { ControlledSpawnSelector } from "./spawnSelector";
 
 export class FruitQueue {

--- a/frontend/src/game/cascade/scoring.ts
+++ b/frontend/src/game/cascade/scoring.ts
@@ -1,4 +1,4 @@
-import { FruitTier } from "../../theme/fruitSets";
+import { FruitTier } from "../../theme/fruitSets.engine";
 
 const WATERMELON_BONUS = 256;
 

--- a/frontend/src/game/cascade/spawnSelector.ts
+++ b/frontend/src/game/cascade/spawnSelector.ts
@@ -1,4 +1,4 @@
-import { FruitTier, MAX_SPAWN_TIER } from "../../theme/fruitSets";
+import { FruitTier, MAX_SPAWN_TIER } from "../../theme/fruitSets.engine";
 
 const SPAWN_TIER_COUNT = MAX_SPAWN_TIER + 1;
 

--- a/frontend/src/theme/fruitSets.engine.ts
+++ b/frontend/src/theme/fruitSets.engine.ts
@@ -1,0 +1,19 @@
+export type FruitTier = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
+export interface FruitDefinition {
+  tier: FruitTier;
+  name: string;
+  nameKey?: string;
+  emoji: string;
+  color: string;
+  radius: number;
+  scoreValue: number;
+}
+
+export interface FruitSet {
+  id: string;
+  label: string;
+  fruits: FruitDefinition[];
+}
+
+export const MAX_SPAWN_TIER: FruitTier = 4;

--- a/frontend/src/theme/fruitSets.ts
+++ b/frontend/src/theme/fruitSets.ts
@@ -1,14 +1,13 @@
 import { ImageSourcePropType } from "react-native";
 
 import { COSMOS_BAKED, COSMOS_ICONS, FRUIT_BAKED, FRUIT_ICONS } from "../game/_shared/images";
+import type { FruitDefinition as FruitDefinitionBase } from "./fruitSets.engine";
 
-export type FruitTier = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+export type { FruitTier } from "./fruitSets.engine";
+export { MAX_SPAWN_TIER } from "./fruitSets.engine";
+import type { FruitTier } from "./fruitSets.engine";
 
-export interface FruitDefinition {
-  tier: FruitTier;
-  name: string;
-  nameKey?: string; // JSON vertex-lookup key when it differs from name.toLowerCase()
-  emoji: string;
+export interface FruitDefinition extends FruitDefinitionBase {
   icon?: ImageSourcePropType;
   /** Pre-baked game canvas PNG — composited, clipped, ready for a single drawImage. */
   bakedIcon?: ImageSourcePropType;
@@ -18,9 +17,6 @@ export interface FruitDefinition {
    * Produced by scripts/bake_sprites.py — do not edit by hand.
    */
   bakedClipR?: number;
-  color: string;
-  radius: number; // physics radius in px — identical across all sets per tier
-  scoreValue: number; // points awarded on merge
 }
 
 export interface FruitSet {
@@ -318,6 +314,3 @@ export const FRUIT_SETS: Record<string, FruitSet> = {
 };
 
 export const DEFAULT_FRUIT_SET = "fruits";
-
-// Max tier that can appear in the drop queue (avoids spawning huge fruits)
-export const MAX_SPAWN_TIER: FruitTier = 4;


### PR DESCRIPTION
## Summary

- Extracts engine-safe types (`FruitTier`, `FruitDefinition`, `FruitSet`, `MAX_SPAWN_TIER`) into new `frontend/src/theme/fruitSets.engine.ts` — zero imports, no react-native
- Updates `fruitSets.ts` to extend `FruitDefinition` with UI-only `icon`/`bakedIcon`/`bakedClipR` fields and re-export the engine primitives
- Redirects all 6 cascade engine files (`engine.ts`, `engine.native.ts`, `engine.shared.ts`, `fruitQueue.ts`, `spawnSelector.ts`, `scoring.ts`) to import from `fruitSets.engine` instead of `fruitSets`
- UI components and test files are unchanged — they continue importing from `fruitSets.ts`

Closes #1059. Part of #894 audit.

## Acceptance verified

- `fruitSets.engine.ts` has zero imports (pure type + const declarations, no react-native transitive chain)
- All cascade engine files import `FruitTier`/`FruitDefinition`/`FruitSet` from `fruitSets.engine` only
- 296 cascade + fruitSets tests pass
- No new TypeScript errors introduced

## Test plan

- [x] `npx jest --testPathPattern="cascade|fruitSets"` — 296 tests pass
- [x] `npx tsc --noEmit` — no new cascade-related errors
- [x] Static import audit: no `react-native` in `fruitSets.engine.ts` or any file it imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)