### PR TITLE
feat(backend): make all games free via ENTITLEMENT_DEV_OVERRIDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ frontend/android/app/upload-keystore.jks
 # Claude Code local overrides (personal, not shared)
 .claude/settings.local.json
 
+# Local env overrides — never committed
+backend/.env
+
 # Entitlement key pair — loaded via env vars in production, never committed
 private.pem
 public.pem

--- a/backend/entitlements/dependencies.py
+++ b/backend/entitlements/dependencies.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_session_factory
 from db.models import GameEntitlement, GameType
+from entitlements.service import is_dev_override_active
 from session import get_session_id
 
 
@@ -28,6 +29,8 @@ async def check_entitlement(db: AsyncSession, session_id: str, game_slug: str) -
 
     No-op for free (non-premium) game types and unknown game slugs.
     """
+    if is_dev_override_active():
+        return
     is_premium = (
         await db.execute(select(GameType.is_premium).where(GameType.name == game_slug))
     ).scalar_one_or_none()

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,10 @@ import logging
 import os
 import time
 
+from dotenv import load_dotenv
+
+load_dotenv()  # loads backend/.env when running locally; no-op in production (Render injects vars)
+
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.135.2
-python-dotenv==1.1.0
+python-dotenv==1.2.2
 sentry-sdk[fastapi]==2.27.0
 starlette==0.52.1
 uvicorn[standard]==0.34.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.135.2
+python-dotenv==1.1.0
 sentry-sdk[fastapi]==2.27.0
 starlette==0.52.1
 uvicorn[standard]==0.34.0


### PR DESCRIPTION
## Summary

- `check_entitlement` now short-circuits when `ENTITLEMENT_DEV_OVERRIDE=true`, so the backend no longer 403s on premium game routes when the flag is set (the JWT-issuing path already respected this flag; now the route enforcement does too)
- Added `python-dotenv` and a `load_dotenv()` call in `main.py` so the flag can be set in `backend/.env` for local dev without shell exports
- Added `backend/.env` (gitignored) with `ENTITLEMENT_DEV_OVERRIDE=true`
- Added `backend/.env` to `.gitignore`

## To activate on Render

Add `ENTITLEMENT_DEV_OVERRIDE=true` to the service's Environment tab.

## To revert

Remove the env var. No code changes needed.

## Test plan

- [ ] Start backend locally — all game routes should be accessible without entitlements
- [ ] Set `ENTITLEMENT_DEV_OVERRIDE=false` or remove the var — premium games should 403 again
- [ ] Existing entitlement enforcement tests still pass (they don't set the env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)