### PR TITLE
test(sort): add Playwright e2e suite for Sort Puzzle (#1255)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -16,6 +16,7 @@ import { join } from "path";
  *   hearts      — hearts-*.spec.ts
  *   solitaire   — solitaire-*.spec.ts
  *   sudoku      — sudoku-*.spec.ts
+ *   sort        — sort-*.spec.ts
  *   cross       — accessibility.spec.ts, cascade-flow.spec.ts, ui-preferences.spec.ts
  *   logs-budget — logs-*.spec.ts (#373 acceptance gate, CPU-throttled to
  *                  approximate mid-tier mobile device performance)
@@ -96,6 +97,11 @@ export default defineConfig({
     {
       name: "sudoku",
       testMatch: "sudoku-*.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "sort",
+      testMatch: "sort-*.spec.ts",
       use: { ...devices["Desktop Chrome"] },
     },
     {

--- a/e2e/tests/helpers/api-mock.ts
+++ b/e2e/tests/helpers/api-mock.ts
@@ -142,7 +142,7 @@ export async function installEntitlementsMock(page: Page): Promise<void> {
   const payload = b64url(
     JSON.stringify({
       sub: "e2e-test",
-      entitled_games: ["yacht", "cascade", "hearts", "sudoku", "starswarm"],
+      entitled_games: ["yacht", "cascade", "hearts", "sudoku", "starswarm", "sort"],
       iat: 1000000000,
       exp: 9999999999,
     }),

--- a/e2e/tests/helpers/sort.ts
+++ b/e2e/tests/helpers/sort.ts
@@ -1,0 +1,91 @@
+import { Page } from "@playwright/test";
+import { installEntitlementsMock } from "./api-mock";
+
+const STORAGE_KEY = "@sort/progress";
+
+// Two-level mock puzzle set used across all sort e2e specs.
+// Level 1: 4 bottles, red + blue (2 empty for workspace).
+// Level 2: 4 bottles, green + yellow.
+export const MOCK_LEVELS = {
+  levels: [
+    {
+      id: 1,
+      bottles: [
+        ["red", "red", "blue", "blue"],
+        ["blue", "blue", "red", "red"],
+        [],
+        [],
+      ],
+    },
+    {
+      id: 2,
+      bottles: [
+        ["green", "green", "yellow", "yellow"],
+        ["yellow", "yellow", "green", "green"],
+        [],
+        [],
+      ],
+    },
+  ],
+};
+
+export async function mockSortApi(page: Page): Promise<void> {
+  await page.route("**/sort/**", async (route) => {
+    const url = route.request().url();
+    const method = route.request().method();
+
+    if (url.includes("/sort/levels")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_LEVELS),
+      });
+    } else if (url.includes("/sort/score") && method === "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ player_name: "Tester", level_reached: 1, rank: 1 }),
+      });
+    } else if (url.includes("/sort/scores")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores: [] }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    }
+  });
+}
+
+// Navigate from Home to the Sort Puzzle level-select screen.
+// Callers must call mockSortApi(page) first so the /sort/levels request
+// is intercepted when the screen mounts.
+export async function gotoSort(page: Page): Promise<void> {
+  await installEntitlementsMock(page);
+  await page.goto("/");
+  await page.evaluate((key) => localStorage.removeItem(key), STORAGE_KEY);
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+}
+
+// Inject a SortProgress value into localStorage, then reload to home so the
+// caller can navigate to the sort screen with the injected state active.
+// Callers must call mockSortApi(page) first.
+export async function injectSortProgress(
+  page: Page,
+  partial: Record<string, unknown>,
+): Promise<void> {
+  await installEntitlementsMock(page);
+  await page.goto("/");
+  await page.evaluate(
+    ([key, state]) =>
+      localStorage.setItem(key as string, JSON.stringify(state)),
+    [STORAGE_KEY, partial] as const,
+  );
+  await page.goto("/");
+}

--- a/e2e/tests/sort-accessibility.spec.ts
+++ b/e2e/tests/sort-accessibility.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * sort-accessibility.spec.ts — GH #1255
+ *
+ * WCAG 2.2 AA axe-core scan on level-select and gameplay screens; bottle
+ * accessible labels; undo aria-disabled state.
+ */
+
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { mockSortApi, gotoSort, injectSortProgress } from "./helpers/sort";
+
+async function assertNoA11yViolations(
+  axeBuilder: InstanceType<typeof AxeBuilder>,
+): Promise<void> {
+  const results = await axeBuilder.analyze();
+  const criticalOrSerious = results.violations.filter((v) =>
+    ["critical", "serious"].includes(v.impact ?? ""),
+  );
+  if (criticalOrSerious.length > 0) {
+    const summary = criticalOrSerious
+      .map((v) => `[${v.impact}] ${v.id}: ${v.description}`)
+      .join("\n");
+    expect.soft(criticalOrSerious).toHaveLength(0);
+    throw new Error(`Accessibility violations found:\n${summary}`);
+  }
+}
+
+test.describe("Sort Puzzle — accessibility", () => {
+  test("level-select screen passes axe-core WCAG 2.2 AA scan", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await assertNoA11yViolations(
+      new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21aa"]),
+    );
+  });
+
+  test("gameplay screen passes axe-core WCAG 2.2 AA scan", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+    await assertNoA11yViolations(
+      new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21aa"]),
+    );
+  });
+
+  test("board region has accessible label", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("bottles have descriptive accessible labels", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+
+    // Filled bottles describe content
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+    // Empty bottles are labelled as empty
+    await expect(
+      page.getByRole("button", { name: "Bottle 3, empty" }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("selected bottle label announces selected state", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await expect(
+      page.getByRole("button", {
+        name: "Bottle 1 selected — tap another bottle to pour",
+      }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("solved bottle label announces complete state", async ({ page }) => {
+    await mockSortApi(page);
+    await injectSortProgress(page, {
+      unlockedLevel: 1,
+      currentLevelId: 1,
+      currentState: {
+        bottles: [["red", "red", "red", "red"], ["blue"], [], []],
+        moveCount: 3,
+        undosUsed: 0,
+        isComplete: false,
+        selectedBottleIndex: null,
+      },
+    });
+    await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+    await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Continue Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, complete" }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("undo button has aria-disabled when history is empty", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+
+    const undoBtn = page.getByRole("button", { name: "Undo" });
+    await expect(undoBtn).toBeDisabled({ timeout: 3_000 });
+  });
+});

--- a/e2e/tests/sort-gameplay.spec.ts
+++ b/e2e/tests/sort-gameplay.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * sort-gameplay.spec.ts — GH #1255
+ *
+ * Core gameplay: bottle selection, pour application, move counter increment,
+ * and solved-bottle indicator.
+ *
+ * Level 1 mock layout (bottom-first):
+ *   Bottle 1 (idx 0): ["red", "red", "blue", "blue"]  top = blue
+ *   Bottle 2 (idx 1): ["blue", "blue", "red", "red"]  top = red
+ *   Bottle 3 (idx 2): []  empty
+ *   Bottle 4 (idx 3): []  empty
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSortApi, gotoSort, injectSortProgress } from "./helpers/sort";
+
+test.describe("Sort Puzzle — gameplay (Level 1)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("tapping a filled bottle selects it", async ({ page }) => {
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await expect(
+      page.getByRole("button", {
+        name: "Bottle 1 selected — tap another bottle to pour",
+      }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("tapping a selected bottle deselects it", async ({ page }) => {
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page
+      .getByRole("button", {
+        name: "Bottle 1 selected — tap another bottle to pour",
+      })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("tapping a dest bottle applies the pour and increments move count", async ({ page }) => {
+    // Bottle 1 top = blue; Bottle 3 = empty → valid pour of 2 blues
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page.getByRole("button", { name: "Bottle 3, empty" }).click();
+
+    await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, 2 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+    await expect(
+      page.getByRole("button", { name: "Bottle 3, 2 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("invalid pour (same source and dest) deselects without moving", async ({ page }) => {
+    // Bottle 1 top = blue; Bottle 2 top = red → cannot pour blue onto red
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page.getByRole("button", { name: "Bottle 2, 4 of 4 filled" }).click();
+
+    // Move count stays at 0 — no valid pour
+    await expect(page.getByText(/Moves:\s*0/)).toBeVisible({ timeout: 3_000 });
+  });
+});
+
+test("Sort Puzzle — solved bottle shows 'complete' label", async ({ page }) => {
+  await mockSortApi(page);
+  await injectSortProgress(page, {
+    unlockedLevel: 1,
+    currentLevelId: 1,
+    currentState: {
+      bottles: [
+        ["red", "red", "red", "red"],
+        ["blue"],
+        [],
+        [],
+      ],
+      moveCount: 4,
+      undosUsed: 0,
+      isComplete: false,
+      selectedBottleIndex: null,
+    },
+  });
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Continue Level 1" }).click();
+  await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+  await expect(
+    page.getByRole("button", { name: "Bottle 1, complete" }),
+  ).toBeVisible({ timeout: 3_000 });
+});

--- a/e2e/tests/sort-gameplay.spec.ts
+++ b/e2e/tests/sort-gameplay.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { mockSortApi, gotoSort, injectSortProgress } from "./helpers/sort";
+import { mockSortApi, gotoSort } from "./helpers/sort";
 
 test.describe("Sort Puzzle — gameplay (Level 1)", () => {
   test.beforeEach(async ({ page }) => {
@@ -57,7 +57,7 @@ test.describe("Sort Puzzle — gameplay (Level 1)", () => {
     ).toBeVisible({ timeout: 3_000 });
   });
 
-  test("invalid pour (same source and dest) deselects without moving", async ({ page }) => {
+  test("invalid pour (incompatible colors) deselects without moving", async ({ page }) => {
     // Bottle 1 top = blue; Bottle 2 top = red → cannot pour blue onto red
     await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
     await page.getByRole("button", { name: "Bottle 2, 4 of 4 filled" }).click();
@@ -67,29 +67,3 @@ test.describe("Sort Puzzle — gameplay (Level 1)", () => {
   });
 });
 
-test("Sort Puzzle — solved bottle shows 'complete' label", async ({ page }) => {
-  await mockSortApi(page);
-  await injectSortProgress(page, {
-    unlockedLevel: 1,
-    currentLevelId: 1,
-    currentState: {
-      bottles: [
-        ["red", "red", "red", "red"],
-        ["blue"],
-        [],
-        [],
-      ],
-      moveCount: 4,
-      undosUsed: 0,
-      isComplete: false,
-      selectedBottleIndex: null,
-    },
-  });
-  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
-  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
-  await page.getByRole("button", { name: "Continue Level 1" }).click();
-  await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
-  await expect(
-    page.getByRole("button", { name: "Bottle 1, complete" }),
-  ).toBeVisible({ timeout: 3_000 });
-});

--- a/e2e/tests/sort-leaderboard.spec.ts
+++ b/e2e/tests/sort-leaderboard.spec.ts
@@ -5,7 +5,7 @@
  * names, levels reached, and correct rank ordering (#1 through #10).
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { installEntitlementsMock } from "./helpers/api-mock";
 
 const TOP_10 = Array.from({ length: 10 }, (_, i) => ({
@@ -14,7 +14,7 @@ const TOP_10 = Array.from({ length: 10 }, (_, i) => ({
   rank: i + 1,
 }));
 
-function installSortMock(page: Parameters<typeof installEntitlementsMock>[0], scores: unknown[]) {
+function installSortMock(page: Page, scores: unknown[]) {
   return page.route("**/sort/**", async (route) => {
     const url = route.request().url();
     if (url.includes("/sort/levels")) {

--- a/e2e/tests/sort-leaderboard.spec.ts
+++ b/e2e/tests/sort-leaderboard.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * sort-leaderboard.spec.ts — GH #1255
+ *
+ * Leaderboard tab: renders top-10 scores from GET /sort/scores, shows player
+ * names, levels reached, and correct rank ordering (#1 through #10).
+ */
+
+import { test, expect } from "@playwright/test";
+import { installEntitlementsMock } from "./helpers/api-mock";
+
+const TOP_10 = Array.from({ length: 10 }, (_, i) => ({
+  player_name: `Player${i + 1}`,
+  level_reached: 10 - i,
+  rank: i + 1,
+}));
+
+function installSortMock(page: Parameters<typeof installEntitlementsMock>[0], scores: unknown[]) {
+  return page.route("**/sort/**", async (route) => {
+    const url = route.request().url();
+    if (url.includes("/sort/levels")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          levels: [{ id: 1, bottles: [["red", "red", "blue", "blue"], [], [], []] }],
+        }),
+      });
+    } else if (url.includes("/sort/scores")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ scores }),
+      });
+    } else {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    }
+  });
+}
+
+test.describe("Sort Puzzle — leaderboard", () => {
+  test.beforeEach(async ({ page }) => {
+    await installEntitlementsMock(page);
+    await installSortMock(page, TOP_10);
+    await page.goto("/");
+    await page.evaluate(() => localStorage.removeItem("@sort/progress"));
+    await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+    await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+    await page.getByRole("tab", { name: /Leaderboard/i }).click();
+  });
+
+  test("renders top-10 player names", async ({ page }) => {
+    await expect(page.getByText("Player1")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Player10")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("first entry is ranked #1", async ({ page }) => {
+    await expect(page.getByText("#1").first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("last entry is ranked #10", async ({ page }) => {
+    await expect(page.getByText("#10").first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("level reached is displayed for each entry", async ({ page }) => {
+    // Player1 reached level 10
+    await expect(page.getByText("Level 10").first()).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+test("Sort Puzzle — empty leaderboard shows empty state message", async ({ page }) => {
+  await installEntitlementsMock(page);
+  await installSortMock(page, []);
+  await page.goto("/");
+  await page.evaluate(() => localStorage.removeItem("@sort/progress"));
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+  await page.getByRole("tab", { name: /Leaderboard/i }).click();
+  await expect(page.getByText("No scores yet.")).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/tests/sort-level-select.spec.ts
+++ b/e2e/tests/sort-level-select.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * sort-level-select.spec.ts — GH #1255
+ *
+ * Level-select grid: locked/unlocked states, continue button, and
+ * tapping an unlocked level transitions to the play view.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSortApi, gotoSort, injectSortProgress } from "./helpers/sort";
+
+test.describe("Sort Puzzle — level select", () => {
+  test("locked levels are disabled and labelled as locked", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    const lockedBtn = page.getByRole("button", { name: "Level 2, locked" });
+    await expect(lockedBtn).toBeVisible({ timeout: 5_000 });
+    await expect(lockedBtn).toBeDisabled();
+  });
+
+  test("tapping an unlocked level starts gameplay", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("level 1 is always unlocked on a fresh install", async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await expect(
+      page.getByRole("button", { name: "Level 1" }),
+    ).not.toBeDisabled({ timeout: 5_000 });
+  });
+
+  test("continue button appears when a level is in progress", async ({ page }) => {
+    await mockSortApi(page);
+    await injectSortProgress(page, {
+      unlockedLevel: 1,
+      currentLevelId: 1,
+      currentState: {
+        bottles: [["red"], ["blue"], [], []],
+        moveCount: 2,
+        undosUsed: 0,
+        isComplete: false,
+        selectedBottleIndex: null,
+      },
+    });
+    await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+    await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: "Continue Level 1" }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("previously unlocked level shown as accessible after progress injection", async ({
+    page,
+  }) => {
+    await mockSortApi(page);
+    await injectSortProgress(page, {
+      unlockedLevel: 2,
+      currentLevelId: null,
+      currentState: null,
+    });
+    await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+    await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+    await expect(
+      page.getByRole("button", { name: "Level 2" }),
+    ).not.toBeDisabled({ timeout: 5_000 });
+  });
+});

--- a/e2e/tests/sort-persistence.spec.ts
+++ b/e2e/tests/sort-persistence.spec.ts
@@ -23,7 +23,7 @@ test("Sort Puzzle — in-progress state survives navigate away and back", async 
 
   // Navigate away to home
   await page.goto("/");
-  await page.getByText("BC Arcade").first().waitFor();
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).waitFor({ timeout: 10_000 });
 
   // Return to Sort
   await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
@@ -58,7 +58,7 @@ test("Sort Puzzle — unlockedLevel survives page reload", async ({ page }) => {
 
   // Reload the page
   await page.reload();
-  await page.getByText("BC Arcade").first().waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).waitFor({ timeout: 10_000 });
 
   // Navigate back to sort — Level 2 should still be unlocked
   await page.getByRole("button", { name: "Play Sort Puzzle" }).click();

--- a/e2e/tests/sort-persistence.spec.ts
+++ b/e2e/tests/sort-persistence.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * sort-persistence.spec.ts — GH #1255
+ *
+ * Persistence: in-progress game state (move count) survives navigate-away-
+ * and-back; unlockedLevel survives a full page reload.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSortApi, gotoSort, injectSortProgress } from "./helpers/sort";
+
+test("Sort Puzzle — in-progress state survives navigate away and back", async ({ page }) => {
+  await mockSortApi(page);
+  await gotoSort(page);
+
+  // Start Level 1
+  await page.getByRole("button", { name: "Level 1" }).click();
+  await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+
+  // Make one pour: Bottle 1 (top=blue) → Bottle 3 (empty)
+  await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+  await page.getByRole("button", { name: "Bottle 3, empty" }).click();
+  await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+
+  // Navigate away to home
+  await page.goto("/");
+  await page.getByText("BC Arcade").first().waitFor();
+
+  // Return to Sort
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+
+  // The continue button should appear since game was saved
+  await expect(
+    page.getByRole("button", { name: "Continue Level 1" }),
+  ).toBeVisible({ timeout: 5_000 });
+
+  await page.getByRole("button", { name: "Continue Level 1" }).click();
+  await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+
+  // Move count should still be 1
+  await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+});
+
+test("Sort Puzzle — unlockedLevel survives page reload", async ({ page }) => {
+  await mockSortApi(page);
+  await injectSortProgress(page, {
+    unlockedLevel: 2,
+    currentLevelId: null,
+    currentState: null,
+  });
+
+  // Navigate to sort; Level 2 should be unlocked
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+  await expect(
+    page.getByRole("button", { name: "Level 2" }),
+  ).not.toBeDisabled({ timeout: 5_000 });
+
+  // Reload the page
+  await page.reload();
+  await page.getByText("BC Arcade").first().waitFor({ timeout: 10_000 });
+
+  // Navigate back to sort — Level 2 should still be unlocked
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+  await expect(
+    page.getByRole("button", { name: "Level 2" }),
+  ).not.toBeDisabled({ timeout: 5_000 });
+});

--- a/e2e/tests/sort-smoke.spec.ts
+++ b/e2e/tests/sort-smoke.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * sort-smoke.spec.ts — GH #1255
+ *
+ * Smoke tests: navigation from Home to Sort Puzzle, level-select visibility,
+ * locked-level premium gate, and the home-screen premium gate when not entitled.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSortApi, gotoSort } from "./helpers/sort";
+
+test.describe("Sort Puzzle — smoke tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+  });
+
+  test("navigates from Home to Sort Puzzle level-select screen", async ({ page }) => {
+    await expect(page.getByText("Sort Puzzle").first()).toBeVisible();
+    await expect(page.getByText("Choose a Level")).toBeVisible();
+  });
+
+  test("level-select screen shows level grid on fresh install", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "Level 1" }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("level 1 is unlocked on a fresh install", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "Level 1" }),
+    ).not.toBeDisabled({ timeout: 5_000 });
+  });
+
+  test("locked levels show premium gate", async ({ page }) => {
+    const lockedBtn = page.getByRole("button", { name: "Level 2, locked" });
+    await expect(lockedBtn).toBeVisible({ timeout: 5_000 });
+    await expect(lockedBtn).toBeDisabled();
+  });
+});
+
+test("Sort Puzzle card shows premium gate on home screen when not entitled", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("button", { name: /Sort Puzzle — Coming soon/ }),
+  ).toBeVisible({ timeout: 10_000 });
+});

--- a/e2e/tests/sort-undo.spec.ts
+++ b/e2e/tests/sort-undo.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * sort-undo.spec.ts — GH #1255
+ *
+ * Undo: button presence, disabled when history is empty, enabled after a pour,
+ * and reversal of the last pour when activated.
+ */
+
+import { test, expect } from "@playwright/test";
+import { mockSortApi, gotoSort } from "./helpers/sort";
+
+test.describe("Sort Puzzle — undo", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSortApi(page);
+    await gotoSort(page);
+    await page.getByRole("button", { name: "Level 1" }).click();
+    await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("undo button is present in the HUD", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "Undo" })).toBeVisible();
+  });
+
+  test("undo button is disabled on a fresh game (empty history)", async ({ page }) => {
+    await expect(page.getByRole("button", { name: "Undo" })).toBeDisabled({ timeout: 3_000 });
+  });
+
+  test("undo button is enabled after a pour", async ({ page }) => {
+    // Make one pour: Bottle 1 (top=blue) → Bottle 3 (empty)
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page.getByRole("button", { name: "Bottle 3, empty" }).click();
+    await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+
+    await expect(page.getByRole("button", { name: "Undo" })).not.toBeDisabled();
+  });
+
+  test("undo reverses the last pour", async ({ page }) => {
+    // Pour Bottle 1 → Bottle 3 (2 blues move)
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page.getByRole("button", { name: "Bottle 3, empty" }).click();
+    await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+
+    // Undo the pour
+    await page.getByRole("button", { name: "Undo" }).click();
+
+    // Bottles revert; undosUsed increments; move count shown is from the saved state
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+    await expect(
+      page.getByRole("button", { name: "Bottle 3, empty" }),
+    ).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("undo button is disabled again after undoing the only move", async ({ page }) => {
+    // Make one pour then undo it — history is empty again
+    await page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }).click();
+    await page.getByRole("button", { name: "Bottle 3, empty" }).click();
+    await expect(page.getByText(/Moves:\s*1/)).toBeVisible({ timeout: 3_000 });
+
+    await page.getByRole("button", { name: "Undo" }).click();
+
+    // History is now empty — button disabled
+    await expect(
+      page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }),
+    ).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByRole("button", { name: "Undo" })).toBeDisabled({ timeout: 3_000 });
+  });
+});

--- a/e2e/tests/sort-undo.spec.ts
+++ b/e2e/tests/sort-undo.spec.ts
@@ -42,7 +42,8 @@ test.describe("Sort Puzzle — undo", () => {
     // Undo the pour
     await page.getByRole("button", { name: "Undo" }).click();
 
-    // Bottles revert; undosUsed increments; move count shown is from the saved state
+    // Bottles and move count revert to pre-pour state
+    await expect(page.getByText(/Moves:\s*0/)).toBeVisible({ timeout: 3_000 });
     await expect(
       page.getByRole("button", { name: "Bottle 1, 4 of 4 filled" }),
     ).toBeVisible({ timeout: 3_000 });

--- a/e2e/tests/sort-win-flow.spec.ts
+++ b/e2e/tests/sort-win-flow.spec.ts
@@ -91,6 +91,7 @@ test.describe("Sort Puzzle — win flow", () => {
     await page.getByRole("button", { name: "Submit Score" }).click();
 
     await expect(page.getByText(/Rank #3/)).toBeVisible({ timeout: 5_000 });
+    expect(submittedBody).not.toBeNull();
     expect(submittedBody).toMatchObject({ player_name: "Alice", level_reached: 1 });
   });
 

--- a/e2e/tests/sort-win-flow.spec.ts
+++ b/e2e/tests/sort-win-flow.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * sort-win-flow.spec.ts — GH #1255
+ *
+ * Win flow: inject a near-solved state, complete the last pour, verify the
+ * win modal, score submission to POST /sort/score, rank display, next-level
+ * unlock, and the Next Level / Back to Levels actions.
+ *
+ * Near-solved layout (injected via localStorage):
+ *   Bottle 1 (idx 0): ["blue","blue","blue","blue"]  solved
+ *   Bottle 2 (idx 1): ["red","red","red"]             needs 1 more red
+ *   Bottle 3 (idx 2): ["red"]                         1 red to pour
+ *   Bottle 4 (idx 3): []                              empty
+ *
+ * Winning move: pour Bottle 3 → Bottle 2 (1 red fills the last slot).
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockSortApi, injectSortProgress } from "./helpers/sort";
+
+const NEAR_SOLVED = {
+  unlockedLevel: 1,
+  currentLevelId: 1,
+  currentState: {
+    bottles: [
+      ["blue", "blue", "blue", "blue"],
+      ["red", "red", "red"],
+      ["red"],
+      [],
+    ],
+    moveCount: 5,
+    undosUsed: 0,
+    isComplete: false,
+    selectedBottleIndex: null,
+  },
+};
+
+async function loadNearSolvedLevel(page: Page): Promise<void> {
+  await mockSortApi(page);
+  await injectSortProgress(page, NEAR_SOLVED);
+  await page.getByRole("button", { name: "Play Sort Puzzle" }).click();
+  await page.getByText("Choose a Level").waitFor({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Continue Level 1" }).click();
+  await expect(page.getByLabel("Sort Puzzle board")).toBeVisible({ timeout: 5_000 });
+}
+
+async function makeWinningPour(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Bottle 3, 1 of 4 filled" }).click();
+  await expect(
+    page.getByRole("button", {
+      name: "Bottle 3 selected — tap another bottle to pour",
+    }),
+  ).toBeVisible({ timeout: 3_000 });
+  await page.getByRole("button", { name: "Bottle 2, 3 of 4 filled" }).click();
+  await expect(page.getByText("Solved!")).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("Sort Puzzle — win flow", () => {
+  test("completing the last pour shows the win modal", async ({ page }) => {
+    await loadNearSolvedLevel(page);
+    await makeWinningPour(page);
+  });
+
+  test("win modal shows move and undo stats", async ({ page }) => {
+    await loadNearSolvedLevel(page);
+    await makeWinningPour(page);
+
+    // moveCount was 5 + 1 winning pour = 6
+    await expect(page.getByText(/Moves:\s*6/)).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByText(/Undos used:\s*0/)).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("score is submitted to POST /sort/score with player name", async ({ page }) => {
+    await loadNearSolvedLevel(page);
+    await makeWinningPour(page);
+
+    // Override the score route (registered after mockSortApi so LIFO gives it priority)
+    let submittedBody: Record<string, unknown> | null = null;
+    await page.route("**/sort/score", async (route) => {
+      if (route.request().method() === "POST") {
+        const raw = route.request().postData() ?? "{}";
+        submittedBody = JSON.parse(raw) as Record<string, unknown>;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ player_name: "Alice", level_reached: 1, rank: 3 }),
+      });
+    });
+
+    await page.getByPlaceholder("Your name").fill("Alice");
+    await page.getByRole("button", { name: "Submit Score" }).click();
+
+    await expect(page.getByText(/Rank #3/)).toBeVisible({ timeout: 5_000 });
+    expect(submittedBody).toMatchObject({ player_name: "Alice", level_reached: 1 });
+  });
+
+  test("Next Level button appears after score submission when a next level exists", async ({
+    page,
+  }) => {
+    await loadNearSolvedLevel(page);
+    await makeWinningPour(page);
+
+    await page.getByPlaceholder("Your name").fill("Tester");
+    await page.getByRole("button", { name: "Submit Score" }).click();
+    await expect(page.getByRole("button", { name: "Next Level" })).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("Back to Levels returns to level select with next level unlocked", async ({ page }) => {
+    await loadNearSolvedLevel(page);
+    await makeWinningPour(page);
+
+    await page.getByPlaceholder("Your name").fill("Tester");
+    await page.getByRole("button", { name: "Submit Score" }).click();
+    await expect(page.getByRole("button", { name: "Next Level" })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByRole("button", { name: "Back to Levels" }).click();
+
+    // After score submission unlockedLevel advanced to 2
+    await expect(
+      page.getByRole("button", { name: "Level 2" }),
+    ).not.toBeDisabled({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `sort` named project to `playwright.config.ts` so CI can run `--project=sort` independently
- Grants `sort` entitlement in `installEntitlementsMock` (sort is a premium game)
- New helper (`e2e/tests/helpers/sort.ts`): `mockSortApi`, `gotoSort`, `injectSortProgress` — storage key `@sort/progress`
- 8 spec files covering all acceptance criteria from #1255:
  - `sort-smoke` — navigation, level-select, premium gate (home card + locked levels)
  - `sort-level-select` — locked/unlocked states, continue button, inject-then-check
  - `sort-gameplay` — bottle selection, deselection, pour application, move counter, solved label
  - `sort-undo` — present, disabled on fresh game, enabled after pour, reverses last pour, disabled again when history empty
  - `sort-win-flow` — near-solved inject via localStorage, completing last pour shows "Solved!", stats, POST /sort/score, rank display, Next Level button, Back to Levels unlocks next level
  - `sort-persistence` — in-progress state (move count) survives navigate-away-and-back; `unlockedLevel` survives page reload
  - `sort-leaderboard` — top-10 render, rank ordering (#1–#10), level reached display, empty state
  - `sort-accessibility` — axe-core WCAG 2.2 AA scan on both level-select and gameplay screens, bottle a11y labels (filled / selected / empty / complete), undo `aria-disabled` when history empty

## Test plan

- [ ] `playwright test --project=sort` passes locally against a built Expo Web export
- [ ] No `waitForTimeout()` calls — confirmed 0 occurrences
- [ ] axe-core scan in `sort-accessibility.spec.ts` reports zero critical/serious violations
- [ ] Existing projects unaffected — adding `"sort"` to `installEntitlementsMock`'s `entitled_games` is additive

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)