### PR TITLE
fix(starswarm): prefix star keys to prevent duplicate-key console flood

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -342,7 +342,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             {/* Starfield */}
             {sf.stars.map((star) => (
               <Circle
-                key={star.id}
+                key={`star-${star.id}`}
                 cx={star.x}
                 cy={star.y}
                 r={star.r}


### PR DESCRIPTION
## Summary

- Prefixes starfield `<Circle>` keys with `"star-"` so they can't collide with game-entity keys (bullets, enemies, buddies, explosions)
- Stops a ~60fps flood of `Encountered two children with the same key, 38` React warnings in the iOS simulator

## Root cause

`starfield.ts` assigns star IDs 0–94 via a local counter. `engine.ts` resets its own counter to 1 on every `initStarSwarm` call. Both stars and game entities render as siblings under the same Skia `<Group>`, so any entity that reaches ID 38 (within seconds of game start) collides with the star already holding that key.

## Test plan

- [ ] Launch StarSwarm in the iOS simulator — confirm zero duplicate-key warnings in the console
- [ ] Visually confirm stars still render and scroll correctly

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)