### PR TITLE
feat(e2e): Solitaire smoke/draw/tableau-move/persistence/leaderboard specs

### DIFF
--- a/e2e/tests/solitaire-draw.spec.ts
+++ b/e2e/tests/solitaire-draw.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * solitaire-draw.spec.ts — GH #1143
+ *
+ * Draw mechanic: tap the stock pile, waste pile shows a face-up card,
+ * and the move counter increments to 1.
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSolitaireApi, gotoSolitaire } from "./helpers/solitaire";
+
+test("tap stock: waste shows face-up card and moves counter increments", async ({
+  page,
+}) => {
+  await mockSolitaireApi(page);
+  await gotoSolitaire(page);
+  // Dismiss the pre-game draw-mode modal.
+  await page.getByRole("button", { name: "Draw 1" }).click();
+  await page.getByLabel("Solitaire board").waitFor({ timeout: 10_000 });
+
+  // Confirm waste is empty before drawing.
+  await expect(page.getByLabel("Empty waste pile")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Tap the stock pile to draw one card.
+  await page.getByLabel(/Draw 1 from stock/).click();
+
+  // Waste pile should now show a face-up card (any rank/suit).
+  await expect(
+    page.getByLabel(/of (?:Spades|Hearts|Diamonds|Clubs)$/).first(),
+  ).toBeVisible({ timeout: 3_000 });
+
+  // Move counter increments to 1.
+  await expect(page.getByLabel("Moves: 1")).toBeVisible({ timeout: 3_000 });
+});

--- a/e2e/tests/solitaire-leaderboard.spec.ts
+++ b/e2e/tests/solitaire-leaderboard.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * solitaire-leaderboard.spec.ts — GH #1143
+ *
+ * Leaderboard integration: inject a completed game (all 52 cards in
+ * foundations, isComplete = true), intercept POST /solitaire/score, enter a
+ * name, submit, and verify the rank confirmation.
+ *
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSolitaireApi, injectSolitaireState } from "./helpers/solitaire";
+
+const allRanks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+const card = (suit: string, rank: number) => ({ suit, rank, faceUp: true });
+
+const WIN_STATE = {
+  _v: 1,
+  drawMode: 1 as const,
+  tableau: [[], [], [], [], [], [], []],
+  foundations: {
+    spades: allRanks.map((r) => card("spades", r)),
+    hearts: allRanks.map((r) => card("hearts", r)),
+    diamonds: allRanks.map((r) => card("diamonds", r)),
+    clubs: allRanks.map((r) => card("clubs", r)),
+  },
+  stock: [],
+  waste: [],
+  score: 1000,
+  undoStack: [],
+  isComplete: true,
+  recycleCount: 0,
+  events: [],
+};
+
+test.describe("Solitaire — leaderboard", () => {
+  test("POST /solitaire/score intercepted and rank confirmation shown after submit", async ({
+    page,
+  }) => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    await page.route("**/solitaire/**", async (route) => {
+      if (route.request().method() === "POST") {
+        capturedBody = JSON.parse(route.request().postData() ?? "{}");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ player_name: "Tester", score: 1000, rank: 1 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ scores: [] }),
+        });
+      }
+    });
+
+    await injectSolitaireState(page, WIN_STATE);
+    await page.getByRole("button", { name: "Play Solitaire" }).click();
+    await page
+      .getByRole("heading", { name: "Solitaire", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    // Win modal appears because isComplete = true.
+    await expect(page.getByText("You Won!")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByLabel("Your name").fill("Tester");
+
+    const submitBtn = page.getByRole("button", { name: "Submit Score" });
+    await expect(submitBtn).toBeEnabled({ timeout: 2_000 });
+    await submitBtn.click();
+
+    await expect(page.getByText("Saved! #1")).toBeVisible({ timeout: 5_000 });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!["player_name"]).toBe("Tester");
+    expect(capturedBody!["score"]).toBe(1000);
+  });
+
+  test("Submit Score button disabled when name field is empty", async ({
+    page,
+  }) => {
+    await mockSolitaireApi(page);
+    await injectSolitaireState(page, WIN_STATE);
+    await page.getByRole("button", { name: "Play Solitaire" }).click();
+    await page
+      .getByRole("heading", { name: "Solitaire", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    await expect(page.getByText("You Won!")).toBeVisible({ timeout: 5_000 });
+
+    await expect(
+      page.getByRole("button", { name: "Submit Score" }),
+    ).toBeDisabled({ timeout: 2_000 });
+  });
+});

--- a/e2e/tests/solitaire-persistence.spec.ts
+++ b/e2e/tests/solitaire-persistence.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * solitaire-persistence.spec.ts — GH #1143
+ *
+ * Persistence: inject a mid-game state with a known card (5♥) in the waste
+ * pile, navigate to Solitaire, verify the card is visible, navigate away,
+ * return, and confirm the waste card is still the same.
+ *
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSolitaireApi, injectSolitaireState } from "./helpers/solitaire";
+
+// 5♥ is the top waste card; stock has the remaining 51 cards face-down.
+function remainingStock() {
+  const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
+  const ranks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const;
+  return suits.flatMap((suit) =>
+    ranks
+      .filter((rank) => !(suit === "hearts" && rank === 5))
+      .map((rank) => ({ suit, rank, faceUp: false })),
+  );
+}
+
+const PERSIST_STATE = {
+  _v: 1,
+  drawMode: 1,
+  tableau: [[], [], [], [], [], [], []],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  stock: remainingStock(),
+  waste: [{ suit: "hearts", rank: 5, faceUp: true }],
+  score: 0,
+  undoStack: [],
+  isComplete: false,
+  recycleCount: 0,
+  events: [],
+};
+
+test("waste card persists after navigating away and back", async ({ page }) => {
+  await mockSolitaireApi(page);
+  await injectSolitaireState(page, PERSIST_STATE);
+
+  await page.getByRole("button", { name: "Play Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Injected state puts 5♥ on top of the waste.
+  await expect(page.getByLabel("5 of Hearts")).toBeVisible({ timeout: 5_000 });
+
+  // Navigate away — SolitaireScreen saves state on blur/unmount.
+  await page.goto("/");
+  await page.getByText("BC Arcade").first().waitFor();
+
+  // Return to Solitaire.
+  await page.getByRole("button", { name: "Play Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Waste card should be the same after resume.
+  await expect(page.getByLabel("5 of Hearts")).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/tests/solitaire-smoke.spec.ts
+++ b/e2e/tests/solitaire-smoke.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * solitaire-smoke.spec.ts — GH #1143
+ *
+ * Smoke tests: navigation, 7 tableau columns render, stock pile visible.
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSolitaireApi, gotoSolitaire } from "./helpers/solitaire";
+
+test.describe("Solitaire — smoke tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSolitaireApi(page);
+    await gotoSolitaire(page);
+    // Choose Draw 1 to dismiss the pre-game modal and deal a fresh board.
+    await page.getByRole("button", { name: "Draw 1" }).click();
+    await page
+      .getByLabel("Solitaire board")
+      .waitFor({ timeout: 10_000 });
+  });
+
+  test("navigates from Home to Solitaire screen", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Solitaire", exact: true }),
+    ).toBeVisible();
+  });
+
+  test("7 tableau columns render after deal", async ({ page }) => {
+    for (let col = 1; col <= 7; col++) {
+      await expect(
+        page
+          .getByLabel(`Tableau column ${col}, ${col} cards`)
+          .or(page.getByLabel(`Empty tableau column ${col}`)),
+      ).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test("stock pile is visible", async ({ page }) => {
+    await expect(
+      page.getByLabel(/Draw 1 from stock/),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/solitaire-tableau-move.spec.ts
+++ b/e2e/tests/solitaire-tableau-move.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * solitaire-tableau-move.spec.ts — GH #1143
+ *
+ * Tableau-to-tableau move: inject a board with a known 7♥ on column 1 and
+ * 8♠ on column 2, tap the 7♥ to select it, tap the 8♠ column as target,
+ * and verify the source column is now empty and the target gained one card.
+ *
+ * Uses .or() when locating the target pile because the pressable target may
+ * resolve to either the column container or the top card's label depending
+ * on the render path.
+ *
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSolitaireApi, injectSolitaireState } from "./helpers/solitaire";
+
+// 7♥ is alone in column 1; 8♠ is the face-up top of column 2.
+// All other 50 cards sit in the stock so the state is structurally valid.
+const r = (rank: number) => rank;
+function stockCards() {
+  const suits = ["spades", "hearts", "diamonds", "clubs"] as const;
+  const ranks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13] as const;
+  const used = new Set(["hearts-7", "spades-9", "spades-8"]);
+  return suits.flatMap((suit) =>
+    ranks
+      .filter((rank) => !used.has(`${suit}-${rank}`))
+      .map((rank) => ({ suit, rank, faceUp: false })),
+  );
+}
+
+const TABLEAU_MOVE_STATE = {
+  _v: 1,
+  drawMode: 1,
+  tableau: [
+    [{ suit: "hearts", rank: r(7), faceUp: true }],
+    [
+      { suit: "spades", rank: r(9), faceUp: false },
+      { suit: "spades", rank: r(8), faceUp: true },
+    ],
+    [],
+    [],
+    [],
+    [],
+    [],
+  ],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  stock: stockCards(),
+  waste: [],
+  score: 0,
+  undoStack: [],
+  isComplete: false,
+  recycleCount: 0,
+  events: [],
+};
+
+test("tableau-to-tableau: move 7♥ from column 1 onto 8♠ in column 2", async ({
+  page,
+}) => {
+  await mockSolitaireApi(page);
+  await injectSolitaireState(page, TABLEAU_MOVE_STATE);
+
+  await page.getByRole("button", { name: "Play Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+  await page.getByLabel("Solitaire board").waitFor({ timeout: 10_000 });
+
+  // Verify starting column counts.
+  await expect(page.getByLabel("Tableau column 1, 1 cards")).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByLabel("Tableau column 2, 2 cards")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Select the 7♥ in column 1.
+  await page.getByLabel("7 of Hearts").click();
+
+  // Tap the 8♠ card button — it is the top face-up card in column 2 and the
+  // valid drop target for 7♥. Use .or() to handle both the unselected and
+  // selected-state aria-label variants.
+  await page
+    .getByRole("button", { name: "8 of Spades" })
+    .or(page.getByRole("button", { name: "8 of Spades (selected)" }))
+    .click();
+
+  // Column 1 is now empty; column 2 gained one card (now 3).
+  await expect(page.getByLabel("Empty tableau column 1")).toBeVisible({
+    timeout: 3_000,
+  });
+  await expect(page.getByLabel("Tableau column 2, 3 cards")).toBeVisible({
+    timeout: 3_000,
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 5 Playwright specs for Solitaire covering the P0/P1/P2 critical path (closes #1143)
- Smoke (navigation + 7 tableau columns + stock pile), draw mechanic, tableau-to-tableau move, persistence across navigation, and leaderboard submit/rank confirmation
- All API calls mocked; no `waitForTimeout`; injected states used for deterministic card layouts

## Test plan
- [x] All 8 tests pass locally: `npx playwright test --project solitaire` → 8 passed (15.6s)
- [x] `.or()` pattern used in tableau-move to handle card vs pile label variants
- [x] `beforeEach` / `injectSolitaireState` clears `solitaire_game` before each test

🤖 Generated with [Claude Code](https://claude.com/claude-code)