### PR TITLE
feat(e2e): add per-game helper files for FreeCell, StarSwarm, Hearts, Solitaire, Sudoku

### DIFF
--- a/e2e/tests/freecell-smoke.spec.ts
+++ b/e2e/tests/freecell-smoke.spec.ts
@@ -9,55 +9,31 @@
  */
 
 import { test, expect } from "@playwright/test";
-
-const API_BASE = "http://localhost:8000";
+import { mockFreecellApi, gotoFreecell } from "./helpers/freecell";
 
 test.describe("FreeCell — smoke tests", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route(`${API_BASE}/freecell/**`, async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ scores: [] }),
-      });
-    });
-    await page.goto("/");
-    await page.evaluate(() => {
-      localStorage.removeItem("freecell_game");
-    });
+    await mockFreecellApi(page);
+    await gotoFreecell(page);
   });
 
   test("navigates from Home to FreeCell screen", async ({ page }) => {
-    await page.getByRole("button", { name: "Play FreeCell" }).click();
     await expect(
       page.getByRole("heading", { name: "FreeCell", exact: true }),
-    ).toBeVisible({ timeout: 10_000 });
+    ).toBeVisible();
   });
 
   test("move counter is visible", async ({ page }) => {
-    await page.getByRole("button", { name: "Play FreeCell" }).click();
-    await expect(
-      page.getByRole("heading", { name: "FreeCell", exact: true }),
-    ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByText(/Moves:\s*\d+/)).toBeVisible({ timeout: 5_000 });
   });
 
   test("board region is accessible", async ({ page }) => {
-    await page.getByRole("button", { name: "Play FreeCell" }).click();
-    await expect(
-      page.getByRole("heading", { name: "FreeCell", exact: true }),
-    ).toBeVisible({ timeout: 10_000 });
     await expect(
       page.getByLabel("FreeCell board").first(),
     ).toBeVisible({ timeout: 5_000 });
   });
 
   test("interacting with the board does not crash the app", async ({ page }) => {
-    await page.getByRole("button", { name: "Play FreeCell" }).click();
-    await expect(
-      page.getByRole("heading", { name: "FreeCell", exact: true }),
-    ).toBeVisible({ timeout: 10_000 });
-
     const board = page.getByLabel("FreeCell board").first();
     await expect(board).toBeVisible({ timeout: 5_000 });
 

--- a/e2e/tests/helpers/freecell.ts
+++ b/e2e/tests/helpers/freecell.ts
@@ -1,0 +1,36 @@
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+const STORAGE_KEY = "freecell_game";
+
+export async function mockFreecellApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/freecell/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+export async function gotoFreecell(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.getByRole("button", { name: "Play FreeCell" }).click();
+  await page
+    .getByRole("heading", { name: "FreeCell", exact: true })
+    .waitFor({ timeout: 10_000 });
+}
+
+export async function injectFreecellState(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    [STORAGE_KEY, partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/helpers/hearts.ts
+++ b/e2e/tests/helpers/hearts.ts
@@ -1,0 +1,36 @@
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+const STORAGE_KEY = "hearts_game";
+
+export async function mockHeartsApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/hearts/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+export async function gotoHearts(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.getByRole("button", { name: "Play Hearts" }).click();
+  await page
+    .getByRole("heading", { name: "Hearts", exact: true })
+    .waitFor({ timeout: 10_000 });
+}
+
+export async function injectHeartsState(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    [STORAGE_KEY, partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/helpers/solitaire.ts
+++ b/e2e/tests/helpers/solitaire.ts
@@ -1,0 +1,36 @@
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+const STORAGE_KEY = "solitaire_game";
+
+export async function mockSolitaireApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/solitaire/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+export async function gotoSolitaire(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.getByRole("button", { name: "Play Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+}
+
+export async function injectSolitaireState(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    [STORAGE_KEY, partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/helpers/starswarm.ts
+++ b/e2e/tests/helpers/starswarm.ts
@@ -1,0 +1,29 @@
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+
+export async function mockStarswarmApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/starswarm/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+export async function gotoStarswarm(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Play Star Swarm" }).click();
+  await page
+    .getByRole("heading", { name: "Star Swarm", exact: true })
+    .waitFor({ timeout: 10_000 });
+}
+
+/** Star Swarm has no localStorage state; this is a no-op placeholder for parity. */
+export async function injectStarswarmState(
+  page: Page,
+  _partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+}

--- a/e2e/tests/helpers/sudoku.ts
+++ b/e2e/tests/helpers/sudoku.ts
@@ -1,0 +1,36 @@
+import { Page } from "@playwright/test";
+
+const API_BASE = "http://localhost:8000";
+const STORAGE_KEY = "sudoku_game";
+
+export async function mockSudokuApi(page: Page): Promise<void> {
+  await page.route(`${API_BASE}/sudoku/**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scores: [] }),
+    });
+  });
+}
+
+export async function gotoSudoku(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.getByRole("button", { name: "Play Sudoku" }).click();
+  await page
+    .getByRole("heading", { name: "Sudoku", exact: true })
+    .waitFor({ timeout: 10_000 });
+}
+
+export async function injectSudokuState(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    [STORAGE_KEY, partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/starswarm-flow.spec.ts
+++ b/e2e/tests/starswarm-flow.spec.ts
@@ -12,18 +12,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-
-const API_BASE = "http://localhost:8000";
+import { mockStarswarmApi } from "./helpers/starswarm";
 
 test.describe("Star Swarm — navigation and smoke tests", () => {
   test.beforeEach(async ({ page }) => {
-    await page.route(`${API_BASE}/starswarm/**`, async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ scores: [] }),
-      });
-    });
+    await mockStarswarmApi(page);
   });
 
   test("navigates from Home to Star Swarm screen", async ({ page }) => {


### PR DESCRIPTION
Closes #1141

## Summary
- Adds `e2e/tests/helpers/freecell.ts`, `starswarm.ts`, `hearts.ts`, `solitaire.ts`, `sudoku.ts` — each exports `mock<Game>Api(page)`, `goto<Game>(page)`, and `inject<Game>State(page, partial)`
- Refactors `freecell-smoke.spec.ts` and `starswarm-flow.spec.ts` to import from helpers, removing inline `page.route()` mocks
- Storage keys confirmed from each game's `storage.ts`: `freecell_game`, `hearts_game`, `solitaire_game`, `sudoku_game`; StarSwarm has no localStorage state (`injectStarswarmState` is a no-op placeholder)
- All API routes mocked via `${API_BASE}/<game>/**` wildcard pattern

## Test plan
- [ ] `playwright test --project=freecell` — all 4 existing smoke tests pass
- [ ] `playwright test --project=starswarm` — all 11 existing tests pass
- [ ] `playwright test --list --project=hearts,solitaire,sudoku` — helpers load without TS errors (no spec files yet; covered by child issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)