### PR TITLE
feat(frontend): lazyScreens guards + prefetchLobbyGameScreens scoping

### DIFF
--- a/e2e/tests/helpers/hearts.ts
+++ b/e2e/tests/helpers/hearts.ts
@@ -29,6 +29,7 @@ export async function injectHeartsState(
   page: Page,
   partial: Record<string, unknown>,
 ): Promise<void> {
+  await installEntitlementsMock(page);
   await page.goto("/");
   await page.evaluate(
     ([key, state]) =>

--- a/e2e/tests/helpers/sudoku.ts
+++ b/e2e/tests/helpers/sudoku.ts
@@ -28,6 +28,7 @@ export async function injectSudokuState(
   page: Page,
   partial: Record<string, unknown>,
 ): Promise<void> {
+  await installEntitlementsMock(page);
   await page.goto("/");
   await page.evaluate(
     ([key, state]) =>

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -16,6 +16,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
+import LockedGameScreen from "./src/screens/LockedGameScreen";
 import GameScreen from "./src/screens/GameScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
 import BottomTabBar from "./src/components/shared/BottomTabBar";
@@ -23,7 +24,7 @@ import { GameState } from "./src/game/yacht/types";
 import { ThemeProvider } from "./src/theme/ThemeContext";
 import { useHtmlAttributes } from "./src/i18n/useHtmlAttributes";
 import { NetworkProvider } from "./src/game/_shared/NetworkContext";
-import { EntitlementProvider } from "./src/entitlements/EntitlementContext";
+import { EntitlementProvider, useEntitlements } from "./src/entitlements/EntitlementContext";
 import { SoundProvider } from "./src/game/_shared/SoundContext";
 import { CardDeckProvider } from "./src/game/_shared/decks/CardDeckContext";
 import { BlackjackGameProvider } from "./src/game/blackjack/BlackjackGameContext";
@@ -147,15 +148,35 @@ function withSuspense<P extends object>(
   return Wrapped;
 }
 
-const LazyCascadeScreen = withSuspense(LazyScreens.Cascade, "cascade");
-const LazyStarSwarmScreen = withSuspense(LazyScreens.StarSwarm, "starswarm");
+// Guard wrapper for premium screens: renders LockedGameScreen for unentitled
+// sessions without loading the actual game chunk (issue #1055). The check runs
+// at navigation time (inside the component) so React context is available.
+// Trade-off vs. factory-level guard: the lazy factory is defined at module
+// scope where context is absent, so a render-time check is the only way to
+// block chunk loading without restructuring the entire lazy/prefetch setup.
+function makePremiumScreen<P extends object>(
+  slug: string,
+  Screen: React.ComponentType<P>
+): React.FC<P> {
+  const PremiumScreen = (props: P) => {
+    const { canPlay, isLoading } = useEntitlements();
+    if (isLoading) return <ActivityIndicator style={{ flex: 1 }} />;
+    if (!canPlay(slug)) return <LockedGameScreen />;
+    return <Screen {...props} />;
+  };
+  PremiumScreen.displayName = `Premium(${slug})`;
+  return PremiumScreen;
+}
+
+const LazyCascadeScreen = makePremiumScreen("cascade", withSuspense(LazyScreens.Cascade, "cascade"));
+const LazyStarSwarmScreen = makePremiumScreen("starswarm", withSuspense(LazyScreens.StarSwarm, "starswarm"));
 const LazyBlackjackBettingScreen = withSuspense(LazyScreens.BlackjackBetting, "blackjack_betting");
 const LazyBlackjackTableScreen = withSuspense(LazyScreens.BlackjackTable, "blackjack_table");
 const LazyTwenty48Screen = withSuspense(LazyScreens.Twenty48, "twenty48");
 const LazySolitaireScreen = withSuspense(LazyScreens.Solitaire, "solitaire");
 const LazyFreeCellScreen = withSuspense(LazyScreens.FreeCell, "freecell");
-const LazyHeartsScreen = withSuspense(LazyScreens.Hearts, "hearts");
-const LazySudokuScreen = withSuspense(LazyScreens.Sudoku, "sudoku");
+const LazyHeartsScreen = makePremiumScreen("hearts", withSuspense(LazyScreens.Hearts, "hearts"));
+const LazySudokuScreen = makePremiumScreen("sudoku", withSuspense(LazyScreens.Sudoku, "sudoku"));
 const LazyMahjongScreen = withSuspense(LazyScreens.Mahjong, "mahjong");
 const LazyLeaderboardScreen = withSuspense(LazyScreens.Leaderboard, "leaderboard");
 const LazyGameDetailScreen = withSuspense(LazyScreens.GameDetail, "game_detail");

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -168,8 +168,14 @@ function makePremiumScreen<P extends object>(
   return PremiumScreen;
 }
 
-const LazyCascadeScreen = makePremiumScreen("cascade", withSuspense(LazyScreens.Cascade, "cascade"));
-const LazyStarSwarmScreen = makePremiumScreen("starswarm", withSuspense(LazyScreens.StarSwarm, "starswarm"));
+const LazyCascadeScreen = makePremiumScreen(
+  "cascade",
+  withSuspense(LazyScreens.Cascade, "cascade")
+);
+const LazyStarSwarmScreen = makePremiumScreen(
+  "starswarm",
+  withSuspense(LazyScreens.StarSwarm, "starswarm")
+);
 const LazyBlackjackBettingScreen = withSuspense(LazyScreens.BlackjackBetting, "blackjack_betting");
 const LazyBlackjackTableScreen = withSuspense(LazyScreens.BlackjackTable, "blackjack_table");
 const LazyTwenty48Screen = withSuspense(LazyScreens.Twenty48, "twenty48");

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -70,10 +70,12 @@ export default function HomeScreen() {
   // Warm lobby game chunks once Home has painted so nav doesn't show a
   // Suspense fallback on tap (issue #706). setTimeout(0) defers past the
   // current frame without the InteractionManager deprecation in RN 0.83.
+  // canPlay is stable until entitlements change, so re-running on change
+  // ensures premium chunks are prefetched as soon as a session is entitled.
   useEffect(() => {
-    const id = setTimeout(prefetchLobbyGameScreens, 0);
+    const id = setTimeout(() => prefetchLobbyGameScreens(canPlay), 0);
     return () => clearTimeout(id);
-  }, []);
+  }, [canPlay]);
 
   async function startYacht() {
     const saved = await loadYachtGame();

--- a/frontend/src/screens/LockedGameScreen.tsx
+++ b/frontend/src/screens/LockedGameScreen.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "../theme/ThemeContext";
+import { typography } from "../theme/typography";
+import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
+
+export default function LockedGameScreen() {
+  const navigation = useNavigation();
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={[styles.screen, { backgroundColor: colors.background }]}>
+      <AppHeader title="Locked" />
+      <View
+        style={[
+          styles.content,
+          { paddingTop: APP_HEADER_HEIGHT + insets.top + 32, paddingBottom: insets.bottom + 24 },
+        ]}
+      >
+        <Text style={styles.lockEmoji}>🔒</Text>
+        <Text style={[styles.heading, { color: colors.text }]}>Premium Game</Text>
+        <Text style={[styles.body, { color: colors.textMuted }]}>
+          This game requires a BC Arcade subscription.
+        </Text>
+        <Pressable
+          style={[styles.backBtn, { backgroundColor: colors.surfaceHigh }]}
+          onPress={() => navigation.goBack()}
+          accessibilityRole="button"
+          accessibilityLabel="Go back to lobby"
+        >
+          <Text style={[styles.backBtnText, { color: colors.text }]}>Back to Lobby</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    gap: 16,
+  },
+  lockEmoji: {
+    fontSize: 64,
+  },
+  heading: {
+    fontFamily: typography.heading,
+    fontSize: 24,
+    letterSpacing: -0.5,
+    textAlign: "center",
+  },
+  body: {
+    fontFamily: typography.body,
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: "center",
+  },
+  backBtn: {
+    marginTop: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 20,
+  },
+  backBtnText: {
+    fontFamily: typography.label,
+    fontSize: 13,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+});

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -168,9 +168,7 @@ describe("HomeScreen — lobby prefetch (issue #706, #1055)", () => {
 
   it("passes canPlay from useEntitlements to prefetchLobbyGameScreens", async () => {
     renderScreen();
-    await waitFor(() =>
-      expect(mockPrefetch).toHaveBeenCalledWith(mockCanPlay)
-    );
+    await waitFor(() => expect(mockPrefetch).toHaveBeenCalledWith(mockCanPlay));
   });
 });
 

--- a/frontend/src/screens/__tests__/HomeScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HomeScreen.test.tsx
@@ -30,7 +30,7 @@ jest.mock("expo-linear-gradient", () => ({
 
 const mockPrefetch = jest.fn();
 jest.mock("../../utils/lazyScreens", () => ({
-  prefetchLobbyGameScreens: () => mockPrefetch(),
+  prefetchLobbyGameScreens: (canPlay: (slug: string) => boolean) => mockPrefetch(canPlay),
 }));
 
 // ---------------------------------------------------------------------------
@@ -160,10 +160,17 @@ describe("HomeScreen — AppHeader", () => {
   });
 });
 
-describe("HomeScreen — lobby prefetch (issue #706)", () => {
+describe("HomeScreen — lobby prefetch (issue #706, #1055)", () => {
   it("warms lobby game chunks after interactions settle", async () => {
     renderScreen();
     await waitFor(() => expect(mockPrefetch).toHaveBeenCalledTimes(1));
+  });
+
+  it("passes canPlay from useEntitlements to prefetchLobbyGameScreens", async () => {
+    renderScreen();
+    await waitFor(() =>
+      expect(mockPrefetch).toHaveBeenCalledWith(mockCanPlay)
+    );
   });
 });
 

--- a/frontend/src/utils/__tests__/lazyScreens.test.tsx
+++ b/frontend/src/utils/__tests__/lazyScreens.test.tsx
@@ -9,10 +9,8 @@ import * as Sentry from "@sentry/react-native";
 
 // Replace the real screen factories with tiny stubs so we don't pull a whole
 // game screen (and its dependencies) into this test.
-jest.mock("../../screens/CascadeScreen", () => ({
-  __esModule: true,
-  default: () => null,
-}));
+jest.mock("../../screens/CascadeScreen", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../screens/StarSwarmScreen", () => ({ __esModule: true, default: () => null }));
 jest.mock("../../screens/BlackjackBettingScreen", () => ({
   __esModule: true,
   default: () => null,
@@ -33,10 +31,34 @@ describe("prefetchLobbyGameScreens", () => {
   it("resolves without throwing when called repeatedly", () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { prefetchLobbyGameScreens } = require("../lazyScreens");
+    const canPlay = jest.fn().mockReturnValue(true);
     expect(() => {
-      prefetchLobbyGameScreens();
-      prefetchLobbyGameScreens();
+      prefetchLobbyGameScreens(canPlay);
+      prefetchLobbyGameScreens(canPlay);
     }).not.toThrow();
+  });
+
+  it("queries canPlay for each of the four premium slugs", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { prefetchLobbyGameScreens } = require("../lazyScreens");
+    const canPlay = jest.fn().mockReturnValue(false);
+    prefetchLobbyGameScreens(canPlay);
+    expect(canPlay).toHaveBeenCalledWith("cascade");
+    expect(canPlay).toHaveBeenCalledWith("starswarm");
+    expect(canPlay).toHaveBeenCalledWith("hearts");
+    expect(canPlay).toHaveBeenCalledWith("sudoku");
+  });
+
+  it("does not query canPlay for free game slugs", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { prefetchLobbyGameScreens } = require("../lazyScreens");
+    const canPlay = jest.fn().mockReturnValue(false);
+    prefetchLobbyGameScreens(canPlay);
+    expect(canPlay).not.toHaveBeenCalledWith("blackjack");
+    expect(canPlay).not.toHaveBeenCalledWith("twenty48");
+    expect(canPlay).not.toHaveBeenCalledWith("solitaire");
+    expect(canPlay).not.toHaveBeenCalledWith("freecell");
+    expect(canPlay).not.toHaveBeenCalledWith("mahjong");
   });
 });
 

--- a/frontend/src/utils/lazyScreens.ts
+++ b/frontend/src/utils/lazyScreens.ts
@@ -37,20 +37,34 @@ export const LazyScreens = {
   Scoreboard: React.lazy(factories.Scoreboard),
 } as const;
 
+// Slugs for the four premium games that have lazy screens.
+const PREMIUM_LAZY: Array<[keyof typeof factories, string]> = [
+  ["Cascade", "cascade"],
+  ["StarSwarm", "starswarm"],
+  ["Hearts", "hearts"],
+  ["Sudoku", "sudoku"],
+];
+
 /**
  * Fire-and-forget prefetch of lobby game chunks. Called from HomeScreen after
  * interactions settle so the Suspense fallback doesn't flash when the user
  * taps into a game (issue #706). Safe to call multiple times — the module
  * loader dedupes.
+ *
+ * Free game chunks are always prefetched. Premium chunks are only prefetched
+ * when canPlay returns true for that slug so unentitled sessions never receive
+ * premium code (issue #1055).
  */
-export function prefetchLobbyGameScreens(): void {
-  factories.Cascade().catch(() => undefined);
-  factories.StarSwarm().catch(() => undefined);
+export function prefetchLobbyGameScreens(canPlay: (slug: string) => boolean): void {
   factories.BlackjackBetting().catch(() => undefined);
   factories.Twenty48().catch(() => undefined);
   factories.Solitaire().catch(() => undefined);
   factories.FreeCell().catch(() => undefined);
-  factories.Hearts().catch(() => undefined);
-  factories.Sudoku().catch(() => undefined);
   factories.Mahjong().catch(() => undefined);
+
+  for (const [key, slug] of PREMIUM_LAZY) {
+    if (canPlay(slug)) {
+      factories[key]().catch(() => undefined);
+    }
+  }
 }


### PR DESCRIPTION
Closes #1055
Part of #971

## Summary
- Adds `LockedGameScreen` — shown when an unentitled session navigates to a premium game (Cascade, StarSwarm, Hearts, Sudoku)
- Wraps the four premium lazy screens in `makePremiumScreen()` in `App.tsx` — a render-time entitlement guard that blocks the `React.lazy` factory from running (and the chunk from loading) for unentitled users
- Updates `prefetchLobbyGameScreens` to accept `canPlay: (slug) => boolean`; free game chunks always prefetch, premium chunks only prefetch when entitled
- `HomeScreen` passes `canPlay` from `useEntitlements()` to the prefetch call; re-runs when entitlements change so a newly-subscribed session gets premium chunks warmed immediately

## Tradeoff note
The guard lives at render time (inside `makePremiumScreen`) rather than inside the `React.lazy` factory. Factory-level guards aren't feasible because the `factories` object is defined at module scope where React context is unavailable. The render-time approach achieves the same result: the lazy component never mounts for unentitled users, so the factory never runs and the chunk is never fetched.

## Test plan
- [ ] All 2078 existing Jest tests pass (`npx jest --no-coverage`)
- [ ] No TypeScript errors introduced in changed files
- [ ] Unentitled session: navigating to Cascade/StarSwarm/Hearts/Sudoku renders `LockedGameScreen`, chunk absent from network tab
- [ ] Entitled session: premium games load normally with no added latency
- [ ] Free game prefetch (Blackjack, 2048, Solitaire, FreeCell, Mahjong) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)