### PR TITLE
chore(engines): remove globalThis dev test hooks from blackjack / twenty48 / yacht (#1060)

### DIFF
--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -178,22 +178,6 @@ function freshShuffledDeck(deckCount: number = 1): Card[] {
   return deck;
 }
 
-// E2E test hook — exposed only when __DEV__ is true OR EXPO_PUBLIC_TEST_HOOKS
-// is set (production e2e builds). Metro strips `if (__DEV__)` branches from
-// production bundles; the EXPO_PUBLIC_TEST_HOOKS env var opts in explicitly
-// for Playwright/Maestro flows that need deterministic deals against a
-// production-shaped bundle. Call `globalThis.__blackjack_setSeed(n)` before
-// the next `newGame()` (or after) — subsequent reshuffles will draw from
-// the seeded stream too, so the entire session is reproducible.
-const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
-const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
-if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
-  (globalThis as unknown as { __blackjack_setSeed?: (seed: number) => void }).__blackjack_setSeed =
-    (seed: number) => {
-      setRng(createSeededRng(seed));
-    };
-}
-
 /**
  * Draw one card from a deck. Returns the new deck (with one fewer card)
  * and the drawn card. Auto-reshuffles if the deck runs dry mid-draw.

--- a/frontend/src/game/twenty48/engine.ts
+++ b/frontend/src/game/twenty48/engine.ts
@@ -175,17 +175,6 @@ export function createSeededRng(seed: number): RandomSource {
   };
 }
 
-// E2E test hook
-const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
-const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
-if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
-  (globalThis as unknown as { __twenty48_setSeed?: (seed: number) => void }).__twenty48_setSeed = (
-    seed: number
-  ) => {
-    setRng(createSeededRng(seed));
-  };
-}
-
 function spawnTile(board: number[][], idBoard: number[][]): void {
   const empty: Array<[number, number]> = [];
   for (let r = 0; r < SIZE; r++) {

--- a/frontend/src/game/yacht/__tests__/engine.test.ts
+++ b/frontend/src/game/yacht/__tests__/engine.test.ts
@@ -15,7 +15,6 @@ import {
   isInProgress,
   setRng,
   createSeededRng,
-  setDiceOverride,
   Category,
   CATEGORIES,
 } from "../engine";
@@ -828,28 +827,23 @@ describe("score — joker event", () => {
   });
 });
 
-describe("setDiceOverride", () => {
-  it("applies override values to unheld dice on the next roll then clears", () => {
-    setDiceOverride([6, 6, 6, 6, 6]);
+describe("roll opts.dice", () => {
+  it("applies override values to unheld dice", () => {
     const state = newGame();
-    const next = roll(state, [false, false, false, false, false]);
+    const next = roll(state, [false, false, false, false, false], { dice: [6, 6, 6, 6, 6] });
     expect(next.dice).toEqual([6, 6, 6, 6, 6]);
-    // Override consumed — subsequent roll uses RNG (not all-6)
+    // Subsequent roll without opts uses RNG (not all-6)
     setRng(createSeededRng(42));
     const next2 = roll({ ...next, rolls_used: 1 }, [false, false, false, false, false]);
     expect(next2.dice).not.toEqual([6, 6, 6, 6, 6]);
   });
 
   it("respects held dice when applying override", () => {
-    setDiceOverride([1, 1, 1, 1, 1]);
     const base = newGame();
-    // First roll to get a held state
     setRng(createSeededRng(7));
     const after1 = roll(base, [false, false, false, false, false]);
     const die0 = after1.dice[0];
-    // Hold die 0, override rest to 1
-    setDiceOverride([99, 1, 1, 1, 1]);
-    const after2 = roll(after1, [true, false, false, false, false]);
+    const after2 = roll(after1, [true, false, false, false, false], { dice: [99, 1, 1, 1, 1] });
     expect(after2.dice[0]).toBe(die0); // held — unchanged
     expect(after2.dice[1]).toBe(1); // override applied
   });

--- a/frontend/src/game/yacht/engine.ts
+++ b/frontend/src/game/yacht/engine.ts
@@ -90,30 +90,6 @@ export function createSeededRng(seed: number): RandomSource {
   };
 }
 
-// E2E test hook — exposed only when __DEV__ is true OR EXPO_PUBLIC_TEST_HOOKS
-// is set (production e2e builds). Metro strips `if (__DEV__)` branches from
-// production bundles; the EXPO_PUBLIC_TEST_HOOKS env var opts in explicitly
-// for Playwright/Maestro flows that need deterministic dice against a
-// production-shaped bundle. Call `globalThis.__yacht_setSeed(n)` before
-// the next `newGame()` to pin the roll sequence.
-let _diceOverride: number[] | null = null;
-
-export function setDiceOverride(values: number[]): void {
-  _diceOverride = [...values];
-}
-
-const _devHook = typeof __DEV__ !== "undefined" && __DEV__;
-const _testHook = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
-if ((_devHook || _testHook) && typeof globalThis !== "undefined") {
-  (globalThis as unknown as { __yacht_setSeed?: (seed: number) => void }).__yacht_setSeed = (
-    seed: number
-  ) => {
-    setRng(createSeededRng(seed));
-  };
-  (globalThis as unknown as { __yacht_setDice?: (values: number[]) => void }).__yacht_setDice =
-    setDiceOverride;
-}
-
 // ---------------------------------------------------------------------------
 // Pure scoring functions
 // ---------------------------------------------------------------------------
@@ -315,7 +291,11 @@ export function newGame(): GameState {
   });
 }
 
-export function roll(state: GameState, heldInput: readonly boolean[]): GameState {
+export function roll(
+  state: GameState,
+  heldInput: readonly boolean[],
+  opts?: { dice?: number[] }
+): GameState {
   if (state.rolls_used >= 3) throw new Error("No rolls remaining this turn.");
   if (state.game_over) throw new Error("Game is over.");
 
@@ -325,11 +305,9 @@ export function roll(state: GameState, heldInput: readonly boolean[]): GameState
 
   const nextDice = [...state.dice];
   const rolledIndices: number[] = [];
-  const override = _diceOverride;
-  _diceOverride = null;
   for (let i = 0; i < 5; i++) {
     if (!held[i]) {
-      nextDice[i] = override != null ? override[i] : 1 + Math.floor(_rng() * 6);
+      nextDice[i] = opts?.dice != null ? opts.dice[i]! : 1 + Math.floor(_rng() * 6);
       rolledIndices.push(i);
     }
   }


### PR DESCRIPTION
Closes #1060

## Summary
- Removed module-level `globalThis`/`__DEV__`/`EXPO_PUBLIC_TEST_HOOKS` side-effect blocks from `blackjack/engine.ts`, `twenty48/engine.ts`, and `yacht/engine.ts`
- Blackjack and twenty48: no test changes needed — tests already import `setRng`/`createSeededRng` directly from the engine
- Yacht: removed `_diceOverride` module state and `setDiceOverride` export; added `opts?: { dice?: number[] }` parameter to `roll()` so callers inject dice directly with no hidden state
- Yacht tests updated to use `roll(state, held, { dice: [...] })` instead of the old `setDiceOverride` + `roll` two-step

## Test plan
- [x] `frontend` Jest: 325 engine tests pass across blackjack, twenty48, yacht (incl. property tests and storage tests)
- [x] No `globalThis`, `__DEV__`, `_diceOverride`, or `EXPO_PUBLIC_TEST_HOOKS` references remain in any of the three engine files

🤖 Generated with [Claude Code](https://claude.com/claude-code)