### PR TITLE
fix(starswarm): replace JSX Fragment with Group in hit flash render

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -444,7 +444,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                       const r = refR * (0.6 + 0.5 * progress);
                       const a = enemy.hitFlashTimer / HIT_FLASH_DURATION; // 1→0 as burst plays
                       return (
-                        <>
+                        <Group>
                           <Circle
                             cx={enemy.x}
                             cy={enemy.y}
@@ -460,7 +460,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                             style="stroke"
                             strokeWidth={2}
                           />
-                        </>
+                        </Group>
                       );
                     })()}
                 </Group>


### PR DESCRIPTION
## Summary
- Non-lethal hits on Elite/Boss enemies were showing a red square instead of the intended blue shield-ring burst animation
- Root cause: the hit flash renderer used a React Fragment (`<>`) to group two `Circle` elements, but the Skia canvas renderer doesn't support fragments — `Group` is the only valid multi-element container inside a Skia canvas
- Fix: swapped `<>...</>` for `<Group>...</Group>` (already imported) in `GameCanvas.tsx`

## Test plan
- [ ] Hit an Elite enemy (2 HP) with one shot — should show expanding blue ring burst, not a red square
- [ ] Hit a Boss enemy with a non-lethal shot — same blue ring burst
- [ ] Confirm Grunt kills (always lethal, no flash) are unaffected
- [ ] Confirm the existing player shield aura still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)