### PR TITLE
fix(hearts): suppress cardPlay sound when Q♠ is played

### DIFF
--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -299,10 +299,11 @@ export default function HeartsScreen() {
     if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing")
       return;
     ensureSyncStarted();
-    playCardPlay();
     if (isQueenOfSpades(card)) {
       humanJustPlayedQSRef.current = true;
       playQueenOfSpades();
+    } else {
+      playCardPlay();
     }
     const willComplete = gameState.currentTrick.length === 3;
     const completedTrick: readonly TrickCard[] | null = willComplete


### PR DESCRIPTION
## Summary

- Q♠ sting and the generic card-place click were firing simultaneously when the human plays Q♠
- Now only the Q♠ sting plays; `cardPlay` is skipped for Q♠ only

## Test plan
- [ ] Play Q♠ as human — hear only the Q♠ sting, no card-place click underneath
- [ ] Play any other card as human — hear the card-place click as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)