### PR TITLE
feat(freecell): add visual gap between freecell slots and foundation piles

### DIFF
--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -322,7 +322,9 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
                   card={card}
                   cellIndex={i}
                   selected={selection?.kind === "freecell" && selection.cell === i}
-                  shakeX={selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined}
+                  shakeX={
+                    selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined
+                  }
                   hintSource={
                     (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
                     (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -20,6 +20,8 @@ import { useCardSelection } from "../../game/_shared/useCardSelection";
 const TABLEAU_COLS = 8;
 const COL_GAP = 2;
 const ROW_GAP = 8;
+// Tighter than COL_GAP so space-between produces a natural ~8px gap between groups
+const TOP_GROUP_GAP = 1;
 const DOUBLE_TAP_MS = 300;
 
 type Selection =
@@ -398,7 +400,7 @@ const styles = StyleSheet.create({
   },
   topGroup: {
     flexDirection: "row",
-    gap: 1,
+    gap: TOP_GROUP_GAP,
   },
   tableau: {
     flexDirection: "row",

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -313,38 +313,42 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
               },
             ]}
           >
-            {state.freeCells.map((card, i) => (
-              <FreeCellSlot
-                key={i}
-                card={card}
-                cellIndex={i}
-                selected={selection?.kind === "freecell" && selection.cell === i}
-                shakeX={selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined}
-                hintSource={
-                  (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
-                  (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
-                }
-                hintDestination={hintDestFreeCellIndex === i}
-                onPress={handleFreeCellPress}
-                dropId={`freecell-slot-${i}`}
-                onDrop={(source) => handleDropToFreeCell(source, i)}
-              />
-            ))}
-            {SUITS.map((suit) => (
-              <FoundationPile
-                key={suit}
-                pile={state.foundations[suit]}
-                suit={suit}
-                selected={selection?.kind === "foundation" && selection.suit === suit}
-                shakeX={
-                  selection?.kind === "foundation" && selection.suit === suit ? shakeX : undefined
-                }
-                hintDestination={hintDestFoundationSuit === suit}
-                onPress={() => handleFoundationPress(suit)}
-                dropId={`freecell-foundation-${suit}`}
-                onDrop={(source) => handleDropToFoundation(source)}
-              />
-            ))}
+            <View style={styles.topGroup}>
+              {state.freeCells.map((card, i) => (
+                <FreeCellSlot
+                  key={i}
+                  card={card}
+                  cellIndex={i}
+                  selected={selection?.kind === "freecell" && selection.cell === i}
+                  shakeX={selection?.kind === "freecell" && selection.cell === i ? shakeX : undefined}
+                  hintSource={
+                    (state.hint?.type === "freecell-to-tableau" && state.hint.fromCell === i) ||
+                    (state.hint?.type === "freecell-to-foundation" && state.hint.fromCell === i)
+                  }
+                  hintDestination={hintDestFreeCellIndex === i}
+                  onPress={handleFreeCellPress}
+                  dropId={`freecell-slot-${i}`}
+                  onDrop={(source) => handleDropToFreeCell(source, i)}
+                />
+              ))}
+            </View>
+            <View style={styles.topGroup}>
+              {SUITS.map((suit) => (
+                <FoundationPile
+                  key={suit}
+                  pile={state.foundations[suit]}
+                  suit={suit}
+                  selected={selection?.kind === "foundation" && selection.suit === suit}
+                  shakeX={
+                    selection?.kind === "foundation" && selection.suit === suit ? shakeX : undefined
+                  }
+                  hintDestination={hintDestFoundationSuit === suit}
+                  onPress={() => handleFoundationPress(suit)}
+                  dropId={`freecell-foundation-${suit}`}
+                  onDrop={(source) => handleDropToFoundation(source)}
+                />
+              ))}
+            </View>
           </View>
 
           <View style={styles.tableau}>
@@ -390,7 +394,11 @@ const styles = StyleSheet.create({
   },
   topRow: {
     flexDirection: "row",
-    gap: COL_GAP,
+    justifyContent: "space-between",
+  },
+  topGroup: {
+    flexDirection: "row",
+    gap: 1,
   },
   tableau: {
     flexDirection: "row",


### PR DESCRIPTION
Closes #1380

## Summary

- Wrapped the 4 freecell slots and 4 foundation piles in their own sub-`View`s
- Switched `topRow` to `justifyContent: "space-between"` so the two groups are pushed to opposite ends of `boardWidth`
- Reduced intra-group gap from 2px → 1px, yielding an ~8px natural gap between the groups while keeping outer card edges flush with the tableau columns below

## Test plan

- [ ] Visible gap appears between the 4th freecell slot and the 1st foundation pile
- [ ] Card piles in both groups remain readable and tap targets are unchanged
- [ ] Drag-and-drop still works correctly for all move types
- [ ] No regression in tableau alignment (outer edges stay flush with columns 1 and 8)
- [ ] All 135 freecell unit tests pass (`npx jest --testPathPattern="freecell"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)