### PR TITLE
fix(backend): catalog security hardening + #1148 review follow-ups (#1150)

### DIFF
--- a/backend/alembic/versions/0014_game_types_premium_cat.py
+++ b/backend/alembic/versions/0014_game_types_premium_cat.py
@@ -1,6 +1,6 @@
 """add is_premium + category to game_types (#1049)
 
-Revision ID: 0014_add_is_premium_category_game_types
+Revision ID: 0014_game_types_premium_cat
 Revises: 0013_add_freecell_game_type
 Create Date: 2026-04-30
 
@@ -14,6 +14,7 @@ Game IDs: 1=yacht 2=twenty48 3=blackjack 4=cascade 6=solitaire
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+from sqlalchemy import text
 from alembic import op
 
 revision: str = "0014_game_types_premium_cat"
@@ -47,13 +48,19 @@ def upgrade() -> None:
         sa.Column("category", sa.Text(), nullable=False, server_default="other"),
     )
 
-    # Explicitly reset existing rows to integer 0/1 — server_default only
-    # controls future inserts; existing rows need an explicit UPDATE.
-    op.execute("UPDATE game_types SET is_premium = 0")
-    op.execute(f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}")
+    # SQLite stores DEFAULT false as the text string "false" on existing rows
+    # (not the integer 0), which SQLAlchemy's Boolean mapper reads back as True.
+    # Explicitly resetting to 0/1 after ADD COLUMN guarantees correct values
+    # regardless of backend — server_default only governs future inserts.
+    op.execute(text("UPDATE game_types SET is_premium = 0"))
+    op.execute(text(f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}"))
 
     for game_id, cat in _CATEGORIES.items():
-        op.execute(f"UPDATE game_types SET category = '{cat}' WHERE id = {game_id}")
+        op.execute(
+            text("UPDATE game_types SET category = :cat WHERE id = :id").bindparams(
+                cat=cat, id=game_id
+            )
+        )
 
 
 def downgrade() -> None:

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     Uuid,
+    false as sa_false,
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -59,7 +60,7 @@ class GameType(Base):
     icon_emoji: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     sort_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, server_default="0")
     is_active: Mapped[bool] = mapped_column(nullable=False, server_default="true")
-    is_premium: Mapped[bool] = mapped_column(nullable=False, server_default="false")
+    is_premium: Mapped[bool] = mapped_column(nullable=False, server_default=sa_false())
     category: Mapped[str] = mapped_column(Text, nullable=False, server_default="other")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/games/router.py
+++ b/backend/games/router.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 
 from db.base import get_session_factory
 from limiter import limiter, session_key
@@ -63,11 +65,15 @@ def _gt_to_out(gt) -> GameTypeOut:
 
 
 @router.get("/catalog", response_model=CatalogResponse)
-async def get_catalog() -> CatalogResponse:
+async def get_catalog() -> JSONResponse:
     factory = get_session_factory()
     async with factory() as db:
         game_types = await service.get_catalog(db)
-    return CatalogResponse(items=[_gt_to_out(gt) for gt in game_types])
+    body = CatalogResponse(items=[_gt_to_out(gt) for gt in game_types])
+    return JSONResponse(
+        content=body.model_dump(),
+        headers={"Cache-Control": "public, max-age=300"},
+    )
 
 
 @router.patch("/catalog/{game_type_id}", response_model=GameTypeOut)
@@ -76,7 +82,12 @@ async def patch_game_type(
     request: Request,
     game_type_id: int,
     body: PatchGameTypeRequest,
+    x_admin_token: str = Header(default=""),
 ) -> GameTypeOut:
+    # TODO: replace with admin role check once #971 ships.
+    admin_token = os.environ.get("ADMIN_API_TOKEN", "")
+    if not admin_token or x_admin_token != admin_token:
+        raise HTTPException(status_code=403, detail="Forbidden.")
     factory = get_session_factory()
     async with factory() as db:
         try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -143,7 +143,7 @@ app.add_middleware(
     allow_origins=_allowed_origins,
     allow_methods=["GET", "POST", "PATCH"],
     expose_headers=["Retry-After"],
-    allow_headers=["Content-Type", "X-Session-ID"],
+    allow_headers=["Content-Type", "X-Session-ID", "X-Admin-Token"],
 )
 app.add_middleware(MaxBodySizeMiddleware)
 app.add_middleware(SlowAPIMiddleware)

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Iterator
 
 import pytest

--- a/backend/tests/test_catalog_api.py
+++ b/backend/tests/test_catalog_api.py
@@ -1,11 +1,14 @@
-"""Tests for GET /games/catalog and PATCH /games/catalog/{id} (#1049)."""
+"""Tests for GET /games/catalog and PATCH /games/catalog/{id} (#1049, #1150)."""
 
 from __future__ import annotations
 
+import os
 from typing import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
+
+_ADMIN_TOKEN = "test-admin-token-1150"
 
 
 @pytest.fixture()
@@ -16,6 +19,23 @@ def client() -> Iterator[TestClient]:
         yield c
 
 
+@pytest.fixture(autouse=True)
+def set_admin_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADMIN_API_TOKEN", _ADMIN_TOKEN)
+
+
+def _admin_headers() -> dict[str, str]:
+    return {
+        "X-Admin-Token": _ADMIN_TOKEN,
+        "Content-Type": "application/json",
+    }
+
+
+def _get_game_id(client: TestClient, name: str) -> int:
+    items = client.get("/games/catalog").json()["items"]
+    return next(g["id"] for g in items if g["name"] == name)
+
+
 # ---------------------------------------------------------------------------
 # GET /games/catalog
 # ---------------------------------------------------------------------------
@@ -24,9 +44,7 @@ def client() -> Iterator[TestClient]:
 def test_catalog_returns_all_active_games(client: TestClient) -> None:
     r = client.get("/games/catalog")
     assert r.status_code == 200
-    body = r.json()
-    assert "items" in body
-    names = {g["name"] for g in body["items"]}
+    names = {g["name"] for g in r.json()["items"]}
     assert {
         "yacht",
         "blackjack",
@@ -83,67 +101,110 @@ def test_catalog_no_session_required(client: TestClient) -> None:
     assert r.status_code == 200
 
 
+def test_catalog_cache_control_header(client: TestClient) -> None:
+    r = client.get("/games/catalog")
+    assert r.status_code == 200
+    assert r.headers.get("Cache-Control") == "public, max-age=300"
+
+
 # ---------------------------------------------------------------------------
-# PATCH /games/catalog/{id}
+# PATCH /games/catalog/{id} — auth
 # ---------------------------------------------------------------------------
 
 
-def _get_game_id(client: TestClient, name: str) -> int:
-    items = client.get("/games/catalog").json()["items"]
-    return next(g["id"] for g in items if g["name"] == name)
+def test_patch_requires_admin_token(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    r = client.patch(f"/games/catalog/{gid}", json={"is_premium": True})
+    assert r.status_code == 403
 
 
-def test_patch_game_type_is_premium(client: TestClient) -> None:
+def test_patch_wrong_admin_token_rejected(client: TestClient) -> None:
     gid = _get_game_id(client, "blackjack")
     r = client.patch(
         f"/games/catalog/{gid}",
         json={"is_premium": True},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+        headers={"X-Admin-Token": "wrong-token", "Content-Type": "application/json"},
     )
-    assert r.status_code == 200
-    assert r.json()["is_premium"] is True
+    assert r.status_code == 403
 
-    # restore
-    client.patch(
-        f"/games/catalog/{gid}",
-        json={"is_premium": False},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
-    )
+
+# ---------------------------------------------------------------------------
+# PATCH /games/catalog/{id} — mutations
+# ---------------------------------------------------------------------------
+
+
+def test_patch_game_type_is_premium(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    try:
+        r = client.patch(
+            f"/games/catalog/{gid}",
+            json={"is_premium": True},
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        assert r.json()["is_premium"] is True
+    finally:
+        client.patch(
+            f"/games/catalog/{gid}",
+            json={"is_premium": False},
+            headers=_admin_headers(),
+        )
 
 
 def test_patch_game_type_category(client: TestClient) -> None:
     gid = _get_game_id(client, "blackjack")
-    r = client.patch(
-        f"/games/catalog/{gid}",
-        json={"category": "strategy"},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
-    )
-    assert r.status_code == 200
-    assert r.json()["category"] == "strategy"
-
-    # restore
-    client.patch(
-        f"/games/catalog/{gid}",
-        json={"category": "card"},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
-    )
+    try:
+        r = client.patch(
+            f"/games/catalog/{gid}",
+            json={"category": "strategy"},
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        assert r.json()["category"] == "strategy"
+    finally:
+        client.patch(
+            f"/games/catalog/{gid}",
+            json={"category": "card"},
+            headers=_admin_headers(),
+        )
 
 
 def test_patch_game_type_not_found(client: TestClient) -> None:
     r = client.patch(
         "/games/catalog/9999",
         json={"is_premium": True},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
+        headers=_admin_headers(),
     )
     assert r.status_code == 404
 
 
 def test_patch_game_type_no_op(client: TestClient) -> None:
     gid = _get_game_id(client, "yacht")
-    r = client.patch(
-        f"/games/catalog/{gid}",
-        json={},
-        headers={"X-Session-ID": "test-session", "Content-Type": "application/json"},
-    )
+    r = client.patch(f"/games/catalog/{gid}", json={}, headers=_admin_headers())
     assert r.status_code == 200
     assert r.json()["name"] == "yacht"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /games/catalog/{id} — schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_patch_category_empty_string_rejected(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    r = client.patch(
+        f"/games/catalog/{gid}",
+        json={"category": ""},
+        headers=_admin_headers(),
+    )
+    assert r.status_code == 422
+
+
+def test_patch_category_too_long_rejected(client: TestClient) -> None:
+    gid = _get_game_id(client, "blackjack")
+    r = client.patch(
+        f"/games/catalog/{gid}",
+        json={"category": "x" * 65},
+        headers=_admin_headers(),
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
Closes #1150

## Summary
- **Security fix**: `PATCH /games/catalog/{id}` now requires `X-Admin-Token` matched against `ADMIN_API_TOKEN` env var — previously any unauthenticated caller could flip `is_premium` on any game globally
- **Migration**: docstring revision ID corrected; SQLite boolean reset explained in comment; seed UPDATEs use `text().bindparams()` instead of f-string interpolation
- **Model**: `server_default=sa_false()` (SQL expression) instead of `"false"` (text string) on `is_premium` — prevents new rows from storing the literal string `"false"` which SQLAlchemy reads back as `True` on SQLite
- **Router**: `Cache-Control: public, max-age=300` on `GET /games/catalog`; `X-Admin-Token` gate on `PATCH`; TODO comment referencing #971 for future admin role
- **CORS**: `X-Admin-Token` added to `allow_headers`
- **Tests**: `autouse` admin-token fixture; `try/finally` restores; schema validation (empty/overlength category → 422); auth rejection (no token → 403, wrong token → 403); Cache-Control header assertion

## Deploy checklist
- [ ] Set `ADMIN_API_TOKEN` in Render env vars before deploying — without it all PATCH requests return 403 (the endpoint is effectively disabled, which is the safe default)

## Test plan
- [x] 342 passed, 0 failed, 80.94% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)