### PR TITLE
docs: add Windows PowerShell setup steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Two terminals from the repo root.
 
 First time (or when `requirements.txt` changes):
 
+**Mac/Linux:**
 ```bash
 cd backend
 python3.13 -m venv .venv
@@ -29,11 +30,30 @@ pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
+**Windows (PowerShell):**
+```powershell
+cd backend
+python3.13 -m venv .venv
+.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+> If PowerShell blocks the `.ps1` script, run once: `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+
 Every time:
 
+**Mac/Linux:**
 ```bash
 cd backend
 source .venv/bin/activate
+python -m uvicorn main:app --reload   # http://localhost:8000
+```
+
+**Windows (PowerShell):**
+```powershell
+cd backend
+.venv\Scripts\Activate.ps1
 python -m uvicorn main:app --reload   # http://localhost:8000
 ```
 
@@ -79,6 +99,7 @@ Backend is hosted on Render — see [`docs/RENDER.md`](docs/RENDER.md).
 
 **`pip install -r requirements.txt` fails building `pydantic-core`** — your venv is using Python 3.14. Recreate it with 3.13:
 
+**Mac/Linux:**
 ```bash
 deactivate
 rm -rf backend/.venv
@@ -86,4 +107,14 @@ python3.13 -m venv backend/.venv
 source backend/.venv/bin/activate
 pip install --upgrade pip
 pip install -r backend/requirements.txt
+```
+
+**Windows (PowerShell):**
+```powershell
+deactivate
+Remove-Item -Recurse -Force backend\.venv
+python3.13 -m venv backend\.venv
+backend\.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r backend\requirements.txt
 ```


### PR DESCRIPTION
## Summary
- Added Windows PowerShell equivalents alongside Mac/Linux bash commands in the **Running Locally** section
- Covers venv creation, activation, and running the backend
- Added a note about unblocking `.ps1` scripts via `Set-ExecutionPolicy`
- Added Windows PowerShell steps to the **Troubleshooting** section for the pydantic-core build failure

## Test plan
- [ ] Verify Mac/Linux steps still render correctly in GitHub
- [ ] Verify Windows PowerShell steps are accurate and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)