### PR TITLE
feat(e2e): Mahjong tile-interaction/persistence/leaderboard specs (#1146)

### DIFF
--- a/e2e/tests/helpers/mahjong.ts
+++ b/e2e/tests/helpers/mahjong.ts
@@ -28,3 +28,17 @@ export async function gotoMahjong(page: Page): Promise<void> {
     .getByRole("img", { name: /Mahjong Solitaire/i })
     .waitFor({ timeout: 15_000 });
 }
+
+/** Inject a MahjongState snapshot into localStorage and reload the home page. */
+export async function injectMahjongState(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    ["mahjong_game", partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/mahjong-leaderboard.spec.ts
+++ b/e2e/tests/mahjong-leaderboard.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * mahjong-leaderboard.spec.ts — GH #1146
+ *
+ * Leaderboard integration: inject a completed game (all 72 pairs removed,
+ * isComplete = true), intercept POST /mahjong/score, and verify the win modal
+ * appears, accepts a name, and shows the submission confirmation.
+ *
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { injectMahjongState, mockMahjongApi } from "./helpers/mahjong";
+
+const API_BASE = "http://localhost:8000";
+
+const WIN_STATE = {
+  _v: 1,
+  tiles: [],
+  pairsRemoved: 72,
+  score: 1220,
+  shufflesLeft: 0,
+  selected: null,
+  undoStack: [],
+  isComplete: true,
+  isDeadlocked: false,
+  startedAt: null,
+  accumulatedMs: 120_000,
+  dealId: "ff00",
+};
+
+test.describe("Mahjong — leaderboard", () => {
+  test("win modal appears and POST /mahjong/score is intercepted for a completed game", async ({
+    page,
+  }) => {
+    await page.route(`${API_BASE}/mahjong/**`, async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ player_name: "Tester", score: 1220, rank: 1 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ scores: [] }),
+        });
+      }
+    });
+
+    await injectMahjongState(page, WIN_STATE);
+    await page.getByRole("button", { name: "Play Mahjong Solitaire" }).click();
+    await page
+      .getByRole("heading", { name: "Mahjong Solitaire", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    // Win modal appears because isComplete = true.
+    await expect(page.getByRole("heading", { name: "YOU WIN!" })).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Score: 1220").first()).toBeVisible({ timeout: 2_000 });
+
+    // Set up POST intercept before triggering submission.
+    const scorePostRequest = page.waitForRequest(
+      (req) => req.url().includes("/mahjong/score") && req.method() === "POST",
+      { timeout: 10_000 },
+    );
+
+    // Enter a name and submit.
+    await page.getByLabel("Enter your name").fill("Tester");
+    await page.getByRole("button", { name: "Submit Score" }).click();
+
+    // Confirmation text appears and POST was made.
+    await expect(page.getByText(/Score saved/).first()).toBeVisible({ timeout: 5_000 });
+    await scorePostRequest;
+  });
+
+  test("NEW GAME dismisses the win modal and starts a fresh game", async ({ page }) => {
+    await mockMahjongApi(page);
+    await injectMahjongState(page, WIN_STATE);
+
+    await page.getByRole("button", { name: "Play Mahjong Solitaire" }).click();
+    await page
+      .getByRole("heading", { name: "Mahjong Solitaire", exact: true })
+      .waitFor({ timeout: 10_000 });
+
+    await expect(page.getByRole("heading", { name: "YOU WIN!" })).toBeVisible({ timeout: 5_000 });
+
+    await page.getByRole("button", { name: "Start a new game" }).click();
+
+    // Win modal dismissed; PAIRS counter resets to 0.
+    await expect(page.getByRole("heading", { name: "YOU WIN!" })).not.toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText(/^PAIRS\s+0\/72/).first()).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/mahjong-persistence.spec.ts
+++ b/e2e/tests/mahjong-persistence.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * mahjong-persistence.spec.ts — GH #1146
+ *
+ * Persistence: inject a mid-game state (score=100, pairsRemoved=5), navigate
+ * to Mahjong, verify the HUD reflects the injected values, navigate away,
+ * return, and confirm the values are unchanged.
+ *
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockMahjongApi, injectMahjongState } from "./helpers/mahjong";
+
+const MID_GAME_STATE = {
+  _v: 1,
+  tiles: [],
+  pairsRemoved: 5,
+  score: 100,
+  shufflesLeft: 2,
+  selected: null,
+  undoStack: [],
+  isComplete: false,
+  isDeadlocked: false,
+  startedAt: null,
+  accumulatedMs: 5000,
+  dealId: "abcd",
+};
+
+test("SCORE and PAIRS persist after navigating away and back", async ({ page }) => {
+  await mockMahjongApi(page);
+  await injectMahjongState(page, MID_GAME_STATE);
+
+  await page.getByRole("button", { name: "Play Mahjong Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Mahjong Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  await expect(page.getByText(/^SCORE\s+100/).first()).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText(/^PAIRS\s+5\/72/).first()).toBeVisible({ timeout: 5_000 });
+
+  // Navigate away — MahjongScreen saves state on every state change.
+  await page.goto("/");
+  await page.getByText("BC Arcade").first().waitFor();
+
+  // Return to Mahjong.
+  await page.getByRole("button", { name: "Play Mahjong Solitaire" }).click();
+  await page
+    .getByRole("heading", { name: "Mahjong Solitaire", exact: true })
+    .waitFor({ timeout: 10_000 });
+
+  // Injected score and pairs should survive the round-trip.
+  await expect(page.getByText(/^SCORE\s+100/).first()).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText(/^PAIRS\s+5\/72/).first()).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/tests/mahjong-tile-interaction.spec.ts
+++ b/e2e/tests/mahjong-tile-interaction.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * mahjong-tile-interaction.spec.ts — GH #1146
+ *
+ * Tile interaction: tap the canvas at several locations, confirm the HUD
+ * (SCORE / PAIRS) remains visible and no error alert is raised.
+ *
+ * Canvas layout is non-deterministic, so assertions target HUD visibility
+ * and crash-freedom rather than specific tile-match outcomes.
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { gotoMahjong, mockMahjongApi } from "./helpers/mahjong";
+
+test.describe("Mahjong — tile interaction", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockMahjongApi(page);
+    await page.goto("/");
+    await page.evaluate(() => {
+      localStorage.removeItem("mahjong_game");
+      localStorage.removeItem("mahjong_stats_v1");
+    });
+  });
+
+  test("tapping the canvas leaves HUD visible and raises no error alert", async ({ page }) => {
+    await gotoMahjong(page);
+    const canvas = page.getByRole("img", { name: /Mahjong Solitaire/i });
+    const box = await canvas.boundingBox();
+    if (box) {
+      const cx = box.x + box.width / 2;
+      const cy = box.y + box.height / 2;
+      await page.mouse.click(cx, cy);
+      await page.mouse.click(cx - 40, cy);
+      await page.mouse.click(cx + 40, cy);
+    }
+    await expect(page.getByText(/^SCORE\s+\d/).first()).toBeVisible();
+    await expect(page.getByText(/^PAIRS\s+\d/).first()).toBeVisible();
+    await expect(page.getByRole("alert")).not.toBeAttached();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `injectMahjongState` helper to `e2e/tests/helpers/mahjong.ts`
- `mahjong-tile-interaction.spec.ts` — taps canvas center + sides, asserts HUD visible and no error alert
- `mahjong-persistence.spec.ts` — injects mid-game state (score=100, pairsRemoved=5), verifies HUD values survive a navigate-away/return round-trip
- `mahjong-leaderboard.spec.ts` — injects completed game (isComplete=true), verifies win modal, name entry, POST /mahjong/score intercept, confirmation text, and NEW GAME dismissal

## Test plan
- [ ] All 4 new specs pass: `npx playwright test mahjong-tile-interaction mahjong-persistence mahjong-leaderboard`
- [ ] All 9 mahjong specs pass (4 smoke + 4 new + 1 helper): `npx playwright test mahjong`
- [ ] Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)