### PR TITLE
fix(yacht): replace Unicode die glyphs with emoji dice (#1303)

### DIFF
--- a/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
+++ b/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
@@ -17,8 +17,8 @@ interface Props {
   variant?: "yacht" | "joker";
 }
 
-// Die face characters scattered around the badge
-const DIE_FACES = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅", "⚅", "⚄"] as const;
+// Emoji dice scattered around the badge (emoji layer renders consistently on all platforms)
+const DIE_FACES = ["🎲", "🎲", "🎲", "🎲", "🎲", "🎲", "🎲", "🎲"] as const;
 const FACE_OFFSETS = [
   { x: -110, y: -110 },
   { x: 110, y: -110 },


### PR DESCRIPTION
## Summary

- Replaces the `DIE_FACES` array in `YachtCelebrationAnimation.tsx` with `"🎲"` emoji instead of Unicode die-face characters (⚀–⚅)
- The Unicode block U+2680–U+2685 is not reliably supported by default system fonts on all iOS/Android versions, causing visible dots/boxes around the YACHT! banner
- Emoji dice use the emoji presentation layer which renders consistently on all modern platforms

## Test plan

- [ ] Score a Yacht (five of a kind) — YACHT! banner appears with 🎲 emoji scattered around it, no glitchy dots or artifacts
- [ ] Score a Joker — JOKER! banner works the same way
- [ ] Verify on both iOS and Android (or simulator) that emoji dice are clearly legible

Closes #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)