### PR TITLE
feat(backend): add is_premium + category to GameType with catalog API (#1049)

### DIFF
--- a/backend/alembic/versions/0014_game_types_premium_cat.py
+++ b/backend/alembic/versions/0014_game_types_premium_cat.py
@@ -24,16 +24,16 @@ depends_on: Union[str, Sequence[str], None] = None
 _PREMIUM_IDS = (1, 4, 7, 8, 10)  # yacht, cascade, hearts, sudoku, starswarm
 
 _CATEGORIES = {
-    1: "dice",    # yacht
+    1: "dice",  # yacht
     2: "puzzle",  # twenty48
-    3: "card",    # blackjack
+    3: "card",  # blackjack
     4: "arcade",  # cascade
-    6: "card",    # solitaire
-    7: "card",    # hearts
+    6: "card",  # solitaire
+    7: "card",  # hearts
     8: "puzzle",  # sudoku
     9: "puzzle",  # mahjong
-    10: "arcade", # starswarm
-    11: "card",   # freecell
+    10: "arcade",  # starswarm
+    11: "card",  # freecell
 }
 
 
@@ -50,14 +50,10 @@ def upgrade() -> None:
     # Explicitly reset existing rows to integer 0/1 — server_default only
     # controls future inserts; existing rows need an explicit UPDATE.
     op.execute("UPDATE game_types SET is_premium = 0")
-    op.execute(
-        f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}"
-    )
+    op.execute(f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}")
 
     for game_id, cat in _CATEGORIES.items():
-        op.execute(
-            f"UPDATE game_types SET category = '{cat}' WHERE id = {game_id}"
-        )
+        op.execute(f"UPDATE game_types SET category = '{cat}' WHERE id = {game_id}")
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0014_game_types_premium_cat.py
+++ b/backend/alembic/versions/0014_game_types_premium_cat.py
@@ -1,0 +1,65 @@
+"""add is_premium + category to game_types (#1049)
+
+Revision ID: 0014_add_is_premium_category_game_types
+Revises: 0013_add_freecell_game_type
+Create Date: 2026-04-30
+
+Adds is_premium (bool, default false) and category (text, default 'other')
+to game_types, then seeds correct values for all existing rows.
+
+Game IDs: 1=yacht 2=twenty48 3=blackjack 4=cascade 6=solitaire
+          7=hearts 8=sudoku 9=mahjong 10=starswarm 11=freecell
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0014_game_types_premium_cat"
+down_revision: Union[str, None] = "0013_add_freecell_game_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_PREMIUM_IDS = (1, 4, 7, 8, 10)  # yacht, cascade, hearts, sudoku, starswarm
+
+_CATEGORIES = {
+    1: "dice",    # yacht
+    2: "puzzle",  # twenty48
+    3: "card",    # blackjack
+    4: "arcade",  # cascade
+    6: "card",    # solitaire
+    7: "card",    # hearts
+    8: "puzzle",  # sudoku
+    9: "puzzle",  # mahjong
+    10: "arcade", # starswarm
+    11: "card",   # freecell
+}
+
+
+def upgrade() -> None:
+    op.add_column(
+        "game_types",
+        sa.Column("is_premium", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "game_types",
+        sa.Column("category", sa.Text(), nullable=False, server_default="other"),
+    )
+
+    # Explicitly reset existing rows to integer 0/1 — server_default only
+    # controls future inserts; existing rows need an explicit UPDATE.
+    op.execute("UPDATE game_types SET is_premium = 0")
+    op.execute(
+        f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}"
+    )
+
+    for game_id, cat in _CATEGORIES.items():
+        op.execute(
+            f"UPDATE game_types SET category = '{cat}' WHERE id = {game_id}"
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("game_types", "category")
+    op.drop_column("game_types", "is_premium")

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -59,6 +59,8 @@ class GameType(Base):
     icon_emoji: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     sort_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
     is_active: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+    is_premium: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+    category: Mapped[str] = mapped_column(Text, nullable=False, server_default="other")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/games/router.py
+++ b/backend/games/router.py
@@ -15,6 +15,7 @@ from . import service
 from .schemas import (
     AppendEventsRequest,
     AppendEventsResponse,
+    CatalogResponse,
     CompleteGameRequest,
     CreateGameRequest,
     CreateGameResponse,
@@ -23,6 +24,8 @@ from .schemas import (
     GameHistoryResponse,
     GameRowResponse,
     GameStateResponse,
+    GameTypeOut,
+    PatchGameTypeRequest,
 )
 
 router = APIRouter()
@@ -39,6 +42,53 @@ def _to_state(game) -> GameStateResponse:
         outcome=game.outcome,
         duration_ms=game.duration_ms,
     )
+
+
+# ---------------------------------------------------------------------------
+# Catalog (#1049) — registered before /{game_id} so literal path wins
+# ---------------------------------------------------------------------------
+
+
+def _gt_to_out(gt) -> GameTypeOut:
+    return GameTypeOut(
+        id=gt.id,
+        name=gt.name,
+        display_name=gt.display_name,
+        icon_emoji=gt.icon_emoji,
+        sort_order=gt.sort_order,
+        is_active=gt.is_active,
+        is_premium=gt.is_premium,
+        category=gt.category,
+    )
+
+
+@router.get("/catalog", response_model=CatalogResponse)
+async def get_catalog() -> CatalogResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        game_types = await service.get_catalog(db)
+    return CatalogResponse(items=[_gt_to_out(gt) for gt in game_types])
+
+
+@router.patch("/catalog/{game_type_id}", response_model=GameTypeOut)
+@limiter.limit("30/minute", key_func=session_key)
+async def patch_game_type(
+    request: Request,
+    game_type_id: int,
+    body: PatchGameTypeRequest,
+) -> GameTypeOut:
+    factory = get_session_factory()
+    async with factory() as db:
+        try:
+            gt = await service.patch_game_type(
+                db,
+                game_type_id=game_type_id,
+                is_premium=body.is_premium,
+                category=body.category,
+            )
+        except service.GameServiceError as e:
+            raise HTTPException(status_code=e.status_code, detail=e.detail)
+    return _gt_to_out(gt)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/games/schemas.py
+++ b/backend/games/schemas.py
@@ -142,3 +142,28 @@ class GameEventResponse(BaseModel):
 
 class GameDetailResponse(GameRowResponse):
     events: list[GameEventResponse] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Catalog (#1049)
+# ---------------------------------------------------------------------------
+
+
+class GameTypeOut(BaseModel):
+    id: int
+    name: str
+    display_name: str
+    icon_emoji: str | None
+    sort_order: int
+    is_active: bool
+    is_premium: bool
+    category: str
+
+
+class CatalogResponse(BaseModel):
+    items: list[GameTypeOut]
+
+
+class PatchGameTypeRequest(BaseModel):
+    is_premium: bool | None = None
+    category: str | None = Field(default=None, min_length=1, max_length=64)

--- a/backend/games/service.py
+++ b/backend/games/service.py
@@ -468,3 +468,41 @@ async def complete_game(
     await session.commit()
     await session.refresh(game)
     return game
+
+
+# ---------------------------------------------------------------------------
+# Catalog (#1049)
+# ---------------------------------------------------------------------------
+
+
+async def get_catalog(session: AsyncSession) -> list[GameType]:
+    return list(
+        (
+            await session.execute(
+                select(GameType).where(GameType.is_active.is_(True)).order_by(GameType.sort_order)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+async def patch_game_type(
+    session: AsyncSession,
+    *,
+    game_type_id: int,
+    is_premium: bool | None,
+    category: str | None,
+) -> GameType:
+    gt = (
+        await session.execute(select(GameType).where(GameType.id == game_type_id))
+    ).scalar_one_or_none()
+    if gt is None:
+        raise GameServiceError(404, "Game type not found.")
+    if is_premium is not None:
+        gt.is_premium = is_premium
+    if category is not None:
+        gt.category = category
+    await session.commit()
+    await session.refresh(gt)
+    return gt

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -27,14 +27,34 @@ def test_catalog_returns_all_active_games(client: TestClient) -> None:
     body = r.json()
     assert "items" in body
     names = {g["name"] for g in body["items"]}
-    assert {"yacht", "blackjack", "cascade", "hearts", "sudoku", "mahjong", "starswarm", "freecell", "solitaire", "twenty48"}.issubset(names)
+    assert {
+        "yacht",
+        "blackjack",
+        "cascade",
+        "hearts",
+        "sudoku",
+        "mahjong",
+        "starswarm",
+        "freecell",
+        "solitaire",
+        "twenty48",
+    }.issubset(names)
 
 
 def test_catalog_fields_present(client: TestClient) -> None:
     r = client.get("/games/catalog")
     assert r.status_code == 200
     item = r.json()["items"][0]
-    for field in ("id", "name", "display_name", "icon_emoji", "sort_order", "is_active", "is_premium", "category"):
+    for field in (
+        "id",
+        "name",
+        "display_name",
+        "icon_emoji",
+        "sort_order",
+        "is_active",
+        "is_premium",
+        "category",
+    ):
         assert field in item, f"missing field: {field}"
 
 

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -1,0 +1,129 @@
+"""Tests for GET /games/catalog and PATCH /games/catalog/{id} (#1049)."""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client() -> Iterator[TestClient]:
+    from main import app
+
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /games/catalog
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_returns_all_active_games(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    names = {g["name"] for g in body["items"]}
+    assert {"yacht", "blackjack", "cascade", "hearts", "sudoku", "mahjong", "starswarm", "freecell", "solitaire", "twenty48"}.issubset(names)
+
+
+def test_catalog_fields_present(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+    item = r.json()["items"][0]
+    for field in ("id", "name", "display_name", "icon_emoji", "sort_order", "is_active", "is_premium", "category"):
+        assert field in item, f"missing field: {field}"
+
+
+def test_catalog_premium_flags(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+    by_name = {g["name"]: g for g in r.json()["items"]}
+    for premium in ("cascade", "hearts", "sudoku", "starswarm", "yacht"):
+        assert by_name[premium]["is_premium"] is True, f"{premium} should be premium"
+    for free in ("blackjack", "solitaire", "freecell", "mahjong", "twenty48"):
+        assert by_name[free]["is_premium"] is False, f"{free} should be free"
+
+
+def test_catalog_categories(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+    by_name = {g["name"]: g for g in r.json()["items"]}
+    assert by_name["yacht"]["category"] == "dice"
+    assert by_name["blackjack"]["category"] == "card"
+    assert by_name["cascade"]["category"] == "arcade"
+    assert by_name["sudoku"]["category"] == "puzzle"
+
+
+def test_catalog_no_session_required(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# PATCH /games/catalog/{id}
+# ---------------------------------------------------------------------------
+
+
+def _get_game_id(client: TestClient, name: str) -> int:
+    items = client.get("/games/catalog").json()["items"]
+    return next(g["id"] for g in items if g["name"] == name)
+
+
+def test_patch_game_type_is_premium(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    r = client.patch(
+        f"/games/catalog/{gid}",
+        json={"is_premium": True},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+    assert r.status_code == 200
+    assert r.json()["is_premium"] is True
+
+    # restore
+    client.patch(
+        f"/games/catalog/{gid}",
+        json={"is_premium": False},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+
+
+def test_patch_game_type_category(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    r = client.patch(
+        f"/games/catalog/{gid}",
+        json={"category": "strategy"},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+    assert r.status_code == 200
+    assert r.json()["category"] == "strategy"
+
+    # restore
+    client.patch(
+        f"/games/catalog/{gid}",
+        json={"category": "card"},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+
+
+def test_patch_game_type_not_found(client: TestClient) -> None:
+    r = client.patch(
+        "/games/catalog/9999",
+        json={"is_premium": True},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+    assert r.status_code == 404
+
+
+def test_patch_game_type_no_op(client: TestClient) -> None:
+    gid = _get_game_id(client, "yacht")
+    r = client.patch(
+        f"/games/catalog/{gid}",
+        json={},
+        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "yacht"

--- a/backend/tests/test_db_connection.py
+++ b/backend/tests/test_db_connection.py
@@ -38,4 +38,4 @@ async def test_alembic_head_applied() -> None:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         version = result.scalar()
         # Latest head — bump when a new migration lands.
-        assert version == "0013_add_freecell_game_type"
+        assert version == "0014_game_types_premium_cat"


### PR DESCRIPTION
Closes #1049

## Summary
- Adds `is_premium` (bool) and `category` (text) fields to `game_types` via Alembic migration `0014`
- Seeds premium flags (cascade, hearts, sudoku, starswarm, yacht) and categories (card/puzzle/arcade/dice) for all existing games
- `GET /games/catalog` — public, no session required; returns all active game types ordered by sort_order
- `PATCH /games/catalog/{id}` — internal admin endpoint; can flip `is_premium` or update `category` without a migration
- `category` is plain text intentionally — new categories need no schema change

## Test plan
- [x] `pytest` passes — 337 passed, 0 failed, 80.85% coverage
- [x] `test_catalog_premium_flags` verifies correct premium seed (yacht/cascade/hearts/sudoku/starswarm = premium, rest free)
- [x] `test_catalog_categories` verifies category seed values
- [x] `test_patch_game_type_is_premium` / `test_patch_game_type_category` verify live updates
- [x] Migration invariant check passes (revision ID ≤ 32 chars: `0014_game_types_premium_cat` = 27 chars)
- [x] `test_db_connection.py` bumped to new head

🤖 Generated with [Claude Code](https://claude.com/claude-code)