### PR TITLE
feat(daily-word): frontend types, API client, storage, and engine

### DIFF
--- a/frontend/src/game/daily_word/__tests__/engine.test.ts
+++ b/frontend/src/game/daily_word/__tests__/engine.test.ts
@@ -97,6 +97,17 @@ describe("applyServerResult — duplicate-letter coloring", () => {
   });
 });
 
+describe("applyServerResult — guards", () => {
+  it("does nothing when game is complete", () => {
+    const tiles: TileState[] = Array.from({ length: 5 }, (_, i) => ({
+      letter: "abcde"[i]!,
+      status: "absent" as const,
+    }));
+    const s = markComplete(initialState("2026-05-03:en", 5, "en"), false);
+    expect(applyServerResult(s, tiles)).toBe(s);
+  });
+});
+
 describe("keyboard promotion rules", () => {
   it("correct is never downgraded to absent", () => {
     const correctTiles: TileState[] = [

--- a/frontend/src/game/daily_word/__tests__/engine.test.ts
+++ b/frontend/src/game/daily_word/__tests__/engine.test.ts
@@ -1,0 +1,247 @@
+import {
+  initialState,
+  applyServerResult,
+  setCurrentRowLetter,
+  deleteLastLetter,
+  markComplete,
+  buildShareText,
+} from "../engine";
+import type { TileState } from "../types";
+
+function typeWord(state: ReturnType<typeof initialState>, word: string) {
+  let s = state;
+  for (const ch of word) {
+    s = setCurrentRowLetter(s, ch);
+  }
+  return s;
+}
+
+describe("initialState", () => {
+  it("creates 6 empty rows with correct metadata", () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    expect(s._v).toBe(1);
+    expect(s.puzzle_id).toBe("2026-05-03:en");
+    expect(s.word_length).toBe(5);
+    expect(s.rows).toHaveLength(6);
+    expect(s.rows[0]!.submitted).toBe(false);
+    expect(s.rows[0]!.tiles).toHaveLength(5);
+    expect(s.rows[0]!.tiles[0]).toEqual({ letter: "", status: "empty" });
+    expect(s.current_row).toBe(0);
+    expect(s.keyboard_state).toEqual({});
+    expect(s.is_complete).toBe(false);
+    expect(s.won).toBe(false);
+    expect(s.completed_at).toBeNull();
+  });
+});
+
+describe("setCurrentRowLetter", () => {
+  it("adds a letter to the current row", () => {
+    const s = setCurrentRowLetter(initialState("2026-05-03:en", 5, "en"), "a");
+    expect(s.rows[0]!.tiles[0]).toEqual({ letter: "a", status: "tbd" });
+    expect(s.rows[0]!.tiles[1]).toEqual({ letter: "", status: "empty" });
+  });
+
+  it("fills multiple letters sequentially", () => {
+    const s = typeWord(initialState("2026-05-03:en", 5, "en"), "crane");
+    expect(s.rows[0]!.tiles.map((t) => t.letter)).toEqual(["c", "r", "a", "n", "e"]);
+    expect(s.rows[0]!.tiles.map((t) => t.status)).toEqual(["tbd", "tbd", "tbd", "tbd", "tbd"]);
+  });
+
+  it("does nothing when row is full", () => {
+    const full = typeWord(initialState("2026-05-03:en", 5, "en"), "crane");
+    const after = setCurrentRowLetter(full, "x");
+    expect(after).toBe(full);
+  });
+
+  it("does nothing when game is complete", () => {
+    const s = markComplete(initialState("2026-05-03:en", 5, "en"), true);
+    const after = setCurrentRowLetter(s, "a");
+    expect(after).toBe(s);
+  });
+});
+
+describe("deleteLastLetter", () => {
+  it("removes the last typed letter", () => {
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "ab");
+    s = deleteLastLetter(s);
+    expect(s.rows[0]!.tiles[0]).toEqual({ letter: "a", status: "tbd" });
+    expect(s.rows[0]!.tiles[1]).toEqual({ letter: "", status: "empty" });
+  });
+
+  it("does nothing on an empty row", () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    expect(deleteLastLetter(s)).toBe(s);
+  });
+});
+
+describe("applyServerResult — duplicate-letter coloring", () => {
+  it('only first "e" gets present when answer is "speed" and guess is "spell"', () => {
+    // Server scoring: answer="speed", guess="spell"
+    // s=correct, p=correct, e=present (answer has one 'e'), l=absent, l=absent
+    const tiles: TileState[] = [
+      { letter: "s", status: "correct" },
+      { letter: "p", status: "correct" },
+      { letter: "e", status: "present" },
+      { letter: "l", status: "absent" },
+      { letter: "l", status: "absent" },
+    ];
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "spell");
+    s = applyServerResult(s, tiles);
+
+    expect(s.keyboard_state["s"]).toBe("correct");
+    expect(s.keyboard_state["p"]).toBe("correct");
+    expect(s.keyboard_state["e"]).toBe("present");
+    expect(s.keyboard_state["l"]).toBe("absent");
+    expect(s.rows[0]!.submitted).toBe(true);
+    expect(s.current_row).toBe(1);
+  });
+});
+
+describe("keyboard promotion rules", () => {
+  it("correct is never downgraded to absent", () => {
+    const correctTiles: TileState[] = [
+      { letter: "a", status: "correct" },
+      { letter: "b", status: "absent" },
+      { letter: "c", status: "absent" },
+      { letter: "d", status: "absent" },
+      { letter: "e", status: "absent" },
+    ];
+    const absentTiles: TileState[] = [
+      { letter: "a", status: "absent" },
+      { letter: "f", status: "absent" },
+      { letter: "g", status: "absent" },
+      { letter: "h", status: "absent" },
+      { letter: "i", status: "absent" },
+    ];
+
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "abcde");
+    s = applyServerResult(s, correctTiles);
+    expect(s.keyboard_state["a"]).toBe("correct");
+
+    s = typeWord(s, "afghi");
+    s = applyServerResult(s, absentTiles);
+    expect(s.keyboard_state["a"]).toBe("correct");
+  });
+
+  it("correct is never downgraded to present", () => {
+    const correctTiles: TileState[] = [
+      { letter: "a", status: "correct" },
+      { letter: "b", status: "absent" },
+      { letter: "c", status: "absent" },
+      { letter: "d", status: "absent" },
+      { letter: "e", status: "absent" },
+    ];
+    const presentTiles: TileState[] = [
+      { letter: "a", status: "present" },
+      { letter: "f", status: "absent" },
+      { letter: "g", status: "absent" },
+      { letter: "h", status: "absent" },
+      { letter: "i", status: "absent" },
+    ];
+
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "abcde");
+    s = applyServerResult(s, correctTiles);
+    expect(s.keyboard_state["a"]).toBe("correct");
+
+    s = typeWord(s, "afghi");
+    s = applyServerResult(s, presentTiles);
+    expect(s.keyboard_state["a"]).toBe("correct");
+  });
+
+  it("absent is promoted to present when seen later", () => {
+    const absentTiles: TileState[] = [
+      { letter: "a", status: "absent" },
+      { letter: "b", status: "absent" },
+      { letter: "c", status: "absent" },
+      { letter: "d", status: "absent" },
+      { letter: "e", status: "absent" },
+    ];
+    const presentTiles: TileState[] = [
+      { letter: "a", status: "present" },
+      { letter: "f", status: "absent" },
+      { letter: "g", status: "absent" },
+      { letter: "h", status: "absent" },
+      { letter: "i", status: "absent" },
+    ];
+
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "abcde");
+    s = applyServerResult(s, absentTiles);
+    expect(s.keyboard_state["a"]).toBe("absent");
+
+    s = typeWord(s, "afghi");
+    s = applyServerResult(s, presentTiles);
+    expect(s.keyboard_state["a"]).toBe("present");
+  });
+});
+
+describe("markComplete", () => {
+  it("sets is_complete and won flags correctly for a win", () => {
+    const s = markComplete(initialState("2026-05-03:en", 5, "en"), true);
+    expect(s.is_complete).toBe(true);
+    expect(s.won).toBe(true);
+    expect(s.completed_at).toBeTruthy();
+  });
+
+  it("sets is_complete and won flags correctly for a loss", () => {
+    const s = markComplete(initialState("2026-05-03:en", 5, "en"), false);
+    expect(s.is_complete).toBe(true);
+    expect(s.won).toBe(false);
+    expect(s.completed_at).toBeTruthy();
+  });
+});
+
+describe("buildShareText", () => {
+  it("produces correct emoji grid for a known 3-guess win", () => {
+    const tiles1: TileState[] = [
+      { letter: "c", status: "absent" },
+      { letter: "r", status: "absent" },
+      { letter: "a", status: "absent" },
+      { letter: "n", status: "absent" },
+      { letter: "e", status: "present" },
+    ];
+    const tiles2: TileState[] = [
+      { letter: "w", status: "absent" },
+      { letter: "h", status: "present" },
+      { letter: "i", status: "present" },
+      { letter: "l", status: "absent" },
+      { letter: "e", status: "correct" },
+    ];
+    const tiles3: TileState[] = [
+      { letter: "s", status: "correct" },
+      { letter: "h", status: "correct" },
+      { letter: "i", status: "correct" },
+      { letter: "n", status: "correct" },
+      { letter: "e", status: "correct" },
+    ];
+
+    let s = typeWord(initialState("2026-05-03:en", 5, "en"), "crane");
+    s = applyServerResult(s, tiles1);
+    s = typeWord(s, "while");
+    s = applyServerResult(s, tiles2);
+    s = typeWord(s, "shine");
+    s = applyServerResult(s, tiles3);
+    s = markComplete(s, true);
+
+    const text = buildShareText(s, "https://bcarcade.com/daily-word");
+    expect(text).toContain("Daily Word #1 — 3/6");
+    expect(text).toContain("⬜⬜⬜⬜🟨");
+    expect(text).toContain("⬜🟨🟨⬜🟩");
+    expect(text).toContain("🟩🟩🟩🟩🟩");
+    expect(text).toContain("https://bcarcade.com/daily-word");
+  });
+
+  it("shows X/6 for a loss", () => {
+    let s = initialState("2026-05-03:en", 5, "en");
+    const absentTiles = (word: string): TileState[] =>
+      word.split("").map((letter) => ({ letter, status: "absent" as const }));
+    for (const word of ["crane", "stole", "bunny", "fizzy", "hippo", "jazzy"]) {
+      s = typeWord(s, word);
+      s = applyServerResult(s, absentTiles(word));
+    }
+    s = markComplete(s, false);
+
+    const text = buildShareText(s, "https://bcarcade.com/daily-word");
+    expect(text).toContain("Daily Word #1 — X/6");
+    expect(text).toContain("⬜⬜⬜⬜⬜");
+  });
+});

--- a/frontend/src/game/daily_word/__tests__/storage.test.ts
+++ b/frontend/src/game/daily_word/__tests__/storage.test.ts
@@ -1,0 +1,79 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+import { saveState, loadState, clearState, looksValid } from "../storage";
+import { initialState } from "../engine";
+
+const STORAGE_KEY = "daily_word_state_v1";
+
+describe("daily_word storage", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it("round-trip save/load", async () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    await saveState(s);
+    const loaded = await loadState();
+    expect(loaded).toEqual(s);
+  });
+
+  it("returns null when no saved state exists", async () => {
+    expect(await loadState()).toBeNull();
+  });
+
+  it("corrupt payload returns null", async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, "not json{{{");
+    expect(await loadState()).toBeNull();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("corrupt payload"),
+      expect.objectContaining({
+        level: "warning",
+        tags: expect.objectContaining({ subsystem: "daily_word.storage" }),
+      })
+    );
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("_v mismatch returns null", async () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ ...s, _v: 2 }));
+    expect(await loadState()).toBeNull();
+  });
+
+  it("clearState removes saved state", async () => {
+    await saveState(initialState("2026-05-03:en", 5, "en"));
+    await clearState();
+    expect(await loadState()).toBeNull();
+  });
+});
+
+describe("looksValid", () => {
+  it("accepts a valid initial state", () => {
+    expect(looksValid(initialState("2026-05-03:en", 5, "en"))).toBe(true);
+  });
+
+  it("rejects null", () => {
+    expect(looksValid(null)).toBe(false);
+  });
+
+  it("rejects a non-object", () => {
+    expect(looksValid("string")).toBe(false);
+  });
+
+  it("rejects wrong _v", () => {
+    expect(looksValid({ _v: 2, puzzle_id: "2026-05-03:en", rows: [] })).toBe(false);
+  });
+
+  it("rejects invalid puzzle_id format", () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    expect(looksValid({ ...s, puzzle_id: "invalid" })).toBe(false);
+  });
+
+  it("rejects rows.length > 6", () => {
+    const s = initialState("2026-05-03:en", 5, "en");
+    expect(looksValid({ ...s, rows: [...s.rows, ...s.rows] })).toBe(false);
+  });
+});

--- a/frontend/src/game/daily_word/api.ts
+++ b/frontend/src/game/daily_word/api.ts
@@ -1,0 +1,32 @@
+import { createGameClient } from "../_shared/httpClient";
+import type { TileStatus } from "./types";
+
+const request = createGameClient({ apiTag: "daily_word" });
+
+export interface TodayResponse {
+  readonly puzzle_id: string;
+  readonly word_length: number;
+}
+
+export interface TileResult {
+  readonly letter: string;
+  readonly status: TileStatus;
+}
+
+export interface GuessResponse {
+  readonly tiles: readonly TileResult[];
+  /** Groupings of code-point indices into visual grapheme clusters. Present for Hindi only. */
+  readonly grapheme_clusters?: readonly (readonly number[])[];
+}
+
+export const dailyWordApi = {
+  getToday: (tz_offset_minutes: number, lang: string) =>
+    request<TodayResponse>(
+      `/daily-word/today?tz_offset_minutes=${tz_offset_minutes}&lang=${encodeURIComponent(lang)}`
+    ),
+  submitGuess: (puzzle_id: string, guess: string, tz_offset_minutes: number) =>
+    request<GuessResponse>("/daily-word/guess", {
+      method: "POST",
+      body: JSON.stringify({ puzzle_id, guess, tz_offset_minutes }),
+    }),
+};

--- a/frontend/src/game/daily_word/engine.ts
+++ b/frontend/src/game/daily_word/engine.ts
@@ -58,6 +58,8 @@ function promoteLetter(
 }
 
 export function applyServerResult(state: DailyWordState, tiles: TileState[]): DailyWordState {
+  if (state.is_complete || state.current_row >= MAX_ROWS) return state;
+
   const newRows = state.rows.map((row, i) =>
     i === state.current_row ? { tiles, submitted: true } : row
   );

--- a/frontend/src/game/daily_word/engine.ts
+++ b/frontend/src/game/daily_word/engine.ts
@@ -1,0 +1,159 @@
+/**
+ * Client-side Daily Word engine — pure functions, no React, no I/O.
+ *
+ * State transitions:
+ *   initialState → setCurrentRowLetter / deleteLastLetter (while typing)
+ *               → applyServerResult (after server scores the guess)
+ *               → markComplete (when won or all 6 guesses exhausted)
+ */
+
+import type { DailyWordState, LetterStatus, RowState, TileState, TileStatus } from "./types";
+
+const MAX_ROWS = 6;
+
+function emptyRow(wordLength: number): RowState {
+  return {
+    tiles: Array.from({ length: wordLength }, () => ({ letter: "", status: "empty" as TileStatus })),
+    submitted: false,
+  };
+}
+
+export function initialState(puzzle_id: string, word_length: number, language: string): DailyWordState {
+  return {
+    _v: 1,
+    puzzle_id,
+    word_length,
+    language,
+    rows: Array.from({ length: MAX_ROWS }, () => emptyRow(word_length)),
+    current_row: 0,
+    keyboard_state: {},
+    is_complete: false,
+    won: false,
+    completed_at: null,
+  };
+}
+
+// Keyboard "best-seen" rule: correct > present > absent > unused.
+// Once correct, never downgrade.
+const STATUS_RANK: Record<LetterStatus, number> = {
+  unused: 0,
+  absent: 1,
+  present: 2,
+  correct: 3,
+};
+
+function promoteLetter(
+  current: LetterStatus | undefined,
+  incoming: "correct" | "present" | "absent"
+): LetterStatus {
+  if (current === undefined) return incoming;
+  return STATUS_RANK[incoming] > STATUS_RANK[current] ? incoming : current;
+}
+
+export function applyServerResult(state: DailyWordState, tiles: TileState[]): DailyWordState {
+  const newRows = state.rows.map((row, i) =>
+    i === state.current_row ? { tiles, submitted: true } : row
+  );
+
+  const newKeyboard = { ...state.keyboard_state };
+  for (const tile of tiles) {
+    if (!tile.letter || tile.status === "empty" || tile.status === "tbd") continue;
+    const status = tile.status as "correct" | "present" | "absent";
+    newKeyboard[tile.letter] = promoteLetter(newKeyboard[tile.letter] as LetterStatus | undefined, status);
+  }
+
+  return {
+    ...state,
+    rows: newRows,
+    current_row: state.current_row + 1,
+    keyboard_state: newKeyboard,
+  };
+}
+
+export function setCurrentRowLetter(state: DailyWordState, letter: string): DailyWordState {
+  if (state.is_complete || state.current_row >= MAX_ROWS) return state;
+
+  const row = state.rows[state.current_row];
+  if (!row) return state;
+
+  // Each tile holds exactly one grapheme cluster (one visible character, even
+  // in Hindi where a cluster may span multiple code points). Counting
+  // non-empty tiles equals counting clusters — no Intl.Segmenter needed.
+  const filledCount = row.tiles.filter((t) => t.letter !== "").length;
+  if (filledCount >= state.word_length) return state;
+
+  const newTiles = [...row.tiles];
+  newTiles[filledCount] = { letter, status: "tbd" };
+
+  const newRows = state.rows.map((r, i) =>
+    i === state.current_row ? { ...r, tiles: newTiles } : r
+  );
+
+  return { ...state, rows: newRows };
+}
+
+export function deleteLastLetter(state: DailyWordState): DailyWordState {
+  if (state.is_complete || state.current_row >= MAX_ROWS) return state;
+
+  const row = state.rows[state.current_row];
+  if (!row) return state;
+
+  let lastFilled = -1;
+  for (let i = row.tiles.length - 1; i >= 0; i--) {
+    if (row.tiles[i]!.letter !== "") {
+      lastFilled = i;
+      break;
+    }
+  }
+  if (lastFilled === -1) return state;
+
+  const newTiles = [...row.tiles];
+  newTiles[lastFilled] = { letter: "", status: "empty" };
+
+  const newRows = state.rows.map((r, i) =>
+    i === state.current_row ? { ...r, tiles: newTiles } : r
+  );
+
+  return { ...state, rows: newRows };
+}
+
+export function markComplete(state: DailyWordState, won: boolean): DailyWordState {
+  return {
+    ...state,
+    is_complete: true,
+    won,
+    completed_at: new Date().toISOString(),
+  };
+}
+
+const TILE_EMOJI: Record<"correct" | "present" | "absent", string> = {
+  correct: "🟩",
+  present: "🟨",
+  absent: "⬜",
+};
+
+// Sequential puzzle counter from launch day (day 1 = 2026-05-03).
+const EPOCH_MS = new Date("2026-05-03T00:00:00Z").getTime();
+
+function puzzleNumber(puzzleId: string): number {
+  const dateStr = puzzleId.split(":")[0] ?? "";
+  const dateMs = new Date(`${dateStr}T00:00:00Z`).getTime();
+  return Math.floor((dateMs - EPOCH_MS) / 86400000) + 1;
+}
+
+export function buildShareText(state: DailyWordState, deepLink: string): string {
+  const n = puzzleNumber(state.puzzle_id);
+  const submittedRows = state.rows.filter((r) => r.submitted);
+  const guessCount = submittedRows.length;
+  const result = state.won ? `${guessCount}/6` : "X/6";
+
+  const grid = submittedRows
+    .map((row) =>
+      row.tiles
+        .map((t) => TILE_EMOJI[t.status as "correct" | "present" | "absent"] ?? "⬜")
+        .join("")
+    )
+    .join("\n");
+
+  return `Daily Word #${n} — ${result}\n${grid}\n${deepLink}`;
+}

--- a/frontend/src/game/daily_word/engine.ts
+++ b/frontend/src/game/daily_word/engine.ts
@@ -13,12 +13,19 @@ const MAX_ROWS = 6;
 
 function emptyRow(wordLength: number): RowState {
   return {
-    tiles: Array.from({ length: wordLength }, () => ({ letter: "", status: "empty" as TileStatus })),
+    tiles: Array.from({ length: wordLength }, () => ({
+      letter: "",
+      status: "empty" as TileStatus,
+    })),
     submitted: false,
   };
 }
 
-export function initialState(puzzle_id: string, word_length: number, language: string): DailyWordState {
+export function initialState(
+  puzzle_id: string,
+  word_length: number,
+  language: string
+): DailyWordState {
   return {
     _v: 1,
     puzzle_id,
@@ -59,7 +66,10 @@ export function applyServerResult(state: DailyWordState, tiles: TileState[]): Da
   for (const tile of tiles) {
     if (!tile.letter || tile.status === "empty" || tile.status === "tbd") continue;
     const status = tile.status as "correct" | "present" | "absent";
-    newKeyboard[tile.letter] = promoteLetter(newKeyboard[tile.letter] as LetterStatus | undefined, status);
+    newKeyboard[tile.letter] = promoteLetter(
+      newKeyboard[tile.letter] as LetterStatus | undefined,
+      status
+    );
   }
 
   return {

--- a/frontend/src/game/daily_word/storage.ts
+++ b/frontend/src/game/daily_word/storage.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+import type { DailyWordState } from "./types";
+
+const STORAGE_KEY = "daily_word_state_v1";
+
+// puzzle_id format: "YYYY-MM-DD:lang"
+const PUZZLE_ID_RE = /^\d{4}-\d{2}-\d{2}:[a-z]{2}$/;
+
+export function looksValid(v: unknown): v is DailyWordState {
+  if (v === null || typeof v !== "object") return false;
+  const s = v as Partial<DailyWordState>;
+  if (s._v !== 1) return false;
+  if (typeof s.puzzle_id !== "string" || !PUZZLE_ID_RE.test(s.puzzle_id)) return false;
+  if (!Array.isArray(s.rows) || s.rows.length > 6) return false;
+  return true;
+}
+
+export async function saveState(state: DailyWordState): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "daily_word.storage", op: "save" } });
+  }
+}
+
+export async function loadState(): Promise<DailyWordState | null> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!looksValid(parsed)) return null;
+    return parsed;
+  } catch (e) {
+    Sentry.captureMessage("daily_word.storage: corrupt payload, discarding", {
+      level: "warning",
+      tags: { subsystem: "daily_word.storage", op: "load" },
+      extra: { error: String(e), key: STORAGE_KEY },
+    });
+    await AsyncStorage.removeItem(STORAGE_KEY).catch(() => {});
+    return null;
+  }
+}
+
+export async function clearState(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "daily_word.storage", op: "clear" } });
+  }
+}

--- a/frontend/src/game/daily_word/storage.ts
+++ b/frontend/src/game/daily_word/storage.ts
@@ -4,6 +4,10 @@ import type { DailyWordState } from "./types";
 
 const STORAGE_KEY = "daily_word_state_v1";
 
+// Callers must compare loaded state's puzzle_id against today's puzzle
+// (via dailyWordApi.getToday) and call clearState() on a mismatch so a
+// stale save from a previous day is never presented to the player.
+
 // puzzle_id format: "YYYY-MM-DD:lang"
 const PUZZLE_ID_RE = /^\d{4}-\d{2}-\d{2}:[a-z]{2}$/;
 

--- a/frontend/src/game/daily_word/types.ts
+++ b/frontend/src/game/daily_word/types.ts
@@ -1,0 +1,25 @@
+export type TileStatus = "correct" | "present" | "absent" | "empty" | "tbd";
+export type LetterStatus = "correct" | "present" | "absent" | "unused";
+
+export interface TileState {
+  letter: string;
+  status: TileStatus;
+}
+
+export interface RowState {
+  tiles: TileState[];
+  submitted: boolean;
+}
+
+export interface DailyWordState {
+  _v: 1;
+  puzzle_id: string;
+  word_length: number;
+  language: string;
+  rows: RowState[];
+  current_row: number;
+  keyboard_state: Record<string, LetterStatus>;
+  is_complete: boolean;
+  won: boolean;
+  completed_at: string | null;
+}


### PR DESCRIPTION
## Summary

Closes #1191, #1192. Part of #1133. Blocks #1193.

- **types.ts** — `TileStatus`, `LetterStatus`, `TileState`, `RowState`, `DailyWordState` with `_v: 1` version field
- **api.ts** — `dailyWordApi.getToday(tz_offset_minutes, lang)` and `.submitGuess(puzzle_id, guess, tz_offset_minutes)` via `createGameClient({apiTag:"daily_word"})`
- **storage.ts** — key `"daily_word_state_v1"`, `saveState/loadState/clearState`, `looksValid()` guard (`_v: 1`, puzzle_id regex, `rows.length ≤ 6`), Sentry error handling identical to yacht pattern
- **engine.ts** — pure functions: `initialState`, `applyServerResult`, `setCurrentRowLetter`, `deleteLastLetter`, `markComplete`, `buildShareText`; keyboard best-seen promotion (correct never downgraded); Hindi grapheme cluster support via tile-based approach (each tile = one cluster — no Intl.Segmenter needed)
- **26 unit tests** — round-trip storage, corrupt payload, `_v` mismatch, duplicate-letter coloring (`"spell"` vs `"speed"`: first `e` = present), keyboard promotion rules, 3-guess win emoji grid, loss share text

## Test plan

- [x] 26 unit tests pass
- [x] TypeScript: zero errors in new files
- [x] ESLint: clean on `src/game/daily_word/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)