### PR TITLE
fix(hearts): add 250ms settle before trick collect animation (#1287)

### DIFF
--- a/frontend/src/components/hearts/TrickArea.tsx
+++ b/frontend/src/components/hearts/TrickArea.tsx
@@ -15,8 +15,11 @@ interface Props {
 
 const POSITIONS = ["bottom", "left", "top", "right"] as const;
 
-// Each card slides out in 500 ms; cards stagger 60 ms apart (bottom→left→top→right).
-// Total window: 3 × 60 + 500 = 680 ms — within the 700 ms test budget.
+// All 4 cards are shown statically for SETTLE_MS before any movement begins,
+// giving the completing player's card time to visibly land in its slot.
+// Then cards stagger out 60 ms apart (bottom→left→top→right) over 500 ms each.
+// Total window: 250 + 3 × 60 + 500 = 930 ms.
+const SETTLE_MS = 250;
 const STAGGER_MS = 60;
 const CARD_DURATION_MS = 500;
 
@@ -73,7 +76,7 @@ export default function TrickArea({
 
     const animations = cardProgress.map((p, i) =>
       Animated.sequence([
-        Animated.delay(i * STAGGER_MS),
+        Animated.delay(SETTLE_MS + i * STAGGER_MS),
         Animated.timing(p, {
           toValue: 1,
           duration: CARD_DURATION_MS,

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -232,12 +232,12 @@ describe("TrickArea", () => {
         />
       );
       act(() => {
-        jest.advanceTimersByTime(700);
+        jest.advanceTimersByTime(950);
       });
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
-    it("fires onAnimationComplete within the 700ms budget (staggered: 3×60ms + 500ms = 680ms)", () => {
+    it("fires onAnimationComplete within the 930ms budget (250ms settle + 3×60ms stagger + 500ms slide)", () => {
       const onComplete = jest.fn();
       wrap(
         <TrickArea
@@ -247,14 +247,49 @@ describe("TrickArea", () => {
           onAnimationComplete={onComplete}
         />
       );
-      // Not yet complete at mid-animation.
+      // Not yet complete mid-settle window.
       act(() => {
         jest.advanceTimersByTime(300);
       });
       expect(onComplete).not.toHaveBeenCalled();
       // Finishes after the full duration.
       act(() => {
-        jest.advanceTimersByTime(400);
+        jest.advanceTimersByTime(650);
+      });
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows all 4 cards statically during settle window (E/W completing-card regression)", () => {
+      // West (seat 1 / George) plays the completing 4th card — previously his card
+      // appeared for only ~60ms before animating, making it imperceptible.
+      const trick: TrickCard[] = [
+        { card: c("spades", 10), playerIndex: 2 }, // North leads
+        { card: c("hearts", 3), playerIndex: 3 },  // East (Elaine)
+        { card: c("clubs", 8), playerIndex: 0 },   // South (human)
+        { card: c("diamonds", 5), playerIndex: 1 }, // West (George) — completing card
+      ];
+      const onComplete = jest.fn();
+      const { getByText } = wrap(
+        <TrickArea
+          trick={trick}
+          playerIndex={0}
+          winnerIndex={1}
+          onAnimationComplete={onComplete}
+        />
+      );
+      // All 4 cards visible immediately (before animation starts).
+      expect(getByText("10")).toBeTruthy(); // North
+      expect(getByText("3")).toBeTruthy();  // East
+      expect(getByText("8")).toBeTruthy();  // South
+      expect(getByText("5")).toBeTruthy();  // West (the completing card)
+      // Animation not complete before settle window ends.
+      act(() => {
+        jest.advanceTimersByTime(249);
+      });
+      expect(onComplete).not.toHaveBeenCalled();
+      // Animation completes after full window.
+      act(() => {
+        jest.advanceTimersByTime(701);
       });
       expect(onComplete).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/components/hearts/__tests__/components.test.tsx
+++ b/frontend/src/components/hearts/__tests__/components.test.tsx
@@ -264,24 +264,19 @@ describe("TrickArea", () => {
       // appeared for only ~60ms before animating, making it imperceptible.
       const trick: TrickCard[] = [
         { card: c("spades", 10), playerIndex: 2 }, // North leads
-        { card: c("hearts", 3), playerIndex: 3 },  // East (Elaine)
-        { card: c("clubs", 8), playerIndex: 0 },   // South (human)
+        { card: c("hearts", 3), playerIndex: 3 }, // East (Elaine)
+        { card: c("clubs", 8), playerIndex: 0 }, // South (human)
         { card: c("diamonds", 5), playerIndex: 1 }, // West (George) — completing card
       ];
       const onComplete = jest.fn();
       const { getByText } = wrap(
-        <TrickArea
-          trick={trick}
-          playerIndex={0}
-          winnerIndex={1}
-          onAnimationComplete={onComplete}
-        />
+        <TrickArea trick={trick} playerIndex={0} winnerIndex={1} onAnimationComplete={onComplete} />
       );
       // All 4 cards visible immediately (before animation starts).
       expect(getByText("10")).toBeTruthy(); // North
-      expect(getByText("3")).toBeTruthy();  // East
-      expect(getByText("8")).toBeTruthy();  // South
-      expect(getByText("5")).toBeTruthy();  // West (the completing card)
+      expect(getByText("3")).toBeTruthy(); // East
+      expect(getByText("8")).toBeTruthy(); // South
+      expect(getByText("5")).toBeTruthy(); // West (the completing card)
       // Animation not complete before settle window ends.
       act(() => {
         jest.advanceTimersByTime(249);


### PR DESCRIPTION
## Summary

- **#1287** — Root cause: when the 4th (completing) trick card is played, `displayTrick` transitions from 3 cards to 4 cards + `winnerIndex` in a single React render. The collect animation fires immediately, so the completing player's card appears for only 0–180ms before its slot starts sliding — imperceptible to the user. East and West are frequently the completing player (depending on who leads), explaining the "only North shows" perception.

Adds `SETTLE_MS = 250` as a pre-animation delay so all 4 cards are displayed statically for 250ms before any movement begins. Total animation window: 930ms (up from 680ms).

## What changed

- `TrickArea.tsx`: Added `SETTLE_MS = 250`; stagger delays now start at `SETTLE_MS + i * STAGGER_MS`
- `components.test.tsx`: Updated 700ms budget assertions to 950ms; added regression test verifying the completing card is visible during the settle window

## Test plan

- [ ] All 196 Hearts unit tests pass (`npx jest --testPathPattern="hearts"`)
- [ ] Play a game and watch a trick complete — all 4 cards should be clearly visible in their slots for ~250ms before sliding toward the winner
- [ ] East (Elaine) and West (George) cards should visibly "land" in their slots when they complete a trick, not appear simultaneously with the animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)