### PR TITLE
feat(infra): provision bc-arcade prod Render services (#505)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,16 +13,16 @@ jobs:
     needs: ci
     uses: wcmchenry3-stack/.github/.github/workflows/called-deploy-render.yml@main
     with:
-      service-name: "gaming-app-api"
-      service-id: "srv-d6vk8c9r0fns73cbbfug"
-      zap-target-url: "https://dev-games-api.buffingchi.com"
+      service-name: "bc-arcade-api"
+      service-id: ${{ secrets.RENDER_PROD_API_SERVICE_ID }}
+      zap-target-url: "https://games-api.buffingchi.com"
     secrets: inherit
 
   deploy-frontend:
     needs: ci
     uses: wcmchenry3-stack/.github/.github/workflows/called-deploy-render.yml@main
     with:
-      service-name: "gaming-app-frontend"
-      service-id: "srv-d6vkanhr0fns73cbcol0"
-      zap-target-url: "https://dev-games.buffingchi.com"
+      service-name: "bc-arcade-frontend"
+      service-id: ${{ secrets.RENDER_PROD_FRONTEND_SERVICE_ID }}
+      zap-target-url: "https://games.buffingchi.com"
     secrets: inherit

--- a/render.yaml
+++ b/render.yaml
@@ -1,8 +1,69 @@
+databases:
+  # --- BC Arcade Postgres (prod) ---
+  # Managed by render.yaml; do not manually edit in the dashboard.
+  # New services reference this via fromDatabase.
+  - name: bc-arcade-db
+    databaseName: bc_arcade
+    user: bc_arcade_user
+    region: oregon
+    plan: basic_256mb
+    version: "18"
+    ipAllowList: []
+
 services:
+  # --- BC Arcade FastAPI backend (prod) ---
+  - type: web
+    name: bc-arcade-api
+    runtime: python
+    branch: main
+    rootDir: backend
+    autoDeploy: true
+    buildCommand: pip install -r requirements.txt
+    startCommand: alembic upgrade head && uvicorn main:app --host 0.0.0.0 --port $PORT --timeout-keep-alive 5 --limit-max-requests 10000
+    healthCheckPath: /health
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.0
+      - key: ALLOWED_ORIGINS
+        value: "https://games.buffingchi.com,https://games-api.buffingchi.com"
+      - key: DATABASE_URL
+        fromDatabase:
+          name: bc-arcade-db
+          property: connectionString
+      - key: SENTRY_DSN
+        sync: false
+
+  # --- BC Arcade Expo Web static frontend (prod) ---
+  - type: web
+    name: bc-arcade-frontend
+    runtime: static
+    branch: main
+    rootDir: frontend
+    autoDeploy: true
+    buildCommand: npm ci && node scripts/fetch-render-env.js && npx expo export --platform web
+    staticPublishPath: dist
+    envVars:
+      - key: EXPO_PUBLIC_API_URL
+        value: "https://games-api.buffingchi.com"
+      - key: EXPO_PUBLIC_SENTRY_DSN
+        sync: false
+      - key: SKIP_SKIA_DOWNLOAD
+        value: "1"
+    headers:
+      - path: /*
+        name: Content-Security-Policy
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://games-api.buffingchi.com https://games.buffingchi.com; img-src 'self' data: blob:; font-src 'self' data:; frame-ancestors 'none'"
+      - path: /*
+        name: X-Content-Type-Options
+        value: nosniff
+      - path: /*
+        name: X-Frame-Options
+        value: DENY
+      - path: /*
+        name: Referrer-Policy
+        value: strict-origin-when-cross-origin
+
   # --- Python FastAPI backend (dev environment) ---
-  # The -dev suffix is explicit: this service tracks the `dev` branch.
-  # A future prod environment should be a separate service (e.g.
-  # `gaming-app-api`) pinned to `main`, with its own Postgres.
   - type: web
     name: gaming-app-api-dev
     runtime: python


### PR DESCRIPTION
## Summary
- Adds `bc-arcade-db` (Postgres 18, basic_256mb) to `render.yaml` — managed by blueprint, `DATABASE_URL` injected via `fromDatabase`
- Adds `bc-arcade-api` web service tracking `main` with correct `ALLOWED_ORIGINS`, `alembic upgrade head` in startCommand, and prod SENTRY_DSN placeholder
- Adds `bc-arcade-frontend` static site tracking `main` with prod `EXPO_PUBLIC_API_URL` and CSP headers pointing at `games-api/games.buffingchi.com`
- Updates `deploy.yml` to use `bc-arcade-*` service names, `RENDER_PROD_*_SERVICE_ID` secrets (to be set in GitHub after blueprint sync), and ZAP targets at prod URLs

## Background
Deleted the old suspended `gaming-app-api` / `gaming-app-frontend` services (yahtzee-era slugs, no traffic, using dev DB by mistake). Fresh start with correct names.

## Post-merge steps (before deploy.yml will pass)
1. Render blueprint sync creates `bc-arcade-api`, `bc-arcade-frontend`, and `bc-arcade-db` on first push to `main`
2. Query the new service IDs via Render API or dashboard
3. Set GitHub repo secrets: `RENDER_PROD_API_SERVICE_ID` and `RENDER_PROD_FRONTEND_SERVICE_ID`
4. Add custom domains `games-api.buffingchi.com` and `games.buffingchi.com` in Render dashboard
5. Add Cloudflare CNAMEs pointing to the new `.onrender.com` slugs (proxied)

## Test plan
- [ ] Render blueprint sync creates all three resources on merge to `main`
- [ ] `GET https://games-api.buffingchi.com/health` returns 200
- [ ] `RENDER_PROD_API_SERVICE_ID` and `RENDER_PROD_FRONTEND_SERVICE_ID` secrets set in GitHub
- [ ] Deploy workflow green on next push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)