### PR TITLE
fix(daily-word): black screen flash on flip + rate limit too tight (#1306, #1307)

### DIFF
--- a/backend/daily_word/router.py
+++ b/backend/daily_word/router.py
@@ -2,8 +2,10 @@
 
 Rate limits:
   GET /today   — 60/minute (IP-keyed, no auth)
-  POST /guess  — 6/hour keyed by f"{session_id}:{puzzle_id}" (compound key
-                 isolates by puzzle so the limit resets naturally each new day)
+  POST /guess  — 20/hour keyed by f"{session_id}:{puzzle_id}" (compound key
+                 isolates by puzzle so the limit resets naturally each new day;
+                 20/hour gives 6 real guesses + room for invalid-word attempts
+                 and network retries without blocking a legitimate game)
 """
 
 from __future__ import annotations
@@ -101,7 +103,7 @@ async def get_today(
 
 
 @router.post("/guess")
-@limiter.limit("6/hour", key_func=_guess_key)
+@limiter.limit("20/hour", key_func=_guess_key)
 async def post_guess(request: Request, body: GuessRequest) -> dict:
     get_session_id(request)
 

--- a/backend/tests/test_daily_word_api.py
+++ b/backend/tests/test_daily_word_api.py
@@ -255,7 +255,7 @@ def test_brute_force_rate_limited(client: TestClient) -> None:
     headers = _sid_headers()
     puzzle_id = _today_puzzle_id()
 
-    for _ in range(6):
+    for _ in range(20):
         r = client.post(
             "/daily-word/guess",
             headers=headers,
@@ -263,12 +263,12 @@ def test_brute_force_rate_limited(client: TestClient) -> None:
         )
         assert r.status_code == 200
 
-    r7 = client.post(
+    r21 = client.post(
         "/daily-word/guess",
         headers=headers,
         json={"puzzle_id": puzzle_id, "guess": "crane", "tz_offset_minutes": 0},
     )
-    assert r7.status_code == 429
+    assert r21.status_code == 429
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -163,7 +163,13 @@ function WordTile({
     transform: [{ rotateY: `${rotation.value}deg` }],
   }));
 
-  const bg = TILE_STATUS_COLORS[visibleStatus];
+  // During the first half of the flip, visibleStatus is still "tbd" (transparent).
+  // A transparent background rotates against the dark screen and causes a black
+  // compositing artifact on web. Use a solid surface color while flipping instead.
+  const bg =
+    isFlipping && (visibleStatus === "tbd" || visibleStatus === "empty")
+      ? (colors.surface ?? "#1a1a1b")
+      : TILE_STATUS_COLORS[visibleStatus];
   const hasBorder = visibleStatus === "empty" || visibleStatus === "tbd";
   const borderColor = letter ? colors.textMuted : colors.border;
 
@@ -779,9 +785,17 @@ export default function DailyWordScreen() {
   const stateRef = useRef<DailyWordState | null>(null);
   stateRef.current = state;
 
+  const lastSubmitMsRef = useRef<number>(0);
+
   const onSubmit = useCallback(async () => {
     const s = stateRef.current;
     if (!s || submitting || s.is_complete) return;
+
+    // Debounce rapid double-taps (e.g. two Enter presses within 500 ms) so they
+    // don't consume a rate-limit slot without advancing the game.
+    const now = Date.now();
+    if (now - lastSubmitMsRef.current < 500) return;
+    lastSubmitMsRef.current = now;
 
     const row = s.rows[s.current_row];
     if (!row) return;
@@ -931,13 +945,19 @@ export default function DailyWordScreen() {
           </View>
         )}
 
-        {/* Keyboard */}
-        {state !== null && !state.is_complete && (
-          <WordKeyboard
-            keyboardState={state.keyboard_state}
-            language={language}
-            onKey={handleKey}
-          />
+        {/* Keyboard — always rendered to prevent layout jump during flip animation;
+            hidden via opacity + pointerEvents once game is complete */}
+        {state !== null && (
+          <View
+            style={{ opacity: state.is_complete ? 0 : 1 }}
+            pointerEvents={state.is_complete ? "none" : "auto"}
+          >
+            <WordKeyboard
+              keyboardState={state.keyboard_state}
+              language={language}
+              onKey={handleKey}
+            />
+          </View>
         )}
 
         {/* Loading indicator during submit */}
@@ -1030,7 +1050,7 @@ export default function DailyWordScreen() {
                     </Pressable>
                     <Text style={styles.devWarningText}>
                       {
-                        "Resets local board only — backend rate limit (6/hr per session+puzzle) still applies"
+                        "Resets local board only — backend rate limit (20/hr per session+puzzle) still applies"
                       }
                     </Text>
                   </>


### PR DESCRIPTION
## Summary

- **#1306** — Fixes a 1–2 s black flash after submitting a guess in Daily Word
- **#1307** — Raises the per-session rate limit so players can always complete a 6-guess game

## #1306 — Black screen flash on guess submit

Three overlapping causes, all fixed:

- **Layout jump (main cause):** `<WordKeyboard>` was unmounting on `is_complete` while the flip animation was still playing. With `justifyContent: "space-between"` in the body, removing the keyboard immediately redistributed the layout, causing the lower half of the screen to shift/black out. Fix: keep the keyboard in the layout tree with `opacity: 0` + `pointerEvents="none"` when the game is complete so the layout stays stable through the animation.
- **Tile compositing artifact:** During the first half of the Y-axis flip, `visibleStatus` is still `"tbd"` → `backgroundColor: "transparent"`. Rotating a transparent element against the dark screen background causes a black compositing artifact on web. Fix: use `colors.surface` (solid) as the background while flipping instead of transparent.
- **Submit debounce:** Rapid double-taps of Enter could dispatch two identical requests before the `submitting` flag was set, consuming an extra rate-limit slot. Fix: 500 ms debounce via a ref in `onSubmit`.

## #1307 — Rate limit fires after ~3 guesses

- **Backend:** `POST /guess` limit raised from `6/hour` → `20/hour`. The original 6/hour budget equalled the maximum legitimate guess count, so any invalid-word 422 or network retry silently consumed a slot and could block a player before their 6th guess. 20/hour gives a full game plus room for invalid-word attempts and retries while still blocking automated abuse.
- **Test updated:** `test_brute_force_rate_limited` now sends 20 successful requests before asserting 429 on the 21st.
- **Dev panel:** warning text updated to reflect the new limit.

## Test plan

- [ ] Submit a valid word on the last guess row — no black flash, layout stays stable during flip
- [ ] Rapid double-tap Enter — only one request fires per 500 ms window
- [ ] Submit 6+ invalid words in a session — no premature rate-limit error
- [ ] Backend pytest suite passes (`test_daily_word_api.py`)

Closes #1306, closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)