### PR TITLE
Fix Hearts AI treating ace as low card in lead/follow/discard decisions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13151,9 +13151,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13173,9 +13170,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13197,9 +13191,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13219,9 +13210,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -374,6 +374,80 @@ describe("selectCardToPlay — always valid", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Ace-high regression tests (issue #1166)
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — ace treated as high card", () => {
+  it("chooseLead: does not lead ace when a lower card exists in the same suit", () => {
+    const hand = [c("spades", 1), c("spades", 3)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 3,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+    });
+    const pick = selectCardToPlay(hand, [], state, 0);
+    expect(pick).toEqual(c("spades", 3));
+  });
+
+  it("chooseDiscard: discards ace as highest heart when void in led suit", () => {
+    const hand = [c("hearts", 1), c("hearts", 3), c("diamonds", 5)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 8), playerIndex: 0 },
+      { card: c("clubs", 9), playerIndex: 1 },
+      { card: c("clubs", 10), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      heartsBroken: true,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    expect(pick).toEqual(c("hearts", 1));
+  });
+
+  it("chooseDiscard: discards ace as highest card of longest suit", () => {
+    const hand = [c("clubs", 1), c("clubs", 4), c("clubs", 7)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 5), playerIndex: 0 },
+      { card: c("spades", 6), playerIndex: 1 },
+      { card: c("spades", 7), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    expect(pick).toEqual(c("clubs", 1));
+  });
+
+  it("moon blocking: dumps ace of hearts before lower hearts", () => {
+    const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const hand = [c("hearts", 1), c("hearts", 3), c("diamonds", 4)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 4), playerIndex: 0 },
+      { card: c("spades", 5), playerIndex: 1 },
+      { card: c("spades", 6), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      handScores: [5, 0, 0, 0],
+      wonCards: [allHearts5, [], [], []],
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3);
+    expect(pick).toEqual(c("hearts", 1));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // detectPotentialMoon
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -201,7 +201,9 @@ export function selectCardToPlay(
 
   // Moon blocking — dump points cards ASAP
   if (moonTarget !== null && moonTarget !== playerIndex) {
-    const pointCards = valid.filter((c) => cardPoints(c) > 0).sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+    const pointCards = valid
+      .filter((c) => cardPoints(c) > 0)
+      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     if (pointCards.length > 0) return pointCards[0]!;
   }
 
@@ -280,7 +282,9 @@ function chooseDiscard(valid: Card[]): Card {
   if (qSpades) return qSpades;
 
   // 2. Dump highest heart
-  const hearts = valid.filter((c) => c.suit === "hearts").sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+  const hearts = valid
+    .filter((c) => c.suit === "hearts")
+    .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   if (hearts.length > 0) return hearts[0]!;
 
   // 3. Dump highest card of longest suit

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -27,11 +27,13 @@ function trickPoints(trick: readonly TrickCard[]): number {
   return trick.reduce((sum, tc) => sum + cardPoints(tc.card), 0);
 }
 
+const aceHigh = (rank: number): number => (rank === 1 ? 14 : rank);
+
 /** Highest card in array, or undefined if empty. */
 function highest(cards: Card[]): Card | undefined {
   return cards.reduce<Card | undefined>((best, c) => {
     if (!best) return c;
-    return c.rank > best.rank ? c : best;
+    return aceHigh(c.rank) > aceHigh(best.rank) ? c : best;
   }, undefined);
 }
 
@@ -39,7 +41,7 @@ function highest(cards: Card[]): Card | undefined {
 function lowest(cards: Card[]): Card | undefined {
   return cards.reduce<Card | undefined>((best, c) => {
     if (!best) return c;
-    return c.rank < best.rank ? c : best;
+    return aceHigh(c.rank) < aceHigh(best.rank) ? c : best;
   }, undefined);
 }
 
@@ -199,7 +201,7 @@ export function selectCardToPlay(
 
   // Moon blocking — dump points cards ASAP
   if (moonTarget !== null && moonTarget !== playerIndex) {
-    const pointCards = valid.filter((c) => cardPoints(c) > 0).sort((a, b) => b.rank - a.rank);
+    const pointCards = valid.filter((c) => cardPoints(c) > 0).sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     if (pointCards.length > 0) return pointCards[0]!;
   }
 
@@ -245,13 +247,13 @@ function chooseFollow(valid: Card[], trick: readonly TrickCard[]): Card {
   // Find the highest card currently winning the trick in led suit
   let winningRank = 0;
   for (const tc of trick) {
-    if (tc.card.suit === ledSuit && tc.card.rank > winningRank) {
-      winningRank = tc.card.rank;
+    if (tc.card.suit === ledSuit && aceHigh(tc.card.rank) > winningRank) {
+      winningRank = aceHigh(tc.card.rank);
     }
   }
 
-  // Cards that would lose (rank < winning rank)
-  const losing = inSuit.filter((c) => c.rank < winningRank);
+  // Cards that would lose (ace-high rank < winning rank)
+  const losing = inSuit.filter((c) => aceHigh(c.rank) < winningRank);
 
   if (pts === 0 && isLastToPlay) {
     // Safe trick, last to play — exhaust high cards
@@ -278,7 +280,7 @@ function chooseDiscard(valid: Card[]): Card {
   if (qSpades) return qSpades;
 
   // 2. Dump highest heart
-  const hearts = valid.filter((c) => c.suit === "hearts").sort((a, b) => b.rank - a.rank);
+  const hearts = valid.filter((c) => c.suit === "hearts").sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   if (hearts.length > 0) return hearts[0]!;
 
   // 3. Dump highest card of longest suit


### PR DESCRIPTION
Adds aceHigh() helper to ai.ts and applies it throughout: highest()/lowest()
helpers, winningRank tracking in chooseFollow, moon-blocking sort, and
high-heart dump sort in chooseDiscard. Adds four regression tests covering
lead, discard-heart, discard-longest-suit, and moon-blocking scenarios.

Fixes #1166

https://claude.ai/code/session_01WD27Jje6B4tWX5dKWYo3hb