### PR TITLE
feat(hearts): Easy/Medium/Hard AI difficulty selector (#1168)

### DIFF
--- a/e2e/tests/hearts-difficulty-select.spec.ts
+++ b/e2e/tests/hearts-difficulty-select.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * hearts-difficulty-select.spec.ts — GH #1168
+ *
+ * Difficulty selector: pre-game picker, Play Again picker, and difficulty persistence.
+ * All backend calls are intercepted — no running backend needed.
+ */
+
+import { test, expect } from "./fixtures";
+import { mockHeartsApi, gotoHearts, injectHeartsState } from "./helpers/hearts";
+import { installEntitlementsMock } from "./helpers/api-mock";
+
+const c = (suit: string, rank: number) => ({ suit: suit, rank: rank });
+
+// A complete game state so we can trigger the game_over overlay
+const GAME_OVER_STATE = {
+  _v: 3,
+  aiDifficulty: "medium",
+  phase: "game_over",
+  handNumber: 5,
+  passDirection: "none",
+  playerHands: [[], [], [], []],
+  cumulativeScores: [105, 30, 25, 22],
+  handScores: [0, 0, 0, 0],
+  scoreHistory: [
+    [26, 0, 0, 0],
+    [26, 0, 0, 0],
+    [26, 0, 0, 0],
+    [27, 30, 25, 22],
+  ],
+  passSelections: [[], [], [], []],
+  passingComplete: true,
+  currentTrick: [],
+  currentLeaderIndex: 0,
+  currentPlayerIndex: 0,
+  wonCards: [[], [], [], []],
+  heartsBroken: true,
+  tricksPlayedInHand: 13,
+  isComplete: true,
+  winnerIndex: 3,
+};
+
+test.describe("Hearts — difficulty selector (#1168)", () => {
+  test("pre-game picker shows Easy / Medium / Hard radio buttons", async ({ page }) => {
+    await mockHeartsApi(page);
+    await installEntitlementsMock(page);
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("hearts_game"));
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    const group = page.getByRole("radiogroup", { name: "AI Difficulty" });
+    await expect(group).toBeVisible({ timeout: 5_000 });
+    await expect(group.getByRole("radio", { name: "Easy" })).toBeVisible();
+    await expect(group.getByRole("radio", { name: "Medium" })).toBeVisible();
+    await expect(group.getByRole("radio", { name: "Hard" })).toBeVisible();
+  });
+
+  test("selecting Easy and clicking Start Game launches a game", async ({ page }) => {
+    await mockHeartsApi(page);
+    await installEntitlementsMock(page);
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("hearts_game"));
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    await page.getByRole("radio", { name: "Easy" }).click();
+    await page.getByRole("button", { name: "Start Game" }).click();
+
+    await expect(page.getByLabel("Your hand, 13 cards")).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("selecting Hard and clicking Start Game launches a game", async ({ page }) => {
+    await mockHeartsApi(page);
+    await installEntitlementsMock(page);
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("hearts_game"));
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    await page.getByRole("radio", { name: "Hard" }).click();
+    await page.getByRole("button", { name: "Start Game" }).click();
+
+    await expect(page.getByLabel("Your hand, 13 cards")).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("Play Again on game over returns to difficulty picker", async ({ page }) => {
+    await mockHeartsApi(page);
+    await injectHeartsState(page, GAME_OVER_STATE);
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    // Game over overlay should show
+    await expect(page.getByText("Game Over")).toBeVisible({ timeout: 5_000 });
+
+    // Difficulty selector appears in game_over panel
+    await expect(page.getByRole("radiogroup", { name: "AI Difficulty" })).toBeVisible({
+      timeout: 3_000,
+    });
+
+    // Click Play Again — goes back to pre-game picker
+    await page.getByRole("button", { name: "Play Again" }).click();
+    await expect(page.getByRole("radiogroup", { name: "AI Difficulty" })).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByRole("button", { name: "Start Game" })).toBeVisible();
+  });
+
+  test("difficulty selector in game_over panel shows Easy / Medium / Hard", async ({ page }) => {
+    await mockHeartsApi(page);
+    await injectHeartsState(page, GAME_OVER_STATE);
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    await expect(page.getByText("Game Over")).toBeVisible({ timeout: 5_000 });
+
+    const groups = page.getByRole("radiogroup", { name: "AI Difficulty" });
+    await expect(groups.first()).toBeVisible({ timeout: 3_000 });
+    await expect(groups.first().getByRole("radio", { name: "Easy" })).toBeVisible();
+    await expect(groups.first().getByRole("radio", { name: "Medium" })).toBeVisible();
+    await expect(groups.first().getByRole("radio", { name: "Hard" })).toBeVisible();
+  });
+
+  test("v2 saved game (no aiDifficulty) loads without showing the picker", async ({ page }) => {
+    await mockHeartsApi(page);
+    // Inject a v2 state — migration should convert it to v3 silently
+    const v2State = {
+      _v: 2,
+      phase: "playing",
+      handNumber: 1,
+      passDirection: "left",
+      playerHands: [
+        [c("spades", 1), c("spades", 13), c("clubs", 7), c("clubs", 8), c("clubs", 9),
+         c("diamonds", 5), c("diamonds", 9), c("clubs", 10), c("diamonds", 3),
+         c("hearts", 5), c("hearts", 6), c("hearts", 7), c("hearts", 8)],
+        Array.from({ length: 13 }, (_, i) => c("spades", i + 1)),
+        Array.from({ length: 13 }, (_, i) => c("diamonds", i + 1)),
+        Array.from({ length: 13 }, (_, i) => c("hearts", i + 1)),
+      ],
+      cumulativeScores: [0, 0, 0, 0],
+      handScores: [0, 0, 0, 0],
+      scoreHistory: [],
+      passSelections: [[], [], [], []],
+      passingComplete: true,
+      currentTrick: [],
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 0,
+      wonCards: [[], [], [], []],
+      heartsBroken: false,
+      tricksPlayedInHand: 0,
+      isComplete: false,
+      winnerIndex: null,
+    };
+    await injectHeartsState(page, v2State);
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
+
+    // No pre-game picker — game loaded from storage
+    await expect(page.getByRole("button", { name: "Start Game" })).toHaveCount(0);
+    await expect(page.getByLabel("Your hand, 13 cards")).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/hearts-smoke.spec.ts
+++ b/e2e/tests/hearts-smoke.spec.ts
@@ -1,35 +1,50 @@
 /**
  * hearts-smoke.spec.ts — GH #1142
  *
- * Smoke tests: navigation, hand render, and trick area visibility.
+ * Smoke tests: navigation, difficulty picker, hand render, and trick area visibility.
  * All backend calls are intercepted — no running backend needed.
  */
 
 import { test, expect } from "@playwright/test";
 import { mockHeartsApi, gotoHearts } from "./helpers/hearts";
+import { installEntitlementsMock } from "./helpers/api-mock";
 
 test.describe("Hearts — smoke tests", () => {
-  test.beforeEach(async ({ page }) => {
+  test("pre-game difficulty selector is visible on first load", async ({ page }) => {
     await mockHeartsApi(page);
-    // gotoHearts navigates to "/" and clears hearts_game before entering the screen.
-    await gotoHearts(page);
-  });
-
-  test("navigates from Home to Hearts screen", async ({ page }) => {
+    await installEntitlementsMock(page);
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("hearts_game"));
+    await page.getByRole("button", { name: "Play Hearts" }).click();
+    await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
     await expect(
-      page.getByRole("heading", { name: "Hearts", exact: true }),
-    ).toBeVisible();
-  });
-
-  test("player hand renders with 13 cards", async ({ page }) => {
-    await expect(
-      page.getByLabel("Your hand, 13 cards"),
+      page.getByRole("radiogroup", { name: "AI Difficulty" }),
     ).toBeVisible({ timeout: 5_000 });
   });
 
-  test("trick area is visible", async ({ page }) => {
-    await expect(
-      page.getByLabel("Current trick"),
-    ).toBeVisible({ timeout: 5_000 });
+  test.describe("after starting game", () => {
+    test.beforeEach(async ({ page }) => {
+      await mockHeartsApi(page);
+      // gotoHearts clears storage, navigates to Hearts, and clicks "Start Game"
+      await gotoHearts(page);
+    });
+
+    test("navigates from Home to Hearts screen", async ({ page }) => {
+      await expect(
+        page.getByRole("heading", { name: "Hearts", exact: true }),
+      ).toBeVisible();
+    });
+
+    test("player hand renders with 13 cards", async ({ page }) => {
+      await expect(
+        page.getByLabel("Your hand, 13 cards"),
+      ).toBeVisible({ timeout: 5_000 });
+    });
+
+    test("trick area is visible", async ({ page }) => {
+      await expect(
+        page.getByLabel("Current trick"),
+      ).toBeVisible({ timeout: 5_000 });
+    });
   });
 });

--- a/e2e/tests/helpers/hearts.ts
+++ b/e2e/tests/helpers/hearts.ts
@@ -23,6 +23,8 @@ export async function gotoHearts(page: Page): Promise<void> {
   await page
     .getByRole("heading", { name: "Hearts", exact: true })
     .waitFor({ timeout: 10_000 });
+  // Dismiss the difficulty picker that appears on a fresh start
+  await page.getByRole("button", { name: "Start Game" }).click();
 }
 
 export async function injectHeartsState(

--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -31,10 +31,7 @@ export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
               defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
             })}
             accessibilityState={{ selected }}
-            style={[
-              styles.btn,
-              { backgroundColor: selected ? colors.accent : colors.surface },
-            ]}
+            style={[styles.btn, { backgroundColor: selected ? colors.accent : colors.surface }]}
           >
             <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
               {t(`difficulty.${d}`, {

--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import type { AiDifficulty } from "../../game/hearts/types";
+import { AI_DIFFICULTIES } from "../../game/hearts/types";
+
+interface Props {
+  value: AiDifficulty;
+  onChange: (d: AiDifficulty) => void;
+}
+
+export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
+  const { t } = useTranslation("hearts");
+  const { colors } = useTheme();
+
+  return (
+    <View
+      accessibilityRole="radiogroup"
+      accessibilityLabel={t("difficulty.groupLabel", { defaultValue: "AI Difficulty" })}
+      style={[styles.row, { borderColor: colors.border }]}
+    >
+      {AI_DIFFICULTIES.map((d) => {
+        const selected = d === value;
+        return (
+          <Pressable
+            key={d}
+            onPress={() => onChange(d)}
+            accessibilityRole="radio"
+            accessibilityLabel={t(`difficulty.${d}`, {
+              defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
+            })}
+            accessibilityState={{ selected }}
+            style={[
+              styles.btn,
+              { backgroundColor: selected ? colors.accent : colors.surface },
+            ]}
+          >
+            <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
+              {t(`difficulty.${d}`, {
+                defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
+              })}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    borderWidth: 1,
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  btn: {
+    flex: 1,
+    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+});

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -26,7 +26,8 @@ function c(suit: Suit, rank: Rank): Card {
 
 function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
   return {
-    _v: 2,
+    _v: 3,
+    aiDifficulty: "medium",
     phase: "playing",
     handNumber: 1,
     passDirection: "left",
@@ -444,6 +445,165 @@ describe("selectCardToPlay — ace treated as high card", () => {
     });
     const pick = selectCardToPlay(hand, trick, state, 3);
     expect(pick).toEqual(c("hearts", 1));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Easy AI — selectCardsToPass
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass — Easy difficulty", () => {
+  it("always returns exactly 3 cards", () => {
+    const hand = [
+      c("spades", 12), c("spades", 1), c("spades", 13),
+      c("hearts", 1), c("hearts", 13), c("clubs", 7),
+      c("diamonds", 5), c("diamonds", 9), c("clubs", 8),
+      c("clubs", 9), c("clubs", 10), c("diamonds", 3), c("hearts", 5),
+    ];
+    expect(selectCardsToPass(hand, "left", "easy")).toHaveLength(3);
+  });
+
+  it("never passes 2♣", () => {
+    const hand = [
+      c("clubs", 2), c("hearts", 1), c("hearts", 13),
+      c("spades", 3), c("spades", 4), c("spades", 5),
+      c("clubs", 7), c("clubs", 8), c("clubs", 9),
+      c("diamonds", 6), c("diamonds", 7), c("diamonds", 8), c("diamonds", 9),
+    ];
+    const passed = selectCardsToPass(hand, "left", "easy");
+    expect(passed).not.toContainEqual(c("clubs", 2));
+  });
+
+  it("all returned cards are from the hand", () => {
+    const hand = [
+      c("spades", 12), c("hearts", 5), c("diamonds", 7),
+      c("clubs", 7), c("hearts", 3), c("spades", 4),
+      c("diamonds", 2), c("clubs", 9), c("hearts", 8),
+      c("spades", 6), c("diamonds", 10), c("clubs", 10), c("hearts", 11),
+    ];
+    const passed = selectCardsToPass(hand, "right", "easy");
+    passed.forEach((p) => expect(hand).toContainEqual(p));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Easy AI — selectCardToPlay
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Easy difficulty", () => {
+  it("leads the lowest valid card", () => {
+    const hand = [c("spades", 1), c("spades", 3), c("diamonds", 5)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 3,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "easy");
+    // Lowest card (ace-high, so spades 3 is lowest)
+    expect(pick).toEqual(c("spades", 3));
+  });
+
+  it("discards the lowest card when void in led suit", () => {
+    const hand = [c("spades", 12), c("hearts", 11), c("diamonds", 3)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 0 },
+      { card: c("clubs", 7), playerIndex: 1 },
+      { card: c("clubs", 9), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    // Easy dumps lowest card, not the strategic Q♠
+    expect(pick).toEqual(c("diamonds", 3));
+  });
+
+  it("follows suit with the lowest card in suit", () => {
+    const hand = [c("spades", 5), c("spades", 9), c("spades", 11)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 10), playerIndex: 0 },
+      { card: c("hearts", 1), playerIndex: 1 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [hand[0]!, hand[1]!, hand[2]!], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 2,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 2, "easy");
+    expect(pick).toEqual(c("spades", 5));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hard AI — moon attempt
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
+  it("discards non-hearts when void in led suit and holding 8+ hearts + Q♠ with no points taken", () => {
+    // AI player 1 holds 8 hearts + Q♠ + two diamonds (void in clubs); no points taken
+    const hearts8 = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const hand = [...hearts8, c("spades", 12), c("diamonds", 7), c("diamonds", 8)];
+    const trick: TrickCard[] = [{ card: c("clubs", 3), playerIndex: 0 }];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 2,
+      currentPlayerIndex: 1,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Void in clubs → can discard freely. Moon attempt: keep hearts and Q♠.
+    // Should discard a diamond (highest of non-hearts/non-Q♠)
+    expect(pick.suit).not.toBe("hearts");
+    expect(pick).not.toEqual(c("spades", 12));
+    expect(pick.suit).toBe("diamonds");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hard AI — card counting (leading)
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Hard difficulty, card counting", () => {
+  it("avoids leading K♠ when Q♠ is still live", () => {
+    const hand = [c("spades", 13), c("spades", 2), c("clubs", 7)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 3,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+      wonCards: [[], [], [], []], // Q♠ not seen
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    // Should not lead K♠ since Q♠ might be discarded onto it
+    expect(pick).not.toEqual(c("spades", 13));
+  });
+
+  it("leads K♠ safely when Q♠ is already in wonCards", () => {
+    const hand = [c("spades", 13), c("spades", 2), c("clubs", 7)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 6,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+      wonCards: [[c("spades", 12)], [], [], []], // Q♠ already taken
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    // Q♠ is gone — K♠ is safe to lead (lowest non-heart in safe pool)
+    // clubs 7 is also safe; the algo picks lowest of longest safe suit
+    // With Q♠ gone, K♠ is in the safe pool; lowest of spades=[K♠,2♠] is 2♠
+    // lowest of clubs=[7♣] is 7♣. bySuitDescending would pick the tie-broken suit.
+    // Either way, K♠ should appear in the valid consideration set now.
+    expect([c("spades", 2), c("clubs", 7)]).toContainEqual(pick);
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -455,20 +455,38 @@ describe("selectCardToPlay — ace treated as high card", () => {
 describe("selectCardsToPass — Easy difficulty", () => {
   it("always returns exactly 3 cards", () => {
     const hand = [
-      c("spades", 12), c("spades", 1), c("spades", 13),
-      c("hearts", 1), c("hearts", 13), c("clubs", 7),
-      c("diamonds", 5), c("diamonds", 9), c("clubs", 8),
-      c("clubs", 9), c("clubs", 10), c("diamonds", 3), c("hearts", 5),
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("clubs", 7),
+      c("diamonds", 5),
+      c("diamonds", 9),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("diamonds", 3),
+      c("hearts", 5),
     ];
     expect(selectCardsToPass(hand, "left", "easy")).toHaveLength(3);
   });
 
   it("never passes 2♣", () => {
     const hand = [
-      c("clubs", 2), c("hearts", 1), c("hearts", 13),
-      c("spades", 3), c("spades", 4), c("spades", 5),
-      c("clubs", 7), c("clubs", 8), c("clubs", 9),
-      c("diamonds", 6), c("diamonds", 7), c("diamonds", 8), c("diamonds", 9),
+      c("clubs", 2),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("diamonds", 9),
     ];
     const passed = selectCardsToPass(hand, "left", "easy");
     expect(passed).not.toContainEqual(c("clubs", 2));
@@ -476,10 +494,19 @@ describe("selectCardsToPass — Easy difficulty", () => {
 
   it("all returned cards are from the hand", () => {
     const hand = [
-      c("spades", 12), c("hearts", 5), c("diamonds", 7),
-      c("clubs", 7), c("hearts", 3), c("spades", 4),
-      c("diamonds", 2), c("clubs", 9), c("hearts", 8),
-      c("spades", 6), c("diamonds", 10), c("clubs", 10), c("hearts", 11),
+      c("spades", 12),
+      c("hearts", 5),
+      c("diamonds", 7),
+      c("clubs", 7),
+      c("hearts", 3),
+      c("spades", 4),
+      c("diamonds", 2),
+      c("clubs", 9),
+      c("hearts", 8),
+      c("spades", 6),
+      c("diamonds", 10),
+      c("clubs", 10),
+      c("hearts", 11),
     ];
     const passed = selectCardsToPass(hand, "right", "easy");
     passed.forEach((p) => expect(hand).toContainEqual(p));

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -49,7 +49,8 @@ function h4(
 
 function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
   return {
-    _v: 2,
+    _v: 3,
+    aiDifficulty: "medium",
     phase: "playing",
     handNumber: 1,
     passDirection: "left",
@@ -106,8 +107,8 @@ describe("dealGame", () => {
     expect(state.scoreHistory).toEqual([]);
   });
 
-  it("uses storage schema v2", () => {
-    expect(dealGame()._v).toBe(2);
+  it("uses storage schema v3", () => {
+    expect(dealGame()._v).toBe(3);
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/storage.test.ts
+++ b/frontend/src/game/hearts/__tests__/storage.test.ts
@@ -26,7 +26,7 @@ describe("hearts storage", () => {
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(state));
     const loaded = await loadGame();
     expect(loaded).not.toBeNull();
-    expect(loaded?._v).toBe(2);
+    expect(loaded?._v).toBe(3);
     expect(loaded?.phase).toBe(state.phase);
   });
 
@@ -75,9 +75,26 @@ describe("hearts storage", () => {
   });
 
   it("loadGame returns null for missing required arrays", async () => {
-    const bad: Partial<HeartsState> = { _v: 2 };
+    const bad: Partial<HeartsState> = { _v: 3 };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(bad));
     expect(await loadGame()).toBeNull();
+  });
+
+  it("loadGame migrates v2 save by defaulting aiDifficulty to medium (#1168)", async () => {
+    const v2Save = { ...dealGame(), _v: 2 } as unknown as Record<string, unknown>;
+    delete v2Save["aiDifficulty"];
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(v2Save));
+    const loaded = await loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded?._v).toBe(3);
+    expect(loaded?.aiDifficulty).toBe("medium");
+  });
+
+  it("loadGame round-trips aiDifficulty: hard", async () => {
+    const state: HeartsState = { ...dealGame(), aiDifficulty: "hard" };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(state));
+    const loaded = await loadGame();
+    expect(loaded?.aiDifficulty).toBe("hard");
   });
 
   it("clearGame removes the storage key", async () => {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -1,13 +1,13 @@
 /**
- * Hearts AI (#606).
+ * Hearts AI (#606, #1168).
  *
  * Pure TypeScript rule-based strategy for the 3 computer opponents.
- * Medium difficulty — human-beatable but not trivial (~1-in-4 AI win rate).
+ * Supports Easy / Medium / Hard difficulty via the `difficulty` parameter.
  * No randomness beyond deterministic tie-breaking. No React/AsyncStorage.
  */
 
 import { getValidPlays } from "./engine";
-import type { Card, HeartsState, PassDirection, TrickCard } from "./types";
+import type { AiDifficulty, Card, HeartsState, PassDirection, TrickCard } from "./types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,15 +60,30 @@ function bySuitDescending(cards: Card[]): Array<[string, Card[]]> {
 // Passing strategy
 // ---------------------------------------------------------------------------
 
+function passSafeFilter(selected: Card[]): (c: Card) => boolean {
+  return (c: Card) => {
+    if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) return false;
+    if (c.suit === "clubs" && c.rank === 2) return false;
+    if (c.suit === "clubs" && c.rank < 6) return false;
+    return true;
+  };
+}
+
+/** Easy: pass the first 3 safe cards with no strategic logic. Never passes 2♣. */
+function selectCardsToPassEasy(hand: Card[]): Card[] {
+  const safe = hand.filter((c) => !(c.suit === "clubs" && c.rank === 2));
+  return safe.slice(0, 3);
+}
+
 /**
- * Select exactly 3 cards to pass. Priority order per issue spec:
+ * Medium: select exactly 3 cards to pass. Priority order:
  * 1. Q♠ — unless protected (holding A♠ + K♠) or void in spades
  * 2. A♥, K♥ — highest hearts first
  * 3. A♠, K♠ — if not needed to protect Q♠
  * 4. High cards of suit being voided (longest suit)
  * 5. Never pass: 2♣ or clubs below 6
  */
-export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[] {
+function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[] {
   void direction;
   const selected: Card[] = [];
 
@@ -81,24 +96,15 @@ export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[
   const qSpadeProtected = hasASpades && hasKSpades;
   const voidInSpades = spades.length === 0;
 
-  // 1. Pass Q♠ if unprotected and not void
   if (hasQSpades && !qSpadeProtected && !voidInSpades) {
     selected.push({ suit: "spades", rank: 12 });
   }
 
-  // Cards eligible to pass (never 2♣, never clubs < 6)
-  const safe = (c: Card) => {
-    if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) return false;
-    if (c.suit === "clubs" && c.rank === 2) return false;
-    if (c.suit === "clubs" && c.rank < 6) return false;
-    return true;
-  };
+  const safe = passSafeFilter(selected);
 
-  // 2. High hearts (A=1, K=13 — pass rank 13 first, then rank 1 as highest)
   const dangerHearts = hand
     .filter((c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= 11) && safe(c))
     .sort((a, b) => {
-      // Treat ace (rank 1) as 14 for sorting purposes
       const ra = a.rank === 1 ? 14 : a.rank;
       const rb = b.rank === 1 ? 14 : b.rank;
       return rb - ra;
@@ -108,7 +114,6 @@ export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[
     selected.push(c);
   }
 
-  // 3. A♠, K♠ — if not protecting Q♠
   if (selected.length < 3 && !hasQSpades) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
@@ -117,10 +122,8 @@ export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[
     }
   }
 
-  // 4. High cards toward voiding a suit
   if (selected.length < 3) {
     const candidates = hand.filter(safe).sort((a, b) => {
-      // Prefer high ranks, prefer non-clubs
       const ra = a.rank === 1 ? 14 : a.rank;
       const rb = b.rank === 1 ? 14 : b.rank;
       if (rb !== ra) return rb - ra;
@@ -135,6 +138,80 @@ export function selectCardsToPass(hand: Card[], direction: PassDirection): Card[
   }
 
   return selected.slice(0, 3);
+}
+
+/**
+ * Hard: like Medium but always passes Q♠ even when holding A♠ + K♠,
+ * maximising danger for opponents.
+ */
+function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
+  void direction;
+  const selected: Card[] = [];
+
+  const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
+  const hasQSpades = hand.some(isQueenOfSpades);
+  const voidInSpades = hand.filter((c) => c.suit === "spades").length === 0;
+
+  // Pass Q♠ even when protected (unlike Medium)
+  if (hasQSpades && !voidInSpades) {
+    selected.push({ suit: "spades", rank: 12 });
+  }
+
+  const safe = passSafeFilter(selected);
+
+  const dangerHearts = hand
+    .filter((c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= 11) && safe(c))
+    .sort((a, b) => {
+      const ra = a.rank === 1 ? 14 : a.rank;
+      const rb = b.rank === 1 ? 14 : b.rank;
+      return rb - ra;
+    });
+  for (const c of dangerHearts) {
+    if (selected.length >= 3) break;
+    selected.push(c);
+  }
+
+  if (selected.length < 3 && !hasQSpades) {
+    for (const rank of [1, 13] as const) {
+      if (selected.length >= 3) break;
+      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c));
+      if (card) selected.push(card);
+    }
+  }
+
+  if (selected.length < 3) {
+    const candidates = hand.filter(safe).sort((a, b) => {
+      const ra = a.rank === 1 ? 14 : a.rank;
+      const rb = b.rank === 1 ? 14 : b.rank;
+      if (rb !== ra) return rb - ra;
+      if (a.suit === "clubs" && b.suit !== "clubs") return 1;
+      if (b.suit === "clubs" && a.suit !== "clubs") return -1;
+      return 0;
+    });
+    for (const c of candidates) {
+      if (selected.length >= 3) break;
+      selected.push(c);
+    }
+  }
+
+  // Ensure at least 1 high heart if possible (pass Q♠ took a slot, still need 3)
+  // The loop above handles fill-in; has already added Q♠
+
+  return selected.slice(0, 3);
+}
+
+/**
+ * Select exactly 3 cards to pass.
+ * `difficulty` defaults to "medium" (current behaviour) so existing callers are unchanged.
+ */
+export function selectCardsToPass(
+  hand: Card[],
+  direction: PassDirection,
+  difficulty: AiDifficulty = "medium"
+): Card[] {
+  if (difficulty === "easy") return selectCardsToPassEasy(hand);
+  if (difficulty === "hard") return selectCardsToPassHard(hand, direction);
+  return selectCardsToPassMedium(hand, direction);
 }
 
 // ---------------------------------------------------------------------------
@@ -168,8 +245,36 @@ export function detectPotentialMoon(state: HeartsState): number | null {
 // Play strategy
 // ---------------------------------------------------------------------------
 
+/** Easy: always play the lowest valid card; no strategic logic. */
+function selectCardToPlayEasy(
+  hand: Card[],
+  trick: TrickCard[],
+  state: HeartsState,
+  playerIndex: number
+): Card {
+  void hand;
+  const valid = getValidPlays(state, playerIndex);
+  if (valid.length === 1) return valid[0]!;
+
+  const isLeading = trick.length === 0;
+
+  if (isLeading) {
+    return lowest(valid) ?? valid[0]!;
+  }
+
+  const first = trick[0];
+  if (!first) return valid[0]!;
+  const ledSuit = first.card.suit;
+  const inSuit = valid.filter((c) => c.suit === ledSuit);
+
+  // Void in led suit — discard lowest
+  if (inSuit.length === 0) return lowest(valid) ?? valid[0]!;
+
+  return lowest(inSuit) ?? valid[0]!;
+}
+
 /**
- * Choose a card to play. Always returns a card from getValidPlays.
+ * Medium: choose a card to play. Always returns a card from getValidPlays.
  *
  * Priority when void (discarding):
  *   1. Dump Q♠ if unprotected
@@ -187,12 +292,13 @@ export function detectPotentialMoon(state: HeartsState): number | null {
  *   - Hearts not broken: lead lowest of longest non-heart suit
  *   - Otherwise: lead lowest non-dangerous card
  */
-export function selectCardToPlay(
+function selectCardToPlayMedium(
   hand: Card[],
   trick: TrickCard[],
   state: HeartsState,
   playerIndex: number
 ): Card {
+  void hand;
   const valid = getValidPlays(state, playerIndex);
   if (valid.length === 1) return valid[0]!;
 
@@ -214,12 +320,118 @@ export function selectCardToPlay(
   return chooseFollow(valid, trick);
 }
 
+/**
+ * Hard: extends Medium with moon-attempt mode and card counting.
+ * When the AI holds 8+ hearts and Q♠ with no points yet taken, it switches
+ * to moon-shot mode: preserve hearts/Q♠ and discard everything else.
+ * Card counting: infers seen cards from wonCards + currentTrick to identify
+ * safe spade leads once all high spades have been played.
+ */
+function selectCardToPlayHard(
+  hand: Card[],
+  trick: TrickCard[],
+  state: HeartsState,
+  playerIndex: number
+): Card {
+  const valid = getValidPlays(state, playerIndex);
+  if (valid.length === 1) return valid[0]!;
+
+  const moonTarget = detectPotentialMoon(state);
+  const isLeading = trick.length === 0;
+
+  // Detect if this AI player should attempt a moon shot
+  const myHearts = hand.filter((c) => c.suit === "hearts").length;
+  const myHasQ = hand.some(isQueenOfSpades);
+  const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
+  const isMoonAttempt = myHearts >= 8 && myHasQ && totalPointsTaken === 0;
+
+  // Moon blocking (skip if we're the one attempting)
+  if (moonTarget !== null && moonTarget !== playerIndex && !isMoonAttempt) {
+    const pointCards = valid
+      .filter((c) => cardPoints(c) > 0)
+      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+    if (pointCards.length > 0) return pointCards[0]!;
+  }
+
+  // Moon attempt mode: keep hearts and Q♠, discard everything else
+  if (isMoonAttempt) {
+    if (isLeading) {
+      const nonHearts = valid.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
+      if (nonHearts.length > 0) return lowest(nonHearts) ?? valid[0]!;
+    }
+    const first = trick[0];
+    if (first) {
+      const inSuit = valid.filter((c) => c.suit === first.card.suit);
+      if (inSuit.length === 0) {
+        const nonHearts = valid.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
+        if (nonHearts.length > 0) return highest(nonHearts) ?? valid[0]!;
+      }
+    }
+  }
+
+  // Card counting: track seen cards to inform smarter leading decisions.
+  const seenKeys = new Set<string>();
+  for (const pile of state.wonCards) {
+    for (const c of pile) seenKeys.add(`${c.suit}:${c.rank}`);
+  }
+  for (const tc of state.currentTrick) seenKeys.add(`${tc.card.suit}:${tc.card.rank}`);
+
+  if (isLeading) {
+    return chooseLeadHard(valid, seenKeys);
+  }
+
+  return chooseFollow(valid, trick);
+}
+
+/**
+ * Choose a card to play.
+ * `difficulty` defaults to "medium" (current behaviour) so existing callers are unchanged.
+ */
+export function selectCardToPlay(
+  hand: Card[],
+  trick: TrickCard[],
+  state: HeartsState,
+  playerIndex: number,
+  difficulty: AiDifficulty = "medium"
+): Card {
+  if (difficulty === "easy") return selectCardToPlayEasy(hand, trick, state, playerIndex);
+  if (difficulty === "hard") return selectCardToPlayHard(hand, trick, state, playerIndex);
+  return selectCardToPlayMedium(hand, trick, state, playerIndex);
+}
+
 function chooseLead(valid: Card[]): Card {
   // Avoid leading hearts or Q♠ unless forced
   const safe = valid.filter((c) => c.suit !== "hearts" && !isQueenOfSpades(c));
   const pool = safe.length > 0 ? safe : valid;
 
   // Lead lowest of longest non-heart suit (exhaust safe suits first)
+  const suitGroups = bySuitDescending(pool);
+  const longestGroup = suitGroups[0];
+  if (longestGroup) {
+    const card = lowest(longestGroup[1]);
+    if (card) return card;
+  }
+
+  return lowest(pool) ?? valid[0]!;
+}
+
+/**
+ * Hard lead: same as Medium but prefers to lead the suit where high cards
+ * are known to be exhausted (card counting via seenKeys).
+ */
+function chooseLeadHard(valid: Card[], seenKeys: Set<string>): Card {
+  const qSpadeGone = seenKeys.has("spades:12");
+
+  // If Q♠ is gone, K♠/A♠ are safe to lead — include them in safe pool
+  const safe = valid.filter((c) => {
+    if (c.suit === "hearts") return false;
+    if (isQueenOfSpades(c)) return false;
+    // K♠ or A♠ are safe to lead only once Q♠ has been played
+    if (c.suit === "spades" && (c.rank === 13 || c.rank === 1) && !qSpadeGone) return false;
+    return true;
+  });
+  const pool = safe.length > 0 ? safe : valid;
+
   const suitGroups = bySuitDescending(pool);
   const longestGroup = suitGroups[0];
   if (longestGroup) {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -148,7 +148,6 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   void direction;
   const selected: Card[] = [];
 
-  const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
   const hasQSpades = hand.some(isQueenOfSpades);
   const voidInSpades = hand.filter((c) => c.suit === "spades").length === 0;
 

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -6,7 +6,7 @@
  * on each transition — state is immutable.
  */
 
-import type { Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
+import type { AiDifficulty, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
 import { RANKS, SUITS } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -88,12 +88,13 @@ export function getPassDirection(handNumber: number): PassDirection {
 }
 
 /** Initial game state for a fresh game (hand 1). */
-export function dealGame(): HeartsState {
+export function dealGame(difficulty: AiDifficulty = "medium"): HeartsState {
   const hands = dealHands();
   const passDirection = getPassDirection(1);
   const leaderIndex = passDirection === "none" ? find2ClubsHolder(hands) : 0;
   return {
-    _v: 2,
+    _v: 3,
+    aiDifficulty: difficulty,
     phase: passDirection === "none" ? "playing" : "passing",
     handNumber: 1,
     passDirection,

--- a/frontend/src/game/hearts/storage.ts
+++ b/frontend/src/game/hearts/storage.ts
@@ -1,8 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import type { HeartsState } from "./types";
+import type { AiDifficulty, HeartsState } from "./types";
 
 const GAME_KEY = "hearts_game";
+const AI_DIFFICULTY_VALUES: readonly string[] = ["easy", "medium", "hard"];
 
 export async function saveGame(state: HeartsState): Promise<void> {
   try {
@@ -16,29 +17,42 @@ export async function loadGame(): Promise<HeartsState | null> {
   try {
     const raw = await AsyncStorage.getItem(GAME_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<HeartsState>;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const rawV = parsed["_v"];
+
+    // v2 → v3 migration: add aiDifficulty default
+    if (rawV === 2) {
+      parsed["_v"] = 3;
+      parsed["aiDifficulty"] = "medium";
+    } else if (rawV !== 3) {
+      await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
+      return null;
+    }
+
+    const p = parsed as Partial<HeartsState>;
     if (
-      parsed._v !== 2 ||
-      !Array.isArray(parsed.playerHands) ||
-      parsed.playerHands.length !== 4 ||
-      !Array.isArray(parsed.cumulativeScores) ||
-      parsed.cumulativeScores.length !== 4 ||
-      !Array.isArray(parsed.handScores) ||
-      parsed.handScores.length !== 4 ||
-      !Array.isArray(parsed.scoreHistory) ||
-      !parsed.scoreHistory.every(
+      p._v !== 3 ||
+      !AI_DIFFICULTY_VALUES.includes(p.aiDifficulty as string) ||
+      !Array.isArray(p.playerHands) ||
+      p.playerHands.length !== 4 ||
+      !Array.isArray(p.cumulativeScores) ||
+      p.cumulativeScores.length !== 4 ||
+      !Array.isArray(p.handScores) ||
+      p.handScores.length !== 4 ||
+      !Array.isArray(p.scoreHistory) ||
+      !p.scoreHistory.every(
         (row) => Array.isArray(row) && row.length === 4 && row.every((v) => typeof v === "number")
       ) ||
-      !Array.isArray(parsed.currentTrick) ||
-      !Array.isArray(parsed.wonCards) ||
-      typeof parsed.tricksPlayedInHand !== "number" ||
-      typeof parsed.heartsBroken !== "boolean" ||
-      typeof parsed.isComplete !== "boolean"
+      !Array.isArray(p.currentTrick) ||
+      !Array.isArray(p.wonCards) ||
+      typeof p.tricksPlayedInHand !== "number" ||
+      typeof p.heartsBroken !== "boolean" ||
+      typeof p.isComplete !== "boolean"
     ) {
       await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
       return null;
     }
-    return parsed as HeartsState;
+    return { ...p, aiDifficulty: p.aiDifficulty as AiDifficulty } as HeartsState;
   } catch (e) {
     Sentry.captureMessage("hearts.storage: corrupt game payload, discarding", {
       level: "warning",

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -5,6 +5,9 @@
  * engine, AI, UI components, and persistence layer alike.
  */
 
+export type AiDifficulty = "easy" | "medium" | "hard";
+export const AI_DIFFICULTIES: readonly AiDifficulty[] = ["easy", "medium", "hard"];
+
 /** UI events emitted by the engine and consumed by the animation layer. */
 export type GameEvent =
   | { readonly type: "moonShot"; readonly shooter: number }
@@ -43,9 +46,11 @@ export type HeartsPhase =
  * Players: index 0 = human, 1 = left AI, 2 = top AI, 3 = right AI.
  * `_v` is a schema version so persisted saves can be migrated or rejected.
  * v2 adds `scoreHistory` so per-round deltas survive screen unmount (#745).
+ * v3 adds `aiDifficulty` for the Easy/Medium/Hard AI difficulty selector (#1168).
  */
 export interface HeartsState {
-  readonly _v: 2;
+  readonly _v: 3;
+  readonly aiDifficulty: AiDifficulty;
   readonly phase: HeartsPhase;
   /** 1-based. Pass direction = getPassDirection(handNumber). */
   readonly handNumber: number;

--- a/frontend/src/i18n/locales/ar/hearts.json
+++ b/frontend/src/i18n/locales/ar/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "كُسرت القلوب",
   "events.moonShot": "{{name}} سيطر على الجولة!",
-  "events.queenOfSpades": "{{name}} أخذ ملكة البستوني!"
+  "events.queenOfSpades": "{{name}} أخذ ملكة البستوني!",
+
+  "difficulty.groupLabel": "الصعوبة",
+  "difficulty.easy": "سهل",
+  "difficulty.medium": "متوسط",
+  "difficulty.hard": "صعب",
+  "game.startGame": "ابدأ اللعبة"
 }

--- a/frontend/src/i18n/locales/de/hearts.json
+++ b/frontend/src/i18n/locales/de/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Herz gebrochen",
   "events.moonShot": "{{name}} hat den Mond geschossen!",
-  "events.queenOfSpades": "{{name}} nimmt die Pik-Dame!"
+  "events.queenOfSpades": "{{name}} nimmt die Pik-Dame!",
+
+  "difficulty.groupLabel": "Schwierigkeit",
+  "difficulty.easy": "Leicht",
+  "difficulty.medium": "Mittel",
+  "difficulty.hard": "Schwer",
+  "game.startGame": "Spiel starten"
 }

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -73,5 +73,11 @@
 
   "events.heartsBroken": "Hearts broken",
   "events.moonShot": "{{name}} shot the moon!",
-  "events.queenOfSpades": "{{name}} takes the Queen of Spades!"
+  "events.queenOfSpades": "{{name}} takes the Queen of Spades!",
+
+  "difficulty.groupLabel": "AI Difficulty",
+  "difficulty.easy": "Easy",
+  "difficulty.medium": "Medium",
+  "difficulty.hard": "Hard",
+  "game.startGame": "Start Game"
 }

--- a/frontend/src/i18n/locales/es/hearts.json
+++ b/frontend/src/i18n/locales/es/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Corazones descubiertos",
   "events.moonShot": "¡{{name}} hizo luna!",
-  "events.queenOfSpades": "¡{{name}} toma la Reina de Espadas!"
+  "events.queenOfSpades": "¡{{name}} toma la Reina de Espadas!",
+
+  "difficulty.groupLabel": "Dificultad",
+  "difficulty.easy": "Fácil",
+  "difficulty.medium": "Media",
+  "difficulty.hard": "Difícil",
+  "game.startGame": "Iniciar juego"
 }

--- a/frontend/src/i18n/locales/fr-CA/hearts.json
+++ b/frontend/src/i18n/locales/fr-CA/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Cœurs brisés",
   "events.moonShot": "{{name}} a raflé la mise!",
-  "events.queenOfSpades": "{{name}} prend la Dame de pique!"
+  "events.queenOfSpades": "{{name}} prend la Dame de pique!",
+
+  "difficulty.groupLabel": "Difficulté",
+  "difficulty.easy": "Facile",
+  "difficulty.medium": "Moyen",
+  "difficulty.hard": "Difficile",
+  "game.startGame": "Commencer"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "הלבבות נשברו",
   "events.moonShot": "{{name}} לקח את הכל!",
-  "events.queenOfSpades": "{{name}} לקח את מלכת הספייד!"
+  "events.queenOfSpades": "{{name}} לקח את מלכת הספייד!",
+
+  "difficulty.groupLabel": "רמת קושי",
+  "difficulty.easy": "קל",
+  "difficulty.medium": "בינוני",
+  "difficulty.hard": "קשה",
+  "game.startGame": "התחל משחק"
 }

--- a/frontend/src/i18n/locales/hi/hearts.json
+++ b/frontend/src/i18n/locales/hi/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "दिल टूटे",
   "events.moonShot": "{{name}} ने चांद मारा!",
-  "events.queenOfSpades": "{{name}} ने हुकुम की रानी ली!"
+  "events.queenOfSpades": "{{name}} ने हुकुम की रानी ली!",
+
+  "difficulty.groupLabel": "मुश्किल स्तर",
+  "difficulty.easy": "आसान",
+  "difficulty.medium": "मध्यम",
+  "difficulty.hard": "कठिन",
+  "game.startGame": "खेल शुरू करें"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "ハートが解禁",
   "events.moonShot": "{{name}}が月を射抜いた！",
-  "events.queenOfSpades": "{{name}}がスペードのQを取った！"
+  "events.queenOfSpades": "{{name}}がスペードのQを取った！",
+
+  "difficulty.groupLabel": "難易度",
+  "difficulty.easy": "かんたん",
+  "difficulty.medium": "ふつう",
+  "difficulty.hard": "むずかしい",
+  "game.startGame": "ゲームスタート"
 }

--- a/frontend/src/i18n/locales/ko/hearts.json
+++ b/frontend/src/i18n/locales/ko/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "하트 해제",
   "events.moonShot": "{{name}}이(가) 올킬 성공!",
-  "events.queenOfSpades": "{{name}}이(가) 스페이드 퀸을 가져갔습니다!"
+  "events.queenOfSpades": "{{name}}이(가) 스페이드 퀸을 가져갔습니다!",
+
+  "difficulty.groupLabel": "난이도",
+  "difficulty.easy": "쉬움",
+  "difficulty.medium": "보통",
+  "difficulty.hard": "어려움",
+  "game.startGame": "게임 시작"
 }

--- a/frontend/src/i18n/locales/nl/hearts.json
+++ b/frontend/src/i18n/locales/nl/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Harten gebroken",
   "events.moonShot": "{{name}} ging voor de volle maan!",
-  "events.queenOfSpades": "{{name}} pakt de Schoppenvrauw!"
+  "events.queenOfSpades": "{{name}} pakt de Schoppenvrauw!",
+
+  "difficulty.groupLabel": "Moeilijkheid",
+  "difficulty.easy": "Makkelijk",
+  "difficulty.medium": "Gemiddeld",
+  "difficulty.hard": "Moeilijk",
+  "game.startGame": "Spel starten"
 }

--- a/frontend/src/i18n/locales/pt/hearts.json
+++ b/frontend/src/i18n/locales/pt/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Copas abertas",
   "events.moonShot": "{{name}} fez a limpa!",
-  "events.queenOfSpades": "{{name}} pega a Dama de Espadas!"
+  "events.queenOfSpades": "{{name}} pega a Dama de Espadas!",
+
+  "difficulty.groupLabel": "Dificuldade",
+  "difficulty.easy": "Fácil",
+  "difficulty.medium": "Médio",
+  "difficulty.hard": "Difícil",
+  "game.startGame": "Iniciar jogo"
 }

--- a/frontend/src/i18n/locales/ru/hearts.json
+++ b/frontend/src/i18n/locales/ru/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "Черви раскрыты",
   "events.moonShot": "{{name}} собрал всё!",
-  "events.queenOfSpades": "{{name}} забирает Даму Пик!"
+  "events.queenOfSpades": "{{name}} забирает Даму Пик!",
+
+  "difficulty.groupLabel": "Сложность",
+  "difficulty.easy": "Легко",
+  "difficulty.medium": "Средне",
+  "difficulty.hard": "Сложно",
+  "game.startGame": "Начать игру"
 }

--- a/frontend/src/i18n/locales/zh/hearts.json
+++ b/frontend/src/i18n/locales/zh/hearts.json
@@ -57,5 +57,11 @@
 
   "events.heartsBroken": "红心已开",
   "events.moonShot": "{{name}}收全红心！",
-  "events.queenOfSpades": "{{name}}拿走了黑桃Q！"
+  "events.queenOfSpades": "{{name}}拿走了黑桃Q！",
+
+  "difficulty.groupLabel": "难度选择",
+  "difficulty.easy": "简单",
+  "difficulty.medium": "中等",
+  "difficulty.hard": "困难",
+  "game.startGame": "开始游戏"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -23,6 +23,7 @@ import {
   selectPassCard,
 } from "../game/hearts/engine";
 import { selectCardToPlay, selectCardsToPass } from "../game/hearts/ai";
+import HeartsAiDifficultySelector from "../components/hearts/HeartsAiDifficultySelector";
 import { clearGame, loadGame, saveGame } from "../game/hearts/storage";
 import {
   DEFAULT_NAMES,
@@ -41,7 +42,7 @@ import { OfflineBanner } from "../components/shared/OfflineBanner";
 import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
 import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnimation";
 import { HeartsQueenOfSpadesAnimation } from "../components/hearts/HeartsQueenOfSpadesAnimation";
-import type { Card, HeartsState, TrickCard } from "../game/hearts/types";
+import type { AiDifficulty, Card, HeartsState, TrickCard } from "../game/hearts/types";
 
 const HUMAN = 0;
 const MAX_NAME_LENGTH = 32;
@@ -69,7 +70,8 @@ export default function HeartsScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
   const { isOnline, isInitialized } = useNetwork();
 
-  const [gameState, setGameState] = useState<HeartsState>(() => dealGame());
+  const [gameState, setGameState] = useState<HeartsState | null>(null);
+  const [selectedDifficulty, setSelectedDifficulty] = useState<AiDifficulty>("medium");
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
   const [showHeartsBroken, setShowHeartsBroken] = useState(false);
   const [showMoonShot, setShowMoonShot] = useState(false);
@@ -83,11 +85,11 @@ export default function HeartsScreen() {
   const [draftNames, setDraftNames] = useState<string[]>([...DEFAULT_NAMES]);
 
   // scoreHistory now lives on HeartsState (engine-authoritative, persisted).
-  const scoreHistory = gameState.scoreHistory;
+  const scoreHistory = gameState?.scoreHistory ?? [];
 
   const unmountedRef = useRef(false);
   const loopActiveRef = useRef(false);
-  const gameStateRef = useRef<HeartsState>(gameState);
+  const gameStateRef = useRef<HeartsState | null>(gameState);
   const trickAnimResolverRef = useRef<(() => void) | null>(null);
   const reportIntegrity = useMemo(() => createIntegrityReporter(), []);
 
@@ -116,7 +118,10 @@ export default function HeartsScreen() {
   // ─── Load saved game and player names on mount ────────────────────────────
   useEffect(() => {
     loadGame().then((saved) => {
-      if (saved && !unmountedRef.current) setGameState(saved);
+      if (!unmountedRef.current && saved) {
+        setGameState(saved);
+        setSelectedDifficulty(saved.aiDifficulty);
+      }
     });
     loadPlayerNames().then((names) => {
       if (!unmountedRef.current) {
@@ -130,15 +135,15 @@ export default function HeartsScreen() {
   const { setSnapshot: setRoundsSnapshot } = useHeartsRounds();
   useEffect(() => {
     setRoundsSnapshot({
-      cumulativeScores: gameState.cumulativeScores,
+      cumulativeScores: gameState?.cumulativeScores ?? [0, 0, 0, 0],
       scoreHistory,
       playerLabels: playerNames,
     });
-  }, [gameState.cumulativeScores, scoreHistory, playerNames, setRoundsSnapshot]);
+  }, [gameState?.cumulativeScores, scoreHistory, playerNames, setRoundsSnapshot]);
 
   // ─── Run integrity validators (Sentry-warns on impossible state) ──────────
   useEffect(() => {
-    reportIntegrity(gameState);
+    if (gameState) reportIntegrity(gameState);
   }, [gameState, reportIntegrity]);
 
   // ─── Save on blur ─────────────────────────────────────────────────────────
@@ -148,8 +153,9 @@ export default function HeartsScreen() {
   useFocusEffect(
     useCallback(() => {
       return () => {
-        if (gameStateRef.current.isComplete) return;
-        void saveGame(gameStateRef.current);
+        const gs = gameStateRef.current;
+        if (!gs || gs.isComplete) return;
+        void saveGame(gs);
       };
     }, [])
   );
@@ -158,7 +164,7 @@ export default function HeartsScreen() {
   useEffect(() => {
     const unsub = navigation.addListener("beforeRemove", () => {
       if (!syncGetGameId()) return;
-      if (gameStateRef.current.isComplete) return;
+      if (gameStateRef.current?.isComplete) return;
       syncComplete(
         { outcome: "abandoned", finalScore: 0, durationMs: 0 },
         { outcome: "abandoned" }
@@ -172,7 +178,7 @@ export default function HeartsScreen() {
   const { play: playQueenOfSpades } = useSound("hearts.queenOfSpades");
 
   useGameEvents(
-    gameState.events,
+    gameState?.events,
     {
       heartsBroken: () => {
         playHeartsBroken();
@@ -189,7 +195,8 @@ export default function HeartsScreen() {
         setShowQueenOfSpades(true);
       },
     },
-    () => setGameState((prev) => ({ ...prev, events: [] }))
+    () =>
+      setGameState((prev) => (prev ? { ...prev, events: [] as HeartsState["events"] } : null))
   );
 
   const playerLabels = playerNames;
@@ -208,7 +215,7 @@ export default function HeartsScreen() {
     try {
       // Start with a clean events slate; initial events are already in React state
       // and will be processed by useGameEvents independently.
-      let s = { ...initial, events: [] as typeof initial.events };
+      let s: HeartsState = { ...initial, events: [] };
       while (s.currentPlayerIndex !== HUMAN && s.phase === "playing") {
         const willComplete = s.currentTrick.length === 3;
         await delay(400);
@@ -218,7 +225,8 @@ export default function HeartsScreen() {
           s.playerHands[s.currentPlayerIndex] as Card[],
           s.currentTrick as TrickCard[],
           s,
-          s.currentPlayerIndex
+          s.currentPlayerIndex,
+          s.aiDifficulty
         );
         const completedTrick: readonly TrickCard[] | null = willComplete
           ? [...s.currentTrick, { card, playerIndex: s.currentPlayerIndex }]
@@ -249,25 +257,26 @@ export default function HeartsScreen() {
 
   // Trigger AI loop when it's their turn; wait for lastTrick display first.
   useEffect(() => {
+    if (!gameState) return;
     if (gameState.phase !== "playing") return;
     if (gameState.currentPlayerIndex === HUMAN) return;
     if (lastTrick !== null) return;
     void runAiTurns(gameState);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gameState.phase, gameState.currentPlayerIndex, gameState.tricksPlayedInHand, lastTrick]);
+  }, [gameState?.phase, gameState?.currentPlayerIndex, gameState?.tricksPlayedInHand, lastTrick]);
 
   // Complete sync when game is over.
   useEffect(() => {
-    if (gameState.phase !== "game_over") return;
+    if (gameState?.phase !== "game_over") return;
     if (!syncGetGameId()) return;
     const humanScore = gameState.cumulativeScores[HUMAN] ?? 0;
     const finalScore = Math.max(0, 100 - humanScore);
     syncComplete({ outcome: "completed", finalScore, durationMs: 0 }, { final_score: finalScore });
-  }, [gameState.phase, gameState.cumulativeScores, syncComplete, syncGetGameId]);
+  }, [gameState?.phase, gameState?.cumulativeScores, syncComplete, syncGetGameId]);
 
   // ─── Human card play ──────────────────────────────────────────────────────
   function handleCardPress(card: Card) {
-    if (gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing") return;
+    if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing") return;
     ensureSyncStarted();
     const willComplete = gameState.currentTrick.length === 3;
     const completedTrick: readonly TrickCard[] | null = willComplete
@@ -304,13 +313,19 @@ export default function HeartsScreen() {
 
   // ─── Passing ──────────────────────────────────────────────────────────────
   function handlePassCardPress(card: Card) {
+    if (!gameState) return;
     setGameState(selectPassCard(gameState, HUMAN, card));
   }
 
   function handlePassConfirm() {
+    if (!gameState) return;
     let s = gameState;
     for (let i = 1; i <= 3; i++) {
-      const aiCards = selectCardsToPass([...(s.playerHands[i] ?? [])], s.passDirection);
+      const aiCards = selectCardsToPass(
+        [...(s.playerHands[i] ?? [])],
+        s.passDirection,
+        s.aiDifficulty
+      );
       for (const c of aiCards) {
         s = selectPassCard(s, i, c);
       }
@@ -320,6 +335,7 @@ export default function HeartsScreen() {
 
   // ─── Hand end / next hand ─────────────────────────────────────────────────
   function handleNextHand() {
+    if (!gameState) return;
     setLastTrick(null);
     const next = dealNextHand(gameState);
     setGameState(next);
@@ -328,7 +344,7 @@ export default function HeartsScreen() {
 
   // ─── Game over / play again ───────────────────────────────────────────────
   async function handleSubmitScore() {
-    if (!playerName.trim() || submitState === "submitting" || submitState === "done") return;
+    if (!gameState || !playerName.trim() || submitState === "submitting" || submitState === "done") return;
     if (isInitialized && !isOnline) return;
     setSubmitState("submitting");
     const humanScore = gameState.cumulativeScores[HUMAN] ?? 0;
@@ -341,14 +357,23 @@ export default function HeartsScreen() {
     }
   }
 
+  function handleStartGame(difficulty: AiDifficulty) {
+    setLastTrick(null);
+    setSubmitState("idle");
+    setPlayerName("");
+    loopActiveRef.current = false;
+    clearGame().catch(() => {});
+    const fresh = dealGame(difficulty);
+    setGameState(fresh);
+  }
+
   function handlePlayAgain() {
     setLastTrick(null);
     setSubmitState("idle");
     setPlayerName("");
     loopActiveRef.current = false;
     clearGame().catch(() => {});
-    const fresh = dealGame();
-    setGameState(fresh);
+    setGameState(null);
   }
 
   function handleOpenRename() {
@@ -366,16 +391,49 @@ export default function HeartsScreen() {
   }
 
   // ─── Derived state ────────────────────────────────────────────────────────
-  const humanHand = [...(gameState.playerHands[HUMAN] ?? [])];
-  const isPassing = gameState.phase === "passing";
-  const humanPassSelections = [...(gameState.passSelections[HUMAN] ?? [])];
+  const humanHand = [...(gameState?.playerHands[HUMAN] ?? [])];
+  const isPassing = gameState?.phase === "passing";
+  const humanPassSelections = [...(gameState?.passSelections[HUMAN] ?? [])];
   const validCards =
-    gameState.phase === "playing" && gameState.currentPlayerIndex === HUMAN
+    gameState?.phase === "playing" && gameState.currentPlayerIndex === HUMAN
       ? getValidPlays(gameState, HUMAN)
       : [];
-  const displayTrick = lastTrick !== null ? lastTrick.trick : gameState.currentTrick;
+  const displayTrick = lastTrick !== null ? lastTrick.trick : (gameState?.currentTrick ?? []);
   const trickWinnerIndex = lastTrick !== null ? lastTrick.winnerIndex : null;
-  const moonShooter = detectMoon(gameState.wonCards);
+  const moonShooter = gameState ? detectMoon(gameState.wonCards) : null;
+
+  // ─── Pre-game: show difficulty picker until a game is started ────────────
+  if (!gameState) {
+    return (
+      <GameShell
+        title={t("game.title")}
+        onBack={() => navigation.goBack()}
+        onNewGame={() => handleStartGame(selectedDifficulty)}
+        onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "hearts" })}
+        onEditPlayerNames={handleOpenRename}
+      >
+        <View style={styles.preGameContainer}>
+          <Text style={[styles.preGameTitle, { color: colors.text }]}>
+            {t("difficulty.groupLabel", { defaultValue: "AI Difficulty" })}
+          </Text>
+          <HeartsAiDifficultySelector
+            value={selectedDifficulty}
+            onChange={setSelectedDifficulty}
+          />
+          <Pressable
+            style={[styles.btn, { backgroundColor: colors.accent }]}
+            onPress={() => handleStartGame(selectedDifficulty)}
+            accessibilityRole="button"
+            accessibilityLabel={t("game.startGame", { defaultValue: "Start Game" })}
+          >
+            <Text style={[styles.btnText, { color: colors.textOnAccent }]}>
+              {t("game.startGame", { defaultValue: "Start Game" })}
+            </Text>
+          </Pressable>
+        </View>
+      </GameShell>
+    );
+  }
 
   return (
     <GameShell
@@ -604,6 +662,10 @@ export default function HeartsScreen() {
                 </Text>
               )}
 
+              <HeartsAiDifficultySelector
+                value={selectedDifficulty}
+                onChange={setSelectedDifficulty}
+              />
               <Pressable
                 style={[styles.btn, { backgroundColor: colors.surfaceAlt }]}
                 onPress={handlePlayAgain}
@@ -807,5 +869,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     fontSize: 15,
+  },
+  preGameContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 32,
+    gap: 20,
+  },
+  preGameTitle: {
+    fontSize: 18,
+    fontWeight: "700",
   },
 });

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -85,7 +85,7 @@ export default function HeartsScreen() {
   const [draftNames, setDraftNames] = useState<string[]>([...DEFAULT_NAMES]);
 
   // scoreHistory now lives on HeartsState (engine-authoritative, persisted).
-  const scoreHistory = gameState?.scoreHistory ?? [];
+  const scoreHistory = useMemo(() => gameState?.scoreHistory ?? [], [gameState?.scoreHistory]);
 
   const unmountedRef = useRef(false);
   const loopActiveRef = useRef(false);

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -195,8 +195,7 @@ export default function HeartsScreen() {
         setShowQueenOfSpades(true);
       },
     },
-    () =>
-      setGameState((prev) => (prev ? { ...prev, events: [] as HeartsState["events"] } : null))
+    () => setGameState((prev) => (prev ? { ...prev, events: [] as HeartsState["events"] } : null))
   );
 
   const playerLabels = playerNames;
@@ -276,7 +275,8 @@ export default function HeartsScreen() {
 
   // ─── Human card play ──────────────────────────────────────────────────────
   function handleCardPress(card: Card) {
-    if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing") return;
+    if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing")
+      return;
     ensureSyncStarted();
     const willComplete = gameState.currentTrick.length === 3;
     const completedTrick: readonly TrickCard[] | null = willComplete
@@ -344,7 +344,8 @@ export default function HeartsScreen() {
 
   // ─── Game over / play again ───────────────────────────────────────────────
   async function handleSubmitScore() {
-    if (!gameState || !playerName.trim() || submitState === "submitting" || submitState === "done") return;
+    if (!gameState || !playerName.trim() || submitState === "submitting" || submitState === "done")
+      return;
     if (isInitialized && !isOnline) return;
     setSubmitState("submitting");
     const humanScore = gameState.cumulativeScores[HUMAN] ?? 0;
@@ -416,10 +417,7 @@ export default function HeartsScreen() {
           <Text style={[styles.preGameTitle, { color: colors.text }]}>
             {t("difficulty.groupLabel", { defaultValue: "AI Difficulty" })}
           </Text>
-          <HeartsAiDifficultySelector
-            value={selectedDifficulty}
-            onChange={setSelectedDifficulty}
-          />
+          <HeartsAiDifficultySelector value={selectedDifficulty} onChange={setSelectedDifficulty} />
           <Pressable
             style={[styles.btn, { backgroundColor: colors.accent }]}
             onPress={() => handleStartGame(selectedDifficulty)}

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react-native";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
 import HeartsScreen from "../HeartsScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import { HeartsRoundsProvider } from "../../game/hearts/RoundsContext";
 import { createSeededRng, setRng } from "../../game/hearts/engine";
 import * as engine from "../../game/hearts/engine";
+import { loadGame } from "../../game/hearts/storage";
 
 jest.mock("../../game/hearts/storage", () => ({
   loadGame: jest.fn().mockResolvedValue(null),
@@ -69,32 +70,42 @@ function renderScreen() {
 describe("HeartsScreen — passing phase (inline banner)", () => {
   beforeEach(() => {
     setRng(createSeededRng(42));
+    // Provide a saved game in passing phase so the screen skips the pre-game picker.
+    (loadGame as jest.Mock).mockResolvedValue(engine.dealGame());
   });
 
-  it("shows inline banner with direction instruction", () => {
+  afterEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(null);
+  });
+
+  it("shows inline banner with direction instruction", async () => {
     const { getByText } = renderScreen();
-    expect(getByText(/pass left/i)).toBeTruthy();
+    await waitFor(() => expect(getByText(/pass left/i)).toBeTruthy());
   });
 
-  it("confirm button starts disabled (no cards selected)", () => {
+  it("confirm button starts disabled (no cards selected)", async () => {
     const { getByRole } = renderScreen();
-    const btn = getByRole("button", { name: /confirm/i });
-    expect(btn.props.accessibilityState.disabled).toBe(true);
+    await waitFor(() => {
+      const btn = getByRole("button", { name: /confirm/i });
+      expect(btn.props.accessibilityState.disabled).toBe(true);
+    });
   });
 
-  it("renders no Modal during passing phase", () => {
+  it("renders no Modal during passing phase", async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Modal } = require("react-native");
     const { UNSAFE_queryAllByType } = renderScreen();
-    const visibleModals = UNSAFE_queryAllByType(Modal).filter(
-      (m: { props: { visible?: boolean } }) => m.props.visible !== false
-    );
-    expect(visibleModals).toHaveLength(0);
+    await waitFor(() => {
+      const visibleModals = UNSAFE_queryAllByType(Modal).filter(
+        (m: { props: { visible?: boolean } }) => m.props.visible !== false
+      );
+      expect(visibleModals).toHaveLength(0);
+    });
   });
 
-  it("tapping a card increments the selection counter", () => {
+  it("tapping a card increments the selection counter", async () => {
     const { getByText, queryAllByRole } = renderScreen();
-    expect(getByText(/0 of 3 selected/i)).toBeTruthy();
+    await waitFor(() => expect(getByText(/0 of 3 selected/i)).toBeTruthy());
     const cardBtns = queryAllByRole("button").filter(
       (el) =>
         typeof el.props.accessibilityLabel === "string" &&
@@ -105,8 +116,9 @@ describe("HeartsScreen — passing phase (inline banner)", () => {
     expect(getByText(/1 of 3 selected/i)).toBeTruthy();
   });
 
-  it("unmounts cleanly while AI loop is pending", () => {
+  it("unmounts cleanly while AI loop is pending", async () => {
     const { unmount } = renderScreen();
+    await waitFor(() => expect(loadGame).toHaveBeenCalled());
     act(() => {
       jest.runAllTimers();
     });
@@ -115,76 +127,72 @@ describe("HeartsScreen — passing phase (inline banner)", () => {
 });
 
 describe("HeartsScreen — playing phase (no modal)", () => {
-  let dealGameSpy: jest.SpyInstance;
-
-  beforeEach(() => {
+  function makePlayingState() {
     setRng(createSeededRng(42));
-    // Produce a real deal, then override phase to "playing" so no overlay blocks.
     const realState = engine.dealGame();
-    const playingState = {
+    return {
       ...realState,
       phase: "playing" as const,
       passDirection: "none" as const,
       passingComplete: true,
       currentPlayerIndex: 0,
     };
-    dealGameSpy = jest.spyOn(engine, "dealGame").mockReturnValue(playingState);
+  }
+
+  beforeEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(makePlayingState());
   });
 
   afterEach(() => {
-    dealGameSpy.mockRestore();
+    (loadGame as jest.Mock).mockResolvedValue(null);
   });
 
-  it("renders the Hearts title in the header", () => {
+  it("renders the Hearts title in the header", async () => {
     const { getAllByText } = renderScreen();
-    expect(getAllByText("Hearts").length).toBeGreaterThan(0);
+    await waitFor(() => expect(getAllByText("Hearts").length).toBeGreaterThan(0));
   });
 
-  it("⋯ menu Scoreboard item navigates to ScoreboardScreen with hearts gameKey", () => {
+  it("⋯ menu Scoreboard item navigates to ScoreboardScreen with hearts gameKey", async () => {
     mockNavigate.mockClear();
     const { getByLabelText, getByText } = renderScreen();
+    await waitFor(() => getByLabelText("More options"));
     fireEvent.press(getByLabelText("More options")); // open ⋯ menu
     fireEvent.press(getByText("Scoreboard")); // tap Scoreboard item
     expect(mockNavigate).toHaveBeenCalledWith("Scoreboard", { gameKey: "hearts" });
   });
 
-  it("⋯ menu Edit Names item opens the rename modal", () => {
+  it("⋯ menu Edit Names item opens the rename modal", async () => {
     const { getByLabelText, getByText } = renderScreen();
+    await waitFor(() => getByLabelText("More options"));
     fireEvent.press(getByLabelText("More options")); // open ⋯ menu
     fireEvent.press(getByText("Edit Names")); // tap Edit Names item
     // Rename modal title is in hearts.json under settings.rename_title
     expect(getByText("Player Names")).toBeTruthy();
   });
 
-  it("human hand cards are rendered", () => {
+  it("human hand cards are rendered", async () => {
     const { queryAllByRole } = renderScreen();
-    // Cards with onPress are buttons; there should be some (13 cards in hand)
-    const cardBtns = queryAllByRole("button").filter(
-      (el) =>
-        el.props.accessibilityLabel &&
-        !["More options", "Go back to home screen"].includes(el.props.accessibilityLabel)
-    );
-    expect(cardBtns.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      const cardBtns = queryAllByRole("button").filter(
+        (el) =>
+          el.props.accessibilityLabel &&
+          !["More options", "Go back to home screen"].includes(el.props.accessibilityLabel)
+      );
+      expect(cardBtns.length).toBeGreaterThan(0);
+    });
   });
 
-  it("does not render numeric score badges next to seat labels during play", () => {
-    // Override cumulativeScores with distinct non-trivial values so any score
-    // rendered next to a seat label would be clearly visible — and clearly
-    // not a card rank (1–13).
-    dealGameSpy.mockRestore();
-    const realState = engine.dealGame();
-    const playingState = {
-      ...realState,
-      phase: "playing" as const,
-      passDirection: "none" as const,
-      passingComplete: true,
-      currentPlayerIndex: 0,
+  it("does not render numeric score badges next to seat labels during play", async () => {
+    // Override with distinct non-trivial scores so any score rendered next to a
+    // seat label would be clearly visible — and clearly not a card rank (1–13).
+    const stateWithScores = {
+      ...makePlayingState(),
       cumulativeScores: [59, 25, 41, 17],
     };
-    dealGameSpy = jest.spyOn(engine, "dealGame").mockReturnValue(playingState);
+    (loadGame as jest.Mock).mockResolvedValue(stateWithScores);
 
     const { queryByText } = renderScreen();
-    expect(queryByText("59")).toBeNull();
+    await waitFor(() => expect(queryByText("59")).toBeNull());
     expect(queryByText("25")).toBeNull();
     expect(queryByText("41")).toBeNull();
     expect(queryByText("17")).toBeNull();


### PR DESCRIPTION
## Summary

- **AI difficulty picker** (Easy / Medium / Hard pill buttons) appears before each new game and in the Play Again panel — selected difficulty is persisted with the save
- **Easy AI**: passes first 3 safe cards (never 2♣); always plays lowest valid card; no moon blocking; dumps lowest card when void
- **Hard AI**: always passes Q♠ even when holding A♠+K♠; switches to moon-attempt mode when holding 8+ hearts + Q♠ with no points yet taken; card-counting lead logic avoids K♠/A♠ while Q♠ is still live
- **Medium** (default): existing behaviour unchanged — all callers with no `difficulty` arg still work
- Schema bumped `_v: 2 → 3`; `loadGame()` migrates old saves to `aiDifficulty: "medium"`
- New `HeartsAiDifficultySelector` component mirrors the Sudoku pill-button pattern with full WCAG 2.2 AA `radiogroup`/`radio` roles
- i18n keys added to all 13 locales

## Test plan

- [ ] 167 unit tests pass (`npx jest src/game/hearts src/components/hearts`)
- [ ] TypeScript: `npx tsc --noEmit` — no Hearts-specific errors
- [ ] Smoke: navigate to Hearts fresh → difficulty picker visible → click Start Game → 13-card hand renders
- [ ] Smoke: inject old `_v: 2` state → game loads directly, no picker shown
- [ ] Gameplay: Easy game plays to completion (AI takes high-point tricks more often)
- [ ] Gameplay: Hard game — AI executes moon shot when it holds 8+ hearts + Q♠ and no points taken
- [ ] Play Again → difficulty picker reappears → selecting Hard and restarting works
- [ ] New Playwright spec: `e2e/tests/hearts-difficulty-select.spec.ts` (6 tests)

Closes #1168
Duplicate of #1128 (separate issue, addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)