### PR TITLE
feat(e2e): Sudoku smoke/difficulty-select/digit-entry/persistence/leaderboard specs

### DIFF
--- a/e2e/tests/sudoku-difficulty-select.spec.ts
+++ b/e2e/tests/sudoku-difficulty-select.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+import { mockSudokuApi, gotoSudoku } from "./helpers/sudoku";
+
+test.describe("Sudoku — difficulty select", () => {
+  test("selecting Easy and starting renders the 9×9 grid with pre-filled clue cells", async ({
+    page,
+  }) => {
+    await mockSudokuApi(page);
+    await gotoSudoku(page);
+
+    await page.getByRole("radio", { name: "Easy" }).click();
+    await page.getByRole("button", { name: "Start" }).click();
+
+    await page.getByLabel("Sudoku board").waitFor({ timeout: 10_000 });
+
+    // At least one pre-filled clue cell (given digit 1–9) should be visible.
+    await expect(
+      page
+        .getByRole("button", { name: /Cell row \d+, column \d+, [1-9]/ })
+        .first(),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/sudoku-digit-entry.spec.ts
+++ b/e2e/tests/sudoku-digit-entry.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+import { mockSudokuApi, injectSudokuState } from "./helpers/sudoku";
+
+// Valid 9×9 solution used across injected states.
+const SOL = "123456789456789123789123456231564897564897231897231564312645978645978312978312645";
+
+// Puzzle string: empty at index 4 (row 1, col 5) and index 80 (row 9, col 9).
+const PUZ = `${SOL.slice(0, 4)}0${SOL.slice(5, 80)}0`;
+
+type Cell = { value: number; given: boolean; notes: number[]; isError: boolean };
+
+function buildGrid(emptyIdxs: number[]): Cell[][] {
+  const empties = new Set(emptyIdxs);
+  return Array.from({ length: 9 }, (_, r) =>
+    Array.from({ length: 9 }, (_, c) => {
+      const idx = r * 9 + c;
+      const v = parseInt(SOL[idx]);
+      if (empties.has(idx)) return { value: 0, given: false, notes: [], isError: false };
+      return { value: v, given: true, notes: [], isError: false };
+    }),
+  );
+}
+
+// Two empty cells so that filling one does not complete the puzzle.
+const STATE = {
+  _v: 1 as const,
+  variant: "classic" as const,
+  difficulty: "easy" as const,
+  puzzle: PUZ,
+  solution: SOL,
+  grid: buildGrid([4, 80]),
+  selectedRow: null,
+  selectedCol: null,
+  notesMode: false,
+  errorCount: 0,
+  isComplete: false,
+  undoStack: [],
+};
+
+test("tapping an empty cell then digit 5 displays 5 in that cell", async ({ page }) => {
+  await mockSudokuApi(page);
+  await injectSudokuState(page, STATE);
+
+  await page.getByRole("button", { name: "Play Sudoku" }).click();
+  await page
+    .getByRole("heading", { name: "Sudoku", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Cell row 1, col 5 is the empty cell (flat index 4).
+  const emptyCell = page.getByRole("button", {
+    name: "Cell row 1, column 5, empty",
+  });
+  await expect(emptyCell).toBeVisible({ timeout: 5_000 });
+  await emptyCell.click();
+
+  await page.getByRole("button", { name: "Enter digit 5" }).click();
+
+  await expect(
+    page.getByRole("button", { name: "Cell row 1, column 5, 5" }),
+  ).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/tests/sudoku-leaderboard.spec.ts
+++ b/e2e/tests/sudoku-leaderboard.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { injectSudokuState } from "./helpers/sudoku";
+
+const SOL = "123456789456789123789123456231564897564897231897231564312645978645978312978312645";
+
+// Puzzle marks only the last cell (row 9, col 9, index 80) as empty.
+// Entering digit 5 there fills the final cell and completes the puzzle.
+const PUZ = `${SOL.slice(0, 80)}0`;
+
+type Cell = { value: number; given: boolean; notes: number[]; isError: boolean };
+
+const NEAR_WIN_GRID: Cell[][] = Array.from({ length: 9 }, (_, r) =>
+  Array.from({ length: 9 }, (_, c) => {
+    const idx = r * 9 + c;
+    if (idx === 80) return { value: 0, given: false, notes: [], isError: false };
+    return { value: parseInt(SOL[idx]), given: true, notes: [], isError: false };
+  }),
+);
+
+const NEAR_WIN_STATE = {
+  _v: 1 as const,
+  variant: "classic" as const,
+  difficulty: "easy" as const,
+  puzzle: PUZ,
+  solution: SOL,
+  grid: NEAR_WIN_GRID,
+  selectedRow: null,
+  selectedCol: null,
+  notesMode: false,
+  errorCount: 0,
+  isComplete: false,
+  undoStack: [],
+};
+
+test.describe("Sudoku — leaderboard", () => {
+  test("PATCH /sudoku/score intercepted and confirmation shown after submit", async ({
+    page,
+  }) => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    await page.route("**/sudoku/**", async (route) => {
+      if (route.request().method() === "PATCH") {
+        capturedBody = JSON.parse(route.request().postData() ?? "{}");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ player_name: "Tester", score: 500, rank: 1 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ scores: [] }),
+        });
+      }
+    });
+
+    await injectSudokuState(page, NEAR_WIN_STATE);
+    await page.getByRole("button", { name: "Play Sudoku" }).click();
+    await page
+      .getByRole("heading", { name: "Sudoku", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    // Enter the final digit to complete the puzzle and trigger the win modal.
+    const lastCell = page.getByRole("button", {
+      name: "Cell row 9, column 9, empty",
+    });
+    await expect(lastCell).toBeVisible({ timeout: 5_000 });
+    await lastCell.click();
+    await page.getByRole("button", { name: "Enter digit 5" }).click();
+
+    // Win modal appears.
+    await expect(page.getByText("You Solved It!")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByLabel("Your name").fill("Tester");
+
+    const submitBtn = page.getByRole("button", { name: "Submit Score" });
+    await expect(submitBtn).toBeEnabled({ timeout: 2_000 });
+    await submitBtn.click();
+
+    await expect(
+      page.getByText("Saved! Score submitted."),
+    ).toBeVisible({ timeout: 5_000 });
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!["player_name"]).toBe("Tester");
+  });
+
+  test("Submit Score button is disabled when name field is empty", async ({ page }) => {
+    await page.route("**/sudoku/**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    });
+
+    await injectSudokuState(page, NEAR_WIN_STATE);
+    await page.getByRole("button", { name: "Play Sudoku" }).click();
+    await page
+      .getByRole("heading", { name: "Sudoku", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    const lastCell = page.getByRole("button", {
+      name: "Cell row 9, column 9, empty",
+    });
+    await expect(lastCell).toBeVisible({ timeout: 5_000 });
+    await lastCell.click();
+    await page.getByRole("button", { name: "Enter digit 5" }).click();
+
+    await expect(page.getByText("You Solved It!")).toBeVisible({ timeout: 5_000 });
+
+    await expect(
+      page.getByRole("button", { name: "Submit Score" }),
+    ).toBeDisabled({ timeout: 2_000 });
+  });
+});

--- a/e2e/tests/sudoku-persistence.spec.ts
+++ b/e2e/tests/sudoku-persistence.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { mockSudokuApi, injectSudokuState } from "./helpers/sudoku";
+
+const SOL = "123456789456789123789123456231564897564897231897231564312645978645978312978312645";
+
+// Puzzle marks row 1 col 5 (index 4) and row 9 col 9 (index 80) as empty.
+const PUZ = `${SOL.slice(0, 4)}0${SOL.slice(5, 80)}0`;
+
+type Cell = { value: number; given: boolean; notes: number[]; isError: boolean };
+
+// Row 1 col 5 (index 4) is user-filled with 5; row 9 col 9 (index 80) stays empty.
+const GRID: Cell[][] = Array.from({ length: 9 }, (_, r) =>
+  Array.from({ length: 9 }, (_, c) => {
+    const idx = r * 9 + c;
+    if (idx === 4) return { value: 5, given: false, notes: [], isError: false };
+    if (idx === 80) return { value: 0, given: false, notes: [], isError: false };
+    return { value: parseInt(SOL[idx]), given: true, notes: [], isError: false };
+  }),
+);
+
+const PERSIST_STATE = {
+  _v: 1 as const,
+  variant: "classic" as const,
+  difficulty: "easy" as const,
+  puzzle: PUZ,
+  solution: SOL,
+  grid: GRID,
+  selectedRow: null,
+  selectedCol: null,
+  notesMode: false,
+  errorCount: 0,
+  isComplete: false,
+  undoStack: [],
+};
+
+test("digit entered in cell persists after navigating away and back", async ({ page }) => {
+  await mockSudokuApi(page);
+  await injectSudokuState(page, PERSIST_STATE);
+
+  await page.getByRole("button", { name: "Play Sudoku" }).click();
+  await page
+    .getByRole("heading", { name: "Sudoku", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Row 1, col 5 already holds the user-entered "5".
+  await expect(
+    page.getByRole("button", { name: "Cell row 1, column 5, 5" }),
+  ).toBeVisible({ timeout: 5_000 });
+
+  // Navigate away.
+  await page.goto("/");
+  await page.getByText("BC Arcade").first().waitFor();
+
+  // Return to Sudoku.
+  await page.getByRole("button", { name: "Play Sudoku" }).click();
+  await page
+    .getByRole("heading", { name: "Sudoku", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Cell should still display "5" after resume.
+  await expect(
+    page.getByRole("button", { name: "Cell row 1, column 5, 5" }),
+  ).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/tests/sudoku-smoke.spec.ts
+++ b/e2e/tests/sudoku-smoke.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { mockSudokuApi, gotoSudoku } from "./helpers/sudoku";
+
+test.describe("Sudoku — smoke tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSudokuApi(page);
+    await gotoSudoku(page);
+  });
+
+  test("navigates from Home to Sudoku screen", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Sudoku", exact: true }),
+    ).toBeVisible();
+  });
+
+  test("pre-game difficulty selector is visible on first load", async ({ page }) => {
+    await expect(
+      page.getByRole("radiogroup", { name: "Difficulty" }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 5 Playwright spec files (7 tests total) covering the Sudoku critical path per #1144
- Uses injected localStorage states for digit-entry, persistence, and leaderboard tests — no running backend needed
- Leaderboard test completes the puzzle naturally (enters last digit) so a sync gameId exists for PATCH submission

## Test plan
- [ ] `sudoku-smoke` — navigate Home → Sudoku; heading + difficulty radiogroup visible
- [ ] `sudoku-difficulty-select` — click Easy → Start; 9×9 grid + pre-filled clue cell visible
- [ ] `sudoku-digit-entry` — inject near-complete state; tap empty cell; enter 5; cell displays 5
- [ ] `sudoku-persistence` — inject state with user-entered digit; navigate away/back; digit persists
- [ ] `sudoku-leaderboard` — enter last digit to complete; PATCH intercepted; "Saved! Score submitted." shown; Submit disabled when name empty

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)