### PR TITLE
feat(sort): SVG flask visuals, pour animation, height-aware layout, and audio

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -37,6 +37,7 @@ jest.mock("react-native-reanimated", () => {
     withTiming: noopAnim,
     withSpring: noopAnim,
     withSequence: (...args: unknown[]) => args[args.length - 1],
+    withRepeat: (v: unknown) => v,
     withDelay: (_ms: number, v: unknown) => v,
     Easing: {
       out: () => () => 0,

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -125,6 +125,11 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   "freecell.gameWin": require("../../../assets/sounds/freecell-game-win.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "freecell.invalidMove": require("../../../assets/sounds/freecell-invalid-move.mp3"),
+  // Sort (#1265, #1268)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "sort.pour": require("../../../assets/sounds/cascade-fruit-merge.ogg"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "sort.win": require("../../../assets/sounds/freecell-game-win.mp3"),
   // Mahjong (#914)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "mahjong.tileSelect": require("../../../assets/sounds/mahjong-tile-select.ogg"),

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -106,10 +106,7 @@ export default function BottleView({
   useEffect(() => {
     if (selected) {
       bounceY.value = withRepeat(
-        withSequence(
-          withTiming(-10, { duration: 250 }),
-          withTiming(0, { duration: 250 })
-        ),
+        withSequence(withTiming(-10, { duration: 250 }), withTiming(0, { duration: 250 })),
         -1,
         false
       );

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -1,22 +1,86 @@
 import React, { useEffect } from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from "react-native-reanimated";
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import Svg, {
+  Circle,
+  ClipPath,
+  Defs,
+  G,
+  LinearGradient,
+  Path,
+  Rect,
+  Stop,
+  Text as SvgText,
+} from "react-native-svg";
 import { useTranslation } from "react-i18next";
-import type { Bottle } from "../types";
+import type { Bottle, Color } from "../types";
 import { BOTTLE_DEPTH } from "../types";
 import { isBottleSolved } from "../engine";
-import BallView, { BALL_SIZE } from "./BallView";
 
-const BOTTLE_PADDING = 6;
-const BALL_GAP = 3;
-export const BOTTLE_WIDTH = BALL_SIZE + BOTTLE_PADDING * 2;
-export const BOTTLE_HEIGHT = BOTTLE_DEPTH * (BALL_SIZE + BALL_GAP) + BOTTLE_PADDING * 2;
+// SVG design dimensions — the viewBox stays fixed; width/height props scale the render.
+const VB_W = 56;
+const VB_H = 168;
+const PAD_TOP = 14; // neck height in viewBox units
+const BODY_BOTTOM = VB_H - 2; // 166
+const INNER_H = BODY_BOTTOM - PAD_TOP; // 152
+const UNIT_H = INNER_H / BOTTLE_DEPTH; // 38 per liquid unit
+
+// Test-tube shape: straight walls → rounded bottom, narrow opening at neck.
+// TUBE_CAVITY clips liquid to body only; TUBE_OUTLINE draws the full silhouette.
+const TUBE_CAVITY = `M 12 ${PAD_TOP} L 12 150 Q 12 ${BODY_BOTTOM} 28 ${BODY_BOTTOM} Q 44 ${BODY_BOTTOM} 44 150 L 44 ${PAD_TOP} Z`;
+const TUBE_OUTLINE = `M 20 0 L 20 ${PAD_TOP} L 12 ${PAD_TOP} L 12 150 Q 12 ${BODY_BOTTOM} 28 ${BODY_BOTTOM} Q 44 ${BODY_BOTTOM} 44 150 L 44 ${PAD_TOP} L 36 ${PAD_TOP} L 36 0 Z`;
+
+export const LIQUID_COLORS: Record<Color, string> = {
+  red: "#ff716c",
+  blue: "#5b8cff",
+  green: "#4ade80",
+  yellow: "#ffae3b",
+  orange: "#ff9f3b",
+  purple: "#d674ff",
+  pink: "#ff5fa8",
+  teal: "#8ff5ff",
+};
+
+const COLORBLIND_SYMBOLS: Record<Color, string> = {
+  red: "▲",
+  blue: "●",
+  green: "■",
+  yellow: "★",
+  orange: "⬡",
+  purple: "◆",
+  pink: "✦",
+  teal: "✚",
+};
+
+export const DEFAULT_BOTTLE_WIDTH = 52;
+export const DEFAULT_BOTTLE_HEIGHT = 156;
+// Backward-compat names used by SortBoard and snapshot tests
+export const BOTTLE_WIDTH = DEFAULT_BOTTLE_WIDTH;
+export const BOTTLE_HEIGHT = DEFAULT_BOTTLE_HEIGHT;
+
+// Pour animation timing (ms)
+const TILT_IN_MS = 250;
+const TILT_HOLD_MS = 150;
+const TILT_OUT_MS = 200;
+const TILT_DEG = 62;
 
 export interface BottleViewProps {
   readonly bottle: Bottle;
   readonly index: number;
   readonly selected?: boolean;
+  readonly pouring?: boolean;
+  readonly pouringDirection?: "left" | "right";
   readonly colorblindMode?: boolean;
+  readonly bottleWidth?: number;
+  readonly bottleHeight?: number;
   readonly onTap?: () => void;
 }
 
@@ -24,22 +88,52 @@ export default function BottleView({
   bottle,
   index,
   selected = false,
+  pouring = false,
+  pouringDirection,
   colorblindMode = false,
+  bottleWidth = DEFAULT_BOTTLE_WIDTH,
+  bottleHeight = DEFAULT_BOTTLE_HEIGHT,
   onTap,
 }: BottleViewProps) {
   const { t } = useTranslation("sort");
-  const scale = useSharedValue(1);
-
-  useEffect(() => {
-    scale.value = withSpring(selected ? 1.06 : 1, { damping: 10, stiffness: 220 });
-  }, [selected, scale]);
-
-  const animStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
+  const bounceY = useSharedValue(0);
+  const tiltDeg = useSharedValue(0);
 
   const isFilled = bottle.length > 0;
   const solved = isBottleSolved(bottle);
+
+  // Continuous bounce while selected
+  useEffect(() => {
+    if (selected) {
+      bounceY.value = withRepeat(
+        withSequence(
+          withTiming(-10, { duration: 250 }),
+          withTiming(0, { duration: 250 })
+        ),
+        -1,
+        false
+      );
+    } else {
+      cancelAnimation(bounceY);
+      bounceY.value = withTiming(0, { duration: 100 });
+    }
+  }, [selected, bounceY]);
+
+  // Tilt toward target bottle while pouring
+  useEffect(() => {
+    if (pouring && pouringDirection) {
+      const angle = pouringDirection === "right" ? TILT_DEG : -TILT_DEG;
+      tiltDeg.value = withSequence(
+        withTiming(angle, { duration: TILT_IN_MS }),
+        withDelay(TILT_HOLD_MS, withTiming(0, { duration: TILT_OUT_MS }))
+      );
+    }
+  }, [pouring, pouringDirection, tiltDeg]);
+
+  const animStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: bounceY.value }, { rotate: `${tiltDeg.value}deg` }],
+  }));
+
   let accessibilityLabel: string;
   if (selected) {
     accessibilityLabel = t("a11y.bottleSelected", { index: index + 1 });
@@ -55,6 +149,12 @@ export default function BottleView({
     });
   }
 
+  const clipId = `bv-clip-${index}`;
+  const gradId = `bv-grad-${index}`;
+  const strokeColor = selected ? "#8ff5ff" : solved && isFilled ? "#22c55e" : "#4a4a56";
+  const strokeWidth = selected ? 2 : 1.2;
+  const bodyFill = selected ? "#8ff5ff22" : "#ffffff0f";
+
   return (
     <TouchableOpacity
       onPress={onTap}
@@ -62,65 +162,95 @@ export default function BottleView({
       accessibilityLabel={accessibilityLabel}
       activeOpacity={0.8}
     >
-      <Animated.View
-        style={[
-          styles.bottle,
-          selected && styles.bottleSelected,
-          solved && isFilled && styles.bottleSolved,
-          animStyle,
-        ]}
-      >
-        {/* Slots rendered bottom→top: column-reverse makes index 0 appear at bottom */}
-        <View style={styles.slots}>
-          {Array.from({ length: BOTTLE_DEPTH }, (_, slotIdx) => {
-            const color = slotIdx < bottle.length ? bottle[slotIdx]! : null;
-            return (
-              <View key={slotIdx} style={styles.slot}>
-                {color !== null ? (
-                  <BallView color={color} colorblindMode={colorblindMode} />
-                ) : (
-                  <View style={styles.emptySlot} />
-                )}
-              </View>
-            );
-          })}
-        </View>
+      <Animated.View style={[{ width: bottleWidth, height: bottleHeight }, animStyle]}>
+        <Svg width={bottleWidth} height={bottleHeight} viewBox={`0 0 ${VB_W} ${VB_H}`}>
+          <Defs>
+            <ClipPath id={clipId}>
+              <Path d={TUBE_CAVITY} />
+            </ClipPath>
+            <LinearGradient id={gradId} x1="0" x2="1" y1="0" y2="0">
+              <Stop offset="0" stopColor="#ffffff" stopOpacity="0.12" />
+              <Stop offset="0.5" stopColor="#ffffff" stopOpacity="0" />
+              <Stop offset="1" stopColor="#000000" stopOpacity="0.15" />
+            </LinearGradient>
+          </Defs>
+
+          {/* Glass body */}
+          <Path d={TUBE_OUTLINE} fill={bodyFill} stroke={strokeColor} strokeWidth={strokeWidth} />
+
+          {/* Liquid layers clipped inside cavity */}
+          <G clipPath={`url(#${clipId})`}>
+            {bottle.map((color, i) => {
+              const y = BODY_BOTTOM - (i + 1) * UNIT_H;
+              const fill = LIQUID_COLORS[color];
+              return (
+                <G key={i}>
+                  <Rect x={0} y={y} width={VB_W} height={UNIT_H + 0.5} fill={fill} />
+                  {/* Glossy highlight at top of each band */}
+                  <Rect
+                    x={0}
+                    y={y}
+                    width={VB_W}
+                    height={Math.min(4, UNIT_H * 0.12)}
+                    fill="rgba(255,255,255,0.2)"
+                  />
+                  {colorblindMode && (
+                    <SvgText
+                      x={VB_W / 2}
+                      y={y + UNIT_H / 2 + 5}
+                      textAnchor="middle"
+                      fontSize={Math.min(UNIT_H * 0.5, 16)}
+                      fill="rgba(0,0,0,0.65)"
+                      fontWeight="700"
+                    >
+                      {COLORBLIND_SYMBOLS[color]}
+                    </SvgText>
+                  )}
+                </G>
+              );
+            })}
+            {/* Glass gloss overlay */}
+            <Rect x={0} y={0} width={VB_W} height={VB_H} fill={`url(#${gradId})`} />
+          </G>
+
+          {/* Cavity outline drawn on top of liquid */}
+          <Path d={TUBE_CAVITY} fill="none" stroke={strokeColor} strokeWidth={strokeWidth} />
+
+          {/* Solved checkmark badge in neck */}
+          {solved && isFilled && (
+            <G>
+              <Circle cx={VB_W / 2} cy={PAD_TOP / 2} r={7} fill="#22c55e" />
+              <Path
+                d={`M ${VB_W / 2 - 3} ${PAD_TOP / 2 + 0.5} L ${VB_W / 2 - 0.5} ${PAD_TOP / 2 + 3} L ${VB_W / 2 + 3.5} ${PAD_TOP / 2 - 2}`}
+                stroke="#0e0e13"
+                strokeWidth="1.8"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </G>
+          )}
+        </Svg>
+
+        {/* Hidden accessible views for each liquid color (screen readers + tests) */}
+        {bottle.map((color, i) => (
+          <View
+            key={`a11y-${i}`}
+            accessible
+            accessibilityLabel={t(`color.${color}` as const)}
+            style={styles.a11yHidden}
+          />
+        ))}
       </Animated.View>
     </TouchableOpacity>
   );
 }
 
 const styles = StyleSheet.create({
-  bottle: {
-    width: BOTTLE_WIDTH,
-    height: BOTTLE_HEIGHT,
-    borderRadius: 10,
-    borderWidth: 2,
-    borderColor: "#4a4a56",
-    backgroundColor: "#ffffff0f",
-    padding: BOTTLE_PADDING,
-    justifyContent: "flex-end",
-  },
-  bottleSelected: {
-    borderColor: "#8ff5ff",
-    backgroundColor: "#8ff5ff1f",
-  },
-  bottleSolved: {
-    borderColor: "#22c55e",
-    backgroundColor: "#22c55e1a",
-  },
-  slots: {
-    flexDirection: "column-reverse",
-    gap: BALL_GAP,
-  },
-  slot: {
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  emptySlot: {
-    width: BALL_SIZE,
-    height: BALL_SIZE,
-    borderRadius: BALL_SIZE / 2,
-    backgroundColor: "#ffffff0a",
+  a11yHidden: {
+    position: "absolute",
+    width: 1,
+    height: 1,
+    overflow: "hidden",
   },
 });

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -156,12 +156,30 @@ function SortWinOverlay({ visible }: OverlayProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
-  const a0 = useAnimatedStyle(() => ({ transform: [{ translateY: y0.value }], opacity: op0.value }));
-  const a1 = useAnimatedStyle(() => ({ transform: [{ translateY: y1.value }], opacity: op1.value }));
-  const a2 = useAnimatedStyle(() => ({ transform: [{ translateY: y2.value }], opacity: op2.value }));
-  const a3 = useAnimatedStyle(() => ({ transform: [{ translateY: y3.value }], opacity: op3.value }));
-  const a4 = useAnimatedStyle(() => ({ transform: [{ translateY: y4.value }], opacity: op4.value }));
-  const a5 = useAnimatedStyle(() => ({ transform: [{ translateY: y5.value }], opacity: op5.value }));
+  const a0 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y0.value }],
+    opacity: op0.value,
+  }));
+  const a1 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y1.value }],
+    opacity: op1.value,
+  }));
+  const a2 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y2.value }],
+    opacity: op2.value,
+  }));
+  const a3 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y3.value }],
+    opacity: op3.value,
+  }));
+  const a4 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y4.value }],
+    opacity: op4.value,
+  }));
+  const a5 = useAnimatedStyle(() => ({
+    transform: [{ translateY: y5.value }],
+    opacity: op5.value,
+  }));
 
   if (!visible || reduceMotion) return null;
 
@@ -172,12 +190,24 @@ function SortWinOverlay({ visible }: OverlayProps) {
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
     >
-      <Animated.View style={[styles.particle, styles.p0, { backgroundColor: PARTICLE_COLORS[0] }, a0]} />
-      <Animated.View style={[styles.particle, styles.p1, { backgroundColor: PARTICLE_COLORS[1] }, a1]} />
-      <Animated.View style={[styles.particle, styles.p2, { backgroundColor: PARTICLE_COLORS[2] }, a2]} />
-      <Animated.View style={[styles.particle, styles.p3, { backgroundColor: PARTICLE_COLORS[3] }, a3]} />
-      <Animated.View style={[styles.particle, styles.p4, { backgroundColor: PARTICLE_COLORS[4] }, a4]} />
-      <Animated.View style={[styles.particle, styles.p5, { backgroundColor: PARTICLE_COLORS[5] }, a5]} />
+      <Animated.View
+        style={[styles.particle, styles.p0, { backgroundColor: PARTICLE_COLORS[0] }, a0]}
+      />
+      <Animated.View
+        style={[styles.particle, styles.p1, { backgroundColor: PARTICLE_COLORS[1] }, a1]}
+      />
+      <Animated.View
+        style={[styles.particle, styles.p2, { backgroundColor: PARTICLE_COLORS[2] }, a2]}
+      />
+      <Animated.View
+        style={[styles.particle, styles.p3, { backgroundColor: PARTICLE_COLORS[3] }, a3]}
+      />
+      <Animated.View
+        style={[styles.particle, styles.p4, { backgroundColor: PARTICLE_COLORS[4] }, a4]}
+      />
+      <Animated.View
+        style={[styles.particle, styles.p5, { backgroundColor: PARTICLE_COLORS[5] }, a5]}
+      />
     </View>
   );
 }

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -67,6 +67,9 @@ export default function SortBoard({
 
   const handlers = useMemo(
     () => state.bottles.map((_, idx) => () => onBottleTap(idx)),
+    // state.bottles identity changes on every pour; keying on .length avoids
+    // rebuilding all handlers when only liquid positions change. onBottleTap is
+    // included so callers that wrap it in useCallback get stable handles too.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.bottles.length, onBottleTap]
   );

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { AccessibilityInfo, StyleSheet, View } from "react-native";
+import { AccessibilityInfo, StyleSheet, useWindowDimensions, View } from "react-native";
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -11,27 +11,62 @@ import Animated, {
 } from "react-native-reanimated";
 import { useTranslation } from "react-i18next";
 import type { SortState } from "../types";
-import BottleView, { BOTTLE_WIDTH } from "./BottleView";
-import { BALL_COLORS } from "./BallView";
+import BottleView, {
+  DEFAULT_BOTTLE_HEIGHT,
+  DEFAULT_BOTTLE_WIDTH,
+  LIQUID_COLORS,
+} from "./BottleView";
 
-const BOTTLE_GAP = 10;
+const BOTTLE_GAP = 12;
+const ASPECT_RATIO = DEFAULT_BOTTLE_WIDTH / DEFAULT_BOTTLE_HEIGHT; // ≈ 0.333
 
 export interface SortBoardProps {
   readonly state: SortState;
   readonly colorblindMode?: boolean;
   readonly onBottleTap: (index: number) => void;
+  readonly pouringFrom?: number | null;
+  readonly pouringTo?: number | null;
+  /** Height of the board container in pixels — used to scale bottles to fit. */
+  readonly availableHeight?: number;
 }
 
-export default function SortBoard({ state, colorblindMode = false, onBottleTap }: SortBoardProps) {
+export default function SortBoard({
+  state,
+  colorblindMode = false,
+  onBottleTap,
+  pouringFrom = null,
+  pouringTo = null,
+  availableHeight,
+}: SortBoardProps) {
   const { t } = useTranslation("sort");
-  const numCols = state.bottles.length > 6 ? 3 : 2;
-  const bottleWidthPct = `${100 / numCols}%` as `${number}%`;
+  const { width: screenW } = useWindowDimensions();
+
+  const numBottles = state.bottles.length;
+  // Single row for ≤4 bottles; 3 cols for 5–6; 4 cols for 7+
+  const numCols = numBottles <= 4 ? numBottles : numBottles <= 6 ? 3 : 4;
+  const numRows = Math.ceil(numBottles / numCols);
+
+  // Scale bottles to fill available height without overflow
+  const avH = availableHeight && availableHeight > 0 ? availableHeight : 480;
+  const maxBottleH = Math.max(60, (avH - BOTTLE_GAP * (numRows - 1)) / numRows);
+  const bottleHFromHeight = Math.min(DEFAULT_BOTTLE_HEIGHT, maxBottleH);
+
+  // Also clamp to horizontal space so bottles never overflow screen width
+  const horizPad = 32;
+  const maxBottleW = (screenW - horizPad - BOTTLE_GAP * (numCols - 1)) / numCols;
+  const bottleW = Math.min(bottleHFromHeight * ASPECT_RATIO, maxBottleW);
+  const bottleH = bottleW / ASPECT_RATIO;
+
+  // Pour tilt direction for the source bottle only
+  const pouringDirection: "left" | "right" | undefined =
+    pouringFrom !== null && pouringTo !== null
+      ? pouringFrom < pouringTo
+        ? "right"
+        : "left"
+      : undefined;
 
   const handlers = useMemo(
     () => state.bottles.map((_, idx) => () => onBottleTap(idx)),
-    // state.bottles identity changes on every pour; keying on .length avoids
-    // rebuilding all handlers when only ball positions change. onBottleTap is
-    // included so callers that wrap it in useCallback get stable handles too.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [state.bottles.length, onBottleTap]
   );
@@ -40,12 +75,16 @@ export default function SortBoard({ state, colorblindMode = false, onBottleTap }
     <View accessibilityLabel={t("a11y.boardRegion")} accessibilityRole="none" style={styles.board}>
       <View style={[styles.grid, { gap: BOTTLE_GAP }]}>
         {state.bottles.map((bottle, idx) => (
-          <View key={idx} style={[styles.bottleCell, { width: bottleWidthPct }]}>
+          <View key={idx} style={[styles.bottleCell, { width: bottleW }]}>
             <BottleView
               bottle={bottle}
               index={idx}
               selected={state.selectedBottleIndex === idx}
+              pouring={idx === pouringFrom}
+              pouringDirection={idx === pouringFrom ? pouringDirection : undefined}
               colorblindMode={colorblindMode}
+              bottleWidth={bottleW}
+              bottleHeight={bottleH}
               onTap={handlers[idx]}
             />
           </View>
@@ -57,10 +96,10 @@ export default function SortBoard({ state, colorblindMode = false, onBottleTap }
 }
 
 // ---------------------------------------------------------------------------
-// Win overlay — coloured ball particles cascade down when the puzzle is solved
+// Win overlay — liquid-coloured confetti cascades down when the puzzle is solved
 // ---------------------------------------------------------------------------
 
-const PARTICLE_COLORS = Object.values(BALL_COLORS).slice(0, 6);
+const PARTICLE_COLORS = Object.values(LIQUID_COLORS).slice(0, 6);
 
 interface OverlayProps {
   readonly visible: boolean;
@@ -114,30 +153,12 @@ function SortWinOverlay({ visible }: OverlayProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
-  const a0 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y0.value }],
-    opacity: op0.value,
-  }));
-  const a1 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y1.value }],
-    opacity: op1.value,
-  }));
-  const a2 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y2.value }],
-    opacity: op2.value,
-  }));
-  const a3 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y3.value }],
-    opacity: op3.value,
-  }));
-  const a4 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y4.value }],
-    opacity: op4.value,
-  }));
-  const a5 = useAnimatedStyle(() => ({
-    transform: [{ translateY: y5.value }],
-    opacity: op5.value,
-  }));
+  const a0 = useAnimatedStyle(() => ({ transform: [{ translateY: y0.value }], opacity: op0.value }));
+  const a1 = useAnimatedStyle(() => ({ transform: [{ translateY: y1.value }], opacity: op1.value }));
+  const a2 = useAnimatedStyle(() => ({ transform: [{ translateY: y2.value }], opacity: op2.value }));
+  const a3 = useAnimatedStyle(() => ({ transform: [{ translateY: y3.value }], opacity: op3.value }));
+  const a4 = useAnimatedStyle(() => ({ transform: [{ translateY: y4.value }], opacity: op4.value }));
+  const a5 = useAnimatedStyle(() => ({ transform: [{ translateY: y5.value }], opacity: op5.value }));
 
   if (!visible || reduceMotion) return null;
 
@@ -148,38 +169,28 @@ function SortWinOverlay({ visible }: OverlayProps) {
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
     >
-      <Animated.View
-        style={[styles.particle, styles.p0, { backgroundColor: PARTICLE_COLORS[0] }, a0]}
-      />
-      <Animated.View
-        style={[styles.particle, styles.p1, { backgroundColor: PARTICLE_COLORS[1] }, a1]}
-      />
-      <Animated.View
-        style={[styles.particle, styles.p2, { backgroundColor: PARTICLE_COLORS[2] }, a2]}
-      />
-      <Animated.View
-        style={[styles.particle, styles.p3, { backgroundColor: PARTICLE_COLORS[3] }, a3]}
-      />
-      <Animated.View
-        style={[styles.particle, styles.p4, { backgroundColor: PARTICLE_COLORS[4] }, a4]}
-      />
-      <Animated.View
-        style={[styles.particle, styles.p5, { backgroundColor: PARTICLE_COLORS[5] }, a5]}
-      />
+      <Animated.View style={[styles.particle, styles.p0, { backgroundColor: PARTICLE_COLORS[0] }, a0]} />
+      <Animated.View style={[styles.particle, styles.p1, { backgroundColor: PARTICLE_COLORS[1] }, a1]} />
+      <Animated.View style={[styles.particle, styles.p2, { backgroundColor: PARTICLE_COLORS[2] }, a2]} />
+      <Animated.View style={[styles.particle, styles.p3, { backgroundColor: PARTICLE_COLORS[3] }, a3]} />
+      <Animated.View style={[styles.particle, styles.p4, { backgroundColor: PARTICLE_COLORS[4] }, a4]} />
+      <Animated.View style={[styles.particle, styles.p5, { backgroundColor: PARTICLE_COLORS[5] }, a5]} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   board: {
+    flex: 1,
     width: "100%",
     alignItems: "center",
+    justifyContent: "center",
   },
   grid: {
     flexDirection: "row",
     flexWrap: "wrap",
     justifyContent: "center",
-    maxWidth: (BOTTLE_WIDTH + BOTTLE_GAP) * 3 + BOTTLE_GAP,
+    alignItems: "center",
   },
   bottleCell: {
     alignItems: "center",

--- a/frontend/src/game/sort/useSortAudio.ts
+++ b/frontend/src/game/sort/useSortAudio.ts
@@ -1,0 +1,7 @@
+import { useSound } from "../_shared/useSound";
+
+export function useSortAudio() {
+  const { play: playPour } = useSound("sort.pour");
+  const { play: playWin } = useSound("sort.win");
+  return { playPour, playWin };
+}

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -85,9 +85,8 @@ export default function SortScreen() {
   const audio = useSortAudio();
 
   useEffect(() => {
-    const timer = pourTimerRef.current;
     return () => {
-      if (timer !== null) clearTimeout(timer);
+      if (pourTimerRef.current !== null) clearTimeout(pourTimerRef.current);
     };
   }, []);
 
@@ -244,6 +243,13 @@ export default function SortScreen() {
   }
 
   function handleBackToSelect() {
+    if (pourTimerRef.current !== null) {
+      clearTimeout(pourTimerRef.current);
+      pourTimerRef.current = null;
+    }
+    setIsPouring(false);
+    setPouringFrom(null);
+    setPouringTo(null);
     setView("select");
     setShowWinModal(false);
   }

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -4,6 +4,7 @@ import {
   AppState,
   AppStateStatus,
   FlatList,
+  LayoutChangeEvent,
   Modal,
   Pressable,
   StyleSheet,
@@ -28,6 +29,7 @@ import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
 import { loadProgress, saveProgress, type SortProgress } from "../game/sort/storage";
 import { useNetwork } from "../game/_shared/NetworkContext";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
+import { useSortAudio } from "../game/sort/useSortAudio";
 
 const MAX_NAME_LENGTH = 32;
 
@@ -63,6 +65,13 @@ export default function SortScreen() {
   const [history, setHistory] = useState<readonly SortState[]>([]);
   const [colorblindMode, setColorblindMode] = useState(false);
 
+  // Pour animation state
+  const [pouringFrom, setPouringFrom] = useState<number | null>(null);
+  const [pouringTo, setPouringTo] = useState<number | null>(null);
+  const [isPouring, setIsPouring] = useState(false);
+  const [boardHeight, setBoardHeight] = useState(0);
+  const pourTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Win modal
   const [showWinModal, setShowWinModal] = useState(false);
   const [playerName, setPlayerName] = useState("");
@@ -72,6 +81,15 @@ export default function SortScreen() {
 
   const progressRef = useRef(progress);
   progressRef.current = progress;
+
+  const audio = useSortAudio();
+
+  useEffect(() => {
+    const timer = pourTimerRef.current;
+    return () => {
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Init — extracted so the retry button can re-invoke it
@@ -147,7 +165,7 @@ export default function SortScreen() {
   // ---------------------------------------------------------------------------
 
   function handleBottleTap(index: number) {
-    if (!gameState || gameState.isComplete) return;
+    if (!gameState || gameState.isComplete || isPouring) return;
     const { selectedBottleIndex } = gameState;
 
     if (selectedBottleIndex === null) {
@@ -163,22 +181,37 @@ export default function SortScreen() {
     }
 
     if (isValidPour(gameState.bottles[selectedBottleIndex], gameState.bottles[index])) {
-      setHistory((h) => [...h, gameState]);
-      setGameState(applyPour(gameState, selectedBottleIndex, index));
+      const snapshot = gameState;
+      setHistory((h) => [...h, snapshot]);
+      setIsPouring(true);
+      setPouringFrom(selectedBottleIndex);
+      setPouringTo(index);
+      setGameState({ ...gameState, selectedBottleIndex: null });
+      audio.playPour();
+      pourTimerRef.current = setTimeout(() => {
+        const nextState = applyPour(snapshot, selectedBottleIndex, index);
+        setGameState(nextState);
+        setIsPouring(false);
+        setPouringFrom(null);
+        setPouringTo(null);
+        if (nextState.isComplete) {
+          audio.playWin();
+        }
+      }, 640);
     } else {
       setGameState({ ...gameState, selectedBottleIndex: null });
     }
   }
 
   function handleUndo() {
-    if (!gameState) return;
+    if (!gameState || isPouring) return;
     const { state: newState, history: newHistory } = undoState(gameState, history);
     setGameState(newState);
     setHistory(newHistory);
   }
 
   function handleHint() {
-    if (!gameState || gameState.isComplete) return;
+    if (!gameState || gameState.isComplete || isPouring) return;
     const hint = getNextHint(gameState);
     if (!hint) return;
     setGameState({ ...gameState, selectedBottleIndex: hint.from });
@@ -563,12 +596,18 @@ export default function SortScreen() {
       </View>
 
       {/* Board */}
-      <View style={styles.boardContainer}>
+      <View
+        style={styles.boardContainer}
+        onLayout={(e: LayoutChangeEvent) => setBoardHeight(e.nativeEvent.layout.height)}
+      >
         {gameState && (
           <SortBoard
             state={gameState}
             colorblindMode={colorblindMode}
             onBottleTap={handleBottleTap}
+            pouringFrom={pouringFrom}
+            pouringTo={pouringTo}
+            availableHeight={boardHeight}
           />
         )}
       </View>


### PR DESCRIPTION
## Summary

- **SVG flask bottles** (`BottleView.tsx`): Replaced rectangle+ball approach with an SVG test-tube shape (straight walls → rounded bottom, narrow neck). Liquid fills as horizontal `Rect` bands stacked from the bottom using a `ClipPath`. Neon color palette (`#ff716c`, `#5b8cff`, `#4ade80`, etc.) with glossy highlights per band. Colorblind symbols rendered inside each band. Solved bottles show a green checkmark badge in the neck.
- **Animations** (`BottleView.tsx`): Selection triggers a continuous bounce (`withRepeat`/`withSequence` on `translateY`). Pouring tilts the source bottle toward the target (62° via `withSequence`/`withDelay` on `rotate`, 250 ms tilt-in + 150 ms hold + 200 ms tilt-out). Win overlay confetti now uses the neon palette.
- **Height-aware layout** (`SortBoard.tsx`): Bottles scale to fit `availableHeight` (measured via `onLayout` in SortScreen), clamped by both row-count and screen width. Level 3+ no longer clips off screen.
- **Pour sequencing** (`SortScreen.tsx`): `applyPour` is delayed 640 ms so the tilt animation fully plays before state updates. `isPouring` guard blocks taps and undo/hint during animation.
- **Audio** (`sounds.ts`, `useSortAudio.ts`): Added `sort.pour` and `sort.win` sound keys; `playPour()` fires on valid pour, `playWin()` fires when puzzle completes.
- **Jest mock** (`jest.setup.ts`): Added `withRepeat` stub to the Reanimated mock.

Closes #1265, #1266, #1267, #1268, #1269

## Test plan

- [ ] All 62 sort game tests pass (`npx jest src/game/sort`)
- [ ] ESLint clean on modified files
- [ ] Play levels 1–5: bottles render as flasks with colored liquid bands
- [ ] Tap a non-empty bottle — it bounces continuously while selected
- [ ] Tap a valid target — source bottle tilts, state updates after animation completes
- [ ] Level 3 (7 bottles) and level 4 (8 bottles): all bottles visible without clipping
- [ ] Win: confetti overlay plays, win sound fires
- [ ] Mute toggle in settings silences pour and win sounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)