### PR TITLE
feat(sort): lower pour lift, liquid stream, scale duration by sections (#1313)

### DIFF
--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -30,6 +30,8 @@ export interface SortBoardProps {
   readonly pouringTo?: number | null;
   /** Height of the board container in pixels — used to scale bottles to fit. */
   readonly availableHeight?: number;
+  /** Tilt-hold duration in ms; defaults to TILT_HOLD_MS_PER_UNIT (1 unit). */
+  readonly pourHoldMs?: number;
 }
 
 interface GhostInfo {
@@ -37,15 +39,23 @@ interface GhostInfo {
   bottleIndex: number;
   startX: number;
   startY: number;
+  dstX: number;
+  dstY: number;
 }
 
-// Ghost animation timing (ms) — TILT_* values must stay in sync with BottleView
-const LIFT_MS = 150;
-const TRAVEL_MS = 150;
-const TILT_IN_MS = 250;
-const TILT_HOLD_MS = 150;
-const TILT_OUT_MS = 200;
-// TILT_DEG imported from BottleView — single source of truth
+// Ghost animation timing constants (ms) — exported so SortScreen can compute total timeout
+export const LIFT_MS = 150;
+export const TRAVEL_MS = 150;
+export const TILT_IN_MS = 250;
+export const TILT_OUT_MS = 200;
+export const TILT_HOLD_MS_PER_UNIT = 150;  // scaled by # of sections poured
+const TILT_HOLD_MS_DEFAULT = TILT_HOLD_MS_PER_UNIT;  // fallback when no prop
+
+// Ghost rises just enough to clear the target bottle's opening
+const LIFT_HEIGHT = 40;
+
+// Stream dimensions
+const STREAM_WIDTH = 5;
 
 export default function SortBoard({
   state,
@@ -54,6 +64,7 @@ export default function SortBoard({
   pouringFrom = null,
   pouringTo = null,
   availableHeight,
+  pourHoldMs = TILT_HOLD_MS_DEFAULT,
 }: SortBoardProps) {
   const { t } = useTranslation("sort");
   const { width: screenW } = useWindowDimensions();
@@ -90,6 +101,7 @@ export default function SortBoard({
   const ghostLiftY = useSharedValue(0);
   const ghostTravelX = useSharedValue(0);
   const ghostTiltDeg = useSharedValue(0);
+  const ghostStreamOpacity = useSharedValue(0);
 
   const ghostAnimStyle = useAnimatedStyle(() => ({
     transform: [
@@ -99,13 +111,15 @@ export default function SortBoard({
     ],
   }));
 
+  const ghostStreamStyle = useAnimatedStyle(() => ({
+    opacity: ghostStreamOpacity.value,
+  }));
+
   // Ghost React state (drives overlay visibility and bottle capture)
   const [ghost, setGhost] = useState<GhostInfo | null>(null);
 
-  // Stable refs for values read inside the effect (avoids stale closure without
+  // Stable ref for values read inside the effect (avoids stale closure without
   // adding them to the dep array, which would re-trigger on every state change)
-  const bottleHRef = useRef(bottleH);
-  bottleHRef.current = bottleH;
   const stateRef = useRef(state);
   stateRef.current = state;
 
@@ -114,9 +128,11 @@ export default function SortBoard({
       cancelAnimation(ghostLiftY);
       cancelAnimation(ghostTravelX);
       cancelAnimation(ghostTiltDeg);
+      cancelAnimation(ghostStreamOpacity);
       ghostLiftY.value = 0;
       ghostTravelX.value = 0;
       ghostTiltDeg.value = 0;
+      ghostStreamOpacity.value = 0;
       setGhost(null);
       return;
     }
@@ -126,7 +142,6 @@ export default function SortBoard({
     if (!srcPos || !dstPos) return; // layout not measured yet — silent fallback
 
     const dx = dstPos.x - srcPos.x;
-    const liftHeight = bottleHRef.current + 20;
     const tiltAngle = pouringFrom < pouringTo ? TILT_DEG : -TILT_DEG;
 
     const sourceBottle = stateRef.current.bottles[pouringFrom];
@@ -135,25 +150,27 @@ export default function SortBoard({
     ghostLiftY.value = 0;
     ghostTravelX.value = 0;
     ghostTiltDeg.value = 0;
+    ghostStreamOpacity.value = 0;
 
     setGhost({
       bottle: sourceBottle,
       bottleIndex: pouringFrom,
       startX: srcPos.x,
       startY: srcPos.y,
+      dstX: dstPos.x,
+      dstY: dstPos.y,
     });
 
-    // Lift → travel → tilt in → hold → tilt out → return travel → lower (~1200ms total).
-    // Ghost clears at ~1200ms; SortScreen commits state at 1250ms — the 50ms gap is
-    // imperceptible and ensures the state update lands after the animation completes.
-    ghostLiftY.value = withTiming(-liftHeight, { duration: LIFT_MS }, (finished) => {
+    // Lift → travel → tilt in → hold → tilt out → return travel → lower.
+    // Ghost clears at end; SortScreen commits state 50ms later.
+    ghostLiftY.value = withTiming(-LIFT_HEIGHT, { duration: LIFT_MS }, (finished) => {
       if (!finished) return;
       ghostTravelX.value = withTiming(dx, { duration: TRAVEL_MS }, (finished) => {
         if (!finished) return;
         ghostTiltDeg.value = withTiming(tiltAngle, { duration: TILT_IN_MS }, (finished) => {
           if (!finished) return;
           ghostTiltDeg.value = withDelay(
-            TILT_HOLD_MS,
+            pourHoldMs,
             withTiming(0, { duration: TILT_OUT_MS }, (finished) => {
               if (!finished) return;
               ghostTravelX.value = withTiming(0, { duration: TRAVEL_MS }, (finished) => {
@@ -167,8 +184,17 @@ export default function SortBoard({
         });
       });
     });
+
+    // Stream fades in at tilt-in start, holds, fades out at tilt-out start.
+    ghostStreamOpacity.value = withDelay(
+      LIFT_MS + TRAVEL_MS,
+      withSequence(
+        withTiming(1, { duration: TILT_IN_MS }),
+        withDelay(pourHoldMs, withTiming(0, { duration: TILT_OUT_MS }))
+      )
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pouringFrom, pouringTo, reduceMotion]);
+  }, [pouringFrom, pouringTo, reduceMotion, pourHoldMs]);
 
   // Pour tilt direction — used for reduce-motion fallback only
   const pouringDirection: "left" | "right" | undefined =
@@ -230,36 +256,58 @@ export default function SortBoard({
 
       {/* Ghost bottle overlay — floats above grid during pour animation.
           ghost is only set when !reduceMotion, so the extra guard is omitted. */}
-      {ghost !== null && (
-        <View
-          style={StyleSheet.absoluteFill}
-          pointerEvents="none"
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-        >
-          <Animated.View
-            style={[
-              styles.ghostBottle,
-              {
-                left: ghost.startX,
-                top: ghost.startY,
-                width: bottleW,
-                height: bottleH,
-              },
-              ghostAnimStyle,
-            ]}
+      {ghost !== null && (() => {
+        const topColor = ghost.bottle.length > 0 ? ghost.bottle[ghost.bottle.length - 1] : null;
+        const streamColor = topColor ? LIQUID_COLORS[topColor] : "#ffffff";
+        const streamTop = ghost.startY - LIFT_HEIGHT;
+        const streamHeight = Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT);
+        const streamLeft = ghost.dstX + (bottleW - STREAM_WIDTH) / 2;
+        return (
+          <View
+            style={StyleSheet.absoluteFill}
+            pointerEvents="none"
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
           >
-            <BottleView
-              bottle={ghost.bottle}
-              index={ghost.bottleIndex}
-              isGhost
-              colorblindMode={colorblindMode}
-              bottleWidth={bottleW}
-              bottleHeight={bottleH}
-            />
-          </Animated.View>
-        </View>
-      )}
+            <Animated.View
+              style={[
+                styles.ghostBottle,
+                {
+                  left: ghost.startX,
+                  top: ghost.startY,
+                  width: bottleW,
+                  height: bottleH,
+                },
+                ghostAnimStyle,
+              ]}
+            >
+              <BottleView
+                bottle={ghost.bottle}
+                index={ghost.bottleIndex}
+                isGhost
+                colorblindMode={colorblindMode}
+                bottleWidth={bottleW}
+                bottleHeight={bottleH}
+              />
+            </Animated.View>
+            {streamHeight > 0 && (
+              <Animated.View
+                style={[
+                  styles.stream,
+                  {
+                    left: streamLeft,
+                    top: streamTop,
+                    width: STREAM_WIDTH,
+                    height: streamHeight,
+                    backgroundColor: streamColor,
+                  },
+                  ghostStreamStyle,
+                ]}
+              />
+            )}
+          </View>
+        );
+      })()}
 
       <SortWinOverlay visible={state.isComplete} />
     </View>
@@ -401,6 +449,10 @@ const styles = StyleSheet.create({
   },
   ghostBottle: {
     position: "absolute",
+  },
+  stream: {
+    position: "absolute",
+    borderRadius: STREAM_WIDTH / 2,
   },
   particle: { position: "absolute", width: 20, height: 20, borderRadius: 10, top: 0 },
   p0: { left: "8%" },

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -212,6 +212,17 @@ export default function SortBoard({
     [state.bottles.length, onBottleTap]
   );
 
+  // Stream geometry — derived from ghost snapshot; stable for the life of each pour.
+  const streamTopColor = ghost !== null && ghost.bottle.length > 0
+    ? ghost.bottle[ghost.bottle.length - 1]
+    : null;
+  const streamColor = streamTopColor ? LIQUID_COLORS[streamTopColor] : "transparent";
+  const streamTop = ghost !== null ? ghost.startY - LIFT_HEIGHT : 0;
+  const streamHeight = ghost !== null
+    ? Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT)
+    : 0;
+  const streamLeft = ghost !== null ? ghost.dstX + (bottleW - STREAM_WIDTH) / 2 : 0;
+
   return (
     <View accessibilityLabel={t("a11y.boardRegion")} accessibilityRole="none" style={styles.board}>
       <View
@@ -255,58 +266,51 @@ export default function SortBoard({
 
       {/* Ghost bottle overlay — floats above grid during pour animation.
           ghost is only set when !reduceMotion, so the extra guard is omitted. */}
-      {ghost !== null && (() => {
-        const topColor = ghost.bottle.length > 0 ? ghost.bottle[ghost.bottle.length - 1] : null;
-        const streamColor = topColor ? LIQUID_COLORS[topColor] : "transparent";
-        const streamTop = ghost.startY - LIFT_HEIGHT;
-        const streamHeight = Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT);
-        const streamLeft = ghost.dstX + (bottleW - STREAM_WIDTH) / 2;
-        return (
-          <View
-            style={StyleSheet.absoluteFill}
-            pointerEvents="none"
-            accessibilityElementsHidden
-            importantForAccessibility="no-hide-descendants"
-          >
-            {streamHeight > 0 && (
-              <Animated.View
-                style={[
-                  styles.stream,
-                  {
-                    left: streamLeft,
-                    top: streamTop,
-                    width: STREAM_WIDTH,
-                    height: streamHeight,
-                    backgroundColor: streamColor,
-                  },
-                  ghostStreamStyle,
-                ]}
-              />
-            )}
+      {ghost !== null && (
+        <View
+          style={StyleSheet.absoluteFill}
+          pointerEvents="none"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+        >
+          {streamHeight > 0 && (
             <Animated.View
               style={[
-                styles.ghostBottle,
+                styles.stream,
                 {
-                  left: ghost.startX,
-                  top: ghost.startY,
-                  width: bottleW,
-                  height: bottleH,
+                  left: streamLeft,
+                  top: streamTop,
+                  width: STREAM_WIDTH,
+                  height: streamHeight,
+                  backgroundColor: streamColor,
                 },
-                ghostAnimStyle,
+                ghostStreamStyle,
               ]}
-            >
-              <BottleView
-                bottle={ghost.bottle}
-                index={ghost.bottleIndex}
-                isGhost
-                colorblindMode={colorblindMode}
-                bottleWidth={bottleW}
-                bottleHeight={bottleH}
-              />
-            </Animated.View>
-          </View>
-        );
-      })()}
+            />
+          )}
+          <Animated.View
+            style={[
+              styles.ghostBottle,
+              {
+                left: ghost.startX,
+                top: ghost.startY,
+                width: bottleW,
+                height: bottleH,
+              },
+              ghostAnimStyle,
+            ]}
+          >
+            <BottleView
+              bottle={ghost.bottle}
+              index={ghost.bottleIndex}
+              isGhost
+              colorblindMode={colorblindMode}
+              bottleWidth={bottleW}
+              bottleHeight={bottleH}
+            />
+          </Animated.View>
+        </View>
+      )}
 
       <SortWinOverlay visible={state.isComplete} />
     </View>

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -48,7 +48,7 @@ export const LIFT_MS = 150;
 export const TRAVEL_MS = 150;
 export const TILT_IN_MS = 250;
 export const TILT_OUT_MS = 200;
-export const TILT_HOLD_MS_PER_UNIT = 150;  // scaled by # of sections poured
+export const TILT_HOLD_MS_PER_UNIT = 150; // scaled by # of sections poured
 
 // Ghost rises just enough to clear the target bottle's opening
 const LIFT_HEIGHT = 40;
@@ -213,14 +213,11 @@ export default function SortBoard({
   );
 
   // Stream geometry — derived from ghost snapshot; stable for the life of each pour.
-  const streamTopColor = ghost !== null && ghost.bottle.length > 0
-    ? ghost.bottle[ghost.bottle.length - 1]
-    : null;
+  const streamTopColor =
+    ghost !== null && ghost.bottle.length > 0 ? ghost.bottle[ghost.bottle.length - 1] : null;
   const streamColor = streamTopColor ? LIQUID_COLORS[streamTopColor] : "transparent";
   const streamTop = ghost !== null ? ghost.startY - LIFT_HEIGHT : 0;
-  const streamHeight = ghost !== null
-    ? Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT)
-    : 0;
+  const streamHeight = ghost !== null ? Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT) : 0;
   const streamLeft = ghost !== null ? ghost.dstX + (bottleW - STREAM_WIDTH) / 2 : 0;
 
   return (

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -49,7 +49,6 @@ export const TRAVEL_MS = 150;
 export const TILT_IN_MS = 250;
 export const TILT_OUT_MS = 200;
 export const TILT_HOLD_MS_PER_UNIT = 150;  // scaled by # of sections poured
-const TILT_HOLD_MS_DEFAULT = TILT_HOLD_MS_PER_UNIT;  // fallback when no prop
 
 // Ghost rises just enough to clear the target bottle's opening
 const LIFT_HEIGHT = 40;
@@ -64,7 +63,7 @@ export default function SortBoard({
   pouringFrom = null,
   pouringTo = null,
   availableHeight,
-  pourHoldMs = TILT_HOLD_MS_DEFAULT,
+  pourHoldMs = TILT_HOLD_MS_PER_UNIT,
 }: SortBoardProps) {
   const { t } = useTranslation("sort");
   const { width: screenW } = useWindowDimensions();
@@ -258,7 +257,7 @@ export default function SortBoard({
           ghost is only set when !reduceMotion, so the extra guard is omitted. */}
       {ghost !== null && (() => {
         const topColor = ghost.bottle.length > 0 ? ghost.bottle[ghost.bottle.length - 1] : null;
-        const streamColor = topColor ? LIQUID_COLORS[topColor] : "#ffffff";
+        const streamColor = topColor ? LIQUID_COLORS[topColor] : "transparent";
         const streamTop = ghost.startY - LIFT_HEIGHT;
         const streamHeight = Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT);
         const streamLeft = ghost.dstX + (bottleW - STREAM_WIDTH) / 2;
@@ -269,6 +268,21 @@ export default function SortBoard({
             accessibilityElementsHidden
             importantForAccessibility="no-hide-descendants"
           >
+            {streamHeight > 0 && (
+              <Animated.View
+                style={[
+                  styles.stream,
+                  {
+                    left: streamLeft,
+                    top: streamTop,
+                    width: STREAM_WIDTH,
+                    height: streamHeight,
+                    backgroundColor: streamColor,
+                  },
+                  ghostStreamStyle,
+                ]}
+              />
+            )}
             <Animated.View
               style={[
                 styles.ghostBottle,
@@ -290,21 +304,6 @@ export default function SortBoard({
                 bottleHeight={bottleH}
               />
             </Animated.View>
-            {streamHeight > 0 && (
-              <Animated.View
-                style={[
-                  styles.stream,
-                  {
-                    left: streamLeft,
-                    top: streamTop,
-                    width: STREAM_WIDTH,
-                    height: streamHeight,
-                    backgroundColor: streamColor,
-                  },
-                  ghostStreamStyle,
-                ]}
-              />
-            )}
           </View>
         );
       })()}

--- a/frontend/src/game/sort/engine.ts
+++ b/frontend/src/game/sort/engine.ts
@@ -33,6 +33,11 @@ function topRun(bottle: Bottle): number {
   return n;
 }
 
+/** Number of units actually poured when moving from `from` to `to`. Assumes the move is valid. */
+export function pourUnits(from: Bottle, to: Bottle): number {
+  return Math.min(topRun(from), BOTTLE_DEPTH - to.length);
+}
+
 export function isBottleSolved(bottle: Bottle): boolean {
   return bottle.length === 0 || (bottle.length === BOTTLE_DEPTH && new Set(bottle).size === 1);
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -265,7 +265,7 @@ export default function HeartsScreen() {
     } finally {
       loopActiveRef.current = false;
     }
-  }, []);
+  }, [playCardPlay]);
 
   // Trigger AI loop when it's their turn; wait for lastTrick display first.
   useEffect(() => {

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -220,52 +220,55 @@ export default function HeartsScreen() {
   }
 
   // ─── AI turn loop ─────────────────────────────────────────────────────────
-  const runAiTurns = useCallback(async (initial: HeartsState) => {
-    if (loopActiveRef.current) return;
-    loopActiveRef.current = true;
-    try {
-      // Start with a clean events slate; initial events are already in React state
-      // and will be processed by useGameEvents independently.
-      let s: HeartsState = { ...initial, events: [] };
-      while (s.currentPlayerIndex !== HUMAN && s.phase === "playing") {
-        const willComplete = s.currentTrick.length === 3;
-        await delay(400);
-        if (unmountedRef.current) return;
-
-        const card = selectCardToPlay(
-          s.playerHands[s.currentPlayerIndex] as Card[],
-          s.currentTrick as TrickCard[],
-          s,
-          s.currentPlayerIndex,
-          s.aiDifficulty
-        );
-        const completedTrick: readonly TrickCard[] | null = willComplete
-          ? [...s.currentTrick, { card, playerIndex: s.currentPlayerIndex }]
-          : null;
-
-        s = playCard(s, s.currentPlayerIndex, card);
-        playCardPlay();
-
-        if (completedTrick) {
-          setLastTrick({ trick: completedTrick, winnerIndex: s.currentLeaderIndex });
-          void saveGame(s);
-        }
-        setGameState(s);
-        // Clear events so the next playCard call doesn't re-emit them via a new array reference.
-        s = { ...s, events: [] };
-
-        if (completedTrick && s.phase === "playing") {
-          await new Promise<void>((resolve) => {
-            trickAnimResolverRef.current = resolve;
-          });
+  const runAiTurns = useCallback(
+    async (initial: HeartsState) => {
+      if (loopActiveRef.current) return;
+      loopActiveRef.current = true;
+      try {
+        // Start with a clean events slate; initial events are already in React state
+        // and will be processed by useGameEvents independently.
+        let s: HeartsState = { ...initial, events: [] };
+        while (s.currentPlayerIndex !== HUMAN && s.phase === "playing") {
+          const willComplete = s.currentTrick.length === 3;
+          await delay(400);
           if (unmountedRef.current) return;
-          setLastTrick(null);
+
+          const card = selectCardToPlay(
+            s.playerHands[s.currentPlayerIndex] as Card[],
+            s.currentTrick as TrickCard[],
+            s,
+            s.currentPlayerIndex,
+            s.aiDifficulty
+          );
+          const completedTrick: readonly TrickCard[] | null = willComplete
+            ? [...s.currentTrick, { card, playerIndex: s.currentPlayerIndex }]
+            : null;
+
+          s = playCard(s, s.currentPlayerIndex, card);
+          playCardPlay();
+
+          if (completedTrick) {
+            setLastTrick({ trick: completedTrick, winnerIndex: s.currentLeaderIndex });
+            void saveGame(s);
+          }
+          setGameState(s);
+          // Clear events so the next playCard call doesn't re-emit them via a new array reference.
+          s = { ...s, events: [] };
+
+          if (completedTrick && s.phase === "playing") {
+            await new Promise<void>((resolve) => {
+              trickAnimResolverRef.current = resolve;
+            });
+            if (unmountedRef.current) return;
+            setLastTrick(null);
+          }
         }
+      } finally {
+        loopActiveRef.current = false;
       }
-    } finally {
-      loopActiveRef.current = false;
-    }
-  }, [playCardPlay]);
+    },
+    [playCardPlay]
+  );
 
   // Trigger AI loop when it's their turn; wait for lastTrick display first.
   useEffect(() => {

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -20,7 +20,13 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
-import { applyPour, initState, isValidPour, pourUnits, undo as undoState } from "../game/sort/engine";
+import {
+  applyPour,
+  initState,
+  isValidPour,
+  pourUnits,
+  undo as undoState,
+} from "../game/sort/engine";
 import { getNextHint } from "../game/sort/solver";
 import type { Color, SortState } from "../game/sort/types";
 import SortBoard, {

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -20,10 +20,16 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
-import { applyPour, initState, isValidPour, undo as undoState } from "../game/sort/engine";
+import { applyPour, initState, isValidPour, pourUnits, undo as undoState } from "../game/sort/engine";
 import { getNextHint } from "../game/sort/solver";
 import type { Color, SortState } from "../game/sort/types";
-import SortBoard from "../game/sort/components/SortBoard";
+import SortBoard, {
+  LIFT_MS,
+  TRAVEL_MS,
+  TILT_IN_MS,
+  TILT_OUT_MS,
+  TILT_HOLD_MS_PER_UNIT,
+} from "../game/sort/components/SortBoard";
 import LevelSelectScreen from "../game/sort/components/LevelSelectScreen";
 import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
 import { loadProgress, saveProgress, type SortProgress } from "../game/sort/storage";
@@ -68,6 +74,7 @@ export default function SortScreen() {
   // Pour animation state
   const [pouringFrom, setPouringFrom] = useState<number | null>(null);
   const [pouringTo, setPouringTo] = useState<number | null>(null);
+  const [pourHoldMs, setPourHoldMs] = useState(TILT_HOLD_MS_PER_UNIT);
   const [isPouring, setIsPouring] = useState(false);
   const [boardHeight, setBoardHeight] = useState(0);
   const pourTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -181,10 +188,15 @@ export default function SortScreen() {
 
     if (isValidPour(gameState.bottles[selectedBottleIndex], gameState.bottles[index])) {
       const snapshot = gameState;
+      const units = pourUnits(gameState.bottles[selectedBottleIndex]!, gameState.bottles[index]!);
+      const holdMs = TILT_HOLD_MS_PER_UNIT * units;
+      const totalMs =
+        LIFT_MS + TRAVEL_MS + TILT_IN_MS + holdMs + TILT_OUT_MS + TRAVEL_MS + LIFT_MS + 50;
       setHistory((h) => [...h, snapshot]);
       setIsPouring(true);
       setPouringFrom(selectedBottleIndex);
       setPouringTo(index);
+      setPourHoldMs(holdMs);
       setGameState({ ...gameState, selectedBottleIndex: null });
       audio.playPour();
       pourTimerRef.current = setTimeout(() => {
@@ -196,7 +208,7 @@ export default function SortScreen() {
         if (nextState.isComplete) {
           audio.playWin();
         }
-      }, 1250);
+      }, totalMs);
     } else {
       setGameState({ ...gameState, selectedBottleIndex: null });
     }
@@ -619,6 +631,7 @@ export default function SortScreen() {
             pouringFrom={pouringFrom}
             pouringTo={pouringTo}
             availableHeight={boardHeight}
+            pourHoldMs={pourHoldMs}
           />
         )}
       </View>


### PR DESCRIPTION
Closes #1313

## Summary

- **Lift height**: Ghost bottle now rises only 40 px (was a full bottle-height + 20 px), giving a realistic "tilting over the next bottle" appearance
- **Liquid stream**: Thin animated rectangle (color-matched to the poured liquid) fades in during tilt, holds, fades out — connecting ghost bottle mouth to target opening
- **Scaled duration**: Tilt-hold phase scales at 150 ms per section poured (1 section = 150 ms, 4 sections = 600 ms); state-commit timeout derives from the sum of all timing constants

## Affected files

- `frontend/src/game/sort/components/SortBoard.tsx` — lift height, stream overlay, exported timing constants, `pourHoldMs` prop
- `frontend/src/screens/SortScreen.tsx` — computes hold duration, passes `pourHoldMs`, derives total timeout
- `frontend/src/game/sort/engine.ts` — exports `pourUnits()` helper

## Test plan

- [ ] Pour 1 section — ghost rises ~40 px, thin colored stream appears during tilt, tilt hold is short
- [ ] Pour 4 sections — tilt hold is noticeably longer than 1-section pour
- [ ] Stream color matches the liquid being poured
- [ ] Stream does not appear when pouring to a bottle in a higher row (upward-row pours)
- [ ] Reduce-motion: no ghost, no stream, just tilt-in-place (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)