### PR TITLE
fix(hearts): Q♠ sound optimistic + card/trick/game-over sounds

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4978,9 +4978,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6249,9 +6249,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10769,9 +10769,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -20,6 +20,12 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   "hearts.moonShot": require("../../../assets/sounds/hearts-moon-shot.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "hearts.queenOfSpades": require("../../../assets/sounds/hearts-queen-of-spades.mp3"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "hearts.cardPlay": require("../../../assets/sounds/solitaire-card-place.ogg"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "hearts.trickWon": require("../../../assets/sounds/solitaire-card-flip.ogg"),
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  "hearts.gameOver": require("../../../assets/sounds/cascade-game-over.ogg"),
   // Blackjack (#826)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "blackjack.cardDeal": require("../../../assets/sounds/blackjack-card-deal.ogg"),

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -19,6 +19,7 @@ import {
   dealNextHand,
   detectMoon,
   getValidPlays,
+  isQueenOfSpades,
   playCard,
   selectPassCard,
 } from "../game/hearts/engine";
@@ -91,6 +92,7 @@ export default function HeartsScreen() {
   const loopActiveRef = useRef(false);
   const gameStateRef = useRef<HeartsState | null>(gameState);
   const trickAnimResolverRef = useRef<(() => void) | null>(null);
+  const humanJustPlayedQSRef = useRef(false);
   const reportIntegrity = useMemo(() => createIntegrityReporter(), []);
 
   const {
@@ -176,6 +178,9 @@ export default function HeartsScreen() {
   const { play: playHeartsBroken } = useSound("hearts.heartsBroken");
   const { play: playMoonShot } = useSound("hearts.moonShot");
   const { play: playQueenOfSpades } = useSound("hearts.queenOfSpades");
+  const { play: playCardPlay } = useSound("hearts.cardPlay");
+  const { play: playTrickWon } = useSound("hearts.trickWon");
+  const { play: playGameOver } = useSound("hearts.gameOver");
 
   useGameEvents(
     gameState?.events,
@@ -190,6 +195,10 @@ export default function HeartsScreen() {
         setShowMoonShot(true);
       },
       queenOfSpadesPlayed: () => {
+        if (humanJustPlayedQSRef.current) {
+          humanJustPlayedQSRef.current = false;
+          return;
+        }
         playQueenOfSpades();
       },
       queenOfSpades: (event) => {
@@ -234,6 +243,7 @@ export default function HeartsScreen() {
           : null;
 
         s = playCard(s, s.currentPlayerIndex, card);
+        playCardPlay();
 
         if (completedTrick) {
           setLastTrick({ trick: completedTrick, winnerIndex: s.currentLeaderIndex });
@@ -275,11 +285,21 @@ export default function HeartsScreen() {
     syncComplete({ outcome: "completed", finalScore, durationMs: 0 }, { final_score: finalScore });
   }, [gameState?.phase, gameState?.cumulativeScores, syncComplete, syncGetGameId]);
 
+  useEffect(() => {
+    if (gameState?.phase === "game_over") playGameOver();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameState?.phase]);
+
   // ─── Human card play ──────────────────────────────────────────────────────
   function handleCardPress(card: Card) {
     if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing")
       return;
     ensureSyncStarted();
+    playCardPlay();
+    if (isQueenOfSpades(card)) {
+      humanJustPlayedQSRef.current = true;
+      playQueenOfSpades();
+    }
     const willComplete = gameState.currentTrick.length === 3;
     const completedTrick: readonly TrickCard[] | null = willComplete
       ? [...gameState.currentTrick, { card, playerIndex: HUMAN }]
@@ -304,6 +324,7 @@ export default function HeartsScreen() {
   // clears lastTrick directly.
   function handleTrickAnimationComplete() {
     if (unmountedRef.current) return;
+    playTrickWon();
     const resolve = trickAnimResolverRef.current;
     if (resolve) {
       trickAnimResolverRef.current = null;

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -93,6 +93,7 @@ export default function HeartsScreen() {
   const gameStateRef = useRef<HeartsState | null>(gameState);
   const trickAnimResolverRef = useRef<(() => void) | null>(null);
   const humanJustPlayedQSRef = useRef(false);
+  const gameOverFiredRef = useRef(false);
   const reportIntegrity = useMemo(() => createIntegrityReporter(), []);
 
   const {
@@ -286,7 +287,10 @@ export default function HeartsScreen() {
   }, [gameState?.phase, gameState?.cumulativeScores, syncComplete, syncGetGameId]);
 
   useEffect(() => {
-    if (gameState?.phase === "game_over") playGameOver();
+    if (gameState?.phase === "game_over" && !gameOverFiredRef.current) {
+      gameOverFiredRef.current = true;
+      playGameOver();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameState?.phase]);
 
@@ -324,7 +328,7 @@ export default function HeartsScreen() {
   // clears lastTrick directly.
   function handleTrickAnimationComplete() {
     if (unmountedRef.current) return;
-    playTrickWon();
+    if (gameState?.phase === "playing") playTrickWon();
     const resolve = trickAnimResolverRef.current;
     if (resolve) {
       trickAnimResolverRef.current = null;
@@ -386,6 +390,7 @@ export default function HeartsScreen() {
     setSubmitState("idle");
     setPlayerName("");
     loopActiveRef.current = false;
+    gameOverFiredRef.current = false;
     clearGame().catch(() => {});
     const fresh = dealGame(difficulty);
     setGameState(fresh);
@@ -396,6 +401,7 @@ export default function HeartsScreen() {
     setSubmitState("idle");
     setPlayerName("");
     loopActiveRef.current = false;
+    gameOverFiredRef.current = false;
     clearGame().catch(() => {});
     setGameState(null);
   }


### PR DESCRIPTION
Closes #1308, closes #1309

## Summary

- **#1309 (bug):** Q♠ sound was firing after a React state update (one render cycle late relative to the card-play animation). Fixed by playing `hearts.queenOfSpades` immediately in `handleCardPress` when the human plays Q♠, before `setGameState`. A `humanJustPlayedQSRef` ref prevents the existing event-driven handler from double-playing. AI-played Q♠ keeps the event-driven path unchanged (no user action to hook into).
- **#1308 (enhancement):** Added three new sound events for the most impactful silent moments:
  - `hearts.cardPlay` (`solitaire-card-place.ogg`) — fires on every card played, human and AI
  - `hearts.trickWon` (`solitaire-card-flip.ogg`) — fires in `handleTrickAnimationComplete` when the trick-sweep animation completes
  - `hearts.gameOver` (`cascade-game-over.ogg`) — fires via `useEffect` on transition to `game_over` phase

New keys reuse existing audio assets, consistent with the shared-sound pattern in `sounds.ts`.

## Test plan

- [ ] Play a card as human — hear card-place sound immediately
- [ ] Play Q♠ as human — hear Q♠ sting in sync with card landing, not after
- [ ] Watch AI play Q♠ — hear Q♠ sting via event path (slight delay is acceptable)
- [ ] Complete a trick — hear trick-collect sound when sweep animation finishes
- [ ] Reach game over — hear game-over sound on modal appearance
- [ ] Confirm no double-play of Q♠ sound when human plays it

🤖 Generated with [Claude Code](https://claude.com/claude-code)