### PR TITLE
feat(starswarm): proportional aiming, inline dev panel, missile toggles, shield-ring hit flash (#1310-#1314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Two terminals from the repo root.
 
 First time (or when `requirements.txt` changes):
 
+**Mac/Linux:**
 ```bash
 cd backend
 python3.13 -m venv .venv
@@ -29,11 +30,30 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
+**Windows (PowerShell):**
+```powershell
+cd backend
+python3.13 -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+> If PowerShell blocks the `.ps1` script, run once: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
 Every time:
 
+**Mac/Linux:**
 ```bash
 cd backend
 source .venv/bin/activate
+python -m uvicorn main:app --reload   # http://localhost:8000
+```
+
+**Windows (PowerShell):**
+```powershell
+cd backend
+.venv\Scripts\Activate.ps1
 python -m uvicorn main:app --reload   # http://localhost:8000
 ```
 
@@ -79,6 +99,7 @@ Backend is hosted on Render — see [`docs/RENDER.md`](docs/RENDER.md).
 
 **`pip install -r requirements.txt` fails building `pydantic-core`** — your venv is using Python 3.14. Recreate it with 3.13:
 
+**Mac/Linux:**
 ```bash
 deactivate
 rm -rf backend/.venv
@@ -86,4 +107,14 @@ python3.13 -m venv backend/.venv
 source backend/.venv/bin/activate
 pip install --upgrade pip
 pip install -r backend/requirements.txt
+```
+
+**Windows (PowerShell):**
+```powershell
+deactivate
+Remove-Item -Recurse -Force backend\.venv
+python3.13 -m venv backend\.venv
+backend\.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r backend\requirements.txt
 ```

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -16,6 +16,7 @@ import {
   tick,
   applyPowerUp,
   BULLET_C_W,
+  HIT_FLASH_DURATION,
   POWERUP_DURATION,
   difficultyLabel,
   difficultyMultiplier,
@@ -41,6 +42,10 @@ export interface DevOptions {
   pauseStraggler?: boolean;
   /** Override difficulty tier for this game (#1037). */
   difficulty?: DifficultyTier;
+  /** Suppress player bullet spawning (#1311). */
+  playerFireDisabled?: boolean;
+  /** Suppress enemy bullet spawning (#1311). */
+  enemyFireDisabled?: boolean;
 }
 
 export interface GameCanvasHandle {
@@ -243,8 +248,11 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             const prevCooldown = prev.player.shootCooldown;
             // #1039: apply pauseStraggler from devOptions each tick
             const pauseStraggler = devOptionsRef.current?.pauseStraggler ?? false;
-            const tickInput =
-              prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
+            const playerFireDisabled = devOptionsRef.current?.playerFireDisabled ?? false;
+            const enemyFireDisabled = devOptionsRef.current?.enemyFireDisabled ?? false;
+            let tickInput = prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
+            if (tickInput.playerFireDisabled !== playerFireDisabled) tickInput = { ...tickInput, playerFireDisabled };
+            if (tickInput.enemyFireDisabled !== enemyFireDisabled) tickInput = { ...tickInput, enemyFireDisabled };
             const next = tick(tickInput, dtMs, {
               playerX: inputRef.current.playerX,
               fire: inputRef.current.fire,
@@ -426,15 +434,31 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                       color={fallbackColor}
                     />
                   )}
-                  {enemy.hitFlashTimer > 0 && (
-                    <Rect
-                      x={enemy.x - enemy.width / 2}
-                      y={enemy.y - enemy.height / 2}
-                      width={enemy.width}
-                      height={enemy.height}
-                      color="rgba(255,255,255,0.7)"
-                    />
-                  )}
+                  {enemy.hitFlashTimer > 0 && (() => {
+                    const progress = 1 - enemy.hitFlashTimer / HIT_FLASH_DURATION;
+                    const refR = Math.max(enemy.width, enemy.height) * 0.6;
+                    const r = refR * (0.6 + 0.5 * progress);
+                    const a = enemy.hitFlashTimer / HIT_FLASH_DURATION; // 1→0 as burst plays
+                    return (
+                      <>
+                        <Circle
+                          cx={enemy.x}
+                          cy={enemy.y}
+                          r={r}
+                          color={`rgba(0,170,255,${(a * 0.25).toFixed(3)})`}
+                          style="fill"
+                        />
+                        <Circle
+                          cx={enemy.x}
+                          cy={enemy.y}
+                          r={r}
+                          color={`rgba(0,170,255,${(a * 0.75).toFixed(3)})`}
+                          style="stroke"
+                          strokeWidth={2}
+                        />
+                      </>
+                    );
+                  })()}
                 </Group>
               );
             })}

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -250,9 +250,12 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             const pauseStraggler = devOptionsRef.current?.pauseStraggler ?? false;
             const playerFireDisabled = devOptionsRef.current?.playerFireDisabled ?? false;
             const enemyFireDisabled = devOptionsRef.current?.enemyFireDisabled ?? false;
-            let tickInput = prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
-            if (tickInput.playerFireDisabled !== playerFireDisabled) tickInput = { ...tickInput, playerFireDisabled };
-            if (tickInput.enemyFireDisabled !== enemyFireDisabled) tickInput = { ...tickInput, enemyFireDisabled };
+            let tickInput =
+              prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
+            if (tickInput.playerFireDisabled !== playerFireDisabled)
+              tickInput = { ...tickInput, playerFireDisabled };
+            if (tickInput.enemyFireDisabled !== enemyFireDisabled)
+              tickInput = { ...tickInput, enemyFireDisabled };
             const next = tick(tickInput, dtMs, {
               playerX: inputRef.current.playerX,
               fire: inputRef.current.fire,
@@ -434,31 +437,32 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                       color={fallbackColor}
                     />
                   )}
-                  {enemy.hitFlashTimer > 0 && (() => {
-                    const progress = 1 - enemy.hitFlashTimer / HIT_FLASH_DURATION;
-                    const refR = Math.max(enemy.width, enemy.height) * 0.6;
-                    const r = refR * (0.6 + 0.5 * progress);
-                    const a = enemy.hitFlashTimer / HIT_FLASH_DURATION; // 1→0 as burst plays
-                    return (
-                      <>
-                        <Circle
-                          cx={enemy.x}
-                          cy={enemy.y}
-                          r={r}
-                          color={`rgba(0,170,255,${(a * 0.25).toFixed(3)})`}
-                          style="fill"
-                        />
-                        <Circle
-                          cx={enemy.x}
-                          cy={enemy.y}
-                          r={r}
-                          color={`rgba(0,170,255,${(a * 0.75).toFixed(3)})`}
-                          style="stroke"
-                          strokeWidth={2}
-                        />
-                      </>
-                    );
-                  })()}
+                  {enemy.hitFlashTimer > 0 &&
+                    (() => {
+                      const progress = 1 - enemy.hitFlashTimer / HIT_FLASH_DURATION;
+                      const refR = Math.max(enemy.width, enemy.height) * 0.6;
+                      const r = refR * (0.6 + 0.5 * progress);
+                      const a = enemy.hitFlashTimer / HIT_FLASH_DURATION; // 1→0 as burst plays
+                      return (
+                        <>
+                          <Circle
+                            cx={enemy.x}
+                            cy={enemy.y}
+                            r={r}
+                            color={`rgba(0,170,255,${(a * 0.25).toFixed(3)})`}
+                            style="fill"
+                          />
+                          <Circle
+                            cx={enemy.x}
+                            cy={enemy.y}
+                            r={r}
+                            color={`rgba(0,170,255,${(a * 0.75).toFixed(3)})`}
+                            style="stroke"
+                            strokeWidth={2}
+                          />
+                        </>
+                      );
+                    })()}
                 </Group>
               );
             })}

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1157,6 +1157,7 @@ describe("Bézier arc dives (#977)", () => {
     const wiggling = s.enemies.find((e) => e.phase === "Wiggling");
     if (!wiggling) throw new Error("no wiggling enemy");
     const id = wiggling.id;
+    s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, WIGGLE_DURATION + DIVE_PATH_DURATION + 200, NO_INPUT);
     const after = s.enemies.find((e) => e.id === id)!;
     const completed =
@@ -2066,6 +2067,7 @@ describe("#1035 Buddy Ship", () => {
     expect(s.buddyShips.length).toBe(1);
 
     // Advance until the buddy has fired (pathT >= 0.45) and completed (pathT > 1.2)
+    s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, 4000, NO_INPUT);
 
     // Buddy should be gone after full traversal
@@ -2305,6 +2307,7 @@ describe("laser sound gating", () => {
 
   it("does not trigger laser sound once lightning power-up expires", () => {
     let s = applyPowerUp(playingState(), "lightning");
+    s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, POWERUP_DURATION + 100, FIRE_INPUT); // advance past expiry while firing
     expect(s.activePowerUp).toBeNull();
     // Advance one more frame: cooldown may already be 0 from continuous fire

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1157,6 +1157,8 @@ describe("Bézier arc dives (#977)", () => {
     const wiggling = s.enemies.find((e) => e.phase === "Wiggling");
     if (!wiggling) throw new Error("no wiggling enemy");
     const id = wiggling.id;
+    // #1314: proportional aiming is more lethal — give invincibility so the player can't die
+    // mid-advance and freeze the game in GameOver before the dive completes.
     s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, WIGGLE_DURATION + DIVE_PATH_DURATION + 200, NO_INPUT);
     const after = s.enemies.find((e) => e.id === id)!;
@@ -2066,7 +2068,8 @@ describe("#1035 Buddy Ship", () => {
     s = applyPowerUp(s, "buddy");
     expect(s.buddyShips.length).toBe(1);
 
-    // Advance until the buddy has fired (pathT >= 0.45) and completed (pathT > 1.2)
+    // Advance until the buddy has fired (pathT >= 0.45) and completed (pathT > 1.2).
+    // #1314: proportional aiming is more lethal — invincibility prevents GameOver mid-advance.
     s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, 4000, NO_INPUT);
 
@@ -2307,6 +2310,8 @@ describe("laser sound gating", () => {
 
   it("does not trigger laser sound once lightning power-up expires", () => {
     let s = applyPowerUp(playingState(), "lightning");
+    // #1314: proportional aiming is more lethal — invincibility prevents GameOver freezing the
+    // power-up timer before it can expire.
     s = { ...s, player: { ...s.player, invincibleTimer: 999_999 } };
     s = advanceMs(s, POWERUP_DURATION + 100, FIRE_INPUT); // advance past expiry while firing
     expect(s.activePowerUp).toBeNull();

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -550,7 +550,9 @@ export function bulletCap(wave: number, paramScale = 1): number {
   return Math.min(24, Math.round((3 + Math.floor((wave - 1) / 2)) * paramScale));
 }
 
-// #1314: proportional aim — keeps vy = BULLET_E_VY (same arrival time), scales vx to intersect the player
+// #1314: proportional aim — keeps vy = BULLET_E_VY (same arrival time), scales vx to intersect the player.
+// vx is capped at ±BULLET_E_VY so the bullet never travels more than 45° from vertical; without the cap,
+// circling enemies near the player's altitude produce extreme vx values (dy is small → dx/dy blows up).
 function aimVelocity(
   enemyX: number,
   enemyY: number,
@@ -560,7 +562,9 @@ function aimVelocity(
   const dy = playerY - enemyY;
   if (dy <= 0) return { vx: 0, vy: BULLET_E_VY }; // player at or above enemy — fire straight down
   const dx = playerX - enemyX;
-  return { vx: (dx / dy) * BULLET_E_VY, vy: BULLET_E_VY };
+  const rawVx = (dx / dy) * BULLET_E_VY;
+  const vx = Math.max(-BULLET_E_VY, Math.min(BULLET_E_VY, rawVx));
+  return { vx, vy: BULLET_E_VY };
 }
 
 // #924/#1314: compute velocity for a Grunt enemy bullet — straight down before wave 1+;
@@ -1536,7 +1540,7 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
           if (state.phase === "Playing") killsSinceLastDrop++;
           return { ...e, hp: 0, isAlive: false, hitFlashTimer: 0 };
         }
-        return { ...e, hp: newHp, hitFlashTimer: 120 };
+        return { ...e, hp: newHp, hitFlashTimer: HIT_FLASH_DURATION };
       });
     } else if (collected.type === "buddy") {
       // #1035: spawn a buddy ship
@@ -1814,7 +1818,7 @@ export function applyPowerUp(state: StarSwarmState, type: PowerUpType): StarSwar
         killsSinceLastDrop++;
         return { ...e, hp: 0, isAlive: false, hitFlashTimer: 0 };
       }
-      return { ...e, hp: newHp, hitFlashTimer: 120 };
+      return { ...e, hp: newHp, hitFlashTimer: HIT_FLASH_DURATION };
     });
     return {
       ...state,

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -131,6 +131,9 @@ const SUPER_DAMAGE = 4;
 // #974: small circle around the player sprite centre — forgiveness hitbox
 export const PLAYER_HURT_RADIUS = 7; // px
 
+// #1310: duration of the shield-ring hit flash on non-lethal Elite/Boss hits
+export const HIT_FLASH_DURATION = 250; // ms
+
 const TIER_SCORE: Record<EnemyTier, number> = { Grunt: 100, Elite: 200, Boss: 400 };
 const TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 2, Boss: 4 };
 
@@ -547,13 +550,34 @@ export function bulletCap(wave: number, paramScale = 1): number {
   return Math.min(24, Math.round((3 + Math.floor((wave - 1) / 2)) * paramScale));
 }
 
-// #924: compute vx for an enemy bullet — non-zero only at wave 4+; cap raised by difficulty
-function aimedBulletVx(enemyX: number, playerX: number, wave: number, paramScale = 1): number {
-  if (wave < AIMED_SHOT_WAVE_START) return 0;
+// #1314: proportional aim — keeps vy = BULLET_E_VY (same arrival time), scales vx to intersect the player
+function aimVelocity(
+  enemyX: number,
+  enemyY: number,
+  playerX: number,
+  playerY: number
+): { vx: number; vy: number } {
+  const dy = playerY - enemyY;
+  if (dy <= 0) return { vx: 0, vy: BULLET_E_VY }; // player at or above enemy — fire straight down
+  const dx = playerX - enemyX;
+  return { vx: (dx / dy) * BULLET_E_VY, vy: BULLET_E_VY };
+}
+
+// #924/#1314: compute velocity for a Grunt enemy bullet — straight down before wave 1+;
+// probability-gated proportional aim that ramps per wave
+function aimedBulletVelocity(
+  enemyX: number,
+  enemyY: number,
+  playerX: number,
+  playerY: number,
+  wave: number,
+  paramScale = 1
+): { vx: number; vy: number } {
+  if (wave < AIMED_SHOT_WAVE_START) return { vx: 0, vy: BULLET_E_VY };
   const cap = Math.min(0.9, 0.6 * paramScale);
   const fraction = Math.min(cap, AIMED_SHOT_FRACTION + (wave - AIMED_SHOT_WAVE_START) * 0.05);
-  if (rng() > fraction) return 0;
-  return Math.sign(playerX - enemyX) * BULLET_E_VY * 0.5;
+  if (rng() > fraction) return { vx: 0, vy: BULLET_E_VY };
+  return aimVelocity(enemyX, enemyY, playerX, playerY);
 }
 
 // ---------------------------------------------------------------------------
@@ -656,6 +680,8 @@ function buildWaveState(
     bombFlashTimer: 0,
     difficulty,
     challengingPerfect: false,
+    playerFireDisabled: false,
+    enemyFireDisabled: false,
   };
 }
 
@@ -738,7 +764,7 @@ function tickPlayer(state: StarSwarmState, dtMs: number, input: StarSwarmInput):
 
   const isSuper = state.activePowerUp?.type === "lightning";
 
-  if (shootCooldown === 0 && input.fire) {
+  if (shootCooldown === 0 && input.fire && !state.playerFireDisabled) {
     const bullet: Bullet = {
       id: nextId(),
       x: newX,
@@ -774,6 +800,7 @@ function tickSingleEnemy(
   enemy: Enemy,
   dtMs: number,
   playerX: number,
+  playerY: number,
   canvasH: number,
   shouldDive: boolean,
   wave: number,
@@ -791,6 +818,7 @@ function tickSingleEnemy(
         enemy,
         dtMs,
         playerX,
+        playerY,
         shouldDive,
         wave,
         bossThresholdCrossed,
@@ -804,11 +832,12 @@ function tickSingleEnemy(
         dtMs,
         canvasH,
         playerX,
+        playerY,
         bossThresholdCrossed,
         bossDeepThresholdCrossed
       );
     case "Circling":
-      return tickCircling(enemy, dtMs, playerX);
+      return tickCircling(enemy, dtMs, playerX, playerY);
     case "Returning":
       return tickReturning(enemy, dtMs);
   }
@@ -845,6 +874,7 @@ function tickFormation(
   enemy: Enemy,
   dtMs: number,
   playerX: number,
+  playerY: number,
   shouldDive: boolean,
   wave: number,
   bossThresholdCrossed: boolean,
@@ -875,22 +905,22 @@ function tickFormation(
 
   // #979: Boss fires in bursts; other tiers use random single-shot interval
   if (enemy.tier === "Boss") {
-    const { enemy: e, bullet } = bossBurstFire(enemy, playerX);
+    const { enemy: e, bullet } = bossBurstFire(enemy, playerX, playerY);
     return { enemy: e, bullet };
   }
 
-  // Elites always fire aimed shots; Grunts use wave-scaled probabilistic aim
-  const vx =
+  // #1314: Elites always fire proportionally-aimed shots; Grunts use wave-scaled probabilistic aim
+  const vel =
     enemy.tier === "Elite"
-      ? Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5
-      : aimedBulletVx(enemy.x, playerX, wave, paramScale);
+      ? aimVelocity(enemy.x, enemy.y, playerX, playerY)
+      : aimedBulletVelocity(enemy.x, enemy.y, playerX, playerY, wave, paramScale);
 
   const bullet: Bullet = {
     id: nextId(),
     x: enemy.x,
     y: enemy.y + enemy.height / 2,
-    vx,
-    vy: BULLET_E_VY,
+    vx: vel.vx,
+    vy: vel.vy,
     owner: "enemy",
     width: BULLET_E_W,
     height: BULLET_E_H,
@@ -903,7 +933,7 @@ function tickFormation(
 }
 
 // #979: shared burst-fire logic for Boss in Formation and Diving phases
-function bossBurstFire(enemy: Enemy, playerX: number): EnemyTickResult {
+function bossBurstFire(enemy: Enemy, playerX: number, playerY: number): EnemyTickResult {
   const newBurstShotsLeft =
     enemy.burstShotsLeft === 0
       ? 2 + Math.floor(rng() * 2) - 1 // start new burst: pick 2 or 3, return remaining
@@ -911,12 +941,13 @@ function bossBurstFire(enemy: Enemy, playerX: number): EnemyTickResult {
   const newShootTimer =
     newBurstShotsLeft > 0 ? BURST_INTERVAL : BURST_PAUSE_BASE + rng() * BURST_PAUSE_JITTER;
 
+  const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY); // #1314
   const bullet: Bullet = {
     id: nextId(),
     x: enemy.x,
     y: enemy.y + enemy.height / 2,
-    vx: Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5,
-    vy: BULLET_E_VY,
+    vx: vel.vx,
+    vy: vel.vy,
     owner: "enemy",
     width: BULLET_E_W,
     height: BULLET_E_H,
@@ -977,6 +1008,7 @@ function tickDiving(
   dtMs: number,
   canvasH: number,
   playerX: number,
+  playerY: number,
   bossThresholdCrossed: boolean,
   bossDeepThresholdCrossed: boolean
 ): EnemyTickResult {
@@ -991,17 +1023,18 @@ function tickDiving(
 
   if (shootTimer <= 0) {
     if (enemy.tier === "Boss") {
-      const result = bossBurstFire(enemy, playerX);
+      const result = bossBurstFire(enemy, playerX, playerY);
       bullet = result.bullet;
       nextShootTimer = result.enemy.shootTimer;
       nextBurstShotsLeft = result.enemy.burstShotsLeft;
     } else {
+      const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY); // #1314
       bullet = {
         id: nextId(),
         x: enemy.x,
         y: enemy.y + enemy.height / 2,
-        vx: Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5,
-        vy: BULLET_E_VY,
+        vx: vel.vx,
+        vy: vel.vy,
         owner: "enemy",
         width: BULLET_E_W,
         height: BULLET_E_H,
@@ -1070,21 +1103,22 @@ function tickDiving(
   };
 }
 
-function tickCircling(enemy: Enemy, dtMs: number, playerX: number): EnemyTickResult {
+function tickCircling(enemy: Enemy, dtMs: number, playerX: number, playerY: number): EnemyTickResult {
   const newAngle = enemy.circleAngle + enemy.circleSpeed * dtMs;
   const newX = enemy.circleCx + Math.cos(newAngle) * enemy.circleRadius;
   const newY = enemy.circleCy + Math.sin(newAngle) * enemy.circleRadius;
 
-  // #944: tick shoot timer and fire aimed bullet if ready
+  // #944/#1314: tick shoot timer and fire proportionally-aimed bullet if ready
   const shootTimer = enemy.shootTimer - dtMs;
   let bullet: Bullet | null = null;
   if (shootTimer <= 0) {
+    const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY);
     bullet = {
       id: nextId(),
       x: enemy.x,
       y: enemy.y + enemy.height / 2,
-      vx: Math.sign(playerX - enemy.x) * BULLET_E_VY * 0.5,
-      vy: BULLET_E_VY,
+      vx: vel.vx,
+      vy: vel.vy,
       owner: "enemy",
       width: BULLET_E_W,
       height: BULLET_E_H,
@@ -1204,6 +1238,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
       enemy,
       dtMs,
       state.player.x,
+      state.player.y,
       state.canvasH,
       shouldDive,
       state.wave,
@@ -1223,7 +1258,7 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     if (e.isAlive && e.hitFlashTimer > 0) {
       e = { ...e, hitFlashTimer: Math.max(0, e.hitFlashTimer - dtMs) };
     }
-    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave, _ps)) {
+    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave, _ps) && !state.enemyFireDisabled) {
       newEnemyBullets.push(result.bullet);
     }
     return e;
@@ -1433,8 +1468,8 @@ function tickCollisions(state: StarSwarmState): StarSwarmState {
         return { ...enemy, hp: 0, isAlive: false, hitFlashTimer: 0 };
       }
 
-      // Non-lethal hit — flash (#976); killing blow skips flash (explosion takes over)
-      return { ...enemy, hp: newHp, hitFlashTimer: 120 };
+      // Non-lethal hit — shield ring burst (#1310); killing blow skips flash (explosion takes over)
+      return { ...enemy, hp: newHp, hitFlashTimer: HIT_FLASH_DURATION };
     }
     return enemy;
   });

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -1107,7 +1107,12 @@ function tickDiving(
   };
 }
 
-function tickCircling(enemy: Enemy, dtMs: number, playerX: number, playerY: number): EnemyTickResult {
+function tickCircling(
+  enemy: Enemy,
+  dtMs: number,
+  playerX: number,
+  playerY: number
+): EnemyTickResult {
   const newAngle = enemy.circleAngle + enemy.circleSpeed * dtMs;
   const newX = enemy.circleCx + Math.cos(newAngle) * enemy.circleRadius;
   const newY = enemy.circleCy + Math.sin(newAngle) * enemy.circleRadius;
@@ -1262,7 +1267,11 @@ function tickEnemies(state: StarSwarmState, dtMs: number): StarSwarmState {
     if (e.isAlive && e.hitFlashTimer > 0) {
       e = { ...e, hitFlashTimer: Math.max(0, e.hitFlashTimer - dtMs) };
     }
-    if (result.bullet && newEnemyBullets.length < bulletCap(state.wave, _ps) && !state.enemyFireDisabled) {
+    if (
+      result.bullet &&
+      newEnemyBullets.length < bulletCap(state.wave, _ps) &&
+      !state.enemyFireDisabled
+    ) {
       newEnemyBullets.push(result.bullet);
     }
     return e;

--- a/frontend/src/game/starswarm/types.ts
+++ b/frontend/src/game/starswarm/types.ts
@@ -211,6 +211,10 @@ export interface StarSwarmState {
   readonly difficulty: DifficultyTier;
   /** True when the player hit all enemies in a Challenging Stage (#1022). */
   readonly challengingPerfect: boolean;
+  /** Dev: suppress player fire (bullets never spawn, cooldown still ticks). */
+  readonly playerFireDisabled: boolean;
+  /** Dev: enemy bullets are never pushed to the bullet list. */
+  readonly enemyFireDisabled: boolean;
 }
 
 /** Input snapshot consumed by each `tick` call. */

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -226,12 +226,16 @@ export default function StarSwarmScreen() {
               // then override live-toggleable fields so they propagate mid-game without New Game.
               // pauseStraggler is also overridden here (fixes a pre-existing gap where the toggle
               // only took effect after New Game).
-              devOptions={__DEV__ ? {
-                ...lastDevOptsRef.current,
-                pauseStraggler: devPauseStraggler,
-                playerFireDisabled: devPlayerFireOff,
-                enemyFireDisabled: devEnemyFireOff,
-              } : undefined}
+              devOptions={
+                __DEV__
+                  ? {
+                      ...lastDevOptsRef.current,
+                      pauseStraggler: devPauseStraggler,
+                      playerFireDisabled: devPlayerFireOff,
+                      enemyFireDisabled: devEnemyFireOff,
+                    }
+                  : undefined
+              }
             />
             <Controls
               canvasRef={canvasRef}
@@ -368,10 +372,7 @@ export default function StarSwarmScreen() {
                 {DIFFICULTY_TIERS.map((tier) => (
                   <Pressable
                     key={tier}
-                    style={[
-                      styles.devTierBtn,
-                      devDifficulty === tier && styles.devTierBtnActive,
-                    ]}
+                    style={[styles.devTierBtn, devDifficulty === tier && styles.devTierBtnActive]}
                     onPress={() => setDevDifficulty(tier)}
                     accessibilityLabel={`Dev difficulty ${difficultyLabel(tier)}`}
                   >

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -222,6 +222,10 @@ export default function StarSwarmScreen() {
               scale={scale}
               difficulty={difficulty}
               resetTick={resetTick}
+              // #1311/#1312: spread lastDevOptsRef for new-game options (wave, lives, etc.),
+              // then override live-toggleable fields so they propagate mid-game without New Game.
+              // pauseStraggler is also overridden here (fixes a pre-existing gap where the toggle
+              // only took effect after New Game).
               devOptions={__DEV__ ? {
                 ...lastDevOptsRef.current,
                 pauseStraggler: devPauseStraggler,
@@ -297,7 +301,12 @@ export default function StarSwarmScreen() {
         )}
 
         {__DEV__ && devPanelOpen && (
-          <View style={dynamicStyles.devPanelOverlay}>
+          <View
+            style={dynamicStyles.devPanelOverlay}
+            accessible
+            accessibilityLabel="Developer panel"
+            accessibilityRole="menu"
+          >
             <ScrollView
               showsVerticalScrollIndicator={false}
               contentContainerStyle={styles.devScrollContent}

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -59,6 +59,8 @@ export default function StarSwarmScreen() {
   const [devPauseStraggler, setDevPauseStraggler] = useState(false);
   const [devDifficulty, setDevDifficulty] = useState<DifficultyTier>("LieutenantJG");
   const [devVolumes, setDevVolumes] = useState<SfxVolumes>(DEFAULT_SFX_VOLUMES);
+  const [devPlayerFireOff, setDevPlayerFireOff] = useState(false);
+  const [devEnemyFireOff, setDevEnemyFireOff] = useState(false);
 
   // Pre-game difficulty selector — shown before each new game
   const [difficulty, setDifficulty] = useState<DifficultyTier>("LieutenantJG");
@@ -220,7 +222,12 @@ export default function StarSwarmScreen() {
               scale={scale}
               difficulty={difficulty}
               resetTick={resetTick}
-              devOptions={lastDevOptsRef.current}
+              devOptions={__DEV__ ? {
+                ...lastDevOptsRef.current,
+                pauseStraggler: devPauseStraggler,
+                playerFireDisabled: devPlayerFireOff,
+                enemyFireDisabled: devEnemyFireOff,
+              } : undefined}
             />
             <Controls
               canvasRef={canvasRef}
@@ -289,161 +296,161 @@ export default function StarSwarmScreen() {
           </Modal>
         )}
 
-        {__DEV__ && (
-          <Modal
-            visible={devPanelOpen}
-            transparent
-            animationType="fade"
-            accessibilityViewIsModal
-            onRequestClose={() => setDevPanelOpen(false)}
-          >
-            <View style={styles.devOverlay}>
-              <View style={dynamicStyles.devPanel}>
-                <ScrollView
-                  showsVerticalScrollIndicator={false}
-                  contentContainerStyle={styles.devScrollContent}
+        {__DEV__ && devPanelOpen && (
+          <View style={dynamicStyles.devPanelOverlay}>
+            <ScrollView
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={styles.devScrollContent}
+            >
+              <Text style={dynamicStyles.devTitle}>DEV</Text>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Wave</Text>
+                <Pressable
+                  style={styles.devStepBtn}
+                  onPress={() => setDevWave((w) => Math.max(1, w - 1))}
+                  accessibilityLabel="Decrease wave"
                 >
-                  <Text style={dynamicStyles.devTitle}>Dev Panel</Text>
-
-                  <View style={styles.devRow}>
-                    <Text style={dynamicStyles.devLabel}>Wave</Text>
-                    <Pressable
-                      style={styles.devStepBtn}
-                      onPress={() => setDevWave((w) => Math.max(1, w - 1))}
-                      accessibilityLabel="Decrease wave"
-                    >
-                      <Text style={styles.devStepText}>−</Text>
-                    </Pressable>
-                    <Text style={styles.devValue}>{devWave}</Text>
-                    <Pressable
-                      style={styles.devStepBtn}
-                      onPress={() => setDevWave((w) => Math.min(15, w + 1))}
-                      accessibilityLabel="Increase wave"
-                    >
-                      <Text style={styles.devStepText}>+</Text>
-                    </Pressable>
-                  </View>
-
-                  <View style={styles.devRow}>
-                    <Text style={dynamicStyles.devLabel}>Infinite lives</Text>
-                    <Switch value={devInfiniteLives} onValueChange={setDevInfiniteLives} />
-                  </View>
-
-                  <View style={styles.devRow}>
-                    <Text style={dynamicStyles.devLabel}>Straggler AI</Text>
-                    <Switch value={devStragglerEnabled} onValueChange={setDevStragglerEnabled} />
-                  </View>
-
-                  <View style={styles.devRow}>
-                    <Text style={dynamicStyles.devLabel}>Pause straggler</Text>
-                    <Switch value={devPauseStraggler} onValueChange={setDevPauseStraggler} />
-                  </View>
-
-                  <Text style={dynamicStyles.devSectionHeader}>── Difficulty Tier ──</Text>
-
-                  <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    style={styles.devTierScroll}
-                    contentContainerStyle={styles.devTierScrollContent}
-                  >
-                    {DIFFICULTY_TIERS.map((tier) => (
-                      <Pressable
-                        key={tier}
-                        style={[
-                          styles.devTierBtn,
-                          devDifficulty === tier && styles.devTierBtnActive,
-                        ]}
-                        onPress={() => setDevDifficulty(tier)}
-                        accessibilityLabel={`Dev difficulty ${difficultyLabel(tier)}`}
-                      >
-                        <Text
-                          style={[
-                            styles.devTierText,
-                            devDifficulty === tier && styles.devTierTextActive,
-                          ]}
-                        >
-                          {difficultyLabel(tier)}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  </ScrollView>
-
-                  <Text style={dynamicStyles.devSectionHeader}>── Power-ups ──</Text>
-
-                  <View style={styles.devPowerUpRow}>
-                    {(["lightning", "shield", "buddy", "bomb"] as PowerUpType[]).map((type) => (
-                      <Pressable
-                        key={type}
-                        style={styles.devPowerUpBtn}
-                        onPress={() => handleTriggerPowerUp(type)}
-                        accessibilityLabel={`Trigger ${type} power-up`}
-                      >
-                        <Text style={styles.devPowerUpText}>{type}</Text>
-                      </Pressable>
-                    ))}
-                  </View>
-
-                  <Text style={dynamicStyles.devSectionHeader}>── Sound Mixer ──</Text>
-
-                  {(
-                    [
-                      ["Laser", "laser"],
-                      ["PU: Lightning", "poweruplightning"],
-                      ["PU: Shield", "powerupshield"],
-                      ["PU: Buddy", "powerupbuddy"],
-                      ["PU: Bomb", "powerupbomb"],
-                      ["Explosion", "explosion"],
-                      ["Player hit", "playerhit"],
-                      ["Wave clear", "waveclear"],
-                      ["Game over", "gameover"],
-                      ["Challenging", "challengingstage"],
-                      ["Perfect bonus", "perfectbonus"],
-                    ] as [string, keyof SfxVolumes][]
-                  ).map(([label, key]) => (
-                    <View key={key} style={styles.devRow}>
-                      <Text style={[dynamicStyles.devLabel, styles.devMixerLabel]}>{label}</Text>
-                      <Pressable
-                        style={styles.devStepBtn}
-                        onPress={() => adjustVolume(key, -0.1)}
-                        accessibilityLabel={`Decrease ${label} volume`}
-                      >
-                        <Text style={styles.devStepText}>−</Text>
-                      </Pressable>
-                      <Text style={styles.devValue}>{devVolumes[key].toFixed(1)}</Text>
-                      <Pressable
-                        style={styles.devStepBtn}
-                        onPress={() => adjustVolume(key, 0.1)}
-                        accessibilityLabel={`Increase ${label} volume`}
-                      >
-                        <Text style={styles.devStepText}>+</Text>
-                      </Pressable>
-                    </View>
-                  ))}
-
-                  <Pressable
-                    style={[styles.devActionBtn, dynamicStyles.devPrimary]}
-                    onPress={() => {
-                      setDevPanelOpen(false);
-                      handleNewGame({
-                        wave: devWave,
-                        infiniteLives: devInfiniteLives,
-                        stragglerEnabled: devStragglerEnabled,
-                        pauseStraggler: devPauseStraggler,
-                        difficulty: devDifficulty,
-                      });
-                    }}
-                  >
-                    <Text style={styles.devPrimaryText}>New Game</Text>
-                  </Pressable>
-
-                  <Pressable style={styles.devActionBtn} onPress={() => setDevPanelOpen(false)}>
-                    <Text style={dynamicStyles.devLabel}>Close</Text>
-                  </Pressable>
-                </ScrollView>
+                  <Text style={styles.devStepText}>−</Text>
+                </Pressable>
+                <Text style={styles.devValue}>{devWave}</Text>
+                <Pressable
+                  style={styles.devStepBtn}
+                  onPress={() => setDevWave((w) => Math.min(15, w + 1))}
+                  accessibilityLabel="Increase wave"
+                >
+                  <Text style={styles.devStepText}>+</Text>
+                </Pressable>
               </View>
-            </View>
-          </Modal>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Infinite lives</Text>
+                <Switch value={devInfiniteLives} onValueChange={setDevInfiniteLives} />
+              </View>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Straggler AI</Text>
+                <Switch value={devStragglerEnabled} onValueChange={setDevStragglerEnabled} />
+              </View>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Pause straggler</Text>
+                <Switch value={devPauseStraggler} onValueChange={setDevPauseStraggler} />
+              </View>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Player missiles off</Text>
+                <Switch value={devPlayerFireOff} onValueChange={setDevPlayerFireOff} />
+              </View>
+
+              <View style={styles.devRow}>
+                <Text style={dynamicStyles.devLabel}>Enemy missiles off</Text>
+                <Switch value={devEnemyFireOff} onValueChange={setDevEnemyFireOff} />
+              </View>
+
+              <Text style={dynamicStyles.devSectionHeader}>── Difficulty ──</Text>
+
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                style={styles.devTierScroll}
+                contentContainerStyle={styles.devTierScrollContent}
+              >
+                {DIFFICULTY_TIERS.map((tier) => (
+                  <Pressable
+                    key={tier}
+                    style={[
+                      styles.devTierBtn,
+                      devDifficulty === tier && styles.devTierBtnActive,
+                    ]}
+                    onPress={() => setDevDifficulty(tier)}
+                    accessibilityLabel={`Dev difficulty ${difficultyLabel(tier)}`}
+                  >
+                    <Text
+                      style={[
+                        styles.devTierText,
+                        devDifficulty === tier && styles.devTierTextActive,
+                      ]}
+                    >
+                      {difficultyLabel(tier)}
+                    </Text>
+                  </Pressable>
+                ))}
+              </ScrollView>
+
+              <Text style={dynamicStyles.devSectionHeader}>── Power-ups ──</Text>
+
+              <View style={styles.devPowerUpRow}>
+                {(["lightning", "shield", "buddy", "bomb"] as PowerUpType[]).map((type) => (
+                  <Pressable
+                    key={type}
+                    style={styles.devPowerUpBtn}
+                    onPress={() => handleTriggerPowerUp(type)}
+                    accessibilityLabel={`Trigger ${type} power-up`}
+                  >
+                    <Text style={styles.devPowerUpText}>{type}</Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              <Text style={dynamicStyles.devSectionHeader}>── Sound ──</Text>
+
+              {(
+                [
+                  ["Laser", "laser"],
+                  ["PU: Lightning", "poweruplightning"],
+                  ["PU: Shield", "powerupshield"],
+                  ["PU: Buddy", "powerupbuddy"],
+                  ["PU: Bomb", "powerupbomb"],
+                  ["Explosion", "explosion"],
+                  ["Player hit", "playerhit"],
+                  ["Wave clear", "waveclear"],
+                  ["Game over", "gameover"],
+                  ["Challenging", "challengingstage"],
+                  ["Perfect bonus", "perfectbonus"],
+                ] as [string, keyof SfxVolumes][]
+              ).map(([label, key]) => (
+                <View key={key} style={styles.devRow}>
+                  <Text style={[dynamicStyles.devLabel, styles.devMixerLabel]}>{label}</Text>
+                  <Pressable
+                    style={styles.devStepBtn}
+                    onPress={() => adjustVolume(key, -0.1)}
+                    accessibilityLabel={`Decrease ${label} volume`}
+                  >
+                    <Text style={styles.devStepText}>−</Text>
+                  </Pressable>
+                  <Text style={styles.devValue}>{devVolumes[key].toFixed(1)}</Text>
+                  <Pressable
+                    style={styles.devStepBtn}
+                    onPress={() => adjustVolume(key, 0.1)}
+                    accessibilityLabel={`Increase ${label} volume`}
+                  >
+                    <Text style={styles.devStepText}>+</Text>
+                  </Pressable>
+                </View>
+              ))}
+
+              <Pressable
+                style={[styles.devActionBtn, dynamicStyles.devPrimary]}
+                onPress={() => {
+                  setDevPanelOpen(false);
+                  handleNewGame({
+                    wave: devWave,
+                    infiniteLives: devInfiniteLives,
+                    stragglerEnabled: devStragglerEnabled,
+                    pauseStraggler: devPauseStraggler,
+                    difficulty: devDifficulty,
+                  });
+                }}
+              >
+                <Text style={styles.devPrimaryText}>New Game</Text>
+              </Pressable>
+
+              <Pressable style={styles.devActionBtn} onPress={() => setDevPanelOpen(false)}>
+                <Text style={dynamicStyles.devLabel}>Collapse</Text>
+              </Pressable>
+            </ScrollView>
+          </View>
         )}
       </View>
     </GameShell>
@@ -461,12 +468,6 @@ const baseStyles = StyleSheet.create({
     fontSize: 10,
     fontWeight: "700",
     letterSpacing: 1,
-  },
-  devOverlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.7)",
-    alignItems: "center",
-    justifyContent: "center",
   },
   devRow: {
     flexDirection: "row",
@@ -612,14 +613,18 @@ const getStyles = (colors: ReturnType<typeof useTheme>["colors"]) =>
       borderRadius: 4,
       zIndex: 100,
     },
-    devPanel: {
-      backgroundColor: colors.surfaceHigh,
-      borderRadius: 12,
-      padding: 24,
-      width: 300,
-      maxHeight: "80%",
-      borderWidth: 1,
-      borderColor: "rgba(255,128,0,0.5)",
+    devPanelOverlay: {
+      position: "absolute",
+      right: 0,
+      top: 0,
+      bottom: 0,
+      width: 180,
+      backgroundColor: "rgba(0,0,0,0.88)",
+      borderLeftWidth: 1,
+      borderLeftColor: "rgba(255,128,0,0.4)",
+      zIndex: 100,
+      paddingHorizontal: 10,
+      paddingVertical: 8,
     },
     devTitle: {
       color: "rgba(255,128,0,1)",


### PR DESCRIPTION
## Summary

- **#1314 Proportional aiming**: Replaces fixed `±0.175 px/ms` lateral deflection with `vx = (dx/dy) × BULLET_E_VY` so every aimed bullet travels to the player's exact x coordinate. Vertical speed (`vy`) is unchanged to preserve timing. Probability gate (`AIMED_SHOT_FRACTION` + wave ramp) still controls how often enemies aim vs. fire straight.
- **#1312 Inline dev panel**: Replaces the Modal overlay with a `position: absolute` right-edge panel (180 px wide, full height) that stays visible while the game runs. The existing toggle button expands/collapses it.
- **#1311 Missile toggles**: Two new Switch controls in the dev panel — "Player missiles off" and "Enemy missiles off" — propagate live via `devOptionsRef` without requiring New Game. Backed by `playerFireDisabled` / `enemyFireDisabled` fields on `StarSwarmState`.
- **#1310 Shield-ring hit flash**: Non-lethal Elite/Boss hits now render an animated cyan ring burst (expanding radius, fading alpha, 250 ms) instead of a white rectangle. Standard AABB collision used for all tiers — no hitbox expansion needed since AABB already fires when the bullet first touches the sprite boundary.

## Test plan

- [ ] Wave 1: shoot an Elite (2 HP) — first hit shows cyan ring burst, second hit destroys it
- [ ] Wave 1: shoot a Boss from safety — ring appears on non-lethal hits, explosion on final hit
- [ ] Dev panel opens inline without covering the full canvas; game remains playable behind it
- [ ] Toggle "Player missiles off" mid-game — player can no longer fire; toggle back restores fire
- [ ] Toggle "Enemy missiles off" mid-game — no new enemy bullets; existing ones still travel
- [ ] Enemy bullets track closer to center at wave 3+ (especially enemies at extreme X positions)
- [ ] All 849 engine unit tests pass (`cd frontend && npx jest engine.test --no-coverage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)