### PR TITLE
fix(freecell): filter reversible tableau swaps from hint (#1295)

### DIFF
--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -22,6 +22,7 @@ import {
   dealGame,
   getHintMoves,
   hasLegalMoves,
+  isProductiveMove,
   setRng,
   undoMove,
   validateMove,
@@ -697,6 +698,195 @@ describe("getHintMoves", () => {
       freeCells: [c("spades", 5), null, null, null],
     });
     expect(getHintMoves(state)).toHaveLength(0);
+  });
+
+  it("excludes reversible single-card swap when it is the only move (#1295)", () => {
+    // 7♥ sits on 8♠; 8♣ is in another column. Freecells full — no parking.
+    // Moving 7♥ between the two black 8s is the only legal move, but non-productive.
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7)], // col 0: 8♠ then 7♥ on top
+        [c("clubs", 8)], // col 1: 8♣ alone
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [c("hearts", 3), c("diamonds", 3), c("clubs", 3), c("spades", 3)],
+    });
+    expect(getHintMoves(state)).toHaveLength(0);
+  });
+
+  it("excludes reversible multi-card swap (7♥+6♠ between two black 8s) (#1295)", () => {
+    // Freecells full — no parking available. Only move is the reversible swap.
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7), c("spades", 6)], // col 0
+        [c("clubs", 8)], // col 1: 8♣ alone
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [c("hearts", 3), c("diamonds", 3), c("clubs", 3), c("spades", 3)],
+    });
+    expect(getHintMoves(state)).toHaveLength(0);
+  });
+
+  it("includes productive move alongside reversible swap (#1295)", () => {
+    // 7♥ can swap between 8♠ (col 0) and 8♣ (col 1) — non-productive.
+    // 5♠ (col 3, alone) can move onto 6♥ (col 2, top) — productive.
+    // Freecells full to remove parking noise.
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7)], // col 0: reversible swap source
+        [c("clubs", 8)], // col 1: reversible swap dest
+        [c("hearts", 6)], // col 2: 6♥ exposed (target for 5♠)
+        [c("spades", 5)], // col 3: 5♠ alone — can move to 6♥ (productive, fromIndex=0)
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [c("hearts", 3), c("diamonds", 3), c("clubs", 3), c("spades", 3)],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.length).toBeGreaterThan(0);
+    // The reversible swap from col 0 must not appear in hints
+    expect(hints.every((m) => m.type !== "tableau-to-tableau" || m.fromCol !== 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isProductiveMove (#1295)
+// ---------------------------------------------------------------------------
+
+describe("isProductiveMove", () => {
+  it("returns true for non-tableau moves", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], [], []],
+    });
+    expect(isProductiveMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(true);
+    expect(
+      isProductiveMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })
+    ).toBe(true);
+  });
+
+  it("returns false for single-card reversible swap (canonical 7♥/8♠/8♣ position)", () => {
+    // 7♥ on 8♠ in col 0; 8♣ in col 1. Moving 7♥ to col 1 is non-productive.
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7)],
+        [c("clubs", 8)],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
+    expect(isProductiveMove(state, move)).toBe(false);
+  });
+
+  it("returns false for multi-card reversible swap (7♥+6♠ between two black 8s)", () => {
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7), c("spades", 6)],
+        [c("clubs", 8)],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
+    expect(isProductiveMove(state, move)).toBe(false);
+  });
+
+  it("returns true when the move exposes a foundation play", () => {
+    // 7♥ on A♠; A♠ can go to foundation after 7♥ is moved.
+    // (A♠ has rank 1; foundations.spades is empty — rank 1 can go to empty foundation)
+    const state = mkState({
+      tableau: [
+        [c("clubs", 8), c("spades", 1), c("hearts", 7)], // col 0: …8♣, A♠, 7♥
+        [c("diamonds", 8)], // col 1: 8♦ (red, so 7♥ can land here)
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    // Moving 7♥ (fromIndex 2) to col 1. Parent of 7♥ is A♠ which can go to foundation.
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 2, toCol: 1 };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+
+  it("returns true when moving from the column base (creates empty column)", () => {
+    const state = mkState({
+      tableau: [
+        [c("hearts", 7)], // col 0: single card (moving it empties the column)
+        [c("spades", 8)],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 0, toCol: 1 };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+
+  it("returns true when parent and destination differ in color", () => {
+    // 7♥ on 8♥ (both red) — not a valid tableau stack, but testing color check directly.
+    // Use 6♠ on 7♠ moving to 7♦: parent 7♠ (black), dest 7♦ (red) — different color.
+    const state = mkState({
+      tableau: [
+        [c("spades", 7), c("diamonds", 6)], // col 0: 7♠ then 6♦
+        [c("hearts", 7)], // col 1: 7♥ (red) — different color from parent 7♠
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    // 6♦ moving to col 1 (over 7♥): parent is 7♠ (black), dest is 7♥ (red) — different color
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+
+  it("returns true when player manually executes non-productive move (applyMove accepts it)", () => {
+    const state = mkState({
+      tableau: [
+        [c("spades", 8), c("hearts", 7)],
+        [c("clubs", 8)],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
+    // isProductiveMove returns false (hint would skip it), but applyMove still accepts it
+    expect(isProductiveMove(state, move)).toBe(false);
+    const next = applyMove(state, move);
+    expect(next).not.toBe(state);
+    expect(next.tableau[1]).toEqual([c("clubs", 8), c("hearts", 7)]);
   });
 });
 

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -755,8 +755,9 @@ describe("getHintMoves", () => {
       freeCells: [c("hearts", 3), c("diamonds", 3), c("clubs", 3), c("spades", 3)],
     });
     const hints = getHintMoves(state);
-    expect(hints.length).toBeGreaterThan(0);
-    // The reversible swap from col 0 must not appear in hints
+    // The productive 5♠→6♥ move (col 3 → col 2) must appear
+    expect(hints.some((m) => m.type === "tableau-to-tableau" && m.fromCol === 3)).toBe(true);
+    // The reversible swap from col 0 must not appear
     expect(hints.every((m) => m.type !== "tableau-to-tableau" || m.fromCol !== 0)).toBe(true);
   });
 });
@@ -771,24 +772,15 @@ describe("isProductiveMove", () => {
       tableau: [[c("spades", 1)], [], [], [], [], [], [], []],
     });
     expect(isProductiveMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(true);
-    expect(
-      isProductiveMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })
-    ).toBe(true);
+    expect(isProductiveMove(state, { type: "tableau-to-freecell", fromCol: 0, toCell: 0 })).toBe(
+      true
+    );
   });
 
   it("returns false for single-card reversible swap (canonical 7♥/8♠/8♣ position)", () => {
     // 7♥ on 8♠ in col 0; 8♣ in col 1. Moving 7♥ to col 1 is non-productive.
     const state = mkState({
-      tableau: [
-        [c("spades", 8), c("hearts", 7)],
-        [c("clubs", 8)],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-      ],
+      tableau: [[c("spades", 8), c("hearts", 7)], [c("clubs", 8)], [], [], [], [], [], []],
     });
     const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
     expect(isProductiveMove(state, move)).toBe(false);
@@ -849,12 +841,15 @@ describe("isProductiveMove", () => {
   });
 
   it("returns true when parent and destination differ in color", () => {
-    // 7♥ on 8♥ (both red) — not a valid tableau stack, but testing color check directly.
-    // Use 6♠ on 7♠ moving to 7♦: parent 7♠ (black), dest 7♦ (red) — different color.
+    // 6♦ on 7♠ in col 0; 7♥ in col 1.
+    // Moving 6♦ to col 1: parent is 7♠ (black), dest is 7♥ (red) — different colors.
+    // Not a reversible swap even though ranks match (black ≠ red).
+    // Note: this move is invalid per validateMove (6♦ red cannot stack on 7♥ red),
+    // but isProductiveMove is a pure predicate tested independently of validateMove.
     const state = mkState({
       tableau: [
-        [c("spades", 7), c("diamonds", 6)], // col 0: 7♠ then 6♦
-        [c("hearts", 7)], // col 1: 7♥ (red) — different color from parent 7♠
+        [c("spades", 7), c("diamonds", 6)], // col 0: 7♠ then 6♦ on top
+        [c("hearts", 7)], // col 1: 7♥ — different color from parent 7♠
         [],
         [],
         [],
@@ -863,23 +858,13 @@ describe("isProductiveMove", () => {
         [],
       ],
     });
-    // 6♦ moving to col 1 (over 7♥): parent is 7♠ (black), dest is 7♥ (red) — different color
     const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
     expect(isProductiveMove(state, move)).toBe(true);
   });
 
   it("returns true when player manually executes non-productive move (applyMove accepts it)", () => {
     const state = mkState({
-      tableau: [
-        [c("spades", 8), c("hearts", 7)],
-        [c("clubs", 8)],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-      ],
+      tableau: [[c("spades", 8), c("hearts", 7)], [c("clubs", 8)], [], [], [], [], [], []],
     });
     const move = { type: "tableau-to-tableau" as const, fromCol: 0, fromIndex: 1, toCol: 1 };
     // isProductiveMove returns false (hint would skip it), but applyMove still accepts it

--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -400,9 +400,46 @@ export function applyMove(state: FreeCellState, move: Move): FreeCellState {
 // ---------------------------------------------------------------------------
 
 /**
+ * Returns false when a tableau-to-tableau move is a pure oscillation: the
+ * moving run's parent card is color-rank-equivalent to the destination card
+ * (same rank, same color), and the move uncovers no new foundation play and
+ * creates no empty column. All other move types are always productive.
+ *
+ * Used by getHintMoves to avoid suggesting reversible swaps (#1295).
+ * applyMove / validateMove are unaffected — players may still execute
+ * non-productive moves via tap/drag.
+ */
+export function isProductiveMove(state: FreeCellState, move: Move): boolean {
+  if (move.type !== "tableau-to-tableau") return true;
+
+  const src = state.tableau[move.fromCol];
+  const dst = state.tableau[move.toCol];
+  if (src === undefined || dst === undefined) return true;
+
+  // No parent card: moving from the column base — could create empty column
+  if (move.fromIndex === 0) return true;
+
+  const parent = src[move.fromIndex - 1];
+  const destTop = topOf(dst);
+  if (parent === undefined || destTop === undefined) return true;
+
+  // Different color or rank → not a reversible swap
+  if (parent.rank !== destTop.rank || cardColor(parent) !== cardColor(destTop)) return true;
+
+  // Exposing the parent enables a foundation play → productive
+  if (canStackOnFoundation(parent, state.foundations[parent.suit])) return true;
+
+  return false;
+}
+
+/**
  * Returns all legal moves from the current state, ordered by desirability:
  * foundation moves first (always progress), then tableau runs, then freecell
  * moves, then parking a card to an empty freecell as a last resort.
+ *
+ * Non-productive tableau-to-tableau moves (reversible swaps with no benefit)
+ * are filtered out (#1295). Returns [] when only non-productive moves exist,
+ * triggering the existing "No moves left" banner in the hint handler.
  *
  * Used by the hint system (#988) and the no-moves detector (#989).
  */
@@ -427,7 +464,7 @@ export function getHintMoves(state: FreeCellState): Move[] {
       for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
         if (toCol === fromCol) continue;
         const m: Move = { type: "tableau-to-tableau", fromCol, fromIndex, toCol };
-        if (validateMove(state, m)) {
+        if (validateMove(state, m) && isProductiveMove(state, m)) {
           moves.push(m);
           break;
         }

--- a/frontend/src/screens/__tests__/FreeCellScreen.test.tsx
+++ b/frontend/src/screens/__tests__/FreeCellScreen.test.tsx
@@ -55,7 +55,10 @@ import { loadGame } from "../../game/freecell/storage";
 const REVERSIBLE_ONLY_STATE: FreeCellState = {
   _v: 1,
   tableau: [
-    [{ suit: "spades", rank: 8 }, { suit: "hearts", rank: 7 }],
+    [
+      { suit: "spades", rank: 8 },
+      { suit: "hearts", rank: 7 },
+    ],
     [{ suit: "clubs", rank: 8 }],
     [],
     [],
@@ -92,11 +95,12 @@ describe("FreeCellScreen — hint on reversible-only position (#1295)", () => {
   });
 
   afterEach(() => {
+    jest.runAllTimers();
     (loadGame as jest.Mock).mockResolvedValue(null);
   });
 
-  it("shows 'No moves left' banner instead of oscillating when Hint is pressed", async () => {
-    const { getByLabelText, queryByText } = renderScreen();
+  it("shows 'No moves left' banner with message and Undo action when Hint is pressed", async () => {
+    const { getByLabelText, queryByText, getAllByLabelText } = renderScreen();
 
     // Wait for loadGame to resolve and state to mount
     await waitFor(() => getByLabelText("Hint"));
@@ -108,36 +112,18 @@ describe("FreeCellScreen — hint on reversible-only position (#1295)", () => {
       fireEvent.press(getByLabelText("Hint"));
     });
 
-    await waitFor(() => expect(queryByText(/no moves left/i)).not.toBeNull());
-  });
-
-  it("banner contains the no-moves message text", async () => {
-    const { getByLabelText, getByText } = renderScreen();
-
-    await waitFor(() => getByLabelText("Hint"));
-
-    act(() => {
-      fireEvent.press(getByLabelText("Hint"));
-    });
-
-    await waitFor(() =>
-      expect(getByText(/no moves left/i)).toBeTruthy()
-    );
-  });
-
-  it("banner includes an Undo action", async () => {
-    const { getByLabelText, getAllByLabelText } = renderScreen();
-
-    await waitFor(() => getByLabelText("Hint"));
-
-    act(() => {
-      fireEvent.press(getByLabelText("Hint"));
-    });
-
-    // After banner appears, an Undo button is rendered inside it
     await waitFor(() => {
-      const undoBtns = getAllByLabelText("Undo");
-      expect(undoBtns.length).toBeGreaterThan(0);
+      // Banner message is visible
+      expect(queryByText(/no moves left/i)).not.toBeNull();
+      // Banner adds a second Undo button (header already has one, banner adds another)
+      expect(getAllByLabelText("Undo").length).toBe(2);
     });
+  });
+
+  it("banner does not appear before Hint is pressed", async () => {
+    const { getByLabelText, queryByText } = renderScreen();
+
+    await waitFor(() => getByLabelText("Hint"));
+    expect(queryByText(/no moves left/i)).toBeNull();
   });
 });

--- a/frontend/src/screens/__tests__/FreeCellScreen.test.tsx
+++ b/frontend/src/screens/__tests__/FreeCellScreen.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * FreeCellScreen — hint and no-moves-banner integration tests (#1295).
+ *
+ * Engine correctness is covered by engine.test.ts. These tests focus on
+ * the screen's hint handler: when getHintMoves returns [] (all moves are
+ * non-productive reversible swaps), pressing Hint must surface the
+ * "No moves left" banner rather than oscillating between two equivalent squares.
+ */
+
+import React from "react";
+import { render, fireEvent, act, waitFor } from "@testing-library/react-native";
+import FreeCellScreen from "../FreeCellScreen";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import type { FreeCellState } from "../../game/freecell/types";
+
+// ---------------------------------------------------------------------------
+// Global setup: expo-blur, navigation, storage
+// ---------------------------------------------------------------------------
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("expo-linear-gradient", () => ({
+  LinearGradient: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({
+    popToTop: jest.fn(),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    addListener: jest.fn(() => jest.fn()),
+  }),
+}));
+
+jest.mock("../../game/freecell/storage", () => ({
+  loadGame: jest.fn().mockResolvedValue(null),
+  saveGame: jest.fn().mockResolvedValue(undefined),
+  clearGame: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { loadGame } from "../../game/freecell/storage";
+
+// ---------------------------------------------------------------------------
+// Canonical reversible-only state (#1295):
+//   col 0: [8♠, 7♥]   col 1: [8♣]   cols 2–7: empty
+//   freeCells: [3♥, 3♦, 3♣, 3♠]  (all filled — no parking available)
+//   foundations: empty
+//
+// Only legal t-t-t move is 7♥ from col 0 to col 1, which isProductiveMove
+// classifies as non-productive. getHintMoves returns [].
+// ---------------------------------------------------------------------------
+
+const REVERSIBLE_ONLY_STATE: FreeCellState = {
+  _v: 1,
+  tableau: [
+    [{ suit: "spades", rank: 8 }, { suit: "hearts", rank: 7 }],
+    [{ suit: "clubs", rank: 8 }],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+  ],
+  freeCells: [
+    { suit: "hearts", rank: 3 },
+    { suit: "diamonds", rank: 3 },
+    { suit: "clubs", rank: 3 },
+    { suit: "spades", rank: 3 },
+  ],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+jest.useFakeTimers();
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <FreeCellScreen />
+    </ThemeProvider>
+  );
+}
+
+describe("FreeCellScreen — hint on reversible-only position (#1295)", () => {
+  beforeEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(REVERSIBLE_ONLY_STATE);
+  });
+
+  afterEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(null);
+  });
+
+  it("shows 'No moves left' banner instead of oscillating when Hint is pressed", async () => {
+    const { getByLabelText, queryByText } = renderScreen();
+
+    // Wait for loadGame to resolve and state to mount
+    await waitFor(() => getByLabelText("Hint"));
+
+    // Before pressing Hint, no banner
+    expect(queryByText(/no moves left/i)).toBeNull();
+
+    act(() => {
+      fireEvent.press(getByLabelText("Hint"));
+    });
+
+    await waitFor(() => expect(queryByText(/no moves left/i)).not.toBeNull());
+  });
+
+  it("banner contains the no-moves message text", async () => {
+    const { getByLabelText, getByText } = renderScreen();
+
+    await waitFor(() => getByLabelText("Hint"));
+
+    act(() => {
+      fireEvent.press(getByLabelText("Hint"));
+    });
+
+    await waitFor(() =>
+      expect(getByText(/no moves left/i)).toBeTruthy()
+    );
+  });
+
+  it("banner includes an Undo action", async () => {
+    const { getByLabelText, getAllByLabelText } = renderScreen();
+
+    await waitFor(() => getByLabelText("Hint"));
+
+    act(() => {
+      fireEvent.press(getByLabelText("Hint"));
+    });
+
+    // After banner appears, an Undo button is rendered inside it
+    await waitFor(() => {
+      const undoBtns = getAllByLabelText("Undo");
+      expect(undoBtns.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `isProductiveMove(state, move)` to `engine.ts`: a tableau-to-tableau move is non-productive when the moving run's parent card is color-rank-equivalent to the destination (same rank, same color) and exposing the parent doesn't unlock a foundation play or empty column
- `getHintMoves` now filters non-productive moves and returns `[]` when only reversible swaps exist — the existing `handleHint` plumbing then shows the "No moves left" banner instead of oscillating between two equivalent squares
- `validateMove`/`applyMove` are untouched — players can still manually drag/tap non-productive moves

## Test plan

- [ ] Unit: `isProductiveMove` returns `false` for canonical 7♥/8♠/8♣ position (single and multi-card run)
- [ ] Unit: `getHintMoves` returns `[]` when only reversible swaps exist (freecells full)
- [ ] Unit: `getHintMoves` returns only the productive move when one productive + one reversible exist
- [ ] Unit: `applyMove` still accepts a non-productive move (engine doesn't block it)
- [ ] Integration: pressing Hint on the reversible-only state shows the "No moves left — undo to continue?" banner
- [ ] Integration: banner contains an Undo action

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)