### PR TITLE
fix(sort): export TILT_HOLD_MS from BottleView to decouple reduce-motion timer (#1350)

### DIFF
--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -74,7 +74,7 @@ export const BOTTLE_HEIGHT = DEFAULT_BOTTLE_HEIGHT;
 
 // Pour animation timing (ms)
 const TILT_IN_MS = 250;
-const TILT_HOLD_MS = 150;
+export const TILT_HOLD_MS = 150;
 const TILT_OUT_MS = 200;
 export const TILT_DEG = 62;
 

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -37,6 +37,7 @@ import SortBoard, {
   TILT_OUT_MS,
   TILT_HOLD_MS_PER_UNIT,
 } from "../game/sort/components/SortBoard";
+import { TILT_HOLD_MS } from "../game/sort/components/BottleView";
 import LevelSelectScreen from "../game/sort/components/LevelSelectScreen";
 import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
 import { loadProgress, saveProgress, type SortProgress } from "../game/sort/storage";
@@ -204,7 +205,7 @@ export default function SortScreen() {
       const holdMs = TILT_HOLD_MS_PER_UNIT * units;
       // Reduce-motion skips the ghost; BottleView does a fixed tilt-only animation (no scaling).
       const totalMs = reduceMotion
-        ? TILT_IN_MS + TILT_HOLD_MS_PER_UNIT + TILT_OUT_MS + 50
+        ? TILT_IN_MS + TILT_HOLD_MS + TILT_OUT_MS + 50
         : LIFT_MS + TRAVEL_MS + TILT_IN_MS + holdMs + TILT_OUT_MS + TRAVEL_MS + LIFT_MS + 50;
       setHistory((h) => [...h, snapshot]);
       setIsPouring(true);


### PR DESCRIPTION
Closes #1350
Part of epic: #1330

## Summary
- Exports `TILT_HOLD_MS` from `BottleView.tsx` (was private)
- `SortScreen` now imports and references it directly in the reduce-motion `totalMs` formula instead of coincidentally reusing `TILT_HOLD_MS_PER_UNIT`
- The computed value (650ms) is unchanged — this is a correctness/maintainability fix only

## Why
`TILT_HOLD_MS` (BottleView, drives the actual tilt animation) and `TILT_HOLD_MS_PER_UNIT` (SortBoard, drives the ghost animation hold) happened to both be 150ms. The reduce-motion timer used `TILT_HOLD_MS_PER_UNIT` as a proxy, meaning an independent change to either constant would silently desync the commit timer from the visible animation. Identified in PR #1349 review.

## Test plan
- [ ] Reduce-motion path: taps unblock at same time as before (~650ms)
- [ ] Normal pour path: unchanged
- [ ] All sort tests pass (`npx jest src/game/sort src/screens/__tests__/SortScreen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)