### PR TITLE
feat(e2e): add hearts/solitaire/sudoku Playwright projects + CI scope detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,21 @@ jobs:
               - 'frontend/src/components/starswarm/**'
               - 'frontend/src/game/starswarm/**'
               - 'backend/starswarm/**'
+            hearts:
+              - 'frontend/src/screens/HeartsScreen*'
+              - 'frontend/src/components/hearts/**'
+              - 'frontend/src/game/hearts/**'
+              - 'backend/hearts/**'
+            solitaire:
+              - 'frontend/src/screens/SolitaireScreen*'
+              - 'frontend/src/components/solitaire/**'
+              - 'frontend/src/game/solitaire/**'
+              - 'backend/solitaire/**'
+            sudoku:
+              - 'frontend/src/screens/SudokuScreen*'
+              - 'frontend/src/components/sudoku/**'
+              - 'frontend/src/game/sudoku/**'
+              - 'backend/sudoku/**'
             logstore:
               - 'frontend/src/game/_shared/eventStore*'
               - 'frontend/src/game/_shared/eventQueueConfig*'
@@ -187,7 +202,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]] || \
              [[ "${{ github.base_ref }}" == "main" ]] || \
              [[ "${{ steps.filter.outputs.shared }}" == "true" ]]; then
-            echo "projects=yacht blackjack twenty48 cascade mahjong freecell starswarm cross logs-budget" >> "$GITHUB_OUTPUT"
+            echo "projects=yacht blackjack twenty48 cascade mahjong freecell starswarm hearts solitaire sudoku cross logs-budget" >> "$GITHUB_OUTPUT"
             echo "label=full suite (push/main/shared change)" >> "$GITHUB_OUTPUT"
           else
             projects="cross"
@@ -199,6 +214,9 @@ jobs:
             [[ "${{ steps.filter.outputs.mahjong }}"   == "true" ]] && projects="$projects mahjong"
             [[ "${{ steps.filter.outputs.freecell }}"  == "true" ]] && projects="$projects freecell"
             [[ "${{ steps.filter.outputs.starswarm }}" == "true" ]] && projects="$projects starswarm"
+            [[ "${{ steps.filter.outputs.hearts }}"    == "true" ]] && projects="$projects hearts"
+            [[ "${{ steps.filter.outputs.solitaire }}" == "true" ]] && projects="$projects solitaire"
+            [[ "${{ steps.filter.outputs.sudoku }}"    == "true" ]] && projects="$projects sudoku"
             [[ "${{ steps.filter.outputs.logstore }}"  == "true" ]] && projects="$projects logs-budget"
             echo "projects=$projects" >> "$GITHUB_OUTPUT"
             echo "label=selective: $projects" >> "$GITHUB_OUTPUT"

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,6 +13,9 @@ import { join } from "path";
  *   twenty48    — twenty48-*.spec.ts
  *   mahjong     — mahjong-*.spec.ts
  *   freecell    — freecell-*.spec.ts
+ *   hearts      — hearts-*.spec.ts
+ *   solitaire   — solitaire-*.spec.ts
+ *   sudoku      — sudoku-*.spec.ts
  *   cross       — accessibility.spec.ts, cascade-flow.spec.ts, ui-preferences.spec.ts
  *   logs-budget — logs-*.spec.ts (#373 acceptance gate, CPU-throttled to
  *                  approximate mid-tier mobile device performance)
@@ -78,6 +81,21 @@ export default defineConfig({
     {
       name: "starswarm",
       testMatch: "starswarm-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "hearts",
+      testMatch: "hearts-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "solitaire",
+      testMatch: "solitaire-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "sudoku",
+      testMatch: "sudoku-*.spec.ts",
       use: { ...devices["Desktop Chrome"] },
     },
     {


### PR DESCRIPTION
Closes #1140

## Summary
- Added `hearts`, `solitaire`, and `sudoku` project entries to `e2e/playwright.config.ts` (matching `hearts-*.spec.ts`, `solitaire-*.spec.ts`, `sudoku-*.spec.ts`)
- Added path filters for the three games in the `detect-e2e-scope` dorny/paths-filter block in `.github/workflows/ci.yml`
- Added `hearts solitaire sudoku` to the full-suite project list string and the selective-scope conditional block

## Test plan
- [x] `npx playwright test --project hearts --list` exits 0 with "No tests found" (no spec files yet)
- [x] `npx playwright test --project solitaire --list` exits 0 with "No tests found"
- [x] `npx playwright test --project sudoku --list` exits 0 with "No tests found"
- [x] Existing `yacht` project still resolves and lists 55 tests — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)