### PR TITLE
fix(sort): bottle sort pour animation polish (#1330 #1337 #1338 #1339)

### DIFF
--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -53,8 +53,8 @@ export const TILT_HOLD_MS_PER_UNIT = 150; // scaled by # of sections poured
 // Ghost rises just enough to clear the target bottle's opening
 const LIFT_HEIGHT = 40;
 
-// Stream dimensions
-const STREAM_WIDTH = 5;
+// Stream dimensions — 7px renders reliably on iOS at all display densities
+const STREAM_WIDTH = 7;
 
 export default function SortBoard({
   state,

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AccessibilityInfo,
   ActivityIndicator,
   AppState,
   AppStateStatus,
@@ -84,6 +85,7 @@ export default function SortScreen() {
   const [isPouring, setIsPouring] = useState(false);
   const [boardHeight, setBoardHeight] = useState(0);
   const pourTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [reduceMotion, setReduceMotion] = useState(false);
 
   // Win modal
   const [showWinModal, setShowWinModal] = useState(false);
@@ -101,6 +103,10 @@ export default function SortScreen() {
     return () => {
       if (pourTimerRef.current !== null) clearTimeout(pourTimerRef.current);
     };
+  }, []);
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
   }, []);
 
   // ---------------------------------------------------------------------------
@@ -196,8 +202,10 @@ export default function SortScreen() {
       const snapshot = gameState;
       const units = pourUnits(gameState.bottles[selectedBottleIndex]!, gameState.bottles[index]!);
       const holdMs = TILT_HOLD_MS_PER_UNIT * units;
-      const totalMs =
-        LIFT_MS + TRAVEL_MS + TILT_IN_MS + holdMs + TILT_OUT_MS + TRAVEL_MS + LIFT_MS + 50;
+      // Reduce-motion skips the ghost; BottleView does a fixed tilt-only animation (no scaling).
+      const totalMs = reduceMotion
+        ? TILT_IN_MS + TILT_HOLD_MS_PER_UNIT + TILT_OUT_MS + 50
+        : LIFT_MS + TRAVEL_MS + TILT_IN_MS + holdMs + TILT_OUT_MS + TRAVEL_MS + LIFT_MS + 50;
       setHistory((h) => [...h, snapshot]);
       setIsPouring(true);
       setPouringFrom(selectedBottleIndex);


### PR DESCRIPTION
## Summary
- **#1337 (audit):** Pour timing already scales correctly (`holdMs = TILT_HOLD_MS_PER_UNIT × units`); stream opacity is synchronized with the tilt-hold phase. Audit passes — no code changes.
- **#1338 (stream width):** `STREAM_WIDTH` increased 5 → 7px so the liquid stream renders reliably on iOS at all display densities (1×, 2×, 3×).
- **#1339 (reduce-motion):** `SortScreen` now reads `AccessibilityInfo.isReduceMotionEnabled()` and commits game state after 650ms on the reduce-motion path (matching the actual `BottleView` tilt animation duration) instead of the full ghost-animation timeout (~1200ms+). Eliminates the dead blocking window where taps were locked but nothing was animating.

## Test plan
- [ ] Normal pour: ghost animation plays, game state commits at end — unchanged
- [ ] Reduce-motion enabled: bottle tilts in-place, taps unblock ~650ms after pour (not ~1200ms)
- [ ] Multi-unit pour (4 units): hold duration visibly longer than 1-unit pour
- [ ] Stream visible during pour — slightly wider (7px) than before
- [ ] All existing sort tests pass (`npx jest src/game/sort src/screens/__tests__/SortScreen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)