### PR TITLE
feat(sudoku): remove 3×3 box highlight and digit-entry sounds

### DIFF
--- a/frontend/src/components/sudoku/SudokuGrid.tsx
+++ b/frontend/src/components/sudoku/SudokuGrid.tsx
@@ -33,12 +33,7 @@ export default function SudokuGrid({
   const isPeer = (r: number, c: number): boolean => {
     if (selectedRow === null || selectedCol === null) return false;
     if (r === selectedRow && c === selectedCol) return false;
-    return (
-      r === selectedRow ||
-      c === selectedCol ||
-      (Math.floor(r / boxRows) === Math.floor(selectedRow / boxRows) &&
-        Math.floor(c / boxCols) === Math.floor(selectedCol / boxCols))
-    );
+    return r === selectedRow || c === selectedCol;
   };
 
   return (

--- a/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
+++ b/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
@@ -3274,7 +3274,7 @@ exports[`SudokuGrid matches snapshot with a typical mid-game state 1`] = `
               "justifyContent": "center",
             },
             {
-              "backgroundColor": "#8ff5ff22",
+              "backgroundColor": "#19191f",
             },
           ]
         }
@@ -3390,7 +3390,7 @@ exports[`SudokuGrid matches snapshot with a typical mid-game state 1`] = `
               "justifyContent": "center",
             },
             {
-              "backgroundColor": "#8ff5ff22",
+              "backgroundColor": "#19191f",
             },
           ]
         }
@@ -4354,7 +4354,7 @@ exports[`SudokuGrid matches snapshot with a typical mid-game state 1`] = `
               "justifyContent": "center",
             },
             {
-              "backgroundColor": "#8ff5ff22",
+              "backgroundColor": "#19191f",
             },
           ]
         }
@@ -4470,7 +4470,7 @@ exports[`SudokuGrid matches snapshot with a typical mid-game state 1`] = `
               "justifyContent": "center",
             },
             {
-              "backgroundColor": "#8ff5ff22",
+              "backgroundColor": "#19191f",
             },
           ]
         }

--- a/frontend/src/components/sudoku/__tests__/components.test.tsx
+++ b/frontend/src/components/sudoku/__tests__/components.test.tsx
@@ -280,9 +280,7 @@ describe("SudokuGrid", () => {
       // (1,1) shares a box with (0,0) but not its row or column — must not be highlighted.
       const boxOnlyCell = cells[1 * 9 + 1]!;
       expect(boxOnlyCell.props.style).not.toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ backgroundColor: "#8ff5ff22" }),
-        ])
+        expect.arrayContaining([expect.objectContaining({ backgroundColor: "#8ff5ff22" })])
       );
     });
 

--- a/frontend/src/components/sudoku/__tests__/components.test.tsx
+++ b/frontend/src/components/sudoku/__tests__/components.test.tsx
@@ -266,7 +266,7 @@ describe("SudokuGrid", () => {
       );
     });
 
-    it("marks cells in the same 3×3 box as peers", () => {
+    it("does not mark box-only cells as peers", () => {
       const { getAllByRole } = wrap(
         <SudokuGrid
           variant="classic"
@@ -277,11 +277,11 @@ describe("SudokuGrid", () => {
         />
       );
       const cells = getAllByRole("button");
-      // (1,1) shares box with (0,0) and is not on the same row/col.
-      const boxPeer = cells[1 * 9 + 1]!;
-      expect(boxPeer.props.style).toEqual(
+      // (1,1) shares a box with (0,0) but not its row or column — must not be highlighted.
+      const boxOnlyCell = cells[1 * 9 + 1]!;
+      expect(boxOnlyCell.props.style).not.toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ backgroundColor: "#8ff5ff22" }), // accent+22 peer tint
+          expect.objectContaining({ backgroundColor: "#8ff5ff22" }),
         ])
       );
     });

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -124,9 +124,6 @@ export default function SudokuScreen() {
   const unitFlashOpacity = useRef(new Animated.Value(0)).current;
   const isComplete = state?.isComplete ?? false;
 
-  const { play: playDigitPlace } = useSound("sudoku.digitPlace");
-  const { play: playErrorEntered } = useSound("sudoku.errorEntered");
-  const { play: playUnitComplete } = useSound("sudoku.unitComplete");
   const { play: playPuzzleComplete } = useSound("sudoku.puzzleComplete");
 
   const {
@@ -345,12 +342,9 @@ export default function SudokuScreen() {
     const evts = state?.events;
     if (!evts?.length) return;
     for (const evt of evts) {
-      if (evt.type === "digitPlace") playDigitPlace();
-      else if (evt.type === "errorEntered") {
-        playErrorEntered();
+      if (evt.type === "errorEntered") {
         flashError();
       } else if (evt.type === "unitComplete") {
-        playUnitComplete();
         Animated.sequence([
           Animated.timing(unitFlashOpacity, { toValue: 0.35, duration: 80, useNativeDriver: true }),
           Animated.timing(unitFlashOpacity, { toValue: 0, duration: 400, useNativeDriver: true }),


### PR DESCRIPTION
## Summary
- Removes 3×3 box peer highlight — selected cell now highlights only its row and column (#1183)
- Removes `digitPlace`, `errorEntered`, and `unitComplete` sound hooks from `SudokuScreen`; puzzle-complete sound is retained (#1184)
- Updates component test and snapshot to assert box-only cells are no longer highlighted

## Test plan
- [ ] All Sudoku tests pass (`npx jest --testPathPattern="sudoku"`)
- [ ] Manual: select a cell — only its row and column are tinted, no box highlight
- [ ] Manual: enter a digit (correct, error, unit-complete) — no sound plays; puzzle complete still plays
- [ ] Regression: existing game cards, navigation, and persistence unaffected

Closes #1183, #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)