### PR TITLE
fix(freecell): use softer solitaire invalid-move sound (#1304)

### DIFF
--- a/frontend/src/game/_shared/sounds.ts
+++ b/frontend/src/game/_shared/sounds.ts
@@ -8,7 +8,7 @@
 //   blackjack-win.ogg      → blackjack.win, solitaire.foundationComplete
 //   cascade-game-over.ogg  → cascade.gameOver, mahjong.deadlock, twenty48.gameOver
 //   starswarm-waveclear.ogg → starswarm.waveclear, starswarm.bonuslife, cascade.cascadeCombo
-//   solitaire-invalid-move.ogg → solitaire.invalidMove, sudoku.errorEntered
+//   solitaire-invalid-move.ogg → solitaire.invalidMove, sudoku.errorEntered, freecell.invalidMove
 export type SoundKey = string;
 
 // Metro resolves require() at bundle time so assets must be static literals.
@@ -130,7 +130,7 @@ export const SOUND_REGISTRY: Partial<Record<SoundKey, number>> = {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "freecell.gameWin": require("../../../assets/sounds/freecell-game-win.mp3"),
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  "freecell.invalidMove": require("../../../assets/sounds/freecell-invalid-move.mp3"),
+  "freecell.invalidMove": require("../../../assets/sounds/solitaire-invalid-move.ogg"),
   // Sort (#1265, #1268)
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   "sort.pour": require("../../../assets/sounds/cascade-fruit-merge.ogg"),


### PR DESCRIPTION
## Summary

- Repoints `freecell.invalidMove` in `sounds.ts` to `solitaire-invalid-move.ogg` (the same asset used by `solitaire.invalidMove` and `sudoku.errorEntered`)
- Updates the shared-asset comment to include `freecell.invalidMove`
- No changes to `FreeCellBoard.tsx` or any game logic

Closes #1304

## Test plan

- [ ] Make an illegal move in FreeCell — confirm the sound is the softer solitaire tone, not the old harsh mp3
- [ ] Confirm Solitaire and Sudoku invalid-move sounds are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)