### PR TITLE
fix(hearts): moon fanfare self-only, Q♠ sound immediate (#1286 #1288)

### DIFF
--- a/frontend/src/components/hearts/TrickArea.tsx
+++ b/frontend/src/components/hearts/TrickArea.tsx
@@ -155,7 +155,7 @@ export default function TrickArea({
       <Text style={[styles.srOnly, { color: colors.text }]}>{t("trick.area")}</Text>
       {([0, 1, 2, 3] as const).map((offset) => {
         const seat = (playerIndex + offset) % 4;
-        const pos = positionForSeat(seat);
+        const pos = POSITIONS[offset] ?? "bottom";
         return renderSlot(pos, seat);
       })}
     </View>

--- a/frontend/src/components/hearts/TrickArea.tsx
+++ b/frontend/src/components/hearts/TrickArea.tsx
@@ -155,7 +155,7 @@ export default function TrickArea({
       <Text style={[styles.srOnly, { color: colors.text }]}>{t("trick.area")}</Text>
       {([0, 1, 2, 3] as const).map((offset) => {
         const seat = (playerIndex + offset) % 4;
-        const pos = POSITIONS[offset] ?? "bottom";
+        const pos = positionForSeat(seat);
         return renderSlot(pos, seat);
       })}
     </View>

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -272,6 +272,7 @@ export function playCard(state: HeartsState, playerIndex: number, card: Card): H
   const newEvents = [
     ...(state.events ?? []),
     ...(!state.heartsBroken && card.suit === "hearts" ? ([{ type: "heartsBroken" }] as const) : []),
+    ...(isQueenOfSpades(card) ? ([{ type: "queenOfSpadesPlayed" }] as const) : []),
   ];
 
   let next: HeartsState = {

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -12,6 +12,7 @@ export const AI_DIFFICULTIES: readonly AiDifficulty[] = ["easy", "medium", "hard
 export type GameEvent =
   | { readonly type: "moonShot"; readonly shooter: number }
   | { readonly type: "heartsBroken" }
+  | { readonly type: "queenOfSpadesPlayed" }
   | { readonly type: "queenOfSpades"; readonly takerSeat: number };
 
 export type Suit = "spades" | "hearts" | "diamonds" | "clubs";

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -185,12 +185,14 @@ export default function HeartsScreen() {
         setShowHeartsBroken(true);
       },
       moonShot: (event) => {
-        playMoonShot();
+        if (event.shooter === HUMAN) playMoonShot();
         setMoonShotLabel(playerNames[event.shooter] ?? "");
         setShowMoonShot(true);
       },
-      queenOfSpades: (event) => {
+      queenOfSpadesPlayed: () => {
         playQueenOfSpades();
+      },
+      queenOfSpades: (event) => {
         setQueenOfSpadesLabel(playerNames[event.takerSeat] ?? "");
         setShowQueenOfSpades(true);
       },


### PR DESCRIPTION
## Summary

- **#1286** Gate `playMoonShot()` on `event.shooter === HUMAN` — opponent moon-shots still show the banner but no celebratory fanfare
- **#1288** Emit new `queenOfSpadesPlayed` event immediately inside `playCard` when Q♠ is detected (mirrors the `heartsBroken` pattern); `HeartsScreen` plays the sound on `queenOfSpadesPlayed` and shows the taker banner on the existing `queenOfSpades` event from `resolveTrick`

**Note:** #1287 (East/West trick cards not visible) was initially included but the suggested fix (`positionForSeat(seat)` vs `POSITIONS[offset]`) is a mathematical no-op when `playerIndex=0`, which is always the case. Root cause investigation is ongoing in the issue.

## Test plan

- [ ] Play a hand where an AI opponent shoots the moon — confirm no fanfare plays, banner still appears with the shooter's name
- [ ] Play a hand where the human player shoots the moon — confirm fanfare plays normally
- [ ] Play a trick containing the Queen of Spades — confirm the Q♠ sound fires the instant the card lands, not after the trick resolves
- [ ] All 195 Hearts unit tests pass (`npx jest --testPathPattern="hearts"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)