### PR TITLE
feat(sort): core engine, BFS solver, and hint system (#1175 #1176)

### DIFF
--- a/frontend/src/game/sort/__tests__/engine.test.ts
+++ b/frontend/src/game/sort/__tests__/engine.test.ts
@@ -68,18 +68,15 @@ describe("applyPour", () => {
   });
 
   it("pours only as many as fit in destination", () => {
-    // source has run of 3, destination has only 1 slot free
-    const state = mkState([["red", "red", "red"], ["blue", "blue", "blue"], []]);
-    // pour from 0 to 2 — destination is empty (4 free), can take all 3
+    // run of 3 into empty bottle — all 3 fit
+    const state = mkState([["blue", "blue", "blue"], ["red", "red", "red"], []]);
     const next = applyPour(state, 0, 2);
-    expect(next.bottles[2]).toEqual(["red", "red", "red"]);
-    // now pour source[1] (3 blues) into a bottle with 1 space
-    const state2 = mkState([[], ["blue", "blue", "blue"], ["red", "red", "red", "red"]]);
-    // no valid destination with enough space here — just test clamp:
-    const state3 = mkState([["blue", "blue", "blue"], ["red", "red", "red"], []]);
-    // pour 3 blues into empty — all 3 fit
-    const next3 = applyPour(state3, 0, 2);
-    expect(next3.bottles[2].length).toBe(3);
+    expect(next.bottles[2]).toEqual(["blue", "blue", "blue"]);
+    // run of 3 reds into dest with 1 space — clamp to 1
+    const state2 = mkState([["blue", "red", "red", "red"], ["red", "red", "red"]]);
+    const next2 = applyPour(state2, 0, 1);
+    expect(next2.bottles[0]).toEqual(["blue", "red", "red"]);
+    expect(next2.bottles[1]).toEqual(["red", "red", "red", "red"]);
   });
 
   it("resets selectedBottleIndex to null", () => {

--- a/frontend/src/game/sort/__tests__/engine.test.ts
+++ b/frontend/src/game/sort/__tests__/engine.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Sort Puzzle engine unit tests (#1175).
+ */
+
+import { applyPour, initState, isComplete, isValidPour, undo } from "../engine";
+import type { SortState } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mkState(bottles: (string | "")[][], overrides: Partial<SortState> = {}): SortState {
+  return {
+    bottles: bottles.map((b) => b.filter((s) => s !== "") as any),
+    moveCount: 0,
+    undosUsed: 0,
+    isComplete: false,
+    selectedBottleIndex: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isValidPour
+// ---------------------------------------------------------------------------
+
+describe("isValidPour", () => {
+  it("returns false when source is empty", () => {
+    expect(isValidPour([], ["red", "red", "red", "red"])).toBe(false);
+  });
+
+  it("returns false when destination is full", () => {
+    expect(isValidPour(["red"], ["blue", "blue", "blue", "blue"])).toBe(false);
+  });
+
+  it("returns false when destination top does not match source top", () => {
+    expect(isValidPour(["red"], ["blue"])).toBe(false);
+  });
+
+  it("returns true when destination is empty", () => {
+    expect(isValidPour(["red"], [])).toBe(true);
+  });
+
+  it("returns true when destination top matches source top", () => {
+    expect(isValidPour(["blue", "red"], ["red"])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyPour
+// ---------------------------------------------------------------------------
+
+describe("applyPour", () => {
+  it("moves a single unit when tops match", () => {
+    const state = mkState([["blue", "red"], ["red", "green"], []]);
+    const next = applyPour(state, 0, 1);
+    expect(next.bottles[0]).toEqual(["blue"]);
+    expect(next.bottles[1]).toEqual(["red", "green", "red"]);
+    expect(next.moveCount).toBe(1);
+  });
+
+  it("moves the full matching run", () => {
+    // source top has 2 reds, destination has space for 2
+    const state = mkState([["blue", "red", "red"], ["green"], []]);
+    const next = applyPour(state, 0, 2);
+    expect(next.bottles[0]).toEqual(["blue"]);
+    expect(next.bottles[2]).toEqual(["red", "red"]);
+  });
+
+  it("pours only as many as fit in destination", () => {
+    // source has run of 3, destination has only 1 slot free
+    const state = mkState([["red", "red", "red"], ["blue", "blue", "blue"], []]);
+    // pour from 0 to 2 — destination is empty (4 free), can take all 3
+    const next = applyPour(state, 0, 2);
+    expect(next.bottles[2]).toEqual(["red", "red", "red"]);
+    // now pour source[1] (3 blues) into a bottle with 1 space
+    const state2 = mkState([[], ["blue", "blue", "blue"], ["red", "red", "red", "red"]]);
+    // no valid destination with enough space here — just test clamp:
+    const state3 = mkState([["blue", "blue", "blue"], ["red", "red", "red"], []]);
+    // pour 3 blues into empty — all 3 fit
+    const next3 = applyPour(state3, 0, 2);
+    expect(next3.bottles[2].length).toBe(3);
+  });
+
+  it("resets selectedBottleIndex to null", () => {
+    const state = mkState([["red"], []], { selectedBottleIndex: 0 });
+    expect(applyPour(state, 0, 1).selectedBottleIndex).toBeNull();
+  });
+
+  it("sets isComplete when solved", () => {
+    // One pour away from complete
+    const state = mkState([["red", "red", "red"], ["red"], []]);
+    const next = applyPour(state, 1, 0);
+    expect(next.isComplete).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isComplete
+// ---------------------------------------------------------------------------
+
+describe("isComplete", () => {
+  it("returns true when all bottles are empty", () => {
+    expect(isComplete(mkState([[], [], []]))).toBe(true);
+  });
+
+  it("returns true when all bottles are full single-color", () => {
+    const state = mkState([
+      ["red", "red", "red", "red"],
+      ["blue", "blue", "blue", "blue"],
+      [],
+    ]);
+    expect(isComplete(state)).toBe(true);
+  });
+
+  it("returns false when a bottle is mixed", () => {
+    const state = mkState([["red", "blue"], ["red", "red", "red", "red"], []]);
+    expect(isComplete(state)).toBe(false);
+  });
+
+  it("returns false when a bottle is a single color but not full", () => {
+    const state = mkState([["red", "red", "red"], ["blue", "blue", "blue", "blue"], []]);
+    expect(isComplete(state)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// undo
+// ---------------------------------------------------------------------------
+
+describe("undo", () => {
+  it("returns unchanged state when history is empty", () => {
+    const state = mkState([["red"], []]);
+    const result = undo(state, []);
+    expect(result.state).toBe(state);
+    expect(result.history).toHaveLength(0);
+  });
+
+  it("restores previous state and pops history", () => {
+    const prev = mkState([["red", "blue"], []]);
+    const cur = mkState([["red"], ["blue"]]);
+    const { state, history } = undo(cur, [prev]);
+    expect(state.bottles).toEqual(prev.bottles);
+    expect(history).toHaveLength(0);
+  });
+
+  it("increments undosUsed", () => {
+    const prev = mkState([["red"], []]);
+    const cur = mkState([[], ["red"]], { undosUsed: 2 });
+    const { state } = undo(cur, [prev]);
+    expect(state.undosUsed).toBe(3);
+  });
+
+  it("resets selectedBottleIndex to null", () => {
+    const prev = mkState([["red"], []], { selectedBottleIndex: 0 });
+    const cur = mkState([[], ["red"]], { selectedBottleIndex: 1 });
+    const { state } = undo(cur, [prev]);
+    expect(state.selectedBottleIndex).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// initState
+// ---------------------------------------------------------------------------
+
+describe("initState", () => {
+  it("strips empty string slots from API bottles", () => {
+    const apiBottles = [
+      ["red", "blue", "", ""],
+      ["green", "green", "green", "green"],
+      ["", "", "", ""],
+    ];
+    const state = initState(apiBottles as any);
+    expect(state.bottles[0]).toEqual(["red", "blue"]);
+    expect(state.bottles[1]).toEqual(["green", "green", "green", "green"]);
+    expect(state.bottles[2]).toEqual([]);
+  });
+
+  it("initialises counters to zero and isComplete to false", () => {
+    const state = initState([["red", "", "", ""], ["", "", "", ""]]);
+    expect(state.moveCount).toBe(0);
+    expect(state.undosUsed).toBe(0);
+    expect(state.isComplete).toBe(false);
+    expect(state.selectedBottleIndex).toBeNull();
+  });
+});

--- a/frontend/src/game/sort/__tests__/engine.test.ts
+++ b/frontend/src/game/sort/__tests__/engine.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { applyPour, initState, isComplete, isValidPour, undo } from "../engine";
-import type { SortState } from "../types";
+import type { Color, SortState } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -11,7 +11,7 @@ import type { SortState } from "../types";
 
 function mkState(bottles: (string | "")[][], overrides: Partial<SortState> = {}): SortState {
   return {
-    bottles: bottles.map((b) => b.filter((s) => s !== "") as any),
+    bottles: bottles.map((b) => b.filter((s): s is Color => s !== "")),
     moveCount: 0,
     undosUsed: 0,
     isComplete: false,
@@ -73,7 +73,10 @@ describe("applyPour", () => {
     const next = applyPour(state, 0, 2);
     expect(next.bottles[2]).toEqual(["blue", "blue", "blue"]);
     // run of 3 reds into dest with 1 space — clamp to 1
-    const state2 = mkState([["blue", "red", "red", "red"], ["red", "red", "red"]]);
+    const state2 = mkState([
+      ["blue", "red", "red", "red"],
+      ["red", "red", "red"],
+    ]);
     const next2 = applyPour(state2, 0, 1);
     expect(next2.bottles[0]).toEqual(["blue", "red", "red"]);
     expect(next2.bottles[1]).toEqual(["red", "red", "red", "red"]);
@@ -102,11 +105,7 @@ describe("isComplete", () => {
   });
 
   it("returns true when all bottles are full single-color", () => {
-    const state = mkState([
-      ["red", "red", "red", "red"],
-      ["blue", "blue", "blue", "blue"],
-      [],
-    ]);
+    const state = mkState([["red", "red", "red", "red"], ["blue", "blue", "blue", "blue"], []]);
     expect(isComplete(state)).toBe(true);
   });
 
@@ -167,14 +166,17 @@ describe("initState", () => {
       ["green", "green", "green", "green"],
       ["", "", "", ""],
     ];
-    const state = initState(apiBottles as any);
+    const state = initState(apiBottles as (Color | "")[][]);
     expect(state.bottles[0]).toEqual(["red", "blue"]);
     expect(state.bottles[1]).toEqual(["green", "green", "green", "green"]);
     expect(state.bottles[2]).toEqual([]);
   });
 
   it("initialises counters to zero and isComplete to false", () => {
-    const state = initState([["red", "", "", ""], ["", "", "", ""]]);
+    const state = initState([
+      ["red", "", "", ""],
+      ["", "", "", ""],
+    ]);
     expect(state.moveCount).toBe(0);
     expect(state.undosUsed).toBe(0);
     expect(state.isComplete).toBe(false);

--- a/frontend/src/game/sort/__tests__/solver.test.ts
+++ b/frontend/src/game/sort/__tests__/solver.test.ts
@@ -2,8 +2,9 @@
  * Sort Puzzle solver unit tests (#1176).
  */
 
+import { applyPour, isValidPour } from "../engine";
 import { getNextHint, solve } from "../solver";
-import type { SortState } from "../types";
+import type { Color, SortState } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -11,7 +12,7 @@ import type { SortState } from "../types";
 
 function mkState(bottles: string[][]): SortState {
   return {
-    bottles: bottles as any,
+    bottles: bottles as Color[][],
     moveCount: 0,
     undosUsed: 0,
     isComplete: false,
@@ -25,26 +26,16 @@ function mkState(bottles: string[][]): SortState {
 
 describe("solve", () => {
   it("returns [] for an already-complete state", () => {
-    const state = mkState([
-      ["red", "red", "red", "red"],
-      ["blue", "blue", "blue", "blue"],
-      [],
-    ]);
+    const state = mkState([["red", "red", "red", "red"], ["blue", "blue", "blue", "blue"], []]);
     expect(solve({ ...state, isComplete: true })).toEqual([]);
   });
 
   it("returns a single-move solution", () => {
     // bottle[1] needs one more red from bottle[2]; blues already complete
-    const state = mkState([
-      ["blue", "blue", "blue", "blue"],
-      ["red", "red", "red"],
-      ["red"],
-      [],
-    ]);
+    const state = mkState([["blue", "blue", "blue", "blue"], ["red", "red", "red"], ["red"], []]);
     const path = solve(state);
     expect(path).not.toBeNull();
     expect(path!.length).toBe(1);
-    const { applyPour } = require("../engine");
     let s = state;
     for (const move of path!) {
       s = applyPour(s, move.from, move.to);
@@ -53,14 +44,9 @@ describe("solve", () => {
   });
 
   it("solves a 2-color, 1-empty puzzle", () => {
-    const state = mkState([
-      ["red", "blue", "red", "blue"],
-      ["blue", "red", "blue", "red"],
-      [],
-    ]);
+    const state = mkState([["red", "blue", "red", "blue"], ["blue", "red", "blue", "red"], []]);
     const path = solve(state);
     expect(path).not.toBeNull();
-    const { applyPour } = require("../engine");
     let s = state;
     for (const move of path!) {
       s = applyPour(s, move.from, move.to);
@@ -82,12 +68,7 @@ describe("solve", () => {
   });
 
   it("path moves are valid (from/to are indices into bottles)", () => {
-    const state = mkState([
-      ["blue", "blue", "blue", "blue"],
-      ["red", "red", "red"],
-      ["red"],
-      [],
-    ]);
+    const state = mkState([["blue", "blue", "blue", "blue"], ["red", "red", "red"], ["red"], []]);
     const path = solve(state);
     expect(path).not.toBeNull();
     for (const move of path!) {
@@ -122,12 +103,7 @@ describe("getNextHint", () => {
   });
 
   it("returns the first move of the optimal path", () => {
-    const state = mkState([
-      ["blue", "blue", "blue", "blue"],
-      ["red", "red", "red"],
-      ["red"],
-      [],
-    ]);
+    const state = mkState([["blue", "blue", "blue", "blue"], ["red", "red", "red"], ["red"], []]);
     const hint = getNextHint(state);
     expect(hint).not.toBeNull();
     expect(hint).toHaveProperty("from");
@@ -135,15 +111,9 @@ describe("getNextHint", () => {
   });
 
   it("hint move is valid for the current state", () => {
-    const state = mkState([
-      ["blue", "blue", "blue", "blue"],
-      ["red", "red", "red"],
-      ["red"],
-      [],
-    ]);
+    const state = mkState([["blue", "blue", "blue", "blue"], ["red", "red", "red"], ["red"], []]);
     const hint = getNextHint(state);
     expect(hint).not.toBeNull();
-    const { isValidPour } = require("../engine");
     expect(isValidPour(state.bottles[hint!.from], state.bottles[hint!.to])).toBe(true);
   });
 });

--- a/frontend/src/game/sort/__tests__/solver.test.ts
+++ b/frontend/src/game/sort/__tests__/solver.test.ts
@@ -43,7 +43,7 @@ describe("solve", () => {
     ]);
     const path = solve(state);
     expect(path).not.toBeNull();
-    expect(path!.length).toBeGreaterThan(0);
+    expect(path!.length).toBe(1);
     const { applyPour } = require("../engine");
     let s = state;
     for (const move of path!) {

--- a/frontend/src/game/sort/__tests__/solver.test.ts
+++ b/frontend/src/game/sort/__tests__/solver.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Sort Puzzle solver unit tests (#1176).
+ */
+
+import { getNextHint, solve } from "../solver";
+import type { SortState } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mkState(bottles: string[][]): SortState {
+  return {
+    bottles: bottles as any,
+    moveCount: 0,
+    undosUsed: 0,
+    isComplete: false,
+    selectedBottleIndex: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// solve
+// ---------------------------------------------------------------------------
+
+describe("solve", () => {
+  it("returns [] for an already-complete state", () => {
+    const state = mkState([
+      ["red", "red", "red", "red"],
+      ["blue", "blue", "blue", "blue"],
+      [],
+    ]);
+    expect(solve({ ...state, isComplete: true })).toEqual([]);
+  });
+
+  it("returns a single-move solution", () => {
+    // bottle[1] needs one more red from bottle[2]; blues already complete
+    const state = mkState([
+      ["blue", "blue", "blue", "blue"],
+      ["red", "red", "red"],
+      ["red"],
+      [],
+    ]);
+    const path = solve(state);
+    expect(path).not.toBeNull();
+    expect(path!.length).toBeGreaterThan(0);
+    const { applyPour } = require("../engine");
+    let s = state;
+    for (const move of path!) {
+      s = applyPour(s, move.from, move.to);
+    }
+    expect(s.isComplete).toBe(true);
+  });
+
+  it("solves a 2-color, 1-empty puzzle", () => {
+    const state = mkState([
+      ["red", "blue", "red", "blue"],
+      ["blue", "red", "blue", "red"],
+      [],
+    ]);
+    const path = solve(state);
+    expect(path).not.toBeNull();
+    const { applyPour } = require("../engine");
+    let s = state;
+    for (const move of path!) {
+      s = applyPour(s, move.from, move.to);
+    }
+    expect(s.isComplete).toBe(true);
+  });
+
+  it("returns null for a dead-end (unsolvable) state", () => {
+    // Two bottles each 2 units of the same color but no empty bottle and
+    // no matching tops — actually let's make a truly locked state.
+    // All bottles full, no matching tops, no empty bottle.
+    const state = mkState([
+      ["red", "blue", "red", "blue"],
+      ["blue", "red", "blue", "red"],
+    ]);
+    // No empty bottle — every pour requires matching top, but tops alternate
+    // and there's no space. This is unsolvable.
+    expect(solve(state)).toBeNull();
+  });
+
+  it("path moves are valid (from/to are indices into bottles)", () => {
+    const state = mkState([
+      ["blue", "blue", "blue", "blue"],
+      ["red", "red", "red"],
+      ["red"],
+      [],
+    ]);
+    const path = solve(state);
+    expect(path).not.toBeNull();
+    for (const move of path!) {
+      expect(move.from).toBeGreaterThanOrEqual(0);
+      expect(move.to).toBeGreaterThanOrEqual(0);
+      expect(move.from).toBeLessThan(state.bottles.length);
+      expect(move.to).toBeLessThan(state.bottles.length);
+      expect(move.from).not.toBe(move.to);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNextHint
+// ---------------------------------------------------------------------------
+
+describe("getNextHint", () => {
+  it("returns null for a complete state", () => {
+    const state = mkState([
+      ["red", "red", "red", "red"],
+      ["blue", "blue", "blue", "blue"],
+    ]);
+    expect(getNextHint({ ...state, isComplete: true })).toBeNull();
+  });
+
+  it("returns null for an unsolvable state", () => {
+    const state = mkState([
+      ["red", "blue", "red", "blue"],
+      ["blue", "red", "blue", "red"],
+    ]);
+    expect(getNextHint(state)).toBeNull();
+  });
+
+  it("returns the first move of the optimal path", () => {
+    const state = mkState([
+      ["blue", "blue", "blue", "blue"],
+      ["red", "red", "red"],
+      ["red"],
+      [],
+    ]);
+    const hint = getNextHint(state);
+    expect(hint).not.toBeNull();
+    expect(hint).toHaveProperty("from");
+    expect(hint).toHaveProperty("to");
+  });
+
+  it("hint move is valid for the current state", () => {
+    const state = mkState([
+      ["blue", "blue", "blue", "blue"],
+      ["red", "red", "red"],
+      ["red"],
+      [],
+    ]);
+    const hint = getNextHint(state);
+    expect(hint).not.toBeNull();
+    const { isValidPour } = require("../engine");
+    expect(isValidPour(state.bottles[hint!.from], state.bottles[hint!.to])).toBe(true);
+  });
+});

--- a/frontend/src/game/sort/engine.ts
+++ b/frontend/src/game/sort/engine.ts
@@ -91,7 +91,7 @@ export function isComplete(state: SortState): boolean {
  */
 export function undo(
   state: SortState,
-  history: readonly SortState[],
+  history: readonly SortState[]
 ): { state: SortState; history: readonly SortState[] } {
   if (history.length === 0) return { state, history };
   const prev = history[history.length - 1];
@@ -107,7 +107,7 @@ export function undo(
  */
 export function initState(levelBottles: (Color | "")[][]): SortState {
   const bottles: Bottle[] = levelBottles.map(
-    (b) => b.filter((s): s is Color => s !== "") as Bottle,
+    (b) => b.filter((s): s is Color => s !== "") as Bottle
   );
   return {
     bottles,

--- a/frontend/src/game/sort/engine.ts
+++ b/frontend/src/game/sort/engine.ts
@@ -1,0 +1,119 @@
+/**
+ * Sort Puzzle engine (#1175).
+ *
+ * Pure TypeScript. No React, AsyncStorage, HTTP, timers, or other
+ * side-effect imports. The UI replaces the entire SortState object on
+ * each transition — state is immutable.
+ *
+ * Pour mechanics mirror the backend BFS in backend/sort/generate_levels.py:
+ * a pour moves the maximal same-color run from the top of the source
+ * bottle, up to the available space in the destination.
+ */
+
+import type { Bottle, Color, Move, SortState } from "./types";
+import { BOTTLE_DEPTH } from "./types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function topColor(bottle: Bottle): Color | null {
+  return bottle.length > 0 ? bottle[bottle.length - 1] : null;
+}
+
+/** Length of the matching-color run at the top of a bottle. */
+function topRun(bottle: Bottle): number {
+  if (bottle.length === 0) return 0;
+  const color = bottle[bottle.length - 1];
+  let n = 0;
+  for (let i = bottle.length - 1; i >= 0; i--) {
+    if (bottle[i] === color) n++;
+    else break;
+  }
+  return n;
+}
+
+function isSolved(bottle: Bottle): boolean {
+  return bottle.length === 0 || (bottle.length === BOTTLE_DEPTH && new Set(bottle).size === 1);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if at least one unit can be poured from `from` into `to`.
+ * Does NOT check bottle indices — caller supplies the bottles directly.
+ */
+export function isValidPour(from: Bottle, to: Bottle): boolean {
+  if (from.length === 0) return false;
+  if (to.length >= BOTTLE_DEPTH) return false;
+  const top = topColor(to);
+  return top === null || top === topColor(from);
+}
+
+/**
+ * Returns a new state with the pour applied. Assumes the move is valid —
+ * call `isValidPour` first. Pours as many units of the top run as fit.
+ */
+export function applyPour(state: SortState, fromIdx: number, toIdx: number): SortState {
+  const src = [...state.bottles[fromIdx]] as Color[];
+  const dst = [...state.bottles[toIdx]] as Color[];
+  const run = topRun(src);
+  const space = BOTTLE_DEPTH - dst.length;
+  const n = Math.min(run, space);
+  for (let i = 0; i < n; i++) {
+    dst.push(src.pop()!);
+  }
+  const bottles = state.bottles.map((b, i) => {
+    if (i === fromIdx) return src as readonly Color[];
+    if (i === toIdx) return dst as readonly Color[];
+    return b;
+  });
+  const complete = isComplete({ ...state, bottles });
+  return {
+    ...state,
+    bottles,
+    moveCount: state.moveCount + 1,
+    isComplete: complete,
+    selectedBottleIndex: null,
+  };
+}
+
+/** True when every bottle is either empty or full with a single color. */
+export function isComplete(state: SortState): boolean {
+  return state.bottles.every(isSolved);
+}
+
+/**
+ * Pops the last state from `history` and returns it as the active state.
+ * Increments `undosUsed`. Returns unchanged inputs if history is empty.
+ */
+export function undo(
+  state: SortState,
+  history: readonly SortState[],
+): { state: SortState; history: readonly SortState[] } {
+  if (history.length === 0) return { state, history };
+  const prev = history[history.length - 1];
+  return {
+    state: { ...prev, undosUsed: state.undosUsed + 1, selectedBottleIndex: null },
+    history: history.slice(0, -1),
+  };
+}
+
+/**
+ * Converts the API-format level bottles (padded with "" for empty slots)
+ * into a SortState ready for play.
+ */
+export function initState(levelBottles: (Color | "")[][]): SortState {
+  const bottles: Bottle[] = levelBottles.map(
+    (b) => b.filter((s): s is Color => s !== "") as Bottle,
+  );
+  return {
+    bottles,
+    moveCount: 0,
+    undosUsed: 0,
+    isComplete: false,
+    selectedBottleIndex: null,
+  };
+}

--- a/frontend/src/game/sort/engine.ts
+++ b/frontend/src/game/sort/engine.ts
@@ -10,7 +10,7 @@
  * bottle, up to the available space in the destination.
  */
 
-import type { Bottle, Color, Move, SortState } from "./types";
+import type { Bottle, Color, SortState } from "./types";
 import { BOTTLE_DEPTH } from "./types";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/sort/solver.ts
+++ b/frontend/src/game/sort/solver.ts
@@ -1,0 +1,75 @@
+/**
+ * Sort Puzzle BFS solver (#1176).
+ *
+ * Pure TypeScript. No side effects. Mirrors the backend BFS in
+ * backend/sort/generate_levels.py but returns the move sequence rather
+ * than a boolean.
+ *
+ * Performance: capped at 200 000 visited states (matches backend generator).
+ * States beyond the cap return null — the puzzle is assumed solvable but the
+ * path is too long to compute client-side in real time. In practice only
+ * levels 16–20 (7–8 colors) approach this limit.
+ */
+
+import { isValidPour, applyPour, isComplete } from "./engine";
+import type { Move, SortState } from "./types";
+
+const BFS_CAP = 200_000;
+
+// ---------------------------------------------------------------------------
+// State serialisation for the visited set
+// ---------------------------------------------------------------------------
+
+function key(state: SortState): string {
+  return state.bottles.map((b) => b.join(",")).join("|");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * BFS over the move graph. Returns the shortest sequence of moves to solve
+ * `state`, or null if unsolvable (or if the BFS cap is hit).
+ */
+export function solve(state: SortState): Move[] | null {
+  if (isComplete(state)) return [];
+
+  const visited = new Set<string>([key(state)]);
+  // Each queue entry: [currentState, movesFromRoot]
+  const queue: Array<[SortState, Move[]]> = [[state, []]];
+
+  while (queue.length > 0) {
+    if (visited.size >= BFS_CAP) return null;
+
+    const [cur, moves] = queue.shift()!;
+
+    for (let from = 0; from < cur.bottles.length; from++) {
+      for (let to = 0; to < cur.bottles.length; to++) {
+        if (from === to) continue;
+        if (!isValidPour(cur.bottles[from], cur.bottles[to])) continue;
+
+        const next = applyPour(cur, from, to);
+        const k = key(next);
+        if (visited.has(k)) continue;
+
+        const path = [...moves, { from, to }];
+        if (next.isComplete) return path;
+
+        visited.add(k);
+        queue.push([next, path]);
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Returns the first move of the optimal solution path, or null if no
+ * solution is found within the BFS cap.
+ */
+export function getNextHint(state: SortState): Move | null {
+  const path = solve(state);
+  return path && path.length > 0 ? path[0] : null;
+}

--- a/frontend/src/game/sort/solver.ts
+++ b/frontend/src/game/sort/solver.ts
@@ -36,13 +36,15 @@ export function solve(state: SortState): Move[] | null {
   if (isComplete(state)) return [];
 
   const visited = new Set<string>([key(state)]);
-  // Each queue entry: [currentState, movesFromRoot]
+  // Each queue entry: [currentState, movesFromRoot]. head is an index cursor
+  // so dequeue is O(1) — Array.shift() would be O(n) on large state spaces.
   const queue: Array<[SortState, Move[]]> = [[state, []]];
+  let head = 0;
 
-  while (queue.length > 0) {
+  while (head < queue.length) {
     if (visited.size >= BFS_CAP) return null;
 
-    const [cur, moves] = queue.shift()!;
+    const [cur, moves] = queue[head++];
 
     for (let from = 0; from < cur.bottles.length; from++) {
       for (let to = 0; to < cur.bottles.length; to++) {

--- a/frontend/src/game/sort/types.ts
+++ b/frontend/src/game/sort/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Sort Puzzle — shared types (#1175).
+ *
+ * Pure data. No React, no side effects.
+ */
+
+export type Color =
+  | "red"
+  | "blue"
+  | "green"
+  | "yellow"
+  | "orange"
+  | "purple"
+  | "pink"
+  | "teal";
+
+/** Max units per bottle — must match DEPTH in backend/sort/generate_levels.py. */
+export const BOTTLE_DEPTH = 4;
+
+/** A bottle is a stack of colors, bottom-first. Length <= BOTTLE_DEPTH. */
+export type Bottle = readonly Color[];
+
+export interface Move {
+  readonly from: number;
+  readonly to: number;
+}
+
+export interface SortState {
+  readonly bottles: readonly Bottle[];
+  readonly moveCount: number;
+  readonly undosUsed: number;
+  readonly isComplete: boolean;
+  readonly selectedBottleIndex: number | null;
+}

--- a/frontend/src/game/sort/types.ts
+++ b/frontend/src/game/sort/types.ts
@@ -4,15 +4,7 @@
  * Pure data. No React, no side effects.
  */
 
-export type Color =
-  | "red"
-  | "blue"
-  | "green"
-  | "yellow"
-  | "orange"
-  | "purple"
-  | "pink"
-  | "teal";
+export type Color = "red" | "blue" | "green" | "yellow" | "orange" | "purple" | "pink" | "teal";
 
 /** Max units per bottle — must match DEPTH in backend/sort/generate_levels.py. */
 export const BOTTLE_DEPTH = 4;


### PR DESCRIPTION
## Summary

- **`frontend/src/game/sort/types.ts`** — `Color` union type, `Bottle` (`Color[]`), `BOTTLE_DEPTH = 4`, `Move`, `SortState` (bottles, moveCount, undosUsed, isComplete, selectedBottleIndex)
- **`frontend/src/game/sort/engine.ts`** — pure functions:
  - `isValidPour(from, to)` — source non-empty, dest has space, tops match or dest empty
  - `applyPour(state, fromIdx, toIdx)` — pours maximal same-color run (clamped to dest space), mirrors backend BFS mechanics
  - `isComplete(state)` — all bottles are empty or full with a single color
  - `undo(state, history)` — pops last state from history stack, increments `undosUsed`
  - `initState(levelBottles)` — converts API-padded bottles (`""` = empty slot) into a fresh `SortState`
- **`frontend/src/game/sort/solver.ts`** — BFS solver:
  - `solve(state)` — returns shortest `Move[]` or `null` if unsolvable / BFS cap (200k states) hit
  - `getNextHint(state)` — returns the first move of the solution path; `null` if no solution found
- 29 unit tests covering all engine transitions, undo, win detection, solver correctness, dead-end detection, and hint validity

Closes #1175, closes #1176

## Test plan

- [ ] `cd frontend && npx jest src/game/sort --no-coverage` — 29 tests pass
- [ ] `npx jest --no-coverage` — no regressions (2135 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)