### PR TITLE
feat(backend): dev/QA entitlement override for internal testers (#1052)

### DIFF
--- a/backend/entitlements/service.py
+++ b/backend/entitlements/service.py
@@ -18,12 +18,6 @@ from sqlalchemy import select
 
 from db.models import GameEntitlement, GameType
 
-_DEV_OVERRIDE_VAR = "ENTITLEMENT_DEV_OVERRIDE"
-
-
-def is_dev_override_active() -> bool:
-    return os.environ.get(_DEV_OVERRIDE_VAR, "").lower() == "true"
-
 TOKEN_TTL_HOURS = 24
 ALGORITHM = "RS256"
 
@@ -31,6 +25,12 @@ ALGORITHM = "RS256"
 # In production Render injects ENTITLEMENT_PRIVATE_KEY, so all workers share the same key.
 _private_key_pem: str | None = None
 _public_key_pem: str | None = None
+
+_DEV_OVERRIDE_VAR = "ENTITLEMENT_DEV_OVERRIDE"
+
+
+def is_dev_override_active() -> bool:
+    return os.environ.get(_DEV_OVERRIDE_VAR, "").lower() == "true"
 
 
 def _load_or_generate_keys() -> tuple[str, str]:
@@ -87,11 +87,7 @@ def issue_token(session_id: str, entitled_games: list[str]) -> tuple[str, dateti
 
 
 async def get_entitled_games(db_session, session_id: str) -> list[str]:
-    """Return this session's entitled game slugs.
-
-    When ENTITLEMENT_DEV_OVERRIDE=true, returns all premium game slugs so
-    internal testers can access every premium game without a purchase (#1052).
-    """
+    """Return entitled game slugs; when DEV_OVERRIDE is active, returns all premium slugs (#1052)."""
     if is_dev_override_active():
         rows = (
             (await db_session.execute(select(GameType.name).where(GameType.is_premium.is_(True))))

--- a/backend/entitlements/service.py
+++ b/backend/entitlements/service.py
@@ -16,7 +16,13 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy import select
 
-from db.models import GameEntitlement
+from db.models import GameEntitlement, GameType
+
+_DEV_OVERRIDE_VAR = "ENTITLEMENT_DEV_OVERRIDE"
+
+
+def is_dev_override_active() -> bool:
+    return os.environ.get(_DEV_OVERRIDE_VAR, "").lower() == "true"
 
 TOKEN_TTL_HOURS = 24
 ALGORITHM = "RS256"
@@ -81,7 +87,18 @@ def issue_token(session_id: str, entitled_games: list[str]) -> tuple[str, dateti
 
 
 async def get_entitled_games(db_session, session_id: str) -> list[str]:
-    """Query game_entitlements for this session. Returns [] until IAP ships (#822)."""
+    """Return this session's entitled game slugs.
+
+    When ENTITLEMENT_DEV_OVERRIDE=true, returns all premium game slugs so
+    internal testers can access every premium game without a purchase (#1052).
+    """
+    if is_dev_override_active():
+        rows = (
+            (await db_session.execute(select(GameType.name).where(GameType.is_premium.is_(True))))
+            .scalars()
+            .all()
+        )
+        return list(rows)
     rows = (
         (
             await db_session.execute(

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from db.base import DATABASE_URL, get_engine, is_configured
 from entitlements.dependencies import EntitlementError
+from entitlements.service import is_dev_override_active
 from limiter import _real_ip, limiter
 from cascade.router import router as cascade_router
 from freecell.router import router as freecell_router
@@ -201,6 +202,14 @@ async def security_headers(request: Request, call_next) -> Response:
     if "server" in response.headers:
         del response.headers["server"]
     return response
+
+
+@app.on_event("startup")
+async def _dev_entitlement_override_warning() -> None:
+    if is_dev_override_active():
+        logging.getLogger("audit").warning(
+            "DEV ENTITLEMENT OVERRIDE ACTIVE — all premium games unlocked for all sessions"
+        )
 
 
 @app.on_event("startup")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ aiosqlite==0.20.0
 alembic==1.14.0
 PyJWT==2.12.0
 cryptography==46.0.7
+PyYAML==6.0.3

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -119,6 +119,7 @@ def test_private_key_not_in_response(client: TestClient, session_id: str) -> Non
 # Dev/QA override (#1052)
 # ---------------------------------------------------------------------------
 
+# Update this set whenever a new premium game is added (mirrors game_types.is_premium=true).
 _PREMIUM_GAMES = {"cascade", "hearts", "sudoku", "starswarm", "yacht"}
 
 

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -1,7 +1,8 @@
-"""Tests for GET /entitlements (#1050)."""
+"""Tests for GET /entitlements (#1050, #1052)."""
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Iterator
@@ -112,3 +113,72 @@ def test_private_key_not_in_response(client: TestClient, session_id: str) -> Non
     raw = r.text
     assert "PRIVATE KEY" not in raw
     assert "BEGIN RSA" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Dev/QA override (#1052)
+# ---------------------------------------------------------------------------
+
+_PREMIUM_GAMES = {"cascade", "hearts", "sudoku", "starswarm", "yacht"}
+
+
+def test_dev_override_returns_all_premium_games(
+    client: TestClient, session_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENTITLEMENT_DEV_OVERRIDE", "true")
+    r = client.get("/entitlements", headers=_headers(session_id))
+    assert r.status_code == 200
+    pub_pem = entitlements_service.get_public_key_pem()
+    decoded = jwt.decode(r.json()["token"], pub_pem, algorithms=["RS256"])
+    assert set(decoded["entitled_games"]) == _PREMIUM_GAMES
+
+
+def test_dev_override_false_gives_normal_path(
+    client: TestClient, session_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENTITLEMENT_DEV_OVERRIDE", "false")
+    r = client.get("/entitlements", headers=_headers(session_id))
+    assert r.status_code == 200
+    pub_pem = entitlements_service.get_public_key_pem()
+    decoded = jwt.decode(r.json()["token"], pub_pem, algorithms=["RS256"])
+    assert decoded["entitled_games"] == []
+
+
+def test_startup_warning_logged_when_override_active(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("ENTITLEMENT_DEV_OVERRIDE", "true")
+    from main import app
+
+    with caplog.at_level(logging.WARNING, logger="audit"):
+        with TestClient(app):
+            pass
+    assert any("DEV ENTITLEMENT OVERRIDE ACTIVE" in r.message for r in caplog.records)
+
+
+def test_no_startup_warning_when_override_inactive(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("ENTITLEMENT_DEV_OVERRIDE", raising=False)
+    from main import app
+
+    with caplog.at_level(logging.WARNING, logger="audit"):
+        with TestClient(app):
+            pass
+    assert not any("DEV ENTITLEMENT OVERRIDE ACTIVE" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# CI safeguard: render.yaml production service must not set the override
+# ---------------------------------------------------------------------------
+
+
+def test_render_yaml_prod_does_not_set_dev_override() -> None:
+    import yaml
+    from pathlib import Path
+
+    render_yaml = Path(__file__).resolve().parent.parent.parent / "render.yaml"
+    config = yaml.safe_load(render_yaml.read_text())
+    prod_service = next(s for s in config["services"] if s["name"] == "bc-arcade-api")
+    env_keys = {e["key"] for e in prod_service.get("envVars", [])}
+    assert "ENTITLEMENT_DEV_OVERRIDE" not in env_keys


### PR DESCRIPTION
Closes #1052

## Summary
- `ENTITLEMENT_DEV_OVERRIDE=true` makes `GET /entitlements` return all 5 premium game slugs (`cascade`, `hearts`, `sudoku`, `starswarm`, `yacht`) regardless of purchase history
- Startup warning logged: `DEV ENTITLEMENT OVERRIDE ACTIVE — all premium games unlocked for all sessions`
- No frontend changes needed — the override JWT is structurally identical to a real entitlement JWT

## Test plan
- [ ] `test_dev_override_returns_all_premium_games` — all 5 slugs in JWT when override is active
- [ ] `test_dev_override_false_gives_normal_path` — empty list when override is `false`
- [ ] `test_startup_warning_logged_when_override_active` — warning captured in `caplog`
- [ ] `test_no_startup_warning_when_override_inactive` — no warning when var is unset
- [ ] `test_render_yaml_prod_does_not_set_dev_override` — CI safeguard that prod render.yaml never enables override

All 373 tests pass, 95.55% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)