### PR TITLE
feat(sort): lift-move-pour animation + randomised level generation (#1276 #1291)

### DIFF
--- a/backend/sort/generate_levels.py
+++ b/backend/sort/generate_levels.py
@@ -147,6 +147,43 @@ LEVEL_SPECS = [
 ]
 
 
+def _build_level_fast(
+    colors: list[str], n_empty: int, rng: random.Random, max_attempts: int = 1000
+) -> list[list[str]]:
+    """Generate a non-trivial level without BFS (for 5+ colors where state space is too large)."""
+    units = [c for c in colors for _ in range(DEPTH)]
+    for _ in range(max_attempts):
+        rng.shuffle(units)
+        state: list[list[str]] = [
+            list(units[i * DEPTH : (i + 1) * DEPTH]) for i in range(len(colors))
+        ]
+        state += [[] for _ in range(n_empty)]
+        if not _is_trivial(state):
+            return state
+    raise RuntimeError(
+        f"No non-trivial level found after {max_attempts} attempts "
+        f"({len(colors)} colors, {n_empty} empty)"
+    )
+
+
+def build_levels(seed: int | None = None) -> list[dict]:
+    """Generate 20 levels with fresh randomisation. seed=None uses a random seed.
+
+    Levels with ≤4 colors are BFS-verified solvable. Levels with 5+ colors skip
+    full BFS (state space exceeds the cap anyway) and are assumed solvable given a
+    non-trivial, balanced random distribution with 2+ empty bottles.
+    """
+    rng = random.Random(seed)
+    levels = []
+    for level_id, colors, n_empty in LEVEL_SPECS:
+        if len(colors) <= 4:
+            state = generate_level(colors, n_empty, rng)
+        else:
+            state = _build_level_fast(colors, n_empty, rng)
+        levels.append({"id": level_id, "bottles": to_json_bottles(state)})
+    return levels
+
+
 def main() -> None:
     rng = random.Random(42)
     levels = []

--- a/backend/sort/router.py
+++ b/backend/sort/router.py
@@ -7,8 +7,7 @@ GET /sort/scores  — top-10 entries by level_reached desc (ties: older wins).
 
 from __future__ import annotations
 
-import json
-import pathlib
+import asyncio
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -21,6 +20,7 @@ from entitlements.dependencies import require_entitlement
 from limiter import limiter
 from vocab import GameType as GameTypeEnum
 
+from .generate_levels import build_levels
 from .models import (
     LeaderboardResponse,
     LevelData,
@@ -33,9 +33,6 @@ router = APIRouter(dependencies=[Depends(require_entitlement("sort"))])
 
 LEADERBOARD_LIMIT = 10
 _SORT_SESSION = "sort-anon"
-
-_LEVELS_PATH = pathlib.Path(__file__).parent / "levels.json"
-_LEVELS: list[LevelData] = [LevelData(**item) for item in json.loads(_LEVELS_PATH.read_text())]
 
 
 async def _sort_game_type_id(db: AsyncSession) -> int:
@@ -83,7 +80,8 @@ async def _top_scores(db: AsyncSession, gt_id: int) -> list[ScoreEntry]:
 @router.get("/levels", response_model=LevelsResponse)
 @limiter.limit("60/minute")
 async def get_levels(request: Request) -> LevelsResponse:
-    return LevelsResponse(levels=_LEVELS)
+    raw = await asyncio.to_thread(build_levels)
+    return LevelsResponse(levels=[LevelData(**item) for item in raw])
 
 
 @router.post("/score", response_model=ScoreEntry, status_code=201)

--- a/backend/tests/test_sort_api.py
+++ b/backend/tests/test_sort_api.py
@@ -59,6 +59,11 @@ class TestGetLevels:
         ids = [lvl["id"] for lvl in levels]
         assert ids == list(range(1, 21))
 
+    def test_consecutive_calls_return_different_levels(self):
+        r1 = client.get("/sort/levels", headers=_HEADERS).json()["levels"]
+        r2 = client.get("/sort/levels", headers=_HEADERS).json()["levels"]
+        assert r1 != r2
+
 
 # ---------------------------------------------------------------------------
 # POST /sort/score

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -158,7 +158,11 @@ export default function BottleView({
 
   const clipId = `bv-clip-${index}`;
   const gradId = `bv-grad-${index}`;
-  const strokeColor = selected ? BOTTLE_STROKE_SELECTED : solved && isFilled ? BOTTLE_STROKE_SOLVED : BOTTLE_STROKE_DEFAULT;
+  const strokeColor = selected
+    ? BOTTLE_STROKE_SELECTED
+    : solved && isFilled
+      ? BOTTLE_STROKE_SOLVED
+      : BOTTLE_STROKE_DEFAULT;
   const strokeWidth = selected ? 2 : 1.2;
   const bodyFill = selected ? BOTTLE_BODY_FILL_SELECTED : BOTTLE_BODY_FILL_DEFAULT;
 

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -82,6 +82,8 @@ export interface BottleViewProps {
   readonly bottleWidth?: number;
   readonly bottleHeight?: number;
   readonly onTap?: () => void;
+  /** When true: renders the SVG only — no touch wrapper, no a11y views, no bounce. */
+  readonly isGhost?: boolean;
 }
 
 export default function BottleView({
@@ -94,6 +96,7 @@ export default function BottleView({
   bottleWidth = DEFAULT_BOTTLE_WIDTH,
   bottleHeight = DEFAULT_BOTTLE_HEIGHT,
   onTap,
+  isGhost = false,
 }: BottleViewProps) {
   const { t } = useTranslation("sort");
   const bounceY = useSharedValue(0);
@@ -102,8 +105,9 @@ export default function BottleView({
   const isFilled = bottle.length > 0;
   const solved = isBottleSolved(bottle);
 
-  // Continuous bounce while selected
+  // Continuous bounce while selected (skipped for ghost clones)
   useEffect(() => {
+    if (isGhost) return;
     if (selected) {
       bounceY.value = withRepeat(
         withSequence(withTiming(-10, { duration: 250 }), withTiming(0, { duration: 250 })),
@@ -114,7 +118,7 @@ export default function BottleView({
       cancelAnimation(bounceY);
       bounceY.value = withTiming(0, { duration: 100 });
     }
-  }, [selected, bounceY]);
+  }, [selected, bounceY, isGhost]);
 
   // Tilt toward target bottle while pouring
   useEffect(() => {
@@ -152,85 +156,80 @@ export default function BottleView({
   const strokeWidth = selected ? 2 : 1.2;
   const bodyFill = selected ? "#8ff5ff22" : "#ffffff0f";
 
-  return (
-    <TouchableOpacity
-      onPress={onTap}
-      disabled={!onTap}
-      accessibilityLabel={accessibilityLabel}
-      activeOpacity={0.8}
-    >
-      <Animated.View style={[{ width: bottleWidth, height: bottleHeight }, animStyle]}>
-        <Svg width={bottleWidth} height={bottleHeight} viewBox={`0 0 ${VB_W} ${VB_H}`}>
-          <Defs>
-            <ClipPath id={clipId}>
-              <Path d={TUBE_CAVITY} />
-            </ClipPath>
-            <LinearGradient id={gradId} x1="0" x2="1" y1="0" y2="0">
-              <Stop offset="0" stopColor="#ffffff" stopOpacity="0.12" />
-              <Stop offset="0.5" stopColor="#ffffff" stopOpacity="0" />
-              <Stop offset="1" stopColor="#000000" stopOpacity="0.15" />
-            </LinearGradient>
-          </Defs>
+  const bottleContent = (
+    <Animated.View style={[{ width: bottleWidth, height: bottleHeight }, animStyle]}>
+      <Svg width={bottleWidth} height={bottleHeight} viewBox={`0 0 ${VB_W} ${VB_H}`}>
+        <Defs>
+          <ClipPath id={clipId}>
+            <Path d={TUBE_CAVITY} />
+          </ClipPath>
+          <LinearGradient id={gradId} x1="0" x2="1" y1="0" y2="0">
+            <Stop offset="0" stopColor="#ffffff" stopOpacity="0.12" />
+            <Stop offset="0.5" stopColor="#ffffff" stopOpacity="0" />
+            <Stop offset="1" stopColor="#000000" stopOpacity="0.15" />
+          </LinearGradient>
+        </Defs>
 
-          {/* Glass body */}
-          <Path d={TUBE_OUTLINE} fill={bodyFill} stroke={strokeColor} strokeWidth={strokeWidth} />
+        {/* Glass body */}
+        <Path d={TUBE_OUTLINE} fill={bodyFill} stroke={strokeColor} strokeWidth={strokeWidth} />
 
-          {/* Liquid layers clipped inside cavity */}
-          <G clipPath={`url(#${clipId})`}>
-            {bottle.map((color, i) => {
-              const y = BODY_BOTTOM - (i + 1) * UNIT_H;
-              const fill = LIQUID_COLORS[color];
-              return (
-                <G key={i}>
-                  <Rect x={0} y={y} width={VB_W} height={UNIT_H + 0.5} fill={fill} />
-                  {/* Glossy highlight at top of each band */}
-                  <Rect
-                    x={0}
-                    y={y}
-                    width={VB_W}
-                    height={Math.min(4, UNIT_H * 0.12)}
-                    fill="rgba(255,255,255,0.2)"
-                  />
-                  {colorblindMode && (
-                    <SvgText
-                      x={VB_W / 2}
-                      y={y + UNIT_H / 2 + 5}
-                      textAnchor="middle"
-                      fontSize={Math.min(UNIT_H * 0.5, 16)}
-                      fill="rgba(0,0,0,0.65)"
-                      fontWeight="700"
-                    >
-                      {COLORBLIND_SYMBOLS[color]}
-                    </SvgText>
-                  )}
-                </G>
-              );
-            })}
-            {/* Glass gloss overlay */}
-            <Rect x={0} y={0} width={VB_W} height={VB_H} fill={`url(#${gradId})`} />
+        {/* Liquid layers clipped inside cavity */}
+        <G clipPath={`url(#${clipId})`}>
+          {bottle.map((color, i) => {
+            const y = BODY_BOTTOM - (i + 1) * UNIT_H;
+            const fill = LIQUID_COLORS[color];
+            return (
+              <G key={i}>
+                <Rect x={0} y={y} width={VB_W} height={UNIT_H + 0.5} fill={fill} />
+                {/* Glossy highlight at top of each band */}
+                <Rect
+                  x={0}
+                  y={y}
+                  width={VB_W}
+                  height={Math.min(4, UNIT_H * 0.12)}
+                  fill="rgba(255,255,255,0.2)"
+                />
+                {colorblindMode && (
+                  <SvgText
+                    x={VB_W / 2}
+                    y={y + UNIT_H / 2 + 5}
+                    textAnchor="middle"
+                    fontSize={Math.min(UNIT_H * 0.5, 16)}
+                    fill="rgba(0,0,0,0.65)"
+                    fontWeight="700"
+                  >
+                    {COLORBLIND_SYMBOLS[color]}
+                  </SvgText>
+                )}
+              </G>
+            );
+          })}
+          {/* Glass gloss overlay */}
+          <Rect x={0} y={0} width={VB_W} height={VB_H} fill={`url(#${gradId})`} />
+        </G>
+
+        {/* Cavity outline drawn on top of liquid */}
+        <Path d={TUBE_CAVITY} fill="none" stroke={strokeColor} strokeWidth={strokeWidth} />
+
+        {/* Solved checkmark badge in neck */}
+        {solved && isFilled && (
+          <G>
+            <Circle cx={VB_W / 2} cy={PAD_TOP / 2} r={7} fill="#22c55e" />
+            <Path
+              d={`M ${VB_W / 2 - 3} ${PAD_TOP / 2 + 0.5} L ${VB_W / 2 - 0.5} ${PAD_TOP / 2 + 3} L ${VB_W / 2 + 3.5} ${PAD_TOP / 2 - 2}`}
+              stroke="#0e0e13"
+              strokeWidth="1.8"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </G>
+        )}
+      </Svg>
 
-          {/* Cavity outline drawn on top of liquid */}
-          <Path d={TUBE_CAVITY} fill="none" stroke={strokeColor} strokeWidth={strokeWidth} />
-
-          {/* Solved checkmark badge in neck */}
-          {solved && isFilled && (
-            <G>
-              <Circle cx={VB_W / 2} cy={PAD_TOP / 2} r={7} fill="#22c55e" />
-              <Path
-                d={`M ${VB_W / 2 - 3} ${PAD_TOP / 2 + 0.5} L ${VB_W / 2 - 0.5} ${PAD_TOP / 2 + 3} L ${VB_W / 2 + 3.5} ${PAD_TOP / 2 - 2}`}
-                stroke="#0e0e13"
-                strokeWidth="1.8"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </G>
-          )}
-        </Svg>
-
-        {/* Hidden accessible views for each liquid color (screen readers + tests) */}
-        {bottle.map((color, i) => (
+      {/* Hidden accessible views for each liquid color — omitted for ghost clones */}
+      {!isGhost &&
+        bottle.map((color, i) => (
           <View
             key={`a11y-${i}`}
             accessible
@@ -238,7 +237,21 @@ export default function BottleView({
             style={styles.a11yHidden}
           />
         ))}
-      </Animated.View>
+    </Animated.View>
+  );
+
+  if (isGhost) {
+    return bottleContent;
+  }
+
+  return (
+    <TouchableOpacity
+      onPress={onTap}
+      disabled={!onTap}
+      accessibilityLabel={accessibilityLabel}
+      activeOpacity={0.8}
+    >
+      {bottleContent}
     </TouchableOpacity>
   );
 }

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -33,6 +33,7 @@ import {
   BOTTLE_BODY_FILL_DEFAULT,
   BOTTLE_GLOSS_HIGHLIGHT,
   BOTTLE_GLOSS_SHADOW,
+  BOTTLE_LIQUID_GLOSS_FILL,
   BOTTLE_CHECKMARK_BG,
   BOTTLE_CHECKMARK_STROKE,
   BOTTLE_COLORBLIND_TEXT,
@@ -75,7 +76,7 @@ export const BOTTLE_HEIGHT = DEFAULT_BOTTLE_HEIGHT;
 const TILT_IN_MS = 250;
 const TILT_HOLD_MS = 150;
 const TILT_OUT_MS = 200;
-const TILT_DEG = 62;
+export const TILT_DEG = 62;
 
 export interface BottleViewProps {
   readonly bottle: Bottle;
@@ -192,7 +193,7 @@ export default function BottleView({
                   y={y}
                   width={VB_W}
                   height={Math.min(4, UNIT_H * 0.12)}
-                  fill={BOTTLE_GLOSS_HIGHLIGHT}
+                  fill={BOTTLE_LIQUID_GLOSS_FILL}
                 />
                 {colorblindMode && (
                   <SvgText

--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -24,6 +24,19 @@ import { useTranslation } from "react-i18next";
 import type { Bottle, Color } from "../types";
 import { BOTTLE_DEPTH } from "../types";
 import { isBottleSolved } from "../engine";
+import {
+  BOTTLE_LIQUID_COLORS,
+  BOTTLE_STROKE_SELECTED,
+  BOTTLE_STROKE_SOLVED,
+  BOTTLE_STROKE_DEFAULT,
+  BOTTLE_BODY_FILL_SELECTED,
+  BOTTLE_BODY_FILL_DEFAULT,
+  BOTTLE_GLOSS_HIGHLIGHT,
+  BOTTLE_GLOSS_SHADOW,
+  BOTTLE_CHECKMARK_BG,
+  BOTTLE_CHECKMARK_STROKE,
+  BOTTLE_COLORBLIND_TEXT,
+} from "../../../theme/theme.bottle";
 
 // SVG design dimensions — the viewBox stays fixed; width/height props scale the render.
 const VB_W = 56;
@@ -38,16 +51,8 @@ const UNIT_H = INNER_H / BOTTLE_DEPTH; // 38 per liquid unit
 const TUBE_CAVITY = `M 12 ${PAD_TOP} L 12 150 Q 12 ${BODY_BOTTOM} 28 ${BODY_BOTTOM} Q 44 ${BODY_BOTTOM} 44 150 L 44 ${PAD_TOP} Z`;
 const TUBE_OUTLINE = `M 20 0 L 20 ${PAD_TOP} L 12 ${PAD_TOP} L 12 150 Q 12 ${BODY_BOTTOM} 28 ${BODY_BOTTOM} Q 44 ${BODY_BOTTOM} 44 150 L 44 ${PAD_TOP} L 36 ${PAD_TOP} L 36 0 Z`;
 
-export const LIQUID_COLORS: Record<Color, string> = {
-  red: "#ff716c",
-  blue: "#5b8cff",
-  green: "#4ade80",
-  yellow: "#ffae3b",
-  orange: "#ff9f3b",
-  purple: "#d674ff",
-  pink: "#ff5fa8",
-  teal: "#8ff5ff",
-};
+// Liquid colors are now imported from theme.bottle
+export const LIQUID_COLORS = BOTTLE_LIQUID_COLORS;
 
 const COLORBLIND_SYMBOLS: Record<Color, string> = {
   red: "▲",
@@ -152,9 +157,9 @@ export default function BottleView({
 
   const clipId = `bv-clip-${index}`;
   const gradId = `bv-grad-${index}`;
-  const strokeColor = selected ? "#8ff5ff" : solved && isFilled ? "#22c55e" : "#4a4a56";
+  const strokeColor = selected ? BOTTLE_STROKE_SELECTED : solved && isFilled ? BOTTLE_STROKE_SOLVED : BOTTLE_STROKE_DEFAULT;
   const strokeWidth = selected ? 2 : 1.2;
-  const bodyFill = selected ? "#8ff5ff22" : "#ffffff0f";
+  const bodyFill = selected ? BOTTLE_BODY_FILL_SELECTED : BOTTLE_BODY_FILL_DEFAULT;
 
   const bottleContent = (
     <Animated.View style={[{ width: bottleWidth, height: bottleHeight }, animStyle]}>
@@ -164,9 +169,9 @@ export default function BottleView({
             <Path d={TUBE_CAVITY} />
           </ClipPath>
           <LinearGradient id={gradId} x1="0" x2="1" y1="0" y2="0">
-            <Stop offset="0" stopColor="#ffffff" stopOpacity="0.12" />
-            <Stop offset="0.5" stopColor="#ffffff" stopOpacity="0" />
-            <Stop offset="1" stopColor="#000000" stopOpacity="0.15" />
+            <Stop offset="0" stopColor={BOTTLE_GLOSS_HIGHLIGHT} stopOpacity="0.12" />
+            <Stop offset="0.5" stopColor={BOTTLE_GLOSS_HIGHLIGHT} stopOpacity="0" />
+            <Stop offset="1" stopColor={BOTTLE_GLOSS_SHADOW} stopOpacity="0.15" />
           </LinearGradient>
         </Defs>
 
@@ -187,7 +192,7 @@ export default function BottleView({
                   y={y}
                   width={VB_W}
                   height={Math.min(4, UNIT_H * 0.12)}
-                  fill="rgba(255,255,255,0.2)"
+                  fill={BOTTLE_GLOSS_HIGHLIGHT}
                 />
                 {colorblindMode && (
                   <SvgText
@@ -195,7 +200,7 @@ export default function BottleView({
                     y={y + UNIT_H / 2 + 5}
                     textAnchor="middle"
                     fontSize={Math.min(UNIT_H * 0.5, 16)}
-                    fill="rgba(0,0,0,0.65)"
+                    fill={BOTTLE_COLORBLIND_TEXT}
                     fontWeight="700"
                   >
                     {COLORBLIND_SYMBOLS[color]}
@@ -214,10 +219,10 @@ export default function BottleView({
         {/* Solved checkmark badge in neck */}
         {solved && isFilled && (
           <G>
-            <Circle cx={VB_W / 2} cy={PAD_TOP / 2} r={7} fill="#22c55e" />
+            <Circle cx={VB_W / 2} cy={PAD_TOP / 2} r={7} fill={BOTTLE_CHECKMARK_BG} />
             <Path
               d={`M ${VB_W / 2 - 3} ${PAD_TOP / 2 + 0.5} L ${VB_W / 2 - 0.5} ${PAD_TOP / 2 + 3} L ${VB_W / 2 + 3.5} ${PAD_TOP / 2 - 2}`}
-              stroke="#0e0e13"
+              stroke={BOTTLE_CHECKMARK_STROKE}
               strokeWidth="1.8"
               fill="none"
               strokeLinecap="round"

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AccessibilityInfo, StyleSheet, useWindowDimensions, View } from "react-native";
 import Animated, {
   cancelAnimation,
+  runOnJS,
   useAnimatedStyle,
   useSharedValue,
   withDelay,
@@ -10,7 +11,7 @@ import Animated, {
   withTiming,
 } from "react-native-reanimated";
 import { useTranslation } from "react-i18next";
-import type { SortState } from "../types";
+import type { Bottle, SortState } from "../types";
 import BottleView, {
   DEFAULT_BOTTLE_HEIGHT,
   DEFAULT_BOTTLE_WIDTH,
@@ -29,6 +30,21 @@ export interface SortBoardProps {
   /** Height of the board container in pixels — used to scale bottles to fit. */
   readonly availableHeight?: number;
 }
+
+interface GhostInfo {
+  bottle: Bottle;
+  bottleIndex: number;
+  startX: number;
+  startY: number;
+}
+
+// Ghost animation timing (ms) — matches BottleView tilt constants
+const LIFT_MS = 150;
+const TRAVEL_MS = 150;
+const TILT_IN_MS = 250;
+const TILT_HOLD_MS = 150;
+const TILT_OUT_MS = 200;
+const TILT_DEG = 62;
 
 export default function SortBoard({
   state,
@@ -57,7 +73,99 @@ export default function SortBoard({
   const bottleW = Math.min(bottleHFromHeight * ASPECT_RATIO, maxBottleW);
   const bottleH = bottleW / ASPECT_RATIO;
 
-  // Pour tilt direction for the source bottle only
+  // Reduce-motion: fall back to tilt-only (no ghost overlay)
+  const [reduceMotion, setReduceMotion] = useState(false);
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  // Position tracking — updated by onLayout, never triggers re-render
+  const gridOffsetRef = useRef({ x: 0, y: 0 });
+  const bottlePositionsRef = useRef<{ x: number; y: number }[]>([]);
+
+  // Ghost shared values — always allocated (hooks can't be conditional)
+  const ghostLiftY = useSharedValue(0);
+  const ghostTravelX = useSharedValue(0);
+  const ghostTiltDeg = useSharedValue(0);
+
+  const ghostAnimStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateY: ghostLiftY.value },
+      { translateX: ghostTravelX.value },
+      { rotate: `${ghostTiltDeg.value}deg` },
+    ],
+  }));
+
+  // Ghost React state (drives overlay visibility and bottle capture)
+  const [ghost, setGhost] = useState<GhostInfo | null>(null);
+
+  // Stable refs for values read inside the effect (avoids stale closure without
+  // adding them to the dep array, which would re-trigger on every state change)
+  const bottleHRef = useRef(bottleH);
+  bottleHRef.current = bottleH;
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  useEffect(() => {
+    if (pouringFrom === null || pouringTo === null || reduceMotion) {
+      cancelAnimation(ghostLiftY);
+      cancelAnimation(ghostTravelX);
+      cancelAnimation(ghostTiltDeg);
+      ghostLiftY.value = 0;
+      ghostTravelX.value = 0;
+      ghostTiltDeg.value = 0;
+      setGhost(null);
+      return;
+    }
+
+    const srcPos = bottlePositionsRef.current[pouringFrom];
+    const dstPos = bottlePositionsRef.current[pouringTo];
+    if (!srcPos || !dstPos) return; // layout not measured yet — silent fallback
+
+    const dx = dstPos.x - srcPos.x;
+    const liftHeight = bottleHRef.current + 20;
+    const tiltAngle = pouringFrom < pouringTo ? TILT_DEG : -TILT_DEG;
+
+    const sourceBottle = stateRef.current.bottles[pouringFrom];
+    if (!sourceBottle) return;
+
+    ghostLiftY.value = 0;
+    ghostTravelX.value = 0;
+    ghostTiltDeg.value = 0;
+
+    setGhost({
+      bottle: sourceBottle,
+      bottleIndex: pouringFrom,
+      startX: srcPos.x,
+      startY: srcPos.y,
+    });
+
+    // Lift → travel → tilt in → hold → tilt out → return travel → lower
+    ghostLiftY.value = withTiming(-liftHeight, { duration: LIFT_MS }, (finished) => {
+      if (!finished) return;
+      ghostTravelX.value = withTiming(dx, { duration: TRAVEL_MS }, (finished) => {
+        if (!finished) return;
+        ghostTiltDeg.value = withTiming(tiltAngle, { duration: TILT_IN_MS }, (finished) => {
+          if (!finished) return;
+          ghostTiltDeg.value = withDelay(
+            TILT_HOLD_MS,
+            withTiming(0, { duration: TILT_OUT_MS }, (finished) => {
+              if (!finished) return;
+              ghostTravelX.value = withTiming(0, { duration: TRAVEL_MS }, (finished) => {
+                if (!finished) return;
+                ghostLiftY.value = withTiming(0, { duration: LIFT_MS }, () => {
+                  runOnJS(setGhost)(null);
+                });
+              });
+            })
+          );
+        });
+      });
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pouringFrom, pouringTo, reduceMotion]);
+
+  // Pour tilt direction — used for reduce-motion fallback only
   const pouringDirection: "left" | "right" | undefined =
     pouringFrom !== null && pouringTo !== null
       ? pouringFrom < pouringTo
@@ -76,15 +184,38 @@ export default function SortBoard({
 
   return (
     <View accessibilityLabel={t("a11y.boardRegion")} accessibilityRole="none" style={styles.board}>
-      <View style={[styles.grid, { gap: BOTTLE_GAP }]}>
+      <View
+        style={[styles.grid, { gap: BOTTLE_GAP }]}
+        onLayout={(e) => {
+          gridOffsetRef.current = {
+            x: e.nativeEvent.layout.x,
+            y: e.nativeEvent.layout.y,
+          };
+        }}
+      >
         {state.bottles.map((bottle, idx) => (
-          <View key={idx} style={[styles.bottleCell, { width: bottleW }]}>
+          <View
+            key={idx}
+            style={[
+              styles.bottleCell,
+              { width: bottleW },
+              idx === pouringFrom && ghost !== null ? styles.bottleHidden : null,
+            ]}
+            onLayout={(e) => {
+              bottlePositionsRef.current[idx] = {
+                x: gridOffsetRef.current.x + e.nativeEvent.layout.x,
+                y: gridOffsetRef.current.y + e.nativeEvent.layout.y,
+              };
+            }}
+          >
             <BottleView
               bottle={bottle}
               index={idx}
               selected={state.selectedBottleIndex === idx}
-              pouring={idx === pouringFrom}
-              pouringDirection={idx === pouringFrom ? pouringDirection : undefined}
+              pouring={reduceMotion ? idx === pouringFrom : false}
+              pouringDirection={
+                reduceMotion && idx === pouringFrom ? pouringDirection : undefined
+              }
               colorblindMode={colorblindMode}
               bottleWidth={bottleW}
               bottleHeight={bottleH}
@@ -93,6 +224,39 @@ export default function SortBoard({
           </View>
         ))}
       </View>
+
+      {/* Ghost bottle overlay — floats above grid during pour animation */}
+      {ghost !== null && !reduceMotion && (
+        <View
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          <Animated.View
+            style={[
+              styles.ghostBottle,
+              {
+                left: ghost.startX,
+                top: ghost.startY,
+                width: bottleW,
+                height: bottleH,
+              },
+              ghostAnimStyle,
+            ]}
+          >
+            <BottleView
+              bottle={ghost.bottle}
+              index={ghost.bottleIndex}
+              isGhost
+              colorblindMode={colorblindMode}
+              bottleWidth={bottleW}
+              bottleHeight={bottleH}
+            />
+          </Animated.View>
+        </View>
+      )}
+
       <SortWinOverlay visible={state.isComplete} />
     </View>
   );
@@ -227,6 +391,12 @@ const styles = StyleSheet.create({
   },
   bottleCell: {
     alignItems: "center",
+  },
+  bottleHidden: {
+    opacity: 0,
+  },
+  ghostBottle: {
+    position: "absolute",
   },
   particle: { position: "absolute", width: 20, height: 20, borderRadius: 10, top: 0 },
   p0: { left: "8%" },

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -218,9 +218,7 @@ export default function SortBoard({
               index={idx}
               selected={state.selectedBottleIndex === idx}
               pouring={reduceMotion ? idx === pouringFrom : false}
-              pouringDirection={
-                reduceMotion && idx === pouringFrom ? pouringDirection : undefined
-              }
+              pouringDirection={reduceMotion && idx === pouringFrom ? pouringDirection : undefined}
               colorblindMode={colorblindMode}
               bottleWidth={bottleW}
               bottleHeight={bottleH}

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -16,6 +16,7 @@ import BottleView, {
   DEFAULT_BOTTLE_HEIGHT,
   DEFAULT_BOTTLE_WIDTH,
   LIQUID_COLORS,
+  TILT_DEG,
 } from "./BottleView";
 
 const BOTTLE_GAP = 12;
@@ -38,13 +39,13 @@ interface GhostInfo {
   startY: number;
 }
 
-// Ghost animation timing (ms) — matches BottleView tilt constants
+// Ghost animation timing (ms) — TILT_* values must stay in sync with BottleView
 const LIFT_MS = 150;
 const TRAVEL_MS = 150;
 const TILT_IN_MS = 250;
 const TILT_HOLD_MS = 150;
 const TILT_OUT_MS = 200;
-const TILT_DEG = 62;
+// TILT_DEG imported from BottleView — single source of truth
 
 export default function SortBoard({
   state,
@@ -79,7 +80,9 @@ export default function SortBoard({
     AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
   }, []);
 
-  // Position tracking — updated by onLayout, never triggers re-render
+  // Position tracking — updated by onLayout, never triggers re-render.
+  // React Native fires onLayout top-down (parent before children), so
+  // gridOffsetRef is populated before any bottle cell onLayout runs.
   const gridOffsetRef = useRef({ x: 0, y: 0 });
   const bottlePositionsRef = useRef<{ x: number; y: number }[]>([]);
 
@@ -140,7 +143,9 @@ export default function SortBoard({
       startY: srcPos.y,
     });
 
-    // Lift → travel → tilt in → hold → tilt out → return travel → lower
+    // Lift → travel → tilt in → hold → tilt out → return travel → lower (~1200ms total).
+    // Ghost clears at ~1200ms; SortScreen commits state at 1250ms — the 50ms gap is
+    // imperceptible and ensures the state update lands after the animation completes.
     ghostLiftY.value = withTiming(-liftHeight, { duration: LIFT_MS }, (finished) => {
       if (!finished) return;
       ghostTravelX.value = withTiming(dx, { duration: TRAVEL_MS }, (finished) => {
@@ -225,8 +230,9 @@ export default function SortBoard({
         ))}
       </View>
 
-      {/* Ghost bottle overlay — floats above grid during pour animation */}
-      {ghost !== null && !reduceMotion && (
+      {/* Ghost bottle overlay — floats above grid during pour animation.
+          ghost is only set when !reduceMotion, so the extra guard is omitted. */}
+      {ghost !== null && (
         <View
           style={StyleSheet.absoluteFill}
           pointerEvents="none"

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -253,7 +253,10 @@ export default function SortScreen() {
     setView("select");
     setShowWinModal(false);
     // Silently refresh levels in the background so the next session gets new mixtures
-    void sortApi.getLevels().then((res) => setLevels(res.levels as LevelData[])).catch(() => {});
+    void sortApi
+      .getLevels()
+      .then((res) => setLevels(res.levels as LevelData[]))
+      .catch(() => {});
   }
 
   const handleLoadLeaderboard = useCallback(async () => {

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -196,7 +196,7 @@ export default function SortScreen() {
         if (nextState.isComplete) {
           audio.playWin();
         }
-      }, 640);
+      }, 1250);
     } else {
       setGameState({ ...gameState, selectedBottleIndex: null });
     }
@@ -252,6 +252,8 @@ export default function SortScreen() {
     setPouringTo(null);
     setView("select");
     setShowWinModal(false);
+    // Silently refresh levels in the background so the next session gets new mixtures
+    void sortApi.getLevels().then((res) => setLevels(res.levels as LevelData[])).catch(() => {});
   }
 
   const handleLoadLeaderboard = useCallback(async () => {

--- a/frontend/src/theme/theme.bottle.ts
+++ b/frontend/src/theme/theme.bottle.ts
@@ -1,0 +1,51 @@
+/**
+ * Bottle game design tokens.
+ *
+ * Matches the design-tokens policy skip pattern `theme\.[^./]+\.[jt]sx?$`,
+ * which lets us keep raw color literals here instead of inlining them in
+ * component files.
+ */
+
+import type { Color } from "../game/sort/types";
+
+/** Liquid colors for each bottle color variant. */
+export const BOTTLE_LIQUID_COLORS: Record<Color, string> = {
+  red: "#ff716c",
+  blue: "#5b8cff",
+  green: "#4ade80",
+  yellow: "#ffae3b",
+  orange: "#ff9f3b",
+  purple: "#d674ff",
+  pink: "#ff5fa8",
+  teal: "#8ff5ff",
+};
+
+/** Bottle stroke color when selected (teal highlight). */
+export const BOTTLE_STROKE_SELECTED = "#8ff5ff";
+
+/** Bottle stroke color when solved (green). */
+export const BOTTLE_STROKE_SOLVED = "#22c55e";
+
+/** Bottle stroke color in default state (dark gray). */
+export const BOTTLE_STROKE_DEFAULT = "#4a4a56";
+
+/** Bottle body fill when selected (teal with transparency). */
+export const BOTTLE_BODY_FILL_SELECTED = "#8ff5ff22";
+
+/** Bottle body fill in default state (white with low opacity). */
+export const BOTTLE_BODY_FILL_DEFAULT = "#ffffff0f";
+
+/** Gloss highlight color (white). */
+export const BOTTLE_GLOSS_HIGHLIGHT = "#ffffff";
+
+/** Gloss shadow color (black). */
+export const BOTTLE_GLOSS_SHADOW = "#000000";
+
+/** Checkmark badge background when bottle is solved (green). */
+export const BOTTLE_CHECKMARK_BG = "#22c55e";
+
+/** Checkmark badge stroke color (dark). */
+export const BOTTLE_CHECKMARK_STROKE = "#0e0e13";
+
+/** Colorblind mode symbol text color (dark with transparency). */
+export const BOTTLE_COLORBLIND_TEXT = "rgba(0,0,0,0.65)";

--- a/frontend/src/theme/theme.bottle.ts
+++ b/frontend/src/theme/theme.bottle.ts
@@ -35,17 +35,20 @@ export const BOTTLE_BODY_FILL_SELECTED = "#8ff5ff22";
 /** Bottle body fill in default state (white with low opacity). */
 export const BOTTLE_BODY_FILL_DEFAULT = "#ffffff0f";
 
-/** Gloss highlight color (white). */
+/** White base used for glass gloss gradient stops (opacity applied via stopOpacity). */
 export const BOTTLE_GLOSS_HIGHLIGHT = "#ffffff";
 
-/** Gloss shadow color (black). */
+/** Black base used for glass gloss shadow gradient stop (opacity applied via stopOpacity). */
 export const BOTTLE_GLOSS_SHADOW = "#000000";
 
-/** Checkmark badge background when bottle is solved (green). */
+/** Fill for the thin gloss stripe at the top of each liquid band (20% white). */
+export const BOTTLE_LIQUID_GLOSS_FILL = "rgba(255,255,255,0.2)";
+
+/** Checkmark badge background when bottle is solved. */
 export const BOTTLE_CHECKMARK_BG = "#22c55e";
 
-/** Checkmark badge stroke color (dark). */
+/** Checkmark badge stroke color. */
 export const BOTTLE_CHECKMARK_STROKE = "#0e0e13";
 
-/** Colorblind mode symbol text color (dark with transparency). */
+/** Colorblind mode symbol text color. */
 export const BOTTLE_COLORBLIND_TEXT = "rgba(0,0,0,0.65)";


### PR DESCRIPTION
## Summary

- **#1276** — Realistic bottle pour animation: source bottle lifts out of grid, travels horizontally above the target, tilts to pour, then returns to its slot. Ghost-bottle overlay keeps the clone above all siblings with no z-index fighting. Reduce-motion falls back to existing tilt-only behaviour.
- **#1291** — Level randomisation: every `GET /sort/levels` call generates 20 fresh levels with a random seed instead of returning static JSON. Difficulty progression is preserved. `SortScreen` silently refreshes levels when the player returns to level select so consecutive sessions get different mixtures.

## Technical approach

**Ghost overlay (#1276)**
- `SortBoard` tracks each bottle cell's position via `onLayout` refs (grid offset + cell offset → board-relative coords)
- On pour start (reduce-motion off): captures the source bottle, renders an `isGhost` `BottleView` clone in an `absoluteFill` overlay positioned at `{left: srcX, top: srcY}`
- Source bottle set to `opacity: 0` while ghost is in flight
- Six chained Reanimated v2 callbacks: lift 150ms → travel 150ms → tilt-in 250ms → hold 150ms → tilt-out 200ms → return travel 150ms → lower 150ms ≈ 1200ms
- Pour timeout in `SortScreen` bumped 640ms → 1250ms
- `BottleView` gains `isGhost` prop: skips `TouchableOpacity`, a11y child views, and bounce animation

**Level randomisation (#1291)**
- `generate_levels.py` gains `build_levels(seed=None)`: BFS-verified for ≤4 colours, non-trivial-only shuffle for 5+ (state space exceeds BFS cap anyway — same assumption the original script made)
- `router.py` calls `build_levels()` via `asyncio.to_thread` per request; static `_LEVELS` load removed
- `SortScreen.handleBackToSelect` fires a background `getLevels()` to pre-load fresh mixtures for the next session

**Design tokens**
- All hardcoded hex/RGB literals in `BottleView.tsx` extracted to `frontend/src/theme/theme.bottle.ts` (policy compliance)

## Test plan

- [x] All backend sort API tests pass (`python -m pytest tests/test_sort_api.py` — 20/20)
- [x] All frontend sort tests pass (`npx jest src/game/sort src/screens/__tests__/SortScreen.test.tsx` — 73/73)
- [x] TypeScript clean on changed files
- [ ] Manual: tap source → destination — observe lift → travel → pour → return sequence
- [ ] Manual: reduce-motion on — confirm tilt-only fallback, no ghost
- [ ] Manual: play two sessions (back-to-select between them) — confirm different mixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)