### PR TITLE
feat(mahjong): responsive layout engine — tiles size to screen

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -110,11 +110,48 @@ function useAllTileSVGs(): ReadonlyArray<TileSVG> {
   const s40 = useSVG(TILE_REQUIRES[40]);
   const s41 = useSVG(TILE_REQUIRES[41]);
   return [
-    s00, s01, s02, s03, s04, s05, s06, s07, s08, s09,
-    s10, s11, s12, s13, s14, s15, s16, s17, s18, s19,
-    s20, s21, s22, s23, s24, s25, s26, s27, s28, s29,
-    s30, s31, s32, s33, s34, s35, s36, s37, s38, s39,
-    s40, s41,
+    s00,
+    s01,
+    s02,
+    s03,
+    s04,
+    s05,
+    s06,
+    s07,
+    s08,
+    s09,
+    s10,
+    s11,
+    s12,
+    s13,
+    s14,
+    s15,
+    s16,
+    s17,
+    s18,
+    s19,
+    s20,
+    s21,
+    s22,
+    s23,
+    s24,
+    s25,
+    s26,
+    s27,
+    s28,
+    s29,
+    s30,
+    s31,
+    s32,
+    s33,
+    s34,
+    s35,
+    s36,
+    s37,
+    s38,
+    s39,
+    s40,
+    s41,
   ];
 }
 
@@ -194,11 +231,16 @@ interface Props {
   onNewGamePress: () => void;
 }
 
-export default function GameCanvas({ state, layout, onTilePress, onShufflePress, onNewGamePress }: Props) {
+export default function GameCanvas({
+  state,
+  layout,
+  onTilePress,
+  onShufflePress,
+  onNewGamePress,
+}: Props) {
   const { t } = useTranslation("mahjong");
   const tileSvgs = useAllTileSVGs();
-  const { tileWidth, tileHeight, sideWidth, layerDx, layerDy, padX, padY, boardWidth, boardHeight } =
-    layout;
+  const { tileWidth, tileHeight, sideWidth, boardWidth, boardHeight } = layout;
 
   const freeTiles = useMemo(() => {
     const s = new Set<number>();

--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -20,7 +20,6 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_BG } from "../../theme/theme.constants";
-import { useMahjongCanvasLayout } from "../../game/mahjong/layout";
 import type { MahjongLayout } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
@@ -189,15 +188,15 @@ function hitTest(
 
 interface Props {
   state: MahjongState;
+  layout: MahjongLayout;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
 }
 
-export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
+export default function GameCanvas({ state, layout, onTilePress, onShufflePress, onNewGamePress }: Props) {
   const { t } = useTranslation("mahjong");
   const tileSvgs = useAllTileSVGs();
-  const layout = useMahjongCanvasLayout();
   const { tileWidth, tileHeight, sideWidth, layerDx, layerDy, padX, padY, boardWidth, boardHeight } =
     layout;
 
@@ -257,9 +256,9 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
           const fw = tileWidth - sideWidth;
           const fh = tileHeight - sideWidth;
 
-          // Lift selected tile upward/outward for a "picked up" cue.
-          const liftX = isSelected ? 4 : 0;
-          const liftY = isSelected ? -5 : 0;
+          // Lift selected tile upward/outward — scale with tile size.
+          const liftX = isSelected ? Math.round(tileWidth * (4 / 44)) : 0;
+          const liftY = isSelected ? -Math.round(tileHeight * (5 / 56)) : 0;
           // 2 px border on selected for visibility at small tile sizes.
           const borderInset = isSelected ? 2 : 1;
 

--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -5,8 +5,8 @@
  * Metro automatically uses GameCanvas.web.tsx on the web platform.
  *
  * Tile geometry (grid → pixels):
- *   pixel_x = PAD_X + (col / 2) * TILE_W + layer * LAYER_DX
- *   pixel_y = PAD_Y + row * TILE_H − layer * LAYER_DY
+ *   pixel_x = padX + (col / 2) * tileWidth + layer * layerDx
+ *   pixel_y = padY + row * tileHeight − layer * layerDy
  *
  * Rendering order: layer ASC so higher layers appear on top.
  * Hit-testing: topmost tile (highest layer) at touch point wins.
@@ -20,29 +20,18 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_BG } from "../../theme/theme.constants";
+import { useMahjongCanvasLayout } from "../../game/mahjong/layout";
+import type { MahjongLayout } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
-// Layout constants
+// Geometry helpers — accept layout so they stay pure functions
 // ---------------------------------------------------------------------------
 
-export const TILE_W = 44; // face width
-export const TILE_H = 56; // face height
-export const SIDE_W = 5; // 3-D side strip width (right + bottom)
-export const LAYER_DX = 6; // rightward offset per layer
-export const LAYER_DY = 5; // upward offset per layer
-export const PAD_X = 6;
-// Layer-0 top-feet tiles sit at row=0 and need PAD_Y > 0 to clear the canvas edge.
-// Higher layers only appear at row≥2, so no stacking offset reaches row 0.
-export const PAD_Y = 10;
-
-export const BOARD_W = PAD_X + 12 * TILE_W + 4 * LAYER_DX + PAD_X; // 548
-export const BOARD_H = PAD_Y + 8 * TILE_H + 4 * LAYER_DY + PAD_Y; // 468
-
-function tileX(col: number, layer: number): number {
-  return PAD_X + (col / 2) * TILE_W + layer * LAYER_DX;
+function tileX(col: number, layer: number, l: MahjongLayout): number {
+  return l.padX + (col / 2) * l.tileWidth + layer * l.layerDx;
 }
-function tileY(row: number, layer: number): number {
-  return PAD_Y + row * TILE_H - layer * LAYER_DY;
+function tileY(row: number, layer: number, l: MahjongLayout): number {
+  return l.padY + row * l.tileHeight - layer * l.layerDy;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,48 +111,11 @@ function useAllTileSVGs(): ReadonlyArray<TileSVG> {
   const s40 = useSVG(TILE_REQUIRES[40]);
   const s41 = useSVG(TILE_REQUIRES[41]);
   return [
-    s00,
-    s01,
-    s02,
-    s03,
-    s04,
-    s05,
-    s06,
-    s07,
-    s08,
-    s09,
-    s10,
-    s11,
-    s12,
-    s13,
-    s14,
-    s15,
-    s16,
-    s17,
-    s18,
-    s19,
-    s20,
-    s21,
-    s22,
-    s23,
-    s24,
-    s25,
-    s26,
-    s27,
-    s28,
-    s29,
-    s30,
-    s31,
-    s32,
-    s33,
-    s34,
-    s35,
-    s36,
-    s37,
-    s38,
-    s39,
-    s40,
-    s41,
+    s00, s01, s02, s03, s04, s05, s06, s07, s08, s09,
+    s10, s11, s12, s13, s14, s15, s16, s17, s18, s19,
+    s20, s21, s22, s23, s24, s25, s26, s27, s28, s29,
+    s30, s31, s32, s33, s34, s35, s36, s37, s38, s39,
+    s40, s41,
   ];
 }
 
@@ -211,14 +163,19 @@ function TileFaceLayer({
 // Hit-testing
 // ---------------------------------------------------------------------------
 
-function hitTest(tiles: readonly SlotTile[], tapX: number, tapY: number): number | null {
-  const fw = TILE_W - SIDE_W;
-  const fh = TILE_H - SIDE_W;
+function hitTest(
+  tiles: readonly SlotTile[],
+  tapX: number,
+  tapY: number,
+  l: MahjongLayout
+): number | null {
+  const fw = l.tileWidth - l.sideWidth;
+  const fh = l.tileHeight - l.sideWidth;
   // Iterate from highest layer down so the topmost tile wins.
   const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
   for (const tile of sorted) {
-    const x = tileX(tile.col, tile.layer);
-    const y = tileY(tile.row, tile.layer);
+    const x = tileX(tile.col, tile.layer, l);
+    const y = tileY(tile.row, tile.layer, l);
     if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
       return tile.id;
     }
@@ -240,6 +197,9 @@ interface Props {
 export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
   const { t } = useTranslation("mahjong");
   const tileSvgs = useAllTileSVGs();
+  const layout = useMahjongCanvasLayout();
+  const { tileWidth, tileHeight, sideWidth, layerDx, layerDy, padX, padY, boardWidth, boardHeight } =
+    layout;
 
   const freeTiles = useMemo(() => {
     const s = new Set<number>();
@@ -277,25 +237,25 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
   function handleTap(e: { nativeEvent: { locationX: number; locationY: number } }) {
     if (!gameActive) return;
     const { locationX, locationY } = e.nativeEvent;
-    const tileId = hitTest(state.tiles, locationX, locationY);
+    const tileId = hitTest(state.tiles, locationX, locationY, layout);
     if (tileId !== null) onTilePress(tileId);
   }
 
   return (
-    <View style={{ width: BOARD_W, height: BOARD_H }}>
+    <View style={{ width: boardWidth, height: boardHeight }}>
       <Canvas
-        style={{ width: BOARD_W, height: BOARD_H }}
+        style={{ width: boardWidth, height: boardHeight }}
         accessibilityLabel={t("game.canvasLabel")}
         accessibilityRole="none"
       >
         <Fill color={BG} />
         {sortedTiles.map((tile) => {
-          const x = tileX(tile.col, tile.layer);
-          const y = tileY(tile.row, tile.layer);
+          const x = tileX(tile.col, tile.layer, layout);
+          const y = tileY(tile.row, tile.layer, layout);
           const isSelected = tile.id === selectedId;
           const isFree = freeTiles.has(tile.id);
-          const fw = TILE_W - SIDE_W;
-          const fh = TILE_H - SIDE_W;
+          const fw = tileWidth - sideWidth;
+          const fh = tileHeight - sideWidth;
 
           // Lift selected tile upward/outward for a "picked up" cue.
           const liftX = isSelected ? 4 : 0;
@@ -313,8 +273,8 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
             <Group key={tile.id}>
               {/* Drop shadow */}
               <Rect
-                x={x + SIDE_W + 2 + liftX}
-                y={y + SIDE_W + 2 + liftY}
+                x={x + sideWidth + 2 + liftX}
+                y={y + sideWidth + 2 + liftY}
                 width={fw}
                 height={fh}
                 color={SHADOW}
@@ -332,17 +292,17 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
               {/* Right 3-D side */}
               <Rect
                 x={x + fw + liftX}
-                y={y + SIDE_W + liftY}
-                width={SIDE_W}
+                y={y + sideWidth + liftY}
+                width={sideWidth}
                 height={fh}
                 color={SIDE_R}
               />
               {/* Bottom 3-D side */}
               <Rect
-                x={x + SIDE_W + liftX}
+                x={x + sideWidth + liftX}
                 y={y + fh + liftY}
                 width={fw}
-                height={SIDE_W}
+                height={sideWidth}
                 color={SIDE_B}
               />
               {/* Border */}

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -17,7 +17,6 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_SHADOW } from "../../theme/theme.constants";
-import { useMahjongCanvasLayout } from "../../game/mahjong/layout";
 import type { MahjongLayout } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
@@ -113,9 +112,9 @@ function drawBoard(
     const fw = tileWidth - sideWidth;
     const fh = tileHeight - sideWidth;
 
-    // Lift selected tile upward/outward for a "picked up" cue.
-    const liftX = isSelected ? 4 : 0;
-    const liftY = isSelected ? -5 : 0;
+    // Lift selected tile upward/outward — scale with tile size.
+    const liftX = isSelected ? Math.round(l.tileWidth * (4 / 44)) : 0;
+    const liftY = isSelected ? -Math.round(l.tileHeight * (5 / 56)) : 0;
     // 2 px border on selected for visibility at small tile sizes.
     const borderInset = isSelected ? 2 : 1;
 
@@ -182,14 +181,14 @@ function drawBoard(
 
 interface Props {
   state: MahjongState;
+  layout: MahjongLayout;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
 }
 
-export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
+export default function GameCanvas({ state, layout, onTilePress, onShufflePress, onNewGamePress }: Props) {
   const { t } = useTranslation("mahjong");
-  const layout = useMahjongCanvasLayout();
   const { boardWidth, boardHeight } = layout;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -275,14 +274,14 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
       const rect = canvas.getBoundingClientRect();
       // getBoundingClientRect reflects the parent's CSS scale transform, so
       // divide by the visual/native ratio to get canvas drawing coordinates.
-      const scaleX = rect.width / boardWidth;
-      const scaleY = rect.height / boardHeight;
+      const scaleX = rect.width / layout.boardWidth;
+      const scaleY = rect.height / layout.boardHeight;
       const tapX = (e.clientX - rect.left) / scaleX;
       const tapY = (e.clientY - rect.top) / scaleY;
       const tileId = hitTest(state.tiles, tapX, tapY, layout);
       if (tileId !== null) onTilePress(tileId);
     },
-    [state.tiles, onTilePress, gameActive, layout, boardWidth, boardHeight]
+    [state.tiles, onTilePress, gameActive, layout]
   );
 
   return (

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -5,8 +5,8 @@
  * Metro uses this file automatically on the web platform.
  *
  * Tile geometry (grid → pixels):
- *   pixel_x = PAD_X + (col / 2) * TILE_W + layer * LAYER_DX
- *   pixel_y = PAD_Y + row * TILE_H − layer * LAYER_DY
+ *   pixel_x = padX + (col / 2) * tileWidth + layer * layerDx
+ *   pixel_y = padY + row * tileHeight − layer * layerDy
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -17,29 +17,18 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_SHADOW } from "../../theme/theme.constants";
+import { useMahjongCanvasLayout } from "../../game/mahjong/layout";
+import type { MahjongLayout } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
-// Layout constants (mirror GameCanvas.tsx exactly)
+// Geometry helpers
 // ---------------------------------------------------------------------------
 
-export const TILE_W = 44;
-export const TILE_H = 56;
-export const SIDE_W = 5;
-export const LAYER_DX = 6;
-export const LAYER_DY = 5;
-export const PAD_X = 6;
-// Layer-0 top-feet tiles sit at row=0 and need PAD_Y > 0 to clear the canvas edge.
-// Higher layers only appear at row≥2, so no stacking offset reaches row 0.
-export const PAD_Y = 10;
-
-export const BOARD_W = PAD_X + 12 * TILE_W + 4 * LAYER_DX + PAD_X; // 548
-export const BOARD_H = PAD_Y + 8 * TILE_H + 4 * LAYER_DY + PAD_Y; // 468
-
-function tileX(col: number, layer: number): number {
-  return PAD_X + (col / 2) * TILE_W + layer * LAYER_DX;
+function tileX(col: number, layer: number, l: MahjongLayout): number {
+  return l.padX + (col / 2) * l.tileWidth + layer * l.layerDx;
 }
-function tileY(row: number, layer: number): number {
-  return PAD_Y + row * TILE_H - layer * LAYER_DY;
+function tileY(row: number, layer: number, l: MahjongLayout): number {
+  return l.padY + row * l.tileHeight - layer * l.layerDy;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,13 +59,18 @@ const SUIT_COLOR: Record<string, string> = {
 // Hit-testing
 // ---------------------------------------------------------------------------
 
-function hitTest(tiles: readonly SlotTile[], tapX: number, tapY: number): number | null {
-  const fw = TILE_W - SIDE_W;
-  const fh = TILE_H - SIDE_W;
+function hitTest(
+  tiles: readonly SlotTile[],
+  tapX: number,
+  tapY: number,
+  l: MahjongLayout
+): number | null {
+  const fw = l.tileWidth - l.sideWidth;
+  const fh = l.tileHeight - l.sideWidth;
   const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
   for (const tile of sorted) {
-    const x = tileX(tile.col, tile.layer);
-    const y = tileY(tile.row, tile.layer);
+    const x = tileX(tile.col, tile.layer, l);
+    const y = tileY(tile.row, tile.layer, l);
     if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
       return tile.id;
     }
@@ -92,13 +86,16 @@ function drawBoard(
   ctx: CanvasRenderingContext2D,
   state: MahjongState,
   freeTiles: ReadonlySet<number>,
-  tileImages: readonly (HTMLImageElement | null)[]
+  tileImages: readonly (HTMLImageElement | null)[],
+  l: MahjongLayout
 ): void {
-  ctx.clearRect(0, 0, BOARD_W, BOARD_H);
+  const { tileWidth, tileHeight, sideWidth, boardWidth, boardHeight } = l;
+
+  ctx.clearRect(0, 0, boardWidth, boardHeight);
 
   // Background
   ctx.fillStyle = BG;
-  ctx.fillRect(0, 0, BOARD_W, BOARD_H);
+  ctx.fillRect(0, 0, boardWidth, boardHeight);
 
   const selectedId = state.selected?.id ?? null;
   const hasSelection = selectedId !== null;
@@ -109,12 +106,12 @@ function drawBoard(
   for (const tile of sorted) {
     ctx.save();
 
-    const x = tileX(tile.col, tile.layer);
-    const y = tileY(tile.row, tile.layer);
+    const x = tileX(tile.col, tile.layer, l);
+    const y = tileY(tile.row, tile.layer, l);
     const isSelected = tile.id === selectedId;
     const isFree = freeTiles.has(tile.id);
-    const fw = TILE_W - SIDE_W;
-    const fh = TILE_H - SIDE_W;
+    const fw = tileWidth - sideWidth;
+    const fh = tileHeight - sideWidth;
 
     // Lift selected tile upward/outward for a "picked up" cue.
     const liftX = isSelected ? 4 : 0;
@@ -131,15 +128,15 @@ function drawBoard(
 
     // Drop shadow
     ctx.fillStyle = "rgba(0,0,0,0.35)";
-    ctx.fillRect(x + SIDE_W + 2 + liftX, y + SIDE_W + 2 + liftY, fw, fh);
+    ctx.fillRect(x + sideWidth + 2 + liftX, y + sideWidth + 2 + liftY, fw, fh);
 
     // Right 3-D side
     ctx.fillStyle = SIDE_R;
-    ctx.fillRect(x + fw + liftX, y + SIDE_W + liftY, SIDE_W, fh);
+    ctx.fillRect(x + fw + liftX, y + sideWidth + liftY, sideWidth, fh);
 
     // Bottom 3-D side
     ctx.fillStyle = SIDE_B;
-    ctx.fillRect(x + SIDE_W + liftX, y + fh + liftY, fw, SIDE_W);
+    ctx.fillRect(x + sideWidth + liftX, y + fh + liftY, fw, sideWidth);
 
     // Gold glow behind selected tile — applied to the border rect only.
     if (isSelected) {
@@ -192,6 +189,9 @@ interface Props {
 
 export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGamePress }: Props) {
   const { t } = useTranslation("mahjong");
+  const layout = useMahjongCanvasLayout();
+  const { boardWidth, boardHeight } = layout;
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const tileImagesRef = useRef<(HTMLImageElement | null)[]>(Array(42).fill(null));
   const [imagesVersion, setImagesVersion] = useState(0);
@@ -258,14 +258,14 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
     };
   }, []);
 
-  // Redraw whenever state or tile images change.
+  // Redraw whenever state, tile images, or layout changes.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    drawBoard(ctx, state, freeTiles, tileImagesRef.current);
-  }, [state, freeTiles, imagesVersion]);
+    drawBoard(ctx, state, freeTiles, tileImagesRef.current, layout);
+  }, [state, freeTiles, imagesVersion, layout]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -275,22 +275,22 @@ export default function GameCanvas({ state, onTilePress, onShufflePress, onNewGa
       const rect = canvas.getBoundingClientRect();
       // getBoundingClientRect reflects the parent's CSS scale transform, so
       // divide by the visual/native ratio to get canvas drawing coordinates.
-      const scaleX = rect.width / BOARD_W;
-      const scaleY = rect.height / BOARD_H;
+      const scaleX = rect.width / boardWidth;
+      const scaleY = rect.height / boardHeight;
       const tapX = (e.clientX - rect.left) / scaleX;
       const tapY = (e.clientY - rect.top) / scaleY;
-      const tileId = hitTest(state.tiles, tapX, tapY);
+      const tileId = hitTest(state.tiles, tapX, tapY, layout);
       if (tileId !== null) onTilePress(tileId);
     },
-    [state.tiles, onTilePress, gameActive]
+    [state.tiles, onTilePress, gameActive, layout, boardWidth, boardHeight]
   );
 
   return (
-    <View style={{ width: BOARD_W, height: BOARD_H }}>
+    <View style={{ width: boardWidth, height: boardHeight }}>
       <canvas
         ref={canvasRef}
-        width={BOARD_W}
-        height={BOARD_H}
+        width={boardWidth}
+        height={boardHeight}
         onClick={handleClick}
         style={{ display: "block", cursor: gameActive ? "pointer" : "default" }}
         aria-label={t("game.canvasLabel")}

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -187,7 +187,13 @@ interface Props {
   onNewGamePress: () => void;
 }
 
-export default function GameCanvas({ state, layout, onTilePress, onShufflePress, onNewGamePress }: Props) {
+export default function GameCanvas({
+  state,
+  layout,
+  onTilePress,
+  onShufflePress,
+  onNewGamePress,
+}: Props) {
   const { t } = useTranslation("mahjong");
   const { boardWidth, boardHeight } = layout;
 

--- a/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
+++ b/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
@@ -77,7 +77,13 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas
+          state={state}
+          layout={testLayout}
+          onTilePress={noop}
+          onShufflePress={noop}
+          onNewGamePress={noop}
+        />
       );
     });
     // i18n returns keys in tests — check for the key, not the translated string.
@@ -90,7 +96,13 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas
+          state={state}
+          layout={testLayout}
+          onTilePress={noop}
+          onShufflePress={noop}
+          onNewGamePress={noop}
+        />
       );
     });
     // Overlay is intentionally delayed — not visible before the timer fires.
@@ -113,7 +125,13 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas
+          state={state}
+          layout={testLayout}
+          onTilePress={noop}
+          onShufflePress={noop}
+          onNewGamePress={noop}
+        />
       );
     });
     // Shuffle CTA shows the noMoves key + shuffle button
@@ -127,7 +145,13 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas
+          state={state}
+          layout={testLayout}
+          onTilePress={noop}
+          onShufflePress={noop}
+          onNewGamePress={noop}
+        />
       );
     });
     const str = JSON.stringify(tree!.toJSON());

--- a/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
+++ b/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
@@ -11,6 +11,7 @@ import { create, act } from "react-test-renderer";
 import type { MahjongState } from "../../../game/mahjong/types";
 import { createGame } from "../../../game/mahjong/engine";
 import { TURTLE_LAYOUT } from "../../../game/mahjong/layouts/turtle";
+import { calculateMahjongLayout } from "../../../game/mahjong/layout";
 
 // Skia requires a native module — stub the whole package.
 jest.mock("@shopify/react-native-skia", () => ({
@@ -38,6 +39,16 @@ jest.mock("expo-asset", () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { default: GameCanvas } = require("../GameCanvas.web");
 
+const testLayout = calculateMahjongLayout({
+  screenWidth: 768,
+  screenHeight: 1024,
+  safeAreaTop: 0,
+  safeAreaBottom: 0,
+  boardRows: 8,
+  boardCols: 12,
+  boardLayers: 4,
+});
+
 function makeState(overrides: Partial<MahjongState> = {}): MahjongState {
   return { ...createGame(TURTLE_LAYOUT, 12345), ...overrides };
 }
@@ -51,6 +62,7 @@ describe("GameCanvas (web)", () => {
         create(
           <GameCanvas
             state={makeState()}
+            layout={testLayout}
             onTilePress={noop}
             onShufflePress={noop}
             onNewGamePress={noop}
@@ -65,7 +77,7 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
       );
     });
     // i18n returns keys in tests — check for the key, not the translated string.
@@ -78,7 +90,7 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
       );
     });
     // Overlay is intentionally delayed — not visible before the timer fires.
@@ -101,7 +113,7 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
       );
     });
     // Shuffle CTA shows the noMoves key + shuffle button
@@ -115,7 +127,7 @@ describe("GameCanvas (web)", () => {
     let tree: ReturnType<typeof create>;
     act(() => {
       tree = create(
-        <GameCanvas state={state} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
+        <GameCanvas state={state} layout={testLayout} onTilePress={noop} onShufflePress={noop} onNewGamePress={noop} />
       );
     });
     const str = JSON.stringify(tree!.toJSON());

--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for calculateMahjongLayout.
+ *
+ * The pure function is tested in isolation (no hooks, no React).
+ */
+
+import { calculateMahjongLayout } from "../layout";
+
+const TURTLE = { boardRows: 8, boardCols: 12, boardLayers: 4 };
+
+describe("calculateMahjongLayout", () => {
+  it("returns a tileWidth clamped to MAX_TILE_W (56) on a large iPad landscape screen", () => {
+    const l = calculateMahjongLayout({
+      screenWidth: 1366,
+      screenHeight: 1024,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    expect(l.tileWidth).toBe(56);
+  });
+
+  it("returns a tileWidth clamped to MIN_TILE_W (28) on a tiny screen", () => {
+    const l = calculateMahjongLayout({
+      screenWidth: 200,
+      screenHeight: 300,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    expect(l.tileWidth).toBe(28);
+  });
+
+  it("clamps to MIN_TILE_W when both dimensions are zero", () => {
+    const l = calculateMahjongLayout({
+      screenWidth: 0,
+      screenHeight: 0,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    expect(l.tileWidth).toBe(28);
+  });
+
+  it("board fits within available height (heightFactor formula is correct)", () => {
+    // A 900×450 screen at typical mahjong aspect — board must not exceed availH.
+    const screenWidth = 900;
+    const screenHeight = 450;
+    const safeAreaTop = 0;
+    const safeAreaBottom = 0;
+    const l = calculateMahjongLayout({ screenWidth, screenHeight, safeAreaTop, safeAreaBottom, ...TURTLE });
+    // availH = screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H (116)
+    const availH = screenHeight - safeAreaTop - safeAreaBottom - 116;
+    expect(l.boardHeight).toBeLessThanOrEqual(availH + 1); // allow 1px rounding
+  });
+
+  it("board fits within available width", () => {
+    const screenWidth = 768;
+    const screenHeight = 1024;
+    const l = calculateMahjongLayout({
+      screenWidth,
+      screenHeight,
+      safeAreaTop: 44,
+      safeAreaBottom: 34,
+      ...TURTLE,
+    });
+    // availW = screenWidth - (max(0,12) + max(0,12)) = screenWidth - 24
+    const availW = screenWidth - 24;
+    expect(l.boardWidth).toBeLessThanOrEqual(availW + 1);
+  });
+
+  it("respects safeAreaLeft and safeAreaRight when larger than the minimum margin", () => {
+    const baseLayout = calculateMahjongLayout({
+      screenWidth: 844,
+      screenHeight: 390,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    const notchedLayout = calculateMahjongLayout({
+      screenWidth: 844,
+      screenHeight: 390,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      safeAreaLeft: 44,
+      safeAreaRight: 44,
+      ...TURTLE,
+    });
+    // Wider safe areas → less available width → smaller or equal tile size.
+    expect(notchedLayout.tileWidth).toBeLessThanOrEqual(baseLayout.tileWidth);
+  });
+
+  it("derived values (sideWidth, layerDx, layerDy, padX, padY) are proportional to tileWidth", () => {
+    const l = calculateMahjongLayout({
+      screenWidth: 1024,
+      screenHeight: 768,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    // All ratios should be ≥ their minima and scale with tileWidth.
+    expect(l.sideWidth).toBeGreaterThanOrEqual(3);
+    expect(l.layerDx).toBeGreaterThanOrEqual(3);
+    expect(l.layerDy).toBeGreaterThanOrEqual(2);
+    expect(l.padX).toBeGreaterThanOrEqual(4);
+    expect(l.padY).toBeGreaterThanOrEqual(6);
+  });
+
+  it("boardWidth and boardHeight match their geometric derivations", () => {
+    const l = calculateMahjongLayout({
+      screenWidth: 800,
+      screenHeight: 600,
+      safeAreaTop: 0,
+      safeAreaBottom: 0,
+      ...TURTLE,
+    });
+    const expectedBoardWidth = l.padX + TURTLE.boardCols * l.tileWidth + TURTLE.boardLayers * l.layerDx + l.padX;
+    const expectedBoardHeight = l.padY + TURTLE.boardRows * l.tileHeight + TURTLE.boardLayers * l.layerDy + l.padY;
+    expect(l.boardWidth).toBe(expectedBoardWidth);
+    expect(l.boardHeight).toBe(expectedBoardHeight);
+  });
+});

--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -48,7 +48,13 @@ describe("calculateMahjongLayout", () => {
     const screenHeight = 450;
     const safeAreaTop = 0;
     const safeAreaBottom = 0;
-    const l = calculateMahjongLayout({ screenWidth, screenHeight, safeAreaTop, safeAreaBottom, ...TURTLE });
+    const l = calculateMahjongLayout({
+      screenWidth,
+      screenHeight,
+      safeAreaTop,
+      safeAreaBottom,
+      ...TURTLE,
+    });
     // availH = screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H (116)
     const availH = screenHeight - safeAreaTop - safeAreaBottom - 116;
     expect(l.boardHeight).toBeLessThanOrEqual(availH + 1); // allow 1px rounding
@@ -114,8 +120,10 @@ describe("calculateMahjongLayout", () => {
       safeAreaBottom: 0,
       ...TURTLE,
     });
-    const expectedBoardWidth = l.padX + TURTLE.boardCols * l.tileWidth + TURTLE.boardLayers * l.layerDx + l.padX;
-    const expectedBoardHeight = l.padY + TURTLE.boardRows * l.tileHeight + TURTLE.boardLayers * l.layerDy + l.padY;
+    const expectedBoardWidth =
+      l.padX + TURTLE.boardCols * l.tileWidth + TURTLE.boardLayers * l.layerDx + l.padX;
+    const expectedBoardHeight =
+      l.padY + TURTLE.boardRows * l.tileHeight + TURTLE.boardLayers * l.layerDy + l.padY;
     expect(l.boardWidth).toBe(expectedBoardWidth);
     expect(l.boardHeight).toBe(expectedBoardHeight);
   });

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -59,7 +59,8 @@ export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout
     boardLayers,
   } = input;
 
-  const horizPad = Math.max(safeAreaLeft, MIN_HORIZ_MARGIN) + Math.max(safeAreaRight, MIN_HORIZ_MARGIN);
+  const horizPad =
+    Math.max(safeAreaLeft, MIN_HORIZ_MARGIN) + Math.max(safeAreaRight, MIN_HORIZ_MARGIN);
   const availW = Math.max(1, screenWidth - horizPad);
   const availH = Math.max(1, screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H);
 

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -7,6 +7,8 @@ export interface MahjongLayoutInput {
   screenHeight: number;
   safeAreaTop: number;
   safeAreaBottom: number;
+  safeAreaLeft?: number;
+  safeAreaRight?: number;
   boardRows: number;
   boardCols: number;
   boardLayers: number;
@@ -22,8 +24,6 @@ export interface MahjongLayout {
   padY: number;
   boardWidth: number;
   boardHeight: number;
-  fontSize: number;
-  symbolSize: number;
 }
 
 const TILE_ASPECT = 56 / 44;
@@ -37,22 +37,38 @@ const LAYER_DY_R = 5 / 44;
 const PAD_X_R = 6 / 44;
 const PAD_Y_R = 10 / 44;
 
-// App header (64) + HUD row (~36) + bottom padding (16) = 116
-const CHROME_H = 116;
-// Left + right margin applied in MahjongScreen
-const HORIZ_MARGIN = 24;
+// Keep APP_HEADER_H in sync with AppHeader.APP_HEADER_HEIGHT
+const APP_HEADER_H = 64;
+const HUD_ROW_H = 36;
+const MIN_BOTTOM_PAD = 16;
+// App header + HUD row + bottom padding = 116
+const MAHJONG_CHROME_H = APP_HEADER_H + HUD_ROW_H + MIN_BOTTOM_PAD;
+// Minimum horizontal margin on each side when safe-area insets are absent
+const MIN_HORIZ_MARGIN = 12;
 
 export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout {
-  const { screenWidth, screenHeight, safeAreaTop, safeAreaBottom, boardRows, boardCols, boardLayers } =
-    input;
+  const {
+    screenWidth,
+    screenHeight,
+    safeAreaTop,
+    safeAreaBottom,
+    safeAreaLeft = 0,
+    safeAreaRight = 0,
+    boardRows,
+    boardCols,
+    boardLayers,
+  } = input;
 
-  const availW = Math.max(1, screenWidth - HORIZ_MARGIN);
-  const availH = Math.max(1, screenHeight - safeAreaTop - safeAreaBottom - CHROME_H);
+  const horizPad = Math.max(safeAreaLeft, MIN_HORIZ_MARGIN) + Math.max(safeAreaRight, MIN_HORIZ_MARGIN);
+  const availW = Math.max(1, screenWidth - horizPad);
+  const availH = Math.max(1, screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H);
 
   // Approximate board dimensions as a multiplier of tileWidth (all derived
   // values scale proportionally, so we can solve for tileWidth directly).
-  const widthFactor = boardCols + (boardLayers + 2) * LAYER_DX_R;
-  const heightFactor = boardRows * TILE_ASPECT + (boardLayers + 2) * LAYER_DY_R;
+  // widthFactor: boardCols half-steps + layer offsets + two padX amounts
+  // heightFactor: board rows (tile-height units) + layer offsets + two padY amounts
+  const widthFactor = boardCols + boardLayers * LAYER_DX_R + 2 * PAD_X_R;
+  const heightFactor = boardRows * TILE_ASPECT + boardLayers * LAYER_DY_R + 2 * PAD_Y_R;
 
   const rawTileW = Math.min(availW / widthFactor, availH / heightFactor);
   const tileWidth = Math.max(MIN_TILE_W, Math.min(MAX_TILE_W, rawTileW));
@@ -77,8 +93,6 @@ export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout
     padY,
     boardWidth,
     boardHeight,
-    fontSize: Math.max(10, Math.round(tileWidth * 0.4)),
-    symbolSize: Math.max(16, Math.round(tileWidth * 0.7)),
   };
 }
 
@@ -97,10 +111,12 @@ export function useMahjongCanvasLayout(): MahjongLayout {
         screenHeight: height,
         safeAreaTop: insets.top,
         safeAreaBottom: insets.bottom,
+        safeAreaLeft: insets.left,
+        safeAreaRight: insets.right,
         boardRows: TURTLE_BOARD_ROWS,
         boardCols: TURTLE_BOARD_COLS,
         boardLayers: TURTLE_BOARD_LAYERS,
       }),
-    [width, height, insets.top, insets.bottom]
+    [width, height, insets.top, insets.bottom, insets.left, insets.right]
   );
 }

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -1,0 +1,106 @@
+import { useMemo } from "react";
+import { useWindowDimensions } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export interface MahjongLayoutInput {
+  screenWidth: number;
+  screenHeight: number;
+  safeAreaTop: number;
+  safeAreaBottom: number;
+  boardRows: number;
+  boardCols: number;
+  boardLayers: number;
+}
+
+export interface MahjongLayout {
+  tileWidth: number;
+  tileHeight: number;
+  sideWidth: number;
+  layerDx: number;
+  layerDy: number;
+  padX: number;
+  padY: number;
+  boardWidth: number;
+  boardHeight: number;
+  fontSize: number;
+  symbolSize: number;
+}
+
+const TILE_ASPECT = 56 / 44;
+const MIN_TILE_W = 28;
+const MAX_TILE_W = 56;
+
+// All proportional ratios derived from base constants (TILE_W=44, TILE_H=56)
+const SIDE_R = 5 / 44;
+const LAYER_DX_R = 6 / 44;
+const LAYER_DY_R = 5 / 44;
+const PAD_X_R = 6 / 44;
+const PAD_Y_R = 10 / 44;
+
+// App header (64) + HUD row (~36) + bottom padding (16) = 116
+const CHROME_H = 116;
+// Left + right margin applied in MahjongScreen
+const HORIZ_MARGIN = 24;
+
+export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout {
+  const { screenWidth, screenHeight, safeAreaTop, safeAreaBottom, boardRows, boardCols, boardLayers } =
+    input;
+
+  const availW = Math.max(1, screenWidth - HORIZ_MARGIN);
+  const availH = Math.max(1, screenHeight - safeAreaTop - safeAreaBottom - CHROME_H);
+
+  // Approximate board dimensions as a multiplier of tileWidth (all derived
+  // values scale proportionally, so we can solve for tileWidth directly).
+  const widthFactor = boardCols + (boardLayers + 2) * LAYER_DX_R;
+  const heightFactor = boardRows * TILE_ASPECT + (boardLayers + 2) * LAYER_DY_R;
+
+  const rawTileW = Math.min(availW / widthFactor, availH / heightFactor);
+  const tileWidth = Math.max(MIN_TILE_W, Math.min(MAX_TILE_W, rawTileW));
+
+  const tileHeight = Math.round(tileWidth * TILE_ASPECT);
+  const sideWidth = Math.max(3, Math.round(tileWidth * SIDE_R));
+  const layerDx = Math.max(3, Math.round(tileWidth * LAYER_DX_R));
+  const layerDy = Math.max(2, Math.round(tileWidth * LAYER_DY_R));
+  const padX = Math.max(4, Math.round(tileWidth * PAD_X_R));
+  const padY = Math.max(6, Math.round(tileWidth * PAD_Y_R));
+
+  const boardWidth = padX + boardCols * tileWidth + boardLayers * layerDx + padX;
+  const boardHeight = padY + boardRows * tileHeight + boardLayers * layerDy + padY;
+
+  return {
+    tileWidth,
+    tileHeight,
+    sideWidth,
+    layerDx,
+    layerDy,
+    padX,
+    padY,
+    boardWidth,
+    boardHeight,
+    fontSize: Math.max(10, Math.round(tileWidth * 0.4)),
+    symbolSize: Math.max(16, Math.round(tileWidth * 0.7)),
+  };
+}
+
+// Turtle layout board grid dimensions
+const TURTLE_BOARD_ROWS = 8;
+const TURTLE_BOARD_COLS = 12;
+const TURTLE_BOARD_LAYERS = 4;
+
+export function useMahjongCanvasLayout(): MahjongLayout {
+  const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  return useMemo(
+    () =>
+      calculateMahjongLayout({
+        screenWidth: width,
+        screenHeight: height,
+        safeAreaTop: insets.top,
+        safeAreaBottom: insets.bottom,
+        boardRows: TURTLE_BOARD_ROWS,
+        boardCols: TURTLE_BOARD_COLS,
+        boardLayers: TURTLE_BOARD_LAYERS,
+      }),
+    [width, height, insets.top, insets.bottom]
+  );
+}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -18,11 +18,9 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   AccessibilityInfo,
   ActivityIndicator,
-  LayoutChangeEvent,
   Modal,
   Platform,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -49,17 +47,9 @@ import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
-import GameCanvas, {
-  BOARD_W,
-  BOARD_H,
-  TILE_W,
-  TILE_H,
-  PAD_X,
-  PAD_Y,
-  LAYER_DX,
-  LAYER_DY,
-  SIDE_W,
-} from "../components/mahjong/GameCanvas";
+import GameCanvas from "../components/mahjong/GameCanvas";
+import { useMahjongCanvasLayout } from "../game/mahjong/layout";
+import type { MahjongLayout } from "../game/mahjong/layout";
 import { createGame, elapsedMs, selectTile, shuffleBoard, undoMove } from "../game/mahjong/engine";
 import { TURTLE_LAYOUT } from "../game/mahjong/layouts/turtle";
 import type { MahjongState, SlotTile } from "../game/mahjong/types";
@@ -80,15 +70,16 @@ import { useNetwork } from "../game/_shared/NetworkContext";
 const MAX_NAME_LENGTH = 32;
 
 // ---------------------------------------------------------------------------
-// Tile layout constants — all imported from GameCanvas (single source of truth)
+// Tile center — used by FlyingPair to compute animation start/end positions
 // ---------------------------------------------------------------------------
 
-const MAX_TILE_W = 72;
-
-function tileCenter(tile: SlotTile): { cx: number; cy: number } {
+function tileCenter(
+  tile: SlotTile,
+  l: MahjongLayout
+): { cx: number; cy: number } {
   return {
-    cx: PAD_X + (tile.col / 2) * TILE_W + tile.layer * LAYER_DX + TILE_W / 2,
-    cy: PAD_Y + tile.row * TILE_H - tile.layer * LAYER_DY + TILE_H / 2,
+    cx: l.padX + (tile.col / 2) * l.tileWidth + tile.layer * l.layerDx + l.tileWidth / 2,
+    cy: l.padY + tile.row * l.tileHeight - tile.layer * l.layerDy + l.tileHeight / 2,
   };
 }
 
@@ -107,19 +98,19 @@ const BURST_R = 22;
 function FlyingPair({
   tile1,
   tile2,
-  scale,
+  layout,
   color,
   onDone,
-}: FlyingPairData & { scale: number; color: string; onDone: () => void }) {
-  const { cx: c1x, cy: c1y } = tileCenter(tile1);
-  const { cx: c2x, cy: c2y } = tileCenter(tile2);
-  const midX = ((c1x + c2x) / 2) * scale;
-  const midY = ((c1y + c2y) / 2) * scale;
+}: FlyingPairData & { layout: MahjongLayout; color: string; onDone: () => void }) {
+  const { cx: c1x, cy: c1y } = tileCenter(tile1, layout);
+  const { cx: c2x, cy: c2y } = tileCenter(tile2, layout);
+  const midX = (c1x + c2x) / 2;
+  const midY = (c1y + c2y) / 2;
 
-  const t1cx = useSharedValue(c1x * scale);
-  const t1cy = useSharedValue(c1y * scale);
-  const t2cx = useSharedValue(c2x * scale);
-  const t2cy = useSharedValue(c2y * scale);
+  const t1cx = useSharedValue(c1x);
+  const t1cy = useSharedValue(c1y);
+  const t2cx = useSharedValue(c2x);
+  const t2cy = useSharedValue(c2y);
   const pairOpacity = useSharedValue(1);
   const burstScaleVal = useSharedValue(0);
   const burstOpacity = useSharedValue(0);
@@ -144,8 +135,8 @@ function FlyingPair({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const tw = (TILE_W - SIDE_W) * scale;
-  const th = (TILE_H - SIDE_W) * scale;
+  const tw = layout.tileWidth - layout.sideWidth;
+  const th = layout.tileHeight - layout.sideWidth;
 
   const tile1Style = useAnimatedStyle(() => ({
     position: "absolute",
@@ -203,11 +194,10 @@ export default function MahjongScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
+  const layout = useMahjongCanvasLayout();
 
   const [state, setState] = useState<MahjongState | null>(null);
   const [loading, setLoading] = useState(true);
-  const [outerWidth, setOuterWidth] = useState(0);
-  const [outerHeight, setOuterHeight] = useState(0);
   const [stats, setStats] = useState<MahjongStats>({
     bestScore: 0,
     bestTimeMs: 0,
@@ -503,16 +493,6 @@ export default function MahjongScreen() {
     syncMarkStarted();
   }, [syncGetGameId, syncComplete, syncStart, syncMarkStarted]);
 
-  const scale =
-    outerWidth > 0 && outerHeight > 0
-      ? Math.min(MAX_TILE_W / TILE_W, outerWidth / BOARD_W, outerHeight / BOARD_H)
-      : 1;
-
-  const onOuterLayout = useCallback((e: LayoutChangeEvent) => {
-    setOuterWidth(Math.floor(e.nativeEvent.layout.width));
-    setOuterHeight(Math.floor(e.nativeEvent.layout.height));
-  }, []);
-
   const undoDisabled = !state || state.undoStack.length === 0 || state.isComplete;
 
   return (
@@ -544,63 +524,52 @@ export default function MahjongScreen() {
         </Pressable>
       }
     >
-      <ScrollView
-        style={styles.scrollArea}
-        contentContainerStyle={styles.scrollContent}
-        onLayout={onOuterLayout}
-        showsVerticalScrollIndicator={false}
-      >
-        {state !== null && (
-          <>
-            <View style={styles.hudRow} accessibilityRole="summary">
-              <Text style={[styles.hudText, { color: colors.text }]}>
-                {t("hud.score")} {state.score}
-              </Text>
-              <Text style={[styles.hudText, { color: colors.textMuted }]}>
-                {t("hud.pairs")} {state.pairsRemoved}/72
-              </Text>
-              <Text style={[styles.hudText, { color: colors.textMuted }]}>
-                {t("action.shuffle")} {state.shufflesLeft}
-              </Text>
-              <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
-                {t("hud.deal")} #{state.dealId}
-              </Text>
-            </View>
+      {state !== null && (
+        <>
+          <View style={styles.hudRow} accessibilityRole="summary">
+            <Text style={[styles.hudText, { color: colors.text }]}>
+              {t("hud.score")} {state.score}
+            </Text>
+            <Text style={[styles.hudText, { color: colors.textMuted }]}>
+              {t("hud.pairs")} {state.pairsRemoved}/72
+            </Text>
+            <Text style={[styles.hudText, { color: colors.textMuted }]}>
+              {t("action.shuffle")} {state.shufflesLeft}
+            </Text>
+            <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
+              {t("hud.deal")} #{state.dealId}
+            </Text>
+          </View>
 
-            <View
-              style={{
-                width: BOARD_W * scale,
-                height: BOARD_H * scale,
-                overflow: "hidden",
-                alignSelf: "center",
-              }}
-            >
-              {/* boardAnimWrap handles shake + pulse; inner board View applies scale transform */}
-              <Animated.View style={[styles.boardAnimWrap, boardAnimStyle]}>
-                <View
-                  style={[styles.board, { width: BOARD_W, transform: [{ scale }] } as ViewStyle]}
-                >
-                  <GameCanvas
-                    state={state}
-                    onTilePress={handleTilePress}
-                    onShufflePress={handleShuffle}
-                    onNewGamePress={startNewGame}
-                  />
-                </View>
-              </Animated.View>
-              {flyingPairs.map((pair) => (
-                <FlyingPair
-                  key={pair.id}
-                  {...pair}
-                  scale={scale}
-                  color={colors.accent + "99"}
-                  onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
-                />
-              ))}
-            </View>
-          </>
-        )}
-      </ScrollView>
+          {/* Board container — overflow:hidden clips FlyingPair animations */}
+          <View
+            style={{
+              width: layout.boardWidth,
+              height: layout.boardHeight,
+              overflow: "hidden",
+              alignSelf: "center",
+            }}
+          >
+            <Animated.View style={boardAnimStyle}>
+              <GameCanvas
+                state={state}
+                onTilePress={handleTilePress}
+                onShufflePress={handleShuffle}
+                onNewGamePress={startNewGame}
+              />
+            </Animated.View>
+            {flyingPairs.map((pair) => (
+              <FlyingPair
+                key={pair.id}
+                {...pair}
+                layout={layout}
+                color={colors.accent + "99"}
+                onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
+              />
+            ))}
+          </View>
+        </>
+      )}
 
       {state?.isComplete && (
         <WinModal
@@ -777,12 +746,6 @@ function WinModal({
 // ---------------------------------------------------------------------------
 
 const styles = StyleSheet.create({
-  scrollArea: {
-    flex: 1,
-  },
-  scrollContent: {
-    flexGrow: 1,
-  },
   headerBtn: {
     paddingHorizontal: 10,
     paddingVertical: 5,
@@ -812,13 +775,6 @@ const styles = StyleSheet.create({
     fontSize: 10,
     opacity: 0.6,
   },
-  boardAnimWrap: {
-    alignSelf: "flex-start",
-  },
-  board: {
-    alignSelf: "flex-start",
-    transformOrigin: "top left",
-  } as ViewStyle,
   modalOverlay: {
     flex: 1,
     alignItems: "center",

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -21,6 +21,7 @@ import {
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -525,7 +526,11 @@ export default function MahjongScreen() {
       }
     >
       {state !== null && (
-        <>
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
           <View style={styles.hudRow} accessibilityRole="summary">
             <Text style={[styles.hudText, { color: colors.text }]}>
               {t("hud.score")} {state.score}
@@ -553,6 +558,7 @@ export default function MahjongScreen() {
             <Animated.View style={boardAnimStyle}>
               <GameCanvas
                 state={state}
+                layout={layout}
                 onTilePress={handleTilePress}
                 onShufflePress={handleShuffle}
                 onNewGamePress={startNewGame}
@@ -568,7 +574,7 @@ export default function MahjongScreen() {
               />
             ))}
           </View>
-        </>
+        </ScrollView>
       )}
 
       {state?.isComplete && (
@@ -759,6 +765,9 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     letterSpacing: 0.8,
     textTransform: "uppercase",
+  },
+  scrollContent: {
+    flexGrow: 1,
   },
   hudRow: {
     flexDirection: "row",

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -74,10 +74,7 @@ const MAX_NAME_LENGTH = 32;
 // Tile center — used by FlyingPair to compute animation start/end positions
 // ---------------------------------------------------------------------------
 
-function tileCenter(
-  tile: SlotTile,
-  l: MahjongLayout
-): { cx: number; cy: number } {
+function tileCenter(tile: SlotTile, l: MahjongLayout): { cx: number; cy: number } {
   return {
     cx: l.padX + (tile.col / 2) * l.tileWidth + tile.layer * l.layerDx + l.tileWidth / 2,
     cy: l.padY + tile.row * l.tileHeight - tile.layer * l.layerDy + l.tileHeight / 2,

--- a/frontend/src/screens/__tests__/MahjongScreen.test.tsx
+++ b/frontend/src/screens/__tests__/MahjongScreen.test.tsx
@@ -36,19 +36,7 @@ jest.mock("../../components/mahjong/GameCanvas", () => {
     );
   }
   MockGameCanvas.displayName = "MockGameCanvas";
-  return {
-    __esModule: true,
-    default: MockGameCanvas,
-    BOARD_W: 548,
-    BOARD_H: 468,
-    TILE_W: 44,
-    TILE_H: 56,
-    PAD_X: 6,
-    PAD_Y: 10,
-    LAYER_DX: 6,
-    LAYER_DY: 5,
-    SIDE_W: 5,
-  };
+  return { __esModule: true, default: MockGameCanvas };
 });
 
 const mockNavListeners = new Map<string, Array<() => void>>();

--- a/frontend/src/screens/__tests__/MahjongScreen.test.tsx
+++ b/frontend/src/screens/__tests__/MahjongScreen.test.tsx
@@ -28,6 +28,7 @@ jest.mock("../../components/mahjong/GameCanvas", () => {
     onTilePress: (id: number) => void;
     onShufflePress: () => void;
     onNewGamePress: () => void;
+    layout: object;
   }) {
     return (
       <View testID="game-canvas">


### PR DESCRIPTION
## Summary
- Closes #1331 (epic), #1341, #1342, #1343, #1340, #1344
- New `frontend/src/game/mahjong/layout.ts` — pure `calculateMahjongLayout()` function + `useMahjongCanvasLayout()` hook; derives all tile pixel geometry from screen dimensions and safe-area insets; tile width clamped to 28–56 px
- `GameCanvas.tsx` and `GameCanvas.web.tsx` — hardcoded constants removed; both canvases call `useMahjongCanvasLayout()` and render at the computed `boardWidth × boardHeight`
- `MahjongScreen.tsx` — scale-based transform wrapper removed; `FlyingPair` animations updated to use native layout coordinates; existing vertical `ScrollView` handles overflow when tiles are clamped to minimum size on small screens (e.g. iPhone SE landscape)

## Test plan
- [ ] All 97 existing mahjong tests pass (`jest src/game/mahjong src/components/mahjong src/screens/__tests__/MahjongScreen`)
- [ ] Desktop web (1280px): board fills screen, tiles at max 56px — no squishing
- [ ] Mobile web (375px portrait): board scrollable, tiles at min 28px — readable
- [ ] iPad landscape: tiles sized up to 56px, board fits without scroll
- [ ] iPhone SE landscape (375×667): tiles 28px, board taller than viewport → scrollable
- [ ] iPhone 16 Pro landscape: tiles 28px (height-constrained), board scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)