### PR TITLE
feat(cards): selection shake, tap state machine, remove red flash (#1235 #1237 #1238 #1239 #1242)

### DIFF
--- a/frontend/src/components/freecell/FoundationPile.tsx
+++ b/frontend/src/components/freecell/FoundationPile.tsx
@@ -11,6 +11,7 @@ import { CARD_WIDTH, CARD_HEIGHT } from "./FreeCellSlot";
 import { useCardSize } from "../../game/_shared/CardSizeContext";
 import { DropTarget } from "../../game/_shared/drag/DropTarget";
 import type { DropHandler } from "../../game/_shared/drag/DragContext";
+import type { SharedValue } from "react-native-reanimated";
 
 const SUIT_SYMBOL: Record<Suit, string> = {
   spades: "♠",
@@ -23,6 +24,7 @@ export interface FoundationPileProps {
   readonly pile: readonly Card[];
   readonly suit: Suit;
   readonly selected?: boolean;
+  readonly shakeX?: SharedValue<number>;
   readonly hintDestination?: boolean;
   readonly onPress?: (suit: Suit) => void;
   readonly dropId?: string;
@@ -33,6 +35,7 @@ export default function FoundationPile({
   pile,
   suit,
   selected = false,
+  shakeX,
   hintDestination = false,
   onPress,
   dropId,
@@ -63,6 +66,7 @@ export default function FoundationPile({
             width={cardWidth}
             height={cardHeight}
             selected={selected}
+            shakeX={shakeX}
             hintHighlighted={hintDestination}
             onPress={onPress ? () => onPress(suit) : undefined}
             accessibilityLabel={label}

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
@@ -14,10 +14,13 @@ import { useCardSize } from "../../game/_shared/CardSizeContext";
 import { DragProvider } from "../../game/_shared/drag/DragContext";
 import { DragContainer } from "../../game/_shared/drag/DragContainer";
 import type { DragSource, DragCard } from "../../game/_shared/drag/DragContext";
+import { useSound } from "../../game/_shared/useSound";
+import { useCardSelection } from "../../game/_shared/useCardSelection";
 
 const TABLEAU_COLS = 8;
 const COL_GAP = 2;
 const ROW_GAP = 8;
+const DOUBLE_TAP_MS = 300;
 
 type Selection =
   | { kind: "tableau"; col: number; index: number }
@@ -36,15 +39,37 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   const { cardWidth: ctxW } = useCardSize();
   const boardWidth = TABLEAU_COLS * (ctxW || CARD_WIDTH) + (TABLEAU_COLS - 1) * COL_GAP;
   const [selection, setSelection] = useState<Selection>(null);
+  const lastTapRef = useRef<{ key: string; time: number } | null>(null);
+
+  const { play: playInvalidMove } = useSound("freecell.invalidMove");
+  const { shakeX, triggerIllegal } = useCardSelection(playInvalidMove);
 
   function tryMove(move: Move) {
     if (validateMove(state, move)) {
       onMove(move);
+      setSelection(null);
+    } else {
+      triggerIllegal();
     }
-    setSelection(null);
   }
 
   function handleTableauCardPress(col: number, index: number) {
+    const pile = state.tableau[col];
+    if (pile === undefined) return;
+    const card = pile[index];
+    if (card === undefined) return;
+
+    const key = `tableau:${col}:${index}`;
+    const now = Date.now();
+    const last = lastTapRef.current;
+    const isDouble = last !== null && last.key === key && now - last.time < DOUBLE_TAP_MS;
+    lastTapRef.current = { key, time: now };
+
+    if (isDouble && index === pile.length - 1) {
+      tryMove({ type: "tableau-to-foundation", fromCol: col });
+      return;
+    }
+
     if (selection === null) {
       setSelection({ kind: "tableau", col, index });
       return;
@@ -84,6 +109,17 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
   }
 
   function handleFreeCellPress(cell: number) {
+    const key = `freecell:${cell}`;
+    const now = Date.now();
+    const last = lastTapRef.current;
+    const isDouble = last !== null && last.key === key && now - last.time < DOUBLE_TAP_MS;
+    lastTapRef.current = { key, time: now };
+
+    if (isDouble && state.freeCells[cell] !== null) {
+      tryMove({ type: "freecell-to-foundation", fromCell: cell });
+      return;
+    }
+
     if (selection === null) {
       if (state.freeCells[cell] !== null) {
         setSelection({ kind: "freecell", cell });
@@ -103,15 +139,17 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
 
   function handleFoundationPress(suit: Suit) {
     if (selection === null) {
-      // Select the foundation card if there is one.
       if (state.foundations[suit].length > 0) {
         setSelection({ kind: "foundation", suit });
       }
       return;
     }
     if (selection.kind === "foundation") {
-      // Tap same foundation again → deselect.
-      setSelection(null);
+      if (selection.suit === suit) {
+        setSelection(null);
+      } else {
+        setSelection({ kind: "foundation", suit });
+      }
       return;
     }
     if (selection.kind === "tableau") {
@@ -240,7 +278,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     if (!hint) return undefined;
     if (hint.type === "tableau-to-foundation") {
       const col = state.tableau[hint.fromCol];
-      return col && col.length > 0 ? col[col.length - 1].suit : undefined;
+      return col && col.length > 0 ? col[col.length - 1]!.suit : undefined;
     }
     if (hint.type === "freecell-to-foundation") {
       return state.freeCells[hint.fromCell]?.suit ?? undefined;
@@ -280,6 +318,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 card={card}
                 cellIndex={i}
                 selected={selection?.kind === "freecell" && selection.cell === i}
+                shakeX={
+                  selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined
+                }
                 hintSource={
                   (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
                   (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
@@ -296,6 +337,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 pile={state.foundations[suit]}
                 suit={suit}
                 selected={selection?.kind === "foundation" && selection.suit === suit}
+                shakeX={
+                  selection?.kind === "foundation" && selection.suit === suit ? shakeX : undefined
+                }
                 hintDestination={hintDestFoundationSuit === suit}
                 onPress={() => handleFoundationPress(suit)}
                 dropId={`freecell-foundation-${suit}`}
@@ -314,6 +358,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                   selection?.kind === "tableau" && selection.col === col
                     ? selection.index
                     : undefined
+                }
+                shakeX={
+                  selection?.kind === "tableau" && selection.col === col ? shakeX : undefined
                 }
                 hintIndex={
                   (state.hint?.type === "tableau-to-tableau" ||

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -65,6 +65,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     const isDouble = last !== null && last.key === key && now - last.time < DOUBLE_TAP_MS;
     lastTapRef.current = { key, time: now };
 
+    // FreeCell cards are always face-up; no faceUp guard needed (contrast Solitaire).
     if (isDouble && index === pile.length - 1) {
       tryMove({ type: "tableau-to-foundation", fromCol: col });
       return;

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -319,9 +319,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                 card={card}
                 cellIndex={i}
                 selected={selection?.kind === "freecell" && selection.cell === i}
-                shakeX={
-                  selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined
-                }
+                shakeX={selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined}
                 hintSource={
                   (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
                   (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
@@ -360,9 +358,7 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                     ? selection.index
                     : undefined
                 }
-                shakeX={
-                  selection?.kind === "tableau" && selection.col === col ? shakeX : undefined
-                }
+                shakeX={selection?.kind === "tableau" && selection.col === col ? shakeX : undefined}
                 hintIndex={
                   (state.hint?.type === "tableau-to-tableau" ||
                     state.hint?.type === "tableau-to-freecell" ||

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -12,6 +12,7 @@ import { useCardSize } from "../../game/_shared/CardSizeContext";
 import { DraggableCard } from "../../game/_shared/drag/DraggableCard";
 import { DropTarget } from "../../game/_shared/drag/DropTarget";
 import type { DropHandler } from "../../game/_shared/drag/DragContext";
+import type { SharedValue } from "react-native-reanimated";
 
 export const CARD_WIDTH = 40;
 export const CARD_HEIGHT = 57;
@@ -20,6 +21,7 @@ export interface FreeCellSlotProps {
   readonly card: Card | null;
   readonly cellIndex: number;
   readonly selected?: boolean;
+  readonly shakeX?: SharedValue<number>;
   readonly hintSource?: boolean;
   readonly hintDestination?: boolean;
   readonly onPress?: (cellIndex: number) => void;
@@ -31,6 +33,7 @@ export default function FreeCellSlot({
   card,
   cellIndex,
   selected = false,
+  shakeX,
   hintSource = false,
   hintDestination = false,
   onPress,
@@ -60,6 +63,7 @@ export default function FreeCellSlot({
         width={cardWidth}
         height={cardHeight}
         selected={selected}
+        shakeX={shakeX}
         hintHighlighted={hintSource}
         accessibilityLabel={label}
       />

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -12,6 +12,7 @@ import SelectableCard from "../../game/_shared/SelectableCard";
 import { DraggableCard } from "../../game/_shared/drag/DraggableCard";
 import { DropTarget } from "../../game/_shared/drag/DropTarget";
 import type { DropHandler } from "../../game/_shared/drag/DragContext";
+import type { SharedValue } from "react-native-reanimated";
 
 const FACE_UP_OFFSET = 36;
 
@@ -19,6 +20,7 @@ export interface TableauColumnProps {
   readonly pile: readonly Card[];
   readonly colIndex: number;
   readonly selectedIndex?: number;
+  readonly shakeX?: SharedValue<number>;
   readonly hintIndex?: number;
   readonly hintDestination?: boolean;
   readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
@@ -31,6 +33,7 @@ export default function TableauColumn({
   pile,
   colIndex,
   selectedIndex,
+  shakeX,
   hintIndex,
   hintDestination = false,
   onCardPress,
@@ -124,6 +127,7 @@ export default function TableauColumn({
           width={cardWidth}
           height={cardHeight}
           selected={isSelected}
+          shakeX={isSelected ? shakeX : undefined}
           hintHighlighted={isHint || isHintDest}
           accessibilityLabel={label}
         />

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.foundationRetreat.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.foundationRetreat.test.tsx
@@ -42,6 +42,8 @@ function renderBoard(state = BASE, onMove = jest.fn()) {
   return { ...utils, onMove };
 }
 
+afterEach(() => jest.useRealTimers());
+
 // ── Selection ────────────────────────────────────────────────────────────────
 
 describe("foundation retreat — selection", () => {

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.foundationRetreat.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.foundationRetreat.test.tsx
@@ -115,11 +115,11 @@ describe("foundation retreat — invalid move", () => {
     expect(onMove).not.toHaveBeenCalled();
   });
 
-  it("clears selection after an invalid attempt", () => {
+  it("preserves selection after an invalid attempt", () => {
     const { getByLabelText, queryByLabelText } = renderBoard();
     fireEvent.press(getByLabelText("2 of Spades"));
-    fireEvent.press(getByLabelText("Empty tableau column 2")); // invalid
-    expect(queryByLabelText(/\(selected\)/)).toBeNull();
+    fireEvent.press(getByLabelText("Empty tableau column 2")); // invalid — non-King on empty col
+    expect(queryByLabelText(/\(selected\)/)).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
@@ -68,11 +68,14 @@ describe("FreeCellBoard — selection", () => {
     expect(getByLabelText("2 of Clubs (selected)")).toBeTruthy();
   });
 
-  it("deselects a tableau card when tapped a second time", () => {
+  it("deselects a tableau card when tapped after the double-tap window", () => {
+    jest.useFakeTimers();
     const { getByLabelText } = renderBoard();
     fireEvent.press(getByLabelText("2 of Clubs"));
+    jest.advanceTimersByTime(301); // past DOUBLE_TAP_MS=300
     fireEvent.press(getByLabelText("2 of Clubs (selected)"));
     expect(getByLabelText("2 of Clubs")).toBeTruthy();
+    jest.useRealTimers();
   });
 
   it("selects a freecell card on first tap", () => {
@@ -102,11 +105,14 @@ describe("FreeCellBoard — selection", () => {
     expect(queryByLabelText(/\(selected\)/)).toBeNull();
   });
 
-  it("clears selection after an invalid move attempt", () => {
+  it("preserves selection after an invalid move attempt", () => {
     const { getByLabelText, queryByLabelText } = renderBoard();
+    jest.useFakeTimers();
     fireEvent.press(getByLabelText("3 of Hearts")); // select col 1
+    jest.advanceTimersByTime(301); // past double-tap window so second tap is not a double-tap
     fireEvent.press(getByLabelText("2 of Clubs")); // invalid destination
-    expect(queryByLabelText(/\(selected\)/)).toBeNull();
+    jest.useRealTimers();
+    expect(queryByLabelText(/\(selected\)/)).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
@@ -50,6 +50,33 @@ const BASE_STATE: FreeCellState = {
   moveCount: 0,
 };
 
+// State with two non-empty foundations for Story 9 re-select test.
+const STATE_WITH_TWO_FOUNDATIONS: FreeCellState = {
+  _v: 1,
+  tableau: [[], [], [], [], [], [], [], []],
+  freeCells: [null, null, null, null],
+  foundations: {
+    spades: [{ suit: "spades", rank: 1 }],
+    hearts: [{ suit: "hearts", rank: 1 }],
+    diamonds: [],
+    clubs: [],
+  },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+// State with an Ace in tableau col 0 for Story 10 double-tap test.
+const STATE_WITH_ACE_TABLEAU: FreeCellState = {
+  _v: 1,
+  tableau: [[{ suit: "diamonds", rank: 1 }], [], [], [], [], [], [], []],
+  freeCells: [null, null, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
 function renderBoard(state = BASE_STATE, onMove = jest.fn()) {
   const utils = render(
     <ThemeProvider>
@@ -58,6 +85,8 @@ function renderBoard(state = BASE_STATE, onMove = jest.fn()) {
   );
   return { ...utils, onMove };
 }
+
+afterEach(() => jest.useRealTimers());
 
 // ── Selection ────────────────────────────────────────────────────────────────
 
@@ -75,7 +104,6 @@ describe("FreeCellBoard — selection", () => {
     jest.advanceTimersByTime(301); // past DOUBLE_TAP_MS=300
     fireEvent.press(getByLabelText("2 of Clubs (selected)"));
     expect(getByLabelText("2 of Clubs")).toBeTruthy();
-    jest.useRealTimers();
   });
 
   it("selects a freecell card on first tap", () => {
@@ -84,9 +112,11 @@ describe("FreeCellBoard — selection", () => {
     expect(getByLabelText("A of Spades (selected)")).toBeTruthy();
   });
 
-  it("deselects a freecell card when tapped a second time", () => {
+  it("deselects a freecell card when tapped after the double-tap window", () => {
+    jest.useFakeTimers();
     const { getByLabelText } = renderBoard();
     fireEvent.press(getByLabelText("A of Spades"));
+    jest.advanceTimersByTime(301); // past DOUBLE_TAP_MS=300 — prevents freecell-to-foundation double-tap
     fireEvent.press(getByLabelText("A of Spades (selected)"));
     expect(getByLabelText("A of Spades")).toBeTruthy();
   });
@@ -106,12 +136,11 @@ describe("FreeCellBoard — selection", () => {
   });
 
   it("preserves selection after an invalid move attempt", () => {
-    const { getByLabelText, queryByLabelText } = renderBoard();
     jest.useFakeTimers();
+    const { getByLabelText, queryByLabelText } = renderBoard();
     fireEvent.press(getByLabelText("3 of Hearts")); // select col 1
     jest.advanceTimersByTime(301); // past double-tap window so second tap is not a double-tap
-    fireEvent.press(getByLabelText("2 of Clubs")); // invalid destination
-    jest.useRealTimers();
+    fireEvent.press(getByLabelText("2 of Clubs")); // invalid destination → re-select col 0
     expect(queryByLabelText(/\(selected\)/)).toBeTruthy();
   });
 });
@@ -222,6 +251,48 @@ describe("FreeCellBoard — invalid moves", () => {
     const { getByLabelText, onMove } = renderBoard();
     fireEvent.press(getByLabelText("A of Spades")); // select freecell 0
     fireEvent.press(getByLabelText("K of Spades")); // tap freecell 1 → deselect
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});
+
+// ── Story 9: foundation re-select ────────────────────────────────────────────
+
+describe("FreeCellBoard — foundation re-select (Story 9)", () => {
+  it("re-selects to a different non-empty foundation when one is already selected", () => {
+    const { getByLabelText, queryByLabelText } = renderBoard(STATE_WITH_TWO_FOUNDATIONS);
+    fireEvent.press(getByLabelText("A of Spades")); // select spades foundation
+    expect(getByLabelText("A of Spades (selected)")).toBeTruthy();
+    fireEvent.press(getByLabelText("A of Hearts")); // tap hearts foundation → re-select
+    expect(getByLabelText("A of Hearts (selected)")).toBeTruthy();
+    expect(queryByLabelText("A of Spades (selected)")).toBeNull();
+  });
+});
+
+// ── Story 10: double-tap ──────────────────────────────────────────────────────
+
+describe("FreeCellBoard — double-tap (Story 10)", () => {
+  it("freecell: two taps within 300ms → freecell-to-foundation", () => {
+    jest.useFakeTimers();
+    const { getByLabelText, onMove } = renderBoard();
+    fireEvent.press(getByLabelText("A of Spades")); // first tap: selects
+    fireEvent.press(getByLabelText("A of Spades (selected)")); // second tap within 300ms → foundation
+    expect(onMove).toHaveBeenCalledWith({ type: "freecell-to-foundation", fromCell: 0 });
+  });
+
+  it("tableau: two taps within 300ms on top card → tableau-to-foundation", () => {
+    jest.useFakeTimers();
+    const { getByLabelText, onMove } = renderBoard(STATE_WITH_ACE_TABLEAU);
+    fireEvent.press(getByLabelText("A of Diamonds")); // first tap: selects
+    fireEvent.press(getByLabelText("A of Diamonds (selected)")); // second tap within 300ms → foundation
+    expect(onMove).toHaveBeenCalledWith({ type: "tableau-to-foundation", fromCol: 0 });
+  });
+
+  it("freecell: two taps separated by >300ms do NOT trigger a foundation move", () => {
+    jest.useFakeTimers();
+    const { getByLabelText, onMove } = renderBoard();
+    fireEvent.press(getByLabelText("A of Spades")); // first tap: selects
+    jest.advanceTimersByTime(301); // past double-tap window
+    fireEvent.press(getByLabelText("A of Spades (selected)")); // second tap: deselects
     expect(onMove).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/game/_shared/__tests__/useCardSelection.test.ts
+++ b/frontend/src/game/_shared/__tests__/useCardSelection.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from "@testing-library/react-native";
+import * as Reanimated from "react-native-reanimated";
+import { useCardSelection } from "../useCardSelection";
+
+describe("useCardSelection", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("triggerShake runs withSequence with 5 steps and does not call sound", () => {
+    const withSequenceSpy = jest.spyOn(Reanimated, "withSequence");
+    const playInvalidMove = jest.fn();
+    const { result } = renderHook(() => useCardSelection(playInvalidMove));
+
+    act(() => {
+      result.current.triggerShake();
+    });
+
+    expect(withSequenceSpy).toHaveBeenCalledTimes(1);
+    expect(withSequenceSpy.mock.calls[0]).toHaveLength(5);
+    expect(playInvalidMove).not.toHaveBeenCalled();
+  });
+
+  it("triggerIllegal calls shake and playInvalidMove", () => {
+    const withSequenceSpy = jest.spyOn(Reanimated, "withSequence");
+    const playInvalidMove = jest.fn();
+    const { result } = renderHook(() => useCardSelection(playInvalidMove));
+
+    act(() => {
+      result.current.triggerIllegal();
+    });
+
+    expect(withSequenceSpy).toHaveBeenCalledTimes(1);
+    expect(playInvalidMove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/game/_shared/useCardSelection.ts
+++ b/frontend/src/game/_shared/useCardSelection.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useSharedValue, withSequence, withTiming } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+
+export function useCardSelection(playInvalidMove: () => void): {
+  shakeX: SharedValue<number>;
+  triggerShake: () => void;
+  triggerIllegal: () => void;
+} {
+  const shakeX = useSharedValue(0);
+
+  const triggerShake = useCallback(() => {
+    shakeX.value = withSequence(
+      withTiming(4, { duration: 40 }),
+      withTiming(-4, { duration: 40 }),
+      withTiming(4, { duration: 40 }),
+      withTiming(-4, { duration: 40 }),
+      withTiming(0, { duration: 40 })
+    );
+  }, [shakeX]);
+
+  const triggerIllegal = useCallback(() => {
+    triggerShake();
+    playInvalidMove();
+  }, [triggerShake, playInvalidMove]);
+
+  return { shakeX, triggerShake, triggerIllegal };
+}

--- a/frontend/src/game/_shared/useCardSelection.ts
+++ b/frontend/src/game/_shared/useCardSelection.ts
@@ -7,6 +7,7 @@ export function useCardSelection(playInvalidMove: () => void): {
   triggerShake: () => void;
   triggerIllegal: () => void;
 } {
+  // useSharedValue returns a stable object — its reference never changes across renders.
   const shakeX = useSharedValue(0);
 
   const triggerShake = useCallback(() => {

--- a/frontend/src/game/solitaire/components/FoundationPile.tsx
+++ b/frontend/src/game/solitaire/components/FoundationPile.tsx
@@ -19,6 +19,7 @@ import { rankLabel } from "../../_shared/decks/cardId";
 import SelectableCard from "../../_shared/SelectableCard";
 import { DropTarget } from "../../_shared/drag/DropTarget";
 import type { DropHandler } from "../../_shared/drag/DragContext";
+import type { SharedValue } from "react-native-reanimated";
 
 const SUIT_SYMBOL: Record<Suit, string> = {
   spades: "♠",
@@ -31,6 +32,7 @@ export interface FoundationPileProps {
   readonly pile: readonly Card[];
   readonly suit: Suit;
   readonly selected?: boolean;
+  readonly shakeX?: SharedValue<number>;
   readonly onPress?: (suit: Suit) => void;
   /** Unique drop-zone ID, e.g. "solitaire-foundation-spades". */
   readonly dropId?: string;
@@ -41,6 +43,7 @@ export default function FoundationPile({
   pile,
   suit,
   selected = false,
+  shakeX,
   onPress,
   dropId,
   onDrop,
@@ -71,6 +74,7 @@ export default function FoundationPile({
             width={cardWidth}
             height={cardHeight}
             selected={selected}
+            shakeX={shakeX}
             onPress={onPress ? () => onPress(suit) : undefined}
             accessibilityLabel={cardLabel}
           />

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -22,12 +22,14 @@ import { useCardSize } from "../../_shared/CardSizeContext";
 import { rankLabel } from "../../_shared/decks/cardId";
 import { DraggableCard } from "../../_shared/drag/DraggableCard";
 import SelectableCard from "../../_shared/SelectableCard";
+import type { SharedValue } from "react-native-reanimated";
 
 export interface StockWastePileProps {
   readonly stock: readonly Card[];
   readonly waste: readonly Card[];
   readonly drawMode: DrawMode;
   readonly wasteSelected?: boolean;
+  readonly shakeX?: SharedValue<number>;
   readonly onStockPress?: () => void;
   readonly onWastePress?: () => void;
 }
@@ -37,6 +39,7 @@ export default function StockWastePile({
   waste,
   drawMode,
   wasteSelected = false,
+  shakeX,
   onStockPress,
   onWastePress,
 }: StockWastePileProps) {
@@ -56,6 +59,7 @@ export default function StockWastePile({
         waste={waste}
         drawMode={drawMode}
         selected={wasteSelected}
+        shakeX={shakeX}
         onPress={onWastePress}
         t={t}
       />
@@ -127,12 +131,14 @@ function Waste({
   waste,
   drawMode,
   selected,
+  shakeX,
   onPress,
   t,
 }: {
   readonly waste: readonly Card[];
   readonly drawMode: DrawMode;
   readonly selected: boolean;
+  readonly shakeX?: SharedValue<number>;
   readonly onPress?: () => void;
   readonly t: TFunction<"solitaire">;
 }) {
@@ -180,6 +186,7 @@ function Waste({
           width={cardWidth}
           height={cardHeight}
           selected={selected}
+          shakeX={shakeX}
           accessibilityLabel={topLabel}
         />
       </DraggableCard>
@@ -215,6 +222,7 @@ function Waste({
                   width={cardWidth}
                   height={cardHeight}
                   selected={selected}
+                  shakeX={shakeX}
                   accessibilityLabel={label}
                 />
               </DraggableCard>

--- a/frontend/src/game/solitaire/components/TableauPile.tsx
+++ b/frontend/src/game/solitaire/components/TableauPile.tsx
@@ -20,6 +20,7 @@ import SelectableCard from "../../_shared/SelectableCard";
 import { DraggableCard } from "../../_shared/drag/DraggableCard";
 import { DropTarget } from "../../_shared/drag/DropTarget";
 import type { DropHandler } from "../../_shared/drag/DragContext";
+import type { SharedValue } from "react-native-reanimated";
 
 const FACE_UP_OFFSET = 24;
 const FACE_DOWN_OFFSET = 14;
@@ -28,6 +29,7 @@ export interface TableauPileProps {
   readonly pile: readonly Card[];
   readonly colIndex: number;
   readonly selectedIndex?: number;
+  readonly shakeX?: SharedValue<number>;
   readonly onCardPress?: (colIndex: number, cardIndex: number) => void;
   readonly onEmptyPress?: (colIndex: number) => void;
   /** Unique drop-zone ID, e.g. "solitaire-tableau-0". Required for DnD. */
@@ -39,6 +41,7 @@ export default function TableauPile({
   pile,
   colIndex,
   selectedIndex,
+  shakeX,
   onCardPress,
   onEmptyPress,
   dropId,
@@ -139,6 +142,7 @@ export default function TableauPile({
             width={cardWidth}
             height={cardHeight}
             selected
+            shakeX={shakeX}
             accessibilityLabel={selectedLabel}
           />
         ) : (

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
-  Animated,
   Modal,
   Platform,
   Pressable,
@@ -50,7 +49,6 @@ export default function FreeCellScreen() {
   const [state, setState] = useState<FreeCellState | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const flashOpacity = useRef(new Animated.Value(0)).current;
   const hasLoadedRef = useRef(false);
   const isMountedRef = useRef(true);
   const autoCompletingRef = useRef(false);
@@ -65,7 +63,6 @@ export default function FreeCellScreen() {
   const { play: playSupermove } = useSound("freecell.supermove", 0.5);
   const { play: playFoundationComplete } = useSound("freecell.foundationComplete");
   const { play: playGameWin } = useSound("freecell.gameWin");
-  const { play: playInvalidMove } = useSound("freecell.invalidMove");
 
   const startAutoComplete = useCallback((fromState: FreeCellState) => {
     if (autoCompletingRef.current) return;
@@ -146,26 +143,15 @@ export default function FreeCellScreen() {
     () => setState((prev) => (prev === null ? null : { ...prev, events: [] }))
   );
 
-  const flashInvalid = useCallback(() => {
-    Animated.sequence([
-      Animated.timing(flashOpacity, { toValue: 0.4, duration: 80, useNativeDriver: true }),
-      Animated.timing(flashOpacity, { toValue: 0, duration: 180, useNativeDriver: true }),
-    ]).start();
-  }, [flashOpacity]);
-
   const handleMove = useCallback(
     (move: Move) => {
       if (state === null || autoCompletingRef.current) return;
       const next = applyMove(state, move);
-      if (next === state) {
-        flashInvalid();
-        playInvalidMove();
-        return;
-      }
+      if (next === state) return;
       setState(next);
       startAutoComplete(next);
     },
-    [state, flashInvalid, playInvalidMove, startAutoComplete]
+    [state, startAutoComplete]
   );
 
   const handleUndo = useCallback(() => {
@@ -288,16 +274,6 @@ export default function FreeCellScreen() {
               </View>
             )}
 
-            <Animated.View
-              pointerEvents="none"
-              accessibilityElementsHidden
-              importantForAccessibility="no-hide-descendants"
-              style={[
-                StyleSheet.absoluteFill,
-                { backgroundColor: colors.error, opacity: flashOpacity },
-              ]}
-              testID="freecell-invalid-flash"
-            />
           </View>
         </CardSizeContext.Provider>
       )}

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -1,13 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Modal,
-  Platform,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-  ViewStyle,
-} from "react-native";
+import { Modal, Platform, Pressable, StyleSheet, Text, View, ViewStyle } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -273,7 +265,6 @@ export default function FreeCellScreen() {
                 </Pressable>
               </View>
             )}
-
           </View>
         </CardSizeContext.Provider>
       )}

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -29,6 +29,7 @@ import {
   View,
   ViewStyle,
 } from "react-native";
+import { useCardSelection } from "../game/_shared/useCardSelection";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -103,9 +104,6 @@ export default function SolitaireScreen() {
     gamesWon: 0,
   });
 
-  // Invalid-move flash — red overlay pulse instead of positional shake so we
-  // don't fight React Navigation / safe-area layout math.
-  const flashOpacity = useRef(new Animated.Value(0)).current;
   const sparkleOpacity = useRef(new Animated.Value(0)).current;
   const lastTapRef = useRef<{ key: string; time: number } | null>(null);
   const autoStepTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -126,6 +124,7 @@ export default function SolitaireScreen() {
   const { play: playFoundationComplete } = useSound("solitaire.foundationComplete");
   const { play: playInvalidMove } = useSound("solitaire.invalidMove");
   const { play: playGameWin } = useSound("solitaire.gameWin");
+  const { shakeX, triggerIllegal } = useCardSelection(playInvalidMove);
 
   const {
     start: syncStart,
@@ -279,15 +278,6 @@ export default function SolitaireScreen() {
     [syncGetGameId, syncStart, syncMarkStarted]
   );
 
-  const flashInvalid = useCallback(() => {
-    playInvalidMove();
-    setSelection(null);
-    Animated.sequence([
-      Animated.timing(flashOpacity, { toValue: 0.4, duration: 80, useNativeDriver: true }),
-      Animated.timing(flashOpacity, { toValue: 0, duration: 180, useNativeDriver: true }),
-    ]).start();
-  }, [flashOpacity, playInvalidMove]);
-
   const deal = useCallback((drawMode: DrawMode) => {
     setState(dealGame(drawMode));
     setSelection(null);
@@ -321,7 +311,7 @@ export default function SolitaireScreen() {
     lastTapRef.current = { key: "waste", time: now };
 
     if (isDouble) {
-      if (!tryMove({ type: "waste-to-foundation" })) flashInvalid();
+      if (!tryMove({ type: "waste-to-foundation" })) triggerIllegal();
       return;
     }
     if (state.waste.length === 0) return;
@@ -330,7 +320,7 @@ export default function SolitaireScreen() {
       return;
     }
     setSelection({ kind: "waste" });
-  }, [state, selection, autoCompleting, tryMove, flashInvalid]);
+  }, [state, selection, autoCompleting, tryMove, triggerIllegal]);
 
   const handleStockPress = useCallback(() => {
     if (state === null || autoCompleting) return;
@@ -351,7 +341,7 @@ export default function SolitaireScreen() {
       if (selection !== null) {
         if (selection.kind === "waste") {
           if (tryMove({ type: "waste-to-foundation" })) return;
-          flashInvalid();
+          triggerIllegal();
           return;
         }
         if (selection.kind === "tableau") {
@@ -359,12 +349,12 @@ export default function SolitaireScreen() {
           if (col !== undefined && selection.index === col.length - 1) {
             if (tryMove({ type: "tableau-to-foundation", fromCol: selection.col })) return;
           }
-          flashInvalid();
+          triggerIllegal();
           return;
         }
         if (selection.kind === "foundation") {
           if (selection.suit === suit) setSelection(null);
-          else flashInvalid();
+          else triggerIllegal();
           return;
         }
       }
@@ -372,7 +362,7 @@ export default function SolitaireScreen() {
         setSelection({ kind: "foundation", suit });
       }
     },
-    [state, selection, autoCompleting, tryMove, flashInvalid]
+    [state, selection, autoCompleting, tryMove, triggerIllegal]
   );
 
   const handleTableauCardPress = useCallback(
@@ -390,20 +380,23 @@ export default function SolitaireScreen() {
       lastTapRef.current = { key, time: now };
 
       if (isDouble && index === pile.length - 1 && card.faceUp) {
-        if (!tryMove({ type: "tableau-to-foundation", fromCol: col })) flashInvalid();
+        if (!tryMove({ type: "tableau-to-foundation", fromCol: col })) triggerIllegal();
         return;
       }
 
       if (selection !== null) {
+        // Face-down card with active selection → no-op (no flash, no deselect).
+        if (!card.faceUp) return;
+
         if (selection.kind === "waste") {
           if (tryMove({ type: "waste-to-tableau", toCol: col })) return;
-          flashInvalid();
+          triggerIllegal();
           return;
         }
         if (selection.kind === "foundation") {
           if (tryMove({ type: "foundation-to-tableau", fromSuit: selection.suit, toCol: col }))
             return;
-          flashInvalid();
+          triggerIllegal();
           return;
         }
         if (selection.kind === "tableau") {
@@ -412,26 +405,29 @@ export default function SolitaireScreen() {
               setSelection(null);
               return;
             }
-            if (card.faceUp) setSelection({ kind: "tableau", col, index });
+            // Face-up guaranteed by the guard above — re-select within same column.
+            setSelection({ kind: "tableau", col, index });
             return;
           }
-          if (
-            tryMove({
-              type: "tableau-to-tableau",
-              fromCol: selection.col,
-              fromIndex: selection.index,
-              toCol: col,
-            })
-          )
-            return;
-          flashInvalid();
+          // Different column, face-up guaranteed. Legal destination → move; otherwise re-select.
+          const move = {
+            type: "tableau-to-tableau" as const,
+            fromCol: selection.col,
+            fromIndex: selection.index,
+            toCol: col,
+          };
+          if (validateMove(state, move)) {
+            tryMove(move);
+          } else {
+            setSelection({ kind: "tableau", col, index });
+          }
           return;
         }
       }
 
       if (card.faceUp) setSelection({ kind: "tableau", col, index });
     },
-    [state, selection, autoCompleting, tryMove, flashInvalid]
+    [state, selection, autoCompleting, tryMove, triggerIllegal]
   );
 
   const handleEmptyTableauPress = useCallback(
@@ -440,12 +436,12 @@ export default function SolitaireScreen() {
       lastTapRef.current = null;
       if (selection === null) return;
       if (selection.kind === "waste") {
-        if (!tryMove({ type: "waste-to-tableau", toCol: col })) flashInvalid();
+        if (!tryMove({ type: "waste-to-tableau", toCol: col })) triggerIllegal();
         return;
       }
       if (selection.kind === "foundation") {
         if (!tryMove({ type: "foundation-to-tableau", fromSuit: selection.suit, toCol: col }))
-          flashInvalid();
+          triggerIllegal();
         return;
       }
       if (selection.kind === "tableau") {
@@ -457,10 +453,10 @@ export default function SolitaireScreen() {
             toCol: col,
           })
         )
-          flashInvalid();
+          triggerIllegal();
       }
     },
-    [state, selection, autoCompleting, tryMove, flashInvalid]
+    [state, selection, autoCompleting, tryMove, triggerIllegal]
   );
 
   // ── Drag-and-drop handlers ─────────────────────────────────────────────────
@@ -661,6 +657,11 @@ export default function SolitaireScreen() {
                         pile={state.foundations[suit]}
                         suit={suit}
                         selected={selection?.kind === "foundation" && selection.suit === suit}
+                        shakeX={
+                          selection?.kind === "foundation" && selection.suit === suit
+                            ? shakeX
+                            : undefined
+                        }
                         onPress={handleFoundationPress}
                         dropId={`solitaire-foundation-${suit}`}
                         onDrop={(source) => handleDropToFoundation(source)}
@@ -685,6 +686,11 @@ export default function SolitaireScreen() {
                       pile={pile}
                       colIndex={col}
                       selectedIndex={tableauSelection(col)}
+                      shakeX={
+                        selection?.kind === "tableau" && selection.col === col
+                          ? shakeX
+                          : undefined
+                      }
                       onCardPress={handleTableauCardPress}
                       onEmptyPress={handleEmptyTableauPress}
                       dropId={`solitaire-tableau-${col}`}
@@ -699,6 +705,7 @@ export default function SolitaireScreen() {
                     waste={state.waste}
                     drawMode={state.drawMode}
                     wasteSelected={selection?.kind === "waste"}
+                    shakeX={selection?.kind === "waste" ? shakeX : undefined}
                     onStockPress={handleStockPress}
                     onWastePress={handleWastePress}
                   />
@@ -719,17 +726,6 @@ export default function SolitaireScreen() {
               )}
 
               <SolitaireWinCascade visible={cascadeVisible} />
-
-              <Animated.View
-                pointerEvents="none"
-                accessibilityElementsHidden
-                importantForAccessibility="no-hide-descendants"
-                style={[
-                  StyleSheet.absoluteFill,
-                  { backgroundColor: colors.error, opacity: flashOpacity },
-                ]}
-                testID="solitaire-invalid-flash"
-              />
             </DragContainer>
           </CardSizeContext.Provider>
         )}

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -29,7 +29,6 @@ import {
   View,
   ViewStyle,
 } from "react-native";
-import { useCardSelection } from "../game/_shared/useCardSelection";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -74,6 +73,7 @@ import { solitaireApi, type ScoreEntry } from "../game/solitaire/api";
 import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
+import { useCardSelection } from "../game/_shared/useCardSelection";
 
 const TABLEAU_COLS = 7;
 const COL_GAP = 6;

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -687,9 +687,7 @@ export default function SolitaireScreen() {
                       colIndex={col}
                       selectedIndex={tableauSelection(col)}
                       shakeX={
-                        selection?.kind === "tableau" && selection.col === col
-                          ? shakeX
-                          : undefined
+                        selection?.kind === "tableau" && selection.col === col ? shakeX : undefined
                       }
                       onCardPress={handleTableauCardPress}
                       onEmptyPress={handleEmptyTableauPress}

--- a/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SolitaireScreen.test.tsx
@@ -411,6 +411,94 @@ describe("SolitaireScreen — win-modal score submission", () => {
 // #761 — stats tracking
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Story 8 — selection state machine: face-down no-op + re-select on invalid
+// ---------------------------------------------------------------------------
+
+describe("SolitaireScreen — selection state machine (Story 8)", () => {
+  it("face-down tableau card with active selection is a no-op (selection preserved)", async () => {
+    // Col 0: 3♥ (face-up valid destination for 2♠)
+    // Col 1: 9♦ (face-down)  ← pressing this should be a no-op
+    // Waste: 2♠
+    const state = {
+      _v: 1,
+      drawMode: 1,
+      tableau: [
+        [{ suit: "hearts", rank: 3, faceUp: true }],
+        [{ suit: "diamonds", rank: 9, faceUp: false }],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      stock: [],
+      waste: [{ suit: "spades", rank: 2, faceUp: true }],
+      score: 0,
+      recycleCount: 0,
+      undoStack: [],
+      isComplete: false,
+      startedAt: null,
+      accumulatedMs: 0,
+    };
+    await AsyncStorage.setItem("solitaire_game", JSON.stringify(state));
+    const api = await mount();
+
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("2 of Spades")); // select waste
+    });
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("Face-down card")); // no-op: face-down card
+    });
+    // If selection was preserved, the next press on a valid destination executes the move.
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("3 of Hearts")); // waste-to-tableau: 2♠ on 3♥
+    });
+    expect(api.getByLabelText("Moves: 1")).toBeTruthy();
+  });
+
+  it("tapping an invalid face-up destination re-selects to that card", async () => {
+    // Col 0: 8♣ (black rank 8 — cannot land on rank 5)
+    // Col 1: 5♥ (red rank 5 — invalid destination for 8♣)
+    const state = {
+      _v: 1,
+      drawMode: 1,
+      tableau: [
+        [{ suit: "clubs", rank: 8, faceUp: true }],
+        [{ suit: "hearts", rank: 5, faceUp: true }],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      stock: [],
+      waste: [],
+      score: 0,
+      recycleCount: 0,
+      undoStack: [],
+      isComplete: false,
+      startedAt: null,
+      accumulatedMs: 0,
+    };
+    await AsyncStorage.setItem("solitaire_game", JSON.stringify(state));
+    const api = await mount();
+
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("8 of Clubs")); // select col 0
+    });
+    expect(api.getByLabelText("8 of Clubs (selected)")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("5 of Hearts")); // invalid destination → re-select col 1
+    });
+    expect(api.getByLabelText("5 of Hearts (selected)")).toBeTruthy();
+    expect(api.queryByLabelText("8 of Clubs (selected)")).toBeNull();
+  });
+});
+
 describe("SolitaireScreen — stats tracking", () => {
   it("increments gamesPlayed when the player chooses a draw mode", async () => {
     const api = await mount();


### PR DESCRIPTION
## Summary

- **#1235** `useCardSelection` hook: `shakeX` SharedValue + `triggerShake` (5-step, 40ms each) + `triggerIllegal` (shake + sound)
- **#1237** Solitaire tap state machine: face-down → no-op; different-col face-up invalid → re-select; selection preserved on failure
- **#1238** FreeCell tap state machine: `tryMove` preserves selection on failure; different foundation → re-select; shake on invalid
- **#1239** FreeCell double-tap (300ms) on tableau top card / freecell → auto-foundation move
- **#1242** Remove `Animated.View` red flash overlay from both screens; replace with per-card shake animation

Review feedback addressed in follow-up commit: import ordering, stable-ref comment, fake timer `afterEach` cleanup, wrong-reason deselect test fixed, Stories 8/9/10 unit tests added.

## Test plan

- [ ] All 2237 existing tests pass locally (`npx jest --no-coverage`)
- [ ] 8 new FreeCellBoard tests (Stories 9 & 10, timer cleanup, freecell deselect fix)
- [ ] 2 new SolitaireScreen tests (Story 8: face-down no-op, re-select on invalid)
- [ ] Manual: tap invalid destination in Solitaire/FreeCell → card shakes, no red flash
- [ ] Manual: double-tap top tableau card / freecell → card moves to foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)