### PR TITLE
feat(cascade): game-over hysteresis + CCD analysis (CASCADE-PHYS-07/08)

### DIFF
--- a/frontend/src/game/cascade/__tests__/engine.native.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.native.test.ts
@@ -11,9 +11,13 @@ import {
   MATTER_POSITION_ITERATIONS,
   MATTER_VELOCITY_ITERATIONS,
   MAX_FRUIT_SPEED_PX_S,
+  FIXED_STEP_MS,
+  WALL_THICKNESS,
   SPAWN_GRACE_TICKS,
   COLLISION_GROUP_DYNAMIC,
   COLLISION_GROUP_WALL,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
 } from "../engine.shared";
 import { FRUIT_SETS, FruitSet, FruitDefinition } from "../../../theme/fruitSets";
 
@@ -212,16 +216,20 @@ describe("game over", () => {
     const tier0 = fruit(0);
     handle.drop(tier0, "fruits", W / 2, 50);
 
-    // Step once so the fruit exists in the world
-    handle.step(1 / 60);
-
     // Advance time past the grace period (3000ms)
     (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
 
-    // Step again — game over should fire since the fruit is above the danger line
-    const { events } = handle.step(1 / 60);
+    // Hysteresis requires GAME_OVER_CONSECUTIVE_TICKS consecutive ticks above the line.
+    // Use tiny dt so physics doesn't advance (fruit stays at y=50 throughout).
+    let fired = false;
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step(1e-7).events.some((e) => e.type === "gameOver")) {
+        fired = true;
+        break;
+      }
+    }
 
-    expect(events.some((e) => e.type === "gameOver")).toBe(true);
+    expect(fired).toBe(true);
     handle.cleanup();
   });
 });
@@ -341,15 +349,185 @@ describe("game-over detection — extended", () => {
 
     const handle = await buildEngine();
     handle.drop(fruit(0), "fruits", W / 2, 50);
-    handle.step(1 / 60);
 
     (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
     let gameOverCount = 0;
-    gameOverCount += handle.step(1 / 60).events.filter((e) => e.type === "gameOver").length;
-    gameOverCount += handle.step(1 / 60).events.filter((e) => e.type === "gameOver").length;
-    gameOverCount += handle.step(1 / 60).events.filter((e) => e.type === "gameOver").length;
+    // Run well past the 30-tick threshold with frozen physics; gameOver must fire exactly once.
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 30; i++) {
+      gameOverCount += handle.step(1e-7).events.filter((e) => e.type === "gameOver").length;
+    }
 
     expect(gameOverCount).toBe(1);
+    handle.cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Game-over hysteresis (CASCADE-PHYS-07) — Matter.js engine
+// ---------------------------------------------------------------------------
+// Tiny dt (1e-7 s) is used so physics sub-steps don't execute
+// (remainingMs < 0.01 ms threshold), keeping body positions frozen
+// while still advancing game-tick counters.
+
+describe("game-over hysteresis", () => {
+  // dangerY = H * 0.18 = 108px; tier-0 top = y - 18; above line when y < 126.
+
+  it("single tick above danger does not fire gameOver", async () => {
+    const fakeNow = Date.now();
+    jest.spyOn(Date, "now").mockReturnValue(fakeNow);
+    const handle = await buildEngine();
+    handle.drop(fruit(0), "fruits", W / 2, 50);
+
+    (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
+    const { events } = handle.step(1e-7); // physics frozen
+
+    expect(events.some((e) => e.type === "gameOver")).toBe(false);
+    handle.cleanup();
+  });
+
+  it("30 consecutive ticks above danger fires gameOver on the 30th", async () => {
+    const fakeNow = Date.now();
+    jest.spyOn(Date, "now").mockReturnValue(fakeNow);
+    const handle = await buildEngine();
+    handle.drop(fruit(0), "fruits", W / 2, 50);
+
+    (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
+    let firedAt = -1;
+    for (let i = 1; i <= GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step(1e-7).events.some((e) => e.type === "gameOver")) {
+        firedAt = i;
+        break;
+      }
+    }
+
+    expect(firedAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+    handle.cleanup();
+  });
+
+  it("counter resets when fruit drops below danger line", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const fakeNow = Date.now();
+    jest.spyOn(Date, "now").mockReturnValue(fakeNow);
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    handle.drop(fruit(0), "fruits", W / 2, 50);
+    (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
+
+    const getDynamic = () =>
+      Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+
+    // 15 ticks above danger — dangerTicksAbove=15; not enough to fire (need 30)
+    const halfThreshold = 15;
+    for (let i = 0; i < halfThreshold; i++) {
+      expect(handle.step(1e-7).events.some((e) => e.type === "gameOver")).toBe(false);
+    }
+
+    // Move below danger line (y=400, top=382 > 108) — counter resets to 0
+    const fruitBody = getDynamic()[0]!;
+    Matter.Body.setPosition(fruitBody, { x: W / 2, y: 400 });
+    handle.step(1e-7);
+
+    // Move back above danger line
+    Matter.Body.setPosition(fruitBody, { x: W / 2, y: 50 });
+
+    // Needs a full 30 consecutive ticks from the reset (not just 15 more)
+    let firedAt = -1;
+    for (let i = 1; i <= GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step(1e-7).events.some((e) => e.type === "gameOver")) {
+        firedAt = i;
+        break;
+      }
+    }
+
+    expect(firedAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+    handle.cleanup();
+  });
+
+  it("merge in last 90 ticks suppresses gameOver even after 30 consecutive ticks above", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const fakeNow = Date.now();
+    jest.spyOn(Date, "now").mockReturnValue(fakeNow);
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    // Dangerous fruit above danger line
+    handle.drop(fruit(0), "fruits", W / 2, 50);
+    // Merge pair — same tier, positioned away from danger zone
+    handle.drop(fruit(0), "fruits", W / 4, 300);
+    handle.drop(fruit(0), "fruits", W / 4 + 1, 300);
+
+    (Date.now as jest.Mock).mockReturnValue(fakeNow + 5000);
+
+    const getDynamic = () =>
+      Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+
+    // 29 ticks above danger — dangerTicksAbove=29
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS - 1; i++) handle.step(1e-7);
+
+    // Inject a synthetic merge between the pair → resets ticksSinceLastMerge to 0
+    const allDynamic = getDynamic();
+    const mergeBodyA = allDynamic.find((b) => Math.abs(b.position.y - 300) < 20)!;
+    const mergeBodyB = allDynamic.find((b) => b !== mergeBodyA && Math.abs(b.position.y - 300) < 20)!;
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: mergeBodyA, bodyB: mergeBodyB }],
+    });
+
+    // This step processes the merge: dangerTicksAbove=30, ticksSinceLastMerge=0
+    // 30 >= 30 but 0 < 90 → must NOT fire
+    const { events: mergeStep } = handle.step(1e-7);
+    expect(mergeStep.some((e) => e.type === "gameOver")).toBe(false);
+    expect(mergeStep.some((e) => e.type === "fruitMerge")).toBe(true);
+
+    // 89 more steps — ticksSinceLastMerge climbs to 89; still suppressed
+    for (let i = 0; i < GAME_OVER_MERGE_COOLDOWN_TICKS - 1; i++) {
+      expect(handle.step(1e-7).events.some((e) => e.type === "gameOver")).toBe(false);
+    }
+
+    // Final step: ticksSinceLastMerge=90 >= cooldown → fires
+    const { events: finalStep } = handle.step(1e-7);
+    expect(finalStep.some((e) => e.type === "gameOver")).toBe(true);
+    handle.cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CCD analysis (CASCADE-PHYS-08)
+// ---------------------------------------------------------------------------
+
+describe("CCD analysis", () => {
+  it("tier-0 fruit cannot tunnel wall in one sub-step at MAX_FRUIT_SPEED_PX_S", () => {
+    // Arithmetic assertion: max travel per 1/60 sub-step must be < WALL_THICKNESS.
+    // tier-0 radius = 18px (smallest fruit); WALL_THICKNESS = 16px.
+    const maxTravelPerStep = (MAX_FRUIT_SPEED_PX_S * FIXED_STEP_MS) / 1000;
+    expect(maxTravelPerStep).toBeLessThan(WALL_THICKNESS);
+  });
+
+  it("fruit at terminal velocity does not escape through floor in one step", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    const tier0 = fruit(0);
+    // Place fruit just above the floor boundary
+    const innerBottom = H - WALL_THICKNESS - tier0.radius;
+    handle.drop(tier0, "fruits", W / 2, innerBottom - 1);
+    handle.step(1 / 60); // register body
+
+    const fruitBody = Matter.Composite.allBodies(engineInstance.world).filter(
+      (b) => !b.isStatic
+    )[0];
+    if (!fruitBody) throw new Error("Expected fruit body");
+
+    // Set velocity to exactly terminal speed downward
+    const maxVelPerStep = (MAX_FRUIT_SPEED_PX_S * FIXED_STEP_MS) / 1000;
+    Matter.Body.setVelocity(fruitBody, { x: 0, y: maxVelPerStep });
+    Matter.Body.setPosition(fruitBody, { x: W / 2, y: innerBottom - 1 });
+
+    handle.step(1 / 60);
+
+    // Fruit must remain within the floor boundary (velocity clamp + wall clamp ensure this)
+    expect(fruitBody.position.y).toBeLessThanOrEqual(innerBottom + 1); // 1px float tolerance
     handle.cleanup();
   });
 });

--- a/frontend/src/game/cascade/__tests__/engine.native.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.native.test.ts
@@ -468,7 +468,9 @@ describe("game-over hysteresis", () => {
     // Inject a synthetic merge between the pair → resets ticksSinceLastMerge to 0
     const allDynamic = getDynamic();
     const mergeBodyA = allDynamic.find((b) => Math.abs(b.position.y - 300) < 20)!;
-    const mergeBodyB = allDynamic.find((b) => b !== mergeBodyA && Math.abs(b.position.y - 300) < 20)!;
+    const mergeBodyB = allDynamic.find(
+      (b) => b !== mergeBodyA && Math.abs(b.position.y - 300) < 20
+    )!;
     Matter.Events.trigger(engineInstance, "collisionStart", {
       pairs: [{ bodyA: mergeBodyA, bodyB: mergeBodyB }],
     });

--- a/frontend/src/game/cascade/__tests__/engine.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.test.ts
@@ -23,6 +23,8 @@ import {
   RAPIER_SOLVER_ITERATIONS,
   MAX_FRUIT_SPEED_PX_S,
   SCALE,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
 } from "../engine.shared";
 import { FRUIT_SETS, FruitSet, FruitDefinition } from "../../../theme/fruitSets";
 import { MockWorld } from "../../../../__mocks__/@dimforge/rapier2d-compat";
@@ -289,10 +291,17 @@ describe("game-over detection", () => {
     // Advance time past the 3-second grace period
     jest.useFakeTimers();
     jest.setSystemTime(Date.now() + 3000);
-    const { events } = handle.step();
+    // Hysteresis requires GAME_OVER_CONSECUTIVE_TICKS (30) above the line before firing.
+    let fired = false;
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step().events.some((e) => e.type === "gameOver")) {
+        fired = true;
+        break;
+      }
+    }
     jest.useRealTimers();
 
-    expect(events.some((e) => e.type === "gameOver")).toBe(true);
+    expect(fired).toBe(true);
   });
 
   it("does NOT emit gameOver during the grace period", async () => {
@@ -325,14 +334,124 @@ describe("game-over detection", () => {
 
     jest.useFakeTimers();
     jest.setSystemTime(Date.now() + 3000);
-    const step1 = handle.step();
-    const step2 = handle.step(); // second step should not re-fire
+    let gameOverCount = 0;
+    // Run well past the 30-tick threshold; gameOver must fire exactly once.
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 30; i++) {
+      gameOverCount += handle.step().events.filter((e) => e.type === "gameOver").length;
+    }
     jest.useRealTimers();
 
-    const totalGameOverEvents =
-      step1.events.filter((e) => e.type === "gameOver").length +
-      step2.events.filter((e) => e.type === "gameOver").length;
-    expect(totalGameOverEvents).toBe(1);
+    expect(gameOverCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Game-over hysteresis (CASCADE-PHYS-07)
+// ---------------------------------------------------------------------------
+
+describe("game-over hysteresis", () => {
+  // dangerY = H * DANGER_LINE_RATIO = 108px. tier-0 top = y - 18; safe when y < 126.
+
+  it("single tick above danger does not fire gameOver", async () => {
+    const handle = await buildEngine();
+    handle.drop(fruit(0), fruitSet.id, 150, 50); // top = 32 < 108
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 5000); // past grace immediately
+    const { events } = handle.step();
+    jest.useRealTimers();
+
+    expect(events.some((e) => e.type === "gameOver")).toBe(false);
+  });
+
+  it("30 consecutive ticks above danger fires gameOver on the 30th", async () => {
+    const handle = await buildEngine();
+    handle.drop(fruit(0), fruitSet.id, 150, 50);
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 5000);
+    let firedAt = -1;
+    for (let i = 1; i <= GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step().events.some((e) => e.type === "gameOver")) {
+        firedAt = i;
+        break;
+      }
+    }
+    jest.useRealTimers();
+
+    expect(firedAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+  });
+
+  it("counter resets when fruit drops below danger line", async () => {
+    const handle = await buildEngine();
+    handle.drop(fruit(0), fruitSet.id, 150, 50); // body handle 0
+    const world = getWorld();
+    const body = world._bodies.get(0)!;
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 5000);
+
+    // 15 ticks above — dangerTicksAbove=15; not enough to fire (need 30)
+    const halfThreshold = 15;
+    for (let i = 0; i < halfThreshold; i++) {
+      expect(handle.step().events.some((e) => e.type === "gameOver")).toBe(false);
+    }
+
+    // Move below danger line (top = 282 > 108) — counter resets to 0
+    body._y = 3.0; // 300 px in physics units → 300/SCALE px
+    handle.step();
+
+    // Move back above danger line
+    body._y = 0.5; // 50 px
+
+    // Needs a full 30 consecutive ticks from the reset (not just 15 more)
+    let firedAt = -1;
+    for (let i = 1; i <= GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (handle.step().events.some((e) => e.type === "gameOver")) {
+        firedAt = i;
+        break;
+      }
+    }
+    jest.useRealTimers();
+
+    expect(firedAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+  });
+
+  it("merge in last 90 ticks suppresses gameOver even after 30 consecutive ticks above", async () => {
+    const handle = await buildEngine();
+    const world = getWorld();
+
+    // Dangerous fruit above danger line (body 0, collider 1003)
+    handle.drop(fruit(0), fruitSet.id, 150, 50);
+    // Merge pair — same tier, positioned away from danger zone (bodies 1-2, colliders 1004-1005)
+    handle.drop(fruit(0), fruitSet.id, 100, 300);
+    handle.drop(fruit(0), fruitSet.id, 110, 300);
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 5000);
+
+    // 29 ticks above danger — dangerTicksAbove=29, ticksSinceLastMerge well above cooldown
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS - 1; i++) handle.step();
+
+    // Trigger a merge between the pair → resets ticksSinceLastMerge to 0
+    world._fireCollision(1004, 1005);
+
+    // This step processes the merge: dangerTicksAbove=30, ticksSinceLastMerge=0
+    // 30 >= 30 but 0 < 90 → must NOT fire
+    const { events: mergeStep } = handle.step();
+    expect(mergeStep.some((e) => e.type === "gameOver")).toBe(false);
+    expect(mergeStep.some((e) => e.type === "fruitMerge")).toBe(true);
+
+    // 89 more steps — ticksSinceLastMerge climbs to 89; still suppressed
+    for (let i = 0; i < GAME_OVER_MERGE_COOLDOWN_TICKS - 1; i++) {
+      expect(handle.step().events.some((e) => e.type === "gameOver")).toBe(false);
+    }
+
+    // Final step: ticksSinceLastMerge=90 >= cooldown → fires
+    const { events: finalStep } = handle.step();
+    jest.useRealTimers();
+
+    expect(finalStep.some((e) => e.type === "gameOver")).toBe(true);
   });
 });
 

--- a/frontend/src/game/cascade/__tests__/engineSimulation.test.ts
+++ b/frontend/src/game/cascade/__tests__/engineSimulation.test.ts
@@ -24,7 +24,7 @@ const _engine: typeof import("../engine") = require(
 /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 const { createEngine } = _engine;
 import type { EngineHandle } from "../engine.shared";
-import { FIXED_STEP_MS } from "../engine.shared";
+import { FIXED_STEP_MS, GAME_OVER_CONSECUTIVE_TICKS } from "../engine.shared";
 import { scoreForMerge } from "../scoring";
 import { FRUIT_SETS, FruitSet, FruitDefinition } from "../../../theme/fruitSets";
 import { MockWorld } from "../../../../__mocks__/@dimforge/rapier2d-compat";
@@ -300,10 +300,17 @@ describe("game-over with multiple fruits above the danger line", () => {
 
     jest.useFakeTimers();
     jest.setSystemTime(Date.now() + 3001);
-    const { events } = handle.step();
+
+    // Hysteresis requires GAME_OVER_CONSECUTIVE_TICKS consecutive ticks above the danger
+    // line — advance enough steps to satisfy it, then verify exactly one gameOver fires.
+    const gameOverEvents: ReturnType<typeof handle.step>["events"] = [];
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      const { events } = handle.step();
+      gameOverEvents.push(...events.filter((e) => e.type === "gameOver"));
+    }
     jest.useRealTimers();
 
-    expect(events.filter((e) => e.type === "gameOver")).toHaveLength(1);
+    expect(gameOverEvents).toHaveLength(1);
   });
 
   it("emits gameOver only once even after additional steps", async () => {
@@ -314,7 +321,8 @@ describe("game-over with multiple fruits above the danger line", () => {
     jest.useFakeTimers();
     jest.setSystemTime(Date.now() + 3001);
     let totalGameOver = 0;
-    for (let i = 0; i < 5; i++) {
+    // Run well past the 30-tick threshold; gameOver must fire exactly once.
+    for (let i = 0; i < GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
       totalGameOver += handle.step().events.filter((e) => e.type === "gameOver").length;
     }
     jest.useRealTimers();

--- a/frontend/src/game/cascade/__tests__/physics-parity.test.ts
+++ b/frontend/src/game/cascade/__tests__/physics-parity.test.ts
@@ -33,6 +33,8 @@ import {
   SPAWN_GRACE_TICKS,
   COLLISION_GROUP_DYNAMIC,
   COLLISION_GROUP_WALL,
+  WALL_THICKNESS,
+  GAME_OVER_CONSECUTIVE_TICKS,
 } from "../engine.shared";
 
 const RAPIER_MOCK = require("@dimforge/rapier2d-compat").default; // eslint-disable-line @typescript-eslint/no-require-imports
@@ -419,6 +421,79 @@ describe("spawn grace parity — both engines apply and expire grace on the same
     expect(restoredBody).toBeDefined();
     expect(restoredBody!.collisionFilter.mask & COLLISION_GROUP_DYNAMIC).not.toBe(0);
 
+    handle.cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Game-over hysteresis parity (CASCADE-PHYS-07)
+// ---------------------------------------------------------------------------
+
+describe("game-over hysteresis parity — both engines fire gameOver on same tick", () => {
+  it("both engines fire gameOver on tick 30 after 30 consecutive ticks above danger line", async () => {
+    const rapierHandle = await createRapierEngine(W, H, fruitSet);
+    const nativeHandle = await createNativeEngine(W, H, fruitSet);
+
+    // Drop tier-0 at y=50; top = 50-18 = 32 < dangerY (108) → above danger line
+    rapierHandle.drop(fruit(0), fruitSet.id, W / 2, 50);
+    nativeHandle.drop(fruit(0), fruitSet.id, W / 2, 50);
+
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.now() + 5000); // past grace for both engines
+
+    let rapierFiredAt = -1;
+    let nativeFiredAt = -1;
+
+    for (let i = 1; i <= GAME_OVER_CONSECUTIVE_TICKS + 5; i++) {
+      if (rapierFiredAt === -1) {
+        if (rapierHandle.step().events.some((e) => e.type === "gameOver")) rapierFiredAt = i;
+      }
+      if (nativeFiredAt === -1) {
+        // Tiny dt keeps Matter.js body frozen at y=50 (no physics advancement)
+        if (nativeHandle.step(1e-7).events.some((e) => e.type === "gameOver")) nativeFiredAt = i;
+      }
+    }
+
+    jest.useRealTimers();
+    nativeHandle.cleanup();
+
+    expect(rapierFiredAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+    expect(nativeFiredAt).toBe(GAME_OVER_CONSECUTIVE_TICKS);
+    expect(rapierFiredAt).toBe(nativeFiredAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wall containment parity (CASCADE-PHYS-08)
+// ---------------------------------------------------------------------------
+
+describe("wall containment parity — no fruit escapes through left or right wall in 600 frames", () => {
+  const tier0Radius = fruit(0).radius;
+  const innerLeft = WALL_THICKNESS + tier0Radius;
+  const innerRight = W - WALL_THICKNESS - tier0Radius;
+
+  it("Rapier: x stays within wall bounds", async () => {
+    const handle = await createRapierEngine(W, H, fruitSet);
+    handle.drop(fruit(0), fruitSet.id, W / 2, 100);
+    for (let i = 0; i < 600; i++) {
+      const { snapshots } = handle.step();
+      for (const snap of snapshots) {
+        expect(snap.x).toBeGreaterThanOrEqual(innerLeft - 1);
+        expect(snap.x).toBeLessThanOrEqual(innerRight + 1);
+      }
+    }
+  });
+
+  it("Matter.js: x stays within wall bounds", async () => {
+    const handle = await createNativeEngine(W, H, fruitSet);
+    handle.drop(fruit(0), fruitSet.id, W / 2, 100);
+    for (let i = 0; i < 600; i++) {
+      const { snapshots } = handle.step(1 / 60);
+      for (const snap of snapshots) {
+        expect(snap.x).toBeGreaterThanOrEqual(innerLeft - 1);
+        expect(snap.x).toBeLessThanOrEqual(innerRight + 1);
+      }
+    }
     handle.cleanup();
   });
 });

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -9,6 +9,8 @@ export {
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
   GAME_OVER_GRACE_MS,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   FRUIT_DENSITY,
@@ -36,6 +38,8 @@ import {
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
   GAME_OVER_GRACE_MS,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   FIXED_STEP_MS,
@@ -104,6 +108,8 @@ export async function createEngine(
 
   const dangerY = H * DANGER_LINE_RATIO;
   let gameOverFired = false;
+  let dangerTicksAbove = 0;
+  let ticksSinceLastMerge = GAME_OVER_MERGE_COOLDOWN_TICKS;
 
   // mergeQueue carries [idA, idB, snapshotTier] — tier is snapshotted at enqueue time
   // so processMerges can re-verify it (mirrors the Rapier engine's guard).
@@ -228,9 +234,11 @@ export async function createEngine(
       if (tier < 10) {
         const nextDef = fruitSet.fruits[(tier + 1) as FruitTier];
         if (nextDef !== undefined) {
-          // Clamp spawn to valid physics bounds so the merged body never
-          // starts inside a wall (which causes Matter.js corrective impulses
-          // that can shoot the fruit through the wall — no CCD for dynamic bodies).
+          // Clamp spawn to valid physics bounds so the merged body never starts inside a wall.
+          // CASCADE-PHYS-08 analysis: Matter.js has no CCD for dynamic bodies.
+          //   tier-0 radius=18 px, MAX_FRUIT_SPEED_PX_S=900 px/s → max travel per 1/60 sub-step = 15 px
+          //   WALL_THICKNESS=16 px → 15 px < 16 px → sub-stepping alone is geometrically sufficient.
+          // Outcome C chosen: MAX_FRUIT_SPEED_PX_S lowered 1200→900 to keep max travel below wall thickness.
           const innerLeft = WALL_THICKNESS + nextDef.radius;
           const innerRight = W - WALL_THICKNESS - nextDef.radius;
           const spawnX = Math.max(innerLeft, Math.min(innerRight, midX));
@@ -273,15 +281,18 @@ export async function createEngine(
       const mergesThisStep = mergeQueue.length;
       processMerges(events);
 
+      // Cascade combo and merge-cooldown tracking.
       if (mergesThisStep > 0) {
         comboMergeCount += mergesThisStep;
         if (!comboFired && comboMergeCount >= COMBO_THRESHOLD) {
           events.push({ type: "cascadeCombo", count: comboMergeCount });
           comboFired = true;
         }
+        ticksSinceLastMerge = 0;
       } else {
         comboMergeCount = 0;
         comboFired = false;
+        ticksSinceLastMerge++;
       }
 
       // Single allBodies snapshot shared by grace-tick, velocity-clamp, and wall-clamp below.
@@ -362,21 +373,28 @@ export async function createEngine(
         });
       }
 
-      // Game-over detection
+      // Game-over: requires GAME_OVER_CONSECUTIVE_TICKS consecutive ticks above the danger line
+      // AND no merge in the last GAME_OVER_MERGE_COOLDOWN_TICKS ticks.
       if (!gameOverFired) {
         const now = Date.now();
+        let anyAbove = false;
         fruitMap.forEach((fb, bodyId) => {
-          if (gameOverFired || fb.isMerging) return;
+          if (anyAbove || fb.isMerging) return;
           if (now - fb.createdAt < GAME_OVER_GRACE_MS) return;
-          const bodies = Matter.Composite.allBodies(world);
-          const body = bodies.find((b) => b.id === bodyId);
+          const body = allBodiesPostMerge.find((b) => b.id === bodyId);
           if (!body) return;
           const topY = body.position.y - fb.fruitRadius;
-          if (topY < dangerY) {
-            gameOverFired = true;
-            events.push({ type: "gameOver" });
-          }
+          if (topY < dangerY) anyAbove = true;
         });
+        if (anyAbove) dangerTicksAbove++;
+        else dangerTicksAbove = 0;
+        if (
+          dangerTicksAbove >= GAME_OVER_CONSECUTIVE_TICKS &&
+          ticksSinceLastMerge >= GAME_OVER_MERGE_COOLDOWN_TICKS
+        ) {
+          gameOverFired = true;
+          events.push({ type: "gameOver" });
+        }
       }
 
       // Collect snapshots and detect boundary escapes

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -12,6 +12,10 @@ export const WALL_THICKNESS = 16;
 /** 18% from top — game over if settled fruit crosses this */
 export const DANGER_LINE_RATIO = 0.18;
 export const GAME_OVER_GRACE_MS = 3000;
+/** Consecutive ticks a settled fruit must be above the danger line before game-over fires. */
+export const GAME_OVER_CONSECUTIVE_TICKS = 30;
+/** Ticks after the last merge before game-over can fire — suppresses spurious loss mid-cascade. */
+export const GAME_OVER_MERGE_COOLDOWN_TICKS = 90;
 
 // --- Physics tuning constants ---
 /** Low restitution = THUD feel (original Suika); fruits barely bounce. */
@@ -44,8 +48,10 @@ export const MATTER_VELOCITY_ITERATIONS = 6;
 export const MATTER_SLEEP_THRESHOLD = 60;
 
 // --- Terminal velocity guard ---
-/** Max fruit speed in px/s. Tier-0 at 1200 px/s travels 20 px per 1/60s frame — within CCD range. */
-export const MAX_FRUIT_SPEED_PX_S = 1200;
+// CASCADE-PHYS-08 (Outcome C): tier-0 at 1200 px/s travels 20 px per 1/60s frame > WALL_THICKNESS (16 px).
+// Lowering to 900 px/s caps travel at 15 px, making sub-stepping alone geometrically sufficient.
+/** Max fruit speed in px/s. Capped so max travel per 1/60s sub-step (15 px) stays below WALL_THICKNESS (16 px). */
+export const MAX_FRUIT_SPEED_PX_S = 900;
 
 // --- Spawn grace period ---
 /** Number of physics ticks a merge-spawned body is immune to dynamic-vs-dynamic collisions. */

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -8,6 +8,8 @@ export {
   WALL_THICKNESS,
   DANGER_LINE_RATIO,
   GAME_OVER_GRACE_MS,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   FRUIT_DENSITY,
@@ -34,6 +36,8 @@ export type { GameEvent } from "./types";
 
 import {
   GAME_OVER_GRACE_MS,
+  GAME_OVER_CONSECUTIVE_TICKS,
+  GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   FRUIT_DENSITY,
@@ -145,6 +149,8 @@ export async function createEngine(
 
   const dangerY = H * DANGER_LINE_RATIO; // pixels
   let gameOverFired = false;
+  let dangerTicksAbove = 0;
+  let ticksSinceLastMerge = GAME_OVER_MERGE_COOLDOWN_TICKS;
   let comboMergeCount = 0;
   let comboFired = false;
   // Accumulator for the fixed-step loop; carries leftover ms across frames.
@@ -357,16 +363,18 @@ export async function createEngine(
         }
       });
 
-      // Cascade combo: fire when a chain of consecutive-step merges reaches COMBO_THRESHOLD.
+      // Cascade combo and merge-cooldown tracking.
       if (mergesThisStep > 0) {
         comboMergeCount += mergesThisStep;
         if (!comboFired && comboMergeCount >= COMBO_THRESHOLD) {
           events.push({ type: "cascadeCombo", count: comboMergeCount });
           comboFired = true;
         }
+        ticksSinceLastMerge = 0;
       } else {
         comboMergeCount = 0;
         comboFired = false;
+        ticksSinceLastMerge++;
       }
 
       // Velocity clamp: prevent unbounded free-fall from producing tunneling speeds.
@@ -386,21 +394,29 @@ export async function createEngine(
         });
       }
 
-      // Game-over: a settled fruit (past grace period) with its top above the danger line
+      // Game-over: requires GAME_OVER_CONSECUTIVE_TICKS consecutive ticks above the danger line
+      // AND no merge in the last GAME_OVER_MERGE_COOLDOWN_TICKS ticks.
       if (!gameOverFired) {
         const now = Date.now();
+        let anyAbove = false;
         fruitMap.forEach((fb, handle) => {
-          if (gameOverFired || fb.isMerging) return;
+          if (anyAbove || fb.isMerging) return;
           if (now - fb.createdAt < GAME_OVER_GRACE_MS) return;
           const rb = world.getRigidBody(handle);
           if (!rb) return;
           const pos = rb.translation();
-          const topY = pos.y / SCALE - fb.fruitRadius; // top edge in pixels
-          if (topY < dangerY) {
-            gameOverFired = true;
-            events.push({ type: "gameOver" });
-          }
+          const topY = pos.y / SCALE - fb.fruitRadius;
+          if (topY < dangerY) anyAbove = true;
         });
+        if (anyAbove) dangerTicksAbove++;
+        else dangerTicksAbove = 0;
+        if (
+          dangerTicksAbove >= GAME_OVER_CONSECUTIVE_TICKS &&
+          ticksSinceLastMerge >= GAME_OVER_MERGE_COOLDOWN_TICKS
+        ) {
+          gameOverFired = true;
+          events.push({ type: "gameOver" });
+        }
       }
 
       // Per-step fruit-count delta check


### PR DESCRIPTION
## Summary

- **CASCADE-PHYS-07 (#1229):** Game-over now requires 30 consecutive ticks above the danger line (`GAME_OVER_CONSECUTIVE_TICKS`) with no merge in the last 90 ticks (`GAME_OVER_MERGE_COOLDOWN_TICKS`). Both Rapier and Matter engines maintain `dangerTicksAbove` and `ticksSinceLastMerge` counters. The existing per-body 3 s grace (`GAME_OVER_GRACE_MS`) is unchanged.
- **CASCADE-PHYS-08 (#1232):** CCD analysis complete — chose **Outcome C**: lowered `MAX_FRUIT_SPEED_PX_S` 1200 → 900 px/s so max travel per 1/60 sub-step (15 px) stays below `WALL_THICKNESS` (16 px). Sub-stepping alone is now geometrically sufficient. Analysis documented inline at the spawn-clamp in `engine.native.ts`.

## Test plan

- [ ] 4 new hysteresis unit tests in `engine.test.ts` (single tick / 30-tick / counter reset / merge suppression)
- [ ] 4 mirrored hysteresis unit tests in `engine.native.test.ts`
- [ ] Arithmetic CCD assertion: `MAX_FRUIT_SPEED_PX_S / 60 < WALL_THICKNESS`
- [ ] Integration floor-escape test at terminal velocity
- [ ] Game-over hysteresis parity test (both engines fire at tick 30)
- [ ] Wall containment parity test (600 frames, neither engine escapes walls)
- [ ] All 897 existing cascade tests continue to pass

Closes #1229, #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)