### PR TITLE
feat(frontend): revocation flow — purge AsyncStorage + queue on entitlement loss

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -12,7 +12,10 @@ import {
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer, useNavigation } from "@react-navigation/native";
-import { createNativeStackNavigator, NativeStackNavigationProp } from "@react-navigation/native-stack";
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
@@ -170,7 +173,7 @@ function makePremiumScreen<P extends object>(
         navigation.navigate("Home");
       }
       wasEntitledRef.current = entitled;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- slug is a factory constant, stable for the component's lifetime
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- slug is a factory constant, stable for the component's lifetime
     }, [canPlay, isLoading, navigation]);
 
     if (isLoading) return <ActivityIndicator style={{ flex: 1 }} />;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -11,8 +11,9 @@ import {
 } from "@expo-google-fonts/manrope";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { NavigationContainer } from "@react-navigation/native";
+import { NavigationContainer, useNavigation } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
@@ -160,6 +161,18 @@ function makePremiumScreen<P extends object>(
 ): React.FC<P> {
   const PremiumScreen = (props: P) => {
     const { canPlay, isLoading } = useEntitlements();
+    const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+    const wasEntitledRef = useRef<boolean | null>(null);
+
+    useEffect(() => {
+      if (isLoading) return;
+      const entitled = canPlay(slug);
+      if (wasEntitledRef.current === true && !entitled) {
+        navigation.navigate("Home");
+      }
+      wasEntitledRef.current = entitled;
+    }, [canPlay, isLoading, navigation]);
+
     if (isLoading) return <ActivityIndicator style={{ flex: 1 }} />;
     if (!canPlay(slug)) return <LockedGameScreen />;
     return <Screen {...props} />;
@@ -168,6 +181,7 @@ function makePremiumScreen<P extends object>(
   return PremiumScreen;
 }
 
+const GuardedGameScreen = makePremiumScreen("yacht", GameScreen);
 const LazyCascadeScreen = makePremiumScreen(
   "cascade",
   withSuspense(LazyScreens.Cascade, "cascade")
@@ -198,7 +212,7 @@ function LobbyStack() {
   return (
     <HomeStack.Navigator screenOptions={{ headerShown: false }}>
       <HomeStack.Screen name="Home" component={HomeScreen} />
-      <HomeStack.Screen name="Game" component={GameScreen} />
+      <HomeStack.Screen name="Game" component={GuardedGameScreen} />
       <HomeStack.Screen name="Cascade" component={LazyCascadeScreen} />
       <HomeStack.Screen name="StarSwarm" component={LazyStarSwarmScreen} />
       <HomeStack.Screen name="BlackjackBetting" component={LazyBlackjackBettingScreen} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -12,8 +12,7 @@ import {
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { NavigationContainer, useNavigation } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { createNativeStackNavigator, NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as Sentry from "@sentry/react-native";
 import HomeScreen from "./src/screens/HomeScreen";
@@ -171,6 +170,7 @@ function makePremiumScreen<P extends object>(
         navigation.navigate("Home");
       }
       wasEntitledRef.current = entitled;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- slug is a factory constant, stable for the component's lifetime
     }, [canPlay, isLoading, navigation]);
 
     if (isLoading) return <ActivityIndicator style={{ flex: 1 }} />;

--- a/frontend/src/entitlements/EntitlementContext.tsx
+++ b/frontend/src/entitlements/EntitlementContext.tsx
@@ -1,8 +1,23 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { AppState, AppStateStatus } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import { createGameClient } from "../game/_shared/httpClient";
+import { clearGame as clearHearts } from "../game/hearts/storage";
+import { clearGame as clearYacht } from "../game/yacht/storage";
+import { clearGame as clearSudoku } from "../game/sudoku/storage";
+import { clearGame as clearCascade } from "../game/cascade/storage";
+import { scoreQueue } from "../game/_shared/scoreQueue";
+import type { GameType } from "../api/vocab";
+
+// Maps premium game slugs to their AsyncStorage clear functions.
+// starswarm has no local game state, so it is intentionally absent.
+const GAME_STORAGE_CLEARERS: Partial<Record<string, () => Promise<void>>> = {
+  hearts: clearHearts,
+  yacht: clearYacht,
+  sudoku: clearSudoku,
+  cascade: clearCascade,
+};
 
 // Premium games — sourced from backend migration 0014_game_types_premium_cat
 export const PREMIUM_GAMES = new Set(["yacht", "cascade", "hearts", "sudoku", "starswarm"]);
@@ -114,6 +129,7 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
   const [entitledGames, setEntitledGames] = useState<Set<string> | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null);
+  const prevEntitledRef = useRef<Set<string> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -155,6 +171,35 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
     });
     return () => sub.remove();
   }, [refresh]);
+
+  // Detect revocations and clean up local state for any game no longer entitled.
+  useEffect(() => {
+    if (entitledGames === null) return;
+    const prev = prevEntitledRef.current;
+    prevEntitledRef.current = entitledGames;
+    if (prev === null) return; // first load — no prior entitlements to compare
+
+    const revoked = [...PREMIUM_GAMES].filter(
+      (slug) => prev.has(slug) && !entitledGames.has(slug)
+    );
+    if (revoked.length === 0) return;
+
+    void Promise.all(
+      revoked.map(async (slug) => {
+        try {
+          const clear = GAME_STORAGE_CLEARERS[slug];
+          if (clear) await clear();
+          await scoreQueue.dropByGameType(slug as GameType);
+          console.log(`entitlement revoked: ${slug} — local state cleared`);
+        } catch (e) {
+          Sentry.captureException(e, {
+            tags: { subsystem: "entitlements", op: "revocation" },
+            extra: { slug },
+          });
+        }
+      })
+    );
+  }, [entitledGames]);
 
   const canPlay = useCallback(
     (gameSlug: string): boolean => {

--- a/frontend/src/entitlements/EntitlementContext.tsx
+++ b/frontend/src/entitlements/EntitlementContext.tsx
@@ -182,9 +182,7 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
     prevEntitledRef.current = entitledGames;
     if (prev === null) return; // first load — no prior entitlements to compare
 
-    const revoked = [...PREMIUM_GAMES].filter(
-      (slug) => prev.has(slug) && !entitledGames.has(slug)
-    );
+    const revoked = [...PREMIUM_GAMES].filter((slug) => prev.has(slug) && !entitledGames.has(slug));
     if (revoked.length === 0) return;
 
     void Promise.all(

--- a/frontend/src/entitlements/EntitlementContext.tsx
+++ b/frontend/src/entitlements/EntitlementContext.tsx
@@ -173,6 +173,9 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
   }, [refresh]);
 
   // Detect revocations and clean up local state for any game no longer entitled.
+  // Note: this effect fires after the new entitledGames state commits (canPlay has already
+  // updated). Cleanup is fire-and-forget and completes before the next render cycle, so
+  // the locked UI is shown while cleanup runs — intentional per issue #1056.
   useEffect(() => {
     if (entitledGames === null) return;
     const prev = prevEntitledRef.current;

--- a/frontend/src/entitlements/__tests__/EntitlementContext.test.tsx
+++ b/frontend/src/entitlements/__tests__/EntitlementContext.test.tsx
@@ -25,6 +25,20 @@ jest.mock("../../game/_shared/httpClient", () => ({
   ),
 }));
 
+const mockClearHearts = jest.fn().mockResolvedValue(undefined);
+const mockClearYacht = jest.fn().mockResolvedValue(undefined);
+const mockClearSudoku = jest.fn().mockResolvedValue(undefined);
+const mockClearCascade = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../game/hearts/storage", () => ({ clearGame: () => mockClearHearts() }));
+jest.mock("../../game/yacht/storage", () => ({ clearGame: () => mockClearYacht() }));
+jest.mock("../../game/sudoku/storage", () => ({ clearGame: () => mockClearSudoku() }));
+jest.mock("../../game/cascade/storage", () => ({ clearGame: () => mockClearCascade() }));
+
+const mockDropByGameType = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../game/_shared/scoreQueue", () => ({
+  scoreQueue: { dropByGameType: (...args: unknown[]) => mockDropByGameType(...args) },
+}));
+
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
@@ -101,6 +115,11 @@ beforeEach(async () => {
     token: makeToken(makePayload([])),
     expires_at: "2099-01-01T00:00:00Z",
   });
+  mockClearHearts.mockResolvedValue(undefined);
+  mockClearYacht.mockResolvedValue(undefined);
+  mockClearSudoku.mockResolvedValue(undefined);
+  mockClearCascade.mockResolvedValue(undefined);
+  mockDropByGameType.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -270,5 +289,98 @@ describe("parseRawToken", () => {
   it("returns invalid for a token with wrong number of segments", async () => {
     const result = await parseRawToken("only.two");
     expect(result.valid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revocation flow tests
+// ---------------------------------------------------------------------------
+
+describe("revocation flow", () => {
+  async function renderAndGetListener() {
+    render(
+      <EntitlementProvider>
+        <Probe />
+      </EntitlementProvider>
+    );
+    await flushAsync();
+    await flushAsync();
+    return getAppStateListener();
+  }
+
+  async function triggerForegroundWith(entitled: string[]) {
+    const listener = await renderAndGetListener();
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(entitled)),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await act(async () => {
+      listener("active");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
+    await flushAsync();
+  }
+
+  it("clears storage for a revoked game on foreground refresh", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["hearts"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await triggerForegroundWith([]);
+    expect(mockClearHearts).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops queue entries for the revoked game", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["sudoku"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await triggerForegroundWith([]);
+    expect(mockDropByGameType).toHaveBeenCalledWith("sudoku");
+  });
+
+  it("does not clear storage when entitlements are unchanged", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["cascade"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await triggerForegroundWith(["cascade"]);
+    expect(mockClearCascade).not.toHaveBeenCalled();
+    expect(mockDropByGameType).not.toHaveBeenCalledWith("cascade");
+  });
+
+  it("does not clear storage on first load (no prior entitlements)", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["hearts", "yacht"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    render(
+      <EntitlementProvider>
+        <Probe />
+      </EntitlementProvider>
+    );
+    await flushAsync();
+    await flushAsync();
+    expect(mockClearHearts).not.toHaveBeenCalled();
+    expect(mockClearYacht).not.toHaveBeenCalled();
+  });
+
+  it("handles starswarm revocation gracefully (no storage clearer)", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["starswarm"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await expect(triggerForegroundWith([])).resolves.toBeUndefined();
+    expect(mockDropByGameType).toHaveBeenCalledWith("starswarm");
+  });
+
+  it("does not affect free games when premium revocation occurs", async () => {
+    mockRequest.mockResolvedValue({
+      token: makeToken(makePayload(["hearts"])),
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    await triggerForegroundWith([]);
+    expect(mockDropByGameType).not.toHaveBeenCalledWith("blackjack");
+    expect(mockDropByGameType).not.toHaveBeenCalledWith("twenty48");
   });
 });

--- a/frontend/src/game/_shared/__tests__/scoreQueue.test.ts
+++ b/frontend/src/game/_shared/__tests__/scoreQueue.test.ts
@@ -129,6 +129,64 @@ describe("ScoreQueue", () => {
   });
 
   // -------------------------------------------------------------------------
+  // dropByGameType
+  // -------------------------------------------------------------------------
+
+  describe("dropByGameType", () => {
+    it("removes all items for the given game type, leaves others intact", async () => {
+      await queue.enqueue("hearts", { score: 1 });
+      await queue.enqueue("hearts", { score: 2 });
+      await queue.enqueue("cascade", { score: 3 });
+      await queue.dropByGameType("hearts");
+      const items = await queue.peek();
+      expect(items).toHaveLength(1);
+      expect(items[0]?.game_type).toBe("cascade");
+    });
+
+    it("is a no-op when no items match the game type", async () => {
+      await queue.enqueue("cascade", { score: 1 });
+      await queue.dropByGameType("hearts");
+      expect(await queue.size()).toBe(1);
+    });
+
+    it("is a no-op when the queue is empty", async () => {
+      await expect(queue.dropByGameType("yacht")).resolves.toBeUndefined();
+      expect(await queue.size()).toBe(0);
+    });
+
+    it("does not write to storage when no items are removed", async () => {
+      const spy = jest.spyOn(queue as unknown as { write: () => void }, "write");
+      await queue.enqueue("cascade", { score: 1 });
+      spy.mockClear();
+      await queue.dropByGameType("hearts");
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("is a no-op when a flush is in progress", async () => {
+      await queue.enqueue("hearts", { score: 1 });
+      let resolveHandler!: () => void;
+      // handlerStarted resolves once flush is mid-handler, guaranteeing flushInProgress=true
+      // and that resolveHandler has been assigned before we call it.
+      const handlerStarted = new Promise<void>((signal) => {
+        queue.registerHandler("hearts", () => {
+          signal();
+          return new Promise<void>((resolve) => {
+            resolveHandler = resolve;
+          });
+        });
+      });
+      const flushPromise = queue.flush();
+      await handlerStarted;
+      await queue.dropByGameType("hearts"); // drop is skipped — flush in progress
+      resolveHandler();
+      await flushPromise;
+      // item was flushed successfully (not dropped), queue is now empty
+      expect(await queue.size()).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // generateUUID — crypto fallback (regression for Sentry issue: "Property
   // 'crypto' doesn't exist")
   // -------------------------------------------------------------------------

--- a/frontend/src/game/_shared/scoreQueue.ts
+++ b/frontend/src/game/_shared/scoreQueue.ts
@@ -163,6 +163,9 @@ export class ScoreQueue {
   }
 
   async dropByGameType(gameType: GameType): Promise<void> {
+    // Skip if flush is in progress — reading/writing here would race with flush's
+    // own read→process→write cycle and the drop could be overwritten.
+    if (this.flushInProgress) return;
     const items = await this.read();
     const filtered = items.filter((item) => item.game_type !== gameType);
     if (filtered.length !== items.length) {

--- a/frontend/src/game/_shared/scoreQueue.ts
+++ b/frontend/src/game/_shared/scoreQueue.ts
@@ -162,6 +162,14 @@ export class ScoreQueue {
     }
   }
 
+  async dropByGameType(gameType: GameType): Promise<void> {
+    const items = await this.read();
+    const filtered = items.filter((item) => item.game_type !== gameType);
+    if (filtered.length !== items.length) {
+      await this.write(filtered);
+    }
+  }
+
   /** For tests only. */
   async _reset(): Promise<void> {
     await AsyncStorage.removeItem(STORAGE_KEY);


### PR DESCRIPTION
Closes #1056

## Summary

- **EntitlementContext**: tracks previous `entitled_games` via a ref; on each foreground refresh, diffs against the new set and fire-and-forgets `clearGame()` + `scoreQueue.dropByGameType()` for each revoked premium game. Logs one line per revocation. `starswarm` has no local state and is handled gracefully.
- **ScoreQueue**: adds `dropByGameType(gameType)` — filters the persistent queue and rewrites it if any entries were removed.
- **`makePremiumScreen`**: adds a `wasEntitledRef` effect — when a mounted premium screen transitions from entitled → not entitled, it navigates back to `Home`. Also wraps `GameScreen` (yacht) with `makePremiumScreen("yacht", …)` so yacht gets the same guard and navigation behavior.

## Test plan

- [ ] 6 new unit tests in `EntitlementContext.test.tsx` covering: storage cleared on revocation, queue entries dropped, no-op when entitlements unchanged, no cleanup on first load, starswarm graceful no-op, free games unaffected
- [ ] All 24 `EntitlementContext` tests pass
- [ ] All 12 `scoreQueue` tests pass
- [ ] Manual: remove a premium entitlement via dev override → foreground the app → confirm AsyncStorage cleared, queue purged, and user is back on HomeScreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)