### PR TITLE
fix(migrations): use SQL boolean literals in 0014 is_premium updates

### DIFF
--- a/backend/alembic/versions/0014_game_types_premium_cat.py
+++ b/backend/alembic/versions/0014_game_types_premium_cat.py
@@ -50,10 +50,10 @@ def upgrade() -> None:
 
     # SQLite stores DEFAULT false as the text string "false" on existing rows
     # (not the integer 0), which SQLAlchemy's Boolean mapper reads back as True.
-    # Explicitly resetting to 0/1 after ADD COLUMN guarantees correct values
-    # regardless of backend — server_default only governs future inserts.
-    op.execute(text("UPDATE game_types SET is_premium = 0"))
-    op.execute(text(f"UPDATE game_types SET is_premium = 1 WHERE id IN {_PREMIUM_IDS}"))
+    # Explicit UPDATEs after ADD COLUMN guarantee correct values on both backends.
+    # Use SQL boolean literals (false/true) — PostgreSQL rejects 0/1 for BOOLEAN.
+    op.execute(text("UPDATE game_types SET is_premium = false"))
+    op.execute(text(f"UPDATE game_types SET is_premium = true WHERE id IN {_PREMIUM_IDS}"))
 
     for game_id, cat in _CATEGORIES.items():
         op.execute(

--- a/backend/tests/test_migration_invariants.py
+++ b/backend/tests/test_migration_invariants.py
@@ -25,6 +25,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 VERSIONS_DIR = pathlib.Path(__file__).parent.parent / "alembic" / "versions"
+
+# Matches: sa.Column("colname", sa.Boolean(), ...)
+_BOOL_COL_DEF_RE = re.compile(r'sa\.Column\(\s*["\'](\w+)["\'],\s*sa\.Boolean')
+# Matches SQL strings passed to op.execute() — plain or f-strings, single/double quoted
+_EXECUTE_SQL_RE = re.compile(r'op\.execute\(\s*(?:text\(\s*)?f?["\']([^"\']+)["\']')
+# Matches SET <col> = <integer> in SQL
+_INT_ASSIGN_RE = re.compile(r'\bSET\s+(\w+)\s*=\s*([01])\b', re.IGNORECASE)
 EVENT_CONFIG_TS = (
     pathlib.Path(__file__).parent.parent.parent
     / "frontend"
@@ -189,4 +196,43 @@ def test_event_queue_config_names_are_seeded_in_backend() -> None:
         + "\n".join(f"  • {n}" for n in unmatched)
         + "\n\nFix: add the missing event_types rows to the relevant migration(s) "
         "so the backend can accept these event names."
+    )
+
+
+def test_no_integer_literals_in_boolean_updates() -> None:
+    """op.execute() SQL must use 'true'/'false' for boolean columns, not 0/1.
+
+    PostgreSQL rejects integer literals for BOOLEAN columns (DatatypeMismatch).
+    SQLite silently coerces them, masking the error until the Postgres deploy fails.
+
+    Regression guard for 0014_game_types_premium_cat (#1154).
+    """
+    # Collect all boolean column names defined across all migrations
+    bool_cols: set[str] = set()
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        for m in _BOOL_COL_DEF_RE.finditer(path.read_text(encoding="utf-8")):
+            bool_cols.add(m.group(1))
+
+    bad: list[str] = []
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        text_src = path.read_text(encoding="utf-8")
+        for sql_m in _EXECUTE_SQL_RE.finditer(text_src):
+            sql = sql_m.group(1)
+            for assign_m in _INT_ASSIGN_RE.finditer(sql):
+                col, val = assign_m.group(1), assign_m.group(2)
+                if col in bool_cols:
+                    suggestion = "true" if val == "1" else "false"
+                    bad.append(
+                        f"  {path.name}: SET {col} = {val}  →  use '{suggestion}'"
+                    )
+
+    assert not bad, (
+        "Migration execute() statements use integer literals for boolean columns.\n"
+        "PostgreSQL rejects this with DatatypeMismatch; use 'true'/'false' instead:\n"
+        + "\n".join(bad)
+        + "\n\nSee: https://github.com/wcmchenry3-stack/BC-Arcade/issues/1154"
     )

--- a/backend/tests/test_migration_invariants.py
+++ b/backend/tests/test_migration_invariants.py
@@ -31,7 +31,7 @@ _BOOL_COL_DEF_RE = re.compile(r'sa\.Column\(\s*["\'](\w+)["\'],\s*sa\.Boolean')
 # Matches SQL strings passed to op.execute() — plain or f-strings, single/double quoted
 _EXECUTE_SQL_RE = re.compile(r'op\.execute\(\s*(?:text\(\s*)?f?["\']([^"\']+)["\']')
 # Matches SET <col> = <integer> in SQL
-_INT_ASSIGN_RE = re.compile(r'\bSET\s+(\w+)\s*=\s*([01])\b', re.IGNORECASE)
+_INT_ASSIGN_RE = re.compile(r"\bSET\s+(\w+)\s*=\s*([01])\b", re.IGNORECASE)
 EVENT_CONFIG_TS = (
     pathlib.Path(__file__).parent.parent.parent
     / "frontend"
@@ -226,9 +226,7 @@ def test_no_integer_literals_in_boolean_updates() -> None:
                 col, val = assign_m.group(1), assign_m.group(2)
                 if col in bool_cols:
                     suggestion = "true" if val == "1" else "false"
-                    bad.append(
-                        f"  {path.name}: SET {col} = {val}  →  use '{suggestion}'"
-                    )
+                    bad.append(f"  {path.name}: SET {col} = {val}  →  use '{suggestion}'")
 
     assert not bad, (
         "Migration execute() statements use integer literals for boolean columns.\n"


### PR DESCRIPTION
## Summary

- Fixes `0014_game_types_premium_cat` migration crash on PostgreSQL (`DatatypeMismatch: column is_premium is of type boolean but expression is of type integer`)
- Replaces `= 0` / `= 1` integer literals with `= false` / `= true` SQL boolean literals in the two `op.execute()` UPDATE statements
- Adds `test_no_integer_literals_in_boolean_updates` to `test_migration_invariants.py` to prevent recurrence

## Root cause

SQLite silently coerces integers to booleans; PostgreSQL does not. The bug was invisible in local dev and CI (both use SQLite) and only surfaced on the Render deploy.

## Test plan

- [ ] `python -m pytest tests/test_migration_invariants.py -v` — all 4 tests pass
- [ ] Full `python -m pytest tests/ -v` passes (coverage ≥ 80%)
- [ ] Render deploy completes without `DatatypeMismatch` error on migration 0014

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)