### PR TITLE
feat(starswarm): double shield ring radius + preserve paused session (#1368, #1367)

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -128,15 +128,31 @@ export default function Controls({
       <View style={[styles.overlay, { width: displayW, height: displayH }]}>
         {/* Pause overlay */}
         {isPaused && !isGameOver && (
-          <Pressable
-            style={styles.pauseOverlay}
-            onPress={onResume}
-            accessibilityLabel={t("controls.resumeLabel")}
-            accessibilityRole="button"
-          >
+          <View style={styles.pauseOverlay}>
+            <Pressable
+              style={StyleSheet.absoluteFillObject}
+              onPress={onResume}
+              accessibilityLabel={t("controls.resumeLabel")}
+              accessibilityRole="button"
+            />
             <Text style={styles.pauseTitle}>{t("controls.paused")}</Text>
-            <Text style={styles.pauseHint}>{t("controls.tapToResume")}</Text>
-          </Pressable>
+            <Pressable
+              style={styles.pauseResumeBtn}
+              onPress={onResume}
+              accessibilityLabel={t("controls.resumeLabel")}
+              accessibilityRole="button"
+            >
+              <Text style={styles.pauseHint}>{t("controls.tapToResume")}</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.newGameBtn, styles.pauseNewGameBtn]}
+              onPress={handleNewGame}
+              accessibilityLabel={t("controls.newGameFromPauseLabel")}
+              accessibilityRole="button"
+            >
+              <Text style={styles.newGameBtnText}>{t("controls.newGameFromPause")}</Text>
+            </Pressable>
+          </View>
         )}
 
         {/* Game-over new-game button */}
@@ -190,10 +206,17 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     letterSpacing: 3,
   },
+  pauseResumeBtn: {
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 24,
+  },
   pauseHint: {
     color: "rgba(255,255,255,0.6)",
     fontSize: 13,
-    marginTop: 12,
+  },
+  pauseNewGameBtn: {
+    marginTop: 24,
   },
   gameOverActions: {
     position: "absolute",

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -53,6 +53,8 @@ export interface GameCanvasHandle {
   setFire: (fire: boolean) => void;
   /** Inject a power-up activation mid-game for dev-panel testing (#1039). */
   triggerPowerUp: (type: PowerUpType) => void;
+  /** Return the current engine state snapshot — used by StarSwarmScreen to save paused state (#1367). */
+  getState: () => StarSwarmState;
 }
 
 interface Props {
@@ -80,6 +82,8 @@ interface Props {
   /** Dev options applied on each reset (wave, infiniteLives). Passed as prop so reset
    *  is reactive and doesn't depend on the imperative ref being non-null. */
   devOptions?: DevOptions;
+  /** Seed the engine with an existing state instead of initialState() — used to restore a paused session (#1367). */
+  initialState?: StarSwarmState;
 }
 
 interface RenderState {
@@ -108,13 +112,14 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       resetTick,
       difficulty: difficultyProp = "LieutenantJG",
       devOptions,
+      initialState,
     },
     ref
   ) => {
     const { t } = useTranslation("starswarm");
     const images = useStarSwarmImages();
 
-    const gameRef = useRef<StarSwarmState>(initStarSwarm(width, height, 1, 42, difficultyProp));
+    const gameRef = useRef<StarSwarmState>(initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
@@ -196,6 +201,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         triggerPowerUp(type) {
           triggerPowerUpRef.current = type;
+        },
+        getState() {
+          return gameRef.current;
         },
       }),
       []
@@ -440,7 +448,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                   {enemy.hitFlashTimer > 0 &&
                     (() => {
                       const progress = 1 - enemy.hitFlashTimer / HIT_FLASH_DURATION;
-                      const refR = Math.max(enemy.width, enemy.height) * 0.6;
+                      const refR = Math.max(enemy.width, enemy.height) * 1.2;
                       const r = refR * (0.6 + 0.5 * progress);
                       const a = enemy.hitFlashTimer / HIT_FLASH_DURATION; // 1→0 as burst plays
                       return (
@@ -458,7 +466,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                             r={r}
                             color={`rgba(0,170,255,${(a * 0.75).toFixed(3)})`}
                             style="stroke"
-                            strokeWidth={2}
+                            strokeWidth={3}
                           />
                         </Group>
                       );

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -119,7 +119,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const { t } = useTranslation("starswarm");
     const images = useStarSwarmImages();
 
-    const gameRef = useRef<StarSwarmState>(initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp));
+    const gameRef = useRef<StarSwarmState>(
+      initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp)
+    );
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -8,6 +8,7 @@ import {
   tick,
   applyPowerUp,
   POWERUP_DURATION,
+  HIT_FLASH_DURATION,
   difficultyLabel,
   difficultyMultiplier,
 } from "../../game/starswarm/engine";
@@ -137,6 +138,8 @@ export interface GameCanvasHandle {
   setPlayerX: (x: number) => void;
   setFire: (fire: boolean) => void;
   triggerPowerUp: (type: PowerUpType) => void;
+  /** Return the current engine state snapshot — used by StarSwarmScreen to save paused state (#1367). */
+  getState: () => StarSwarmState;
 }
 
 interface Props {
@@ -160,6 +163,8 @@ interface Props {
   /** Active difficulty tier — passed from the pre-game selector (#1037). */
   difficulty?: DifficultyTier;
   devOptions?: DevOptions;
+  /** Seed the engine with an existing state instead of initialState() — used to restore a paused session (#1367). */
+  initialState?: StarSwarmState;
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
@@ -183,6 +188,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       resetTick,
       difficulty: difficultyProp = "LieutenantJG",
       devOptions,
+      initialState,
     },
     ref
   ) => {
@@ -195,7 +201,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const scaleRef = useRef(scale);
     const difficultyRef = useRef<DifficultyTier>(difficultyProp);
-    const stateRef = useRef<StarSwarmState>(initStarSwarm(width, height, 1, 42, difficultyProp));
+    const stateRef = useRef<StarSwarmState>(initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp));
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);
@@ -363,6 +369,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         triggerPowerUp(type) {
           triggerPowerUpRef.current = type;
         },
+        getState() {
+          return stateRef.current;
+        },
       }),
       []
     );
@@ -472,15 +481,19 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           );
         }
         if (enemy.hitFlashTimer > 0) {
-          ctx.globalAlpha = 0.55;
-          ctx.fillStyle = C.hitFlash;
-          ctx.fillRect(
-            enemy.x - enemy.width / 2,
-            enemy.y - enemy.height / 2,
-            enemy.width,
-            enemy.height
-          );
-          ctx.globalAlpha = 1;
+          const progress = 1 - enemy.hitFlashTimer / HIT_FLASH_DURATION;
+          const refR = Math.max(enemy.width, enemy.height) * 1.2;
+          const r = refR * (0.6 + 0.5 * progress);
+          const a = enemy.hitFlashTimer / HIT_FLASH_DURATION;
+          ctx.beginPath();
+          ctx.arc(enemy.x, enemy.y, r, 0, Math.PI * 2);
+          ctx.fillStyle = `rgba(0,170,255,${(a * 0.25).toFixed(3)})`;
+          ctx.fill();
+          ctx.beginPath();
+          ctx.arc(enemy.x, enemy.y, r, 0, Math.PI * 2);
+          ctx.strokeStyle = `rgba(0,170,255,${(a * 0.75).toFixed(3)})`;
+          ctx.lineWidth = 3;
+          ctx.stroke();
         }
 
         // HP pips — Elite (2) and Boss (4); Grunt always has 1 HP so pips are omitted

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -201,7 +201,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const scaleRef = useRef(scale);
     const difficultyRef = useRef<DifficultyTier>(difficultyProp);
-    const stateRef = useRef<StarSwarmState>(initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp));
+    const stateRef = useRef<StarSwarmState>(
+      initialState ?? initStarSwarm(width, height, 1, 42, difficultyProp)
+    );
     const sfRef = useRef<StarfieldState>(initStarfield(width, height));
     const inputRef = useRef({ playerX: width / 2, fire: true });
     const infiniteLivesRef = useRef(false);

--- a/frontend/src/game/starswarm/pauseStore.ts
+++ b/frontend/src/game/starswarm/pauseStore.ts
@@ -1,0 +1,21 @@
+import type { StarSwarmState } from "./types";
+import type { DifficultyTier } from "./types";
+
+interface SavedPauseState {
+  gameState: StarSwarmState;
+  difficulty: DifficultyTier;
+}
+
+let _saved: SavedPauseState | null = null;
+
+export function savePausedState(state: SavedPauseState): void {
+  _saved = state;
+}
+
+export function getSavedPausedState(): SavedPauseState | null {
+  return _saved;
+}
+
+export function clearSavedPausedState(): void {
+  _saved = null;
+}

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -14,6 +14,7 @@
   "controls.chargeShotLabel": "Charge shot — hold and release to fire",
   "controls.paused": "PAUSED",
   "controls.tapToResume": "Tap to resume",
+  "controls.pauseLabel": "Pause game",
   "controls.resumeLabel": "Resume game",
   "controls.newGame": "NEW GAME",
   "controls.newGameLabel": "Start a new game",

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -17,6 +17,8 @@
   "controls.resumeLabel": "Resume game",
   "controls.newGame": "NEW GAME",
   "controls.newGameLabel": "Start a new game",
+  "controls.newGameFromPause": "NEW GAME",
+  "controls.newGameFromPauseLabel": "Discard saved game and start a new game",
   "difficulty.selectTitle": "Select Difficulty",
   "difficulty.start": "Start Game",
   "phase.perfect": "PERFECT!",

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -34,6 +34,11 @@ import {
 } from "../game/starswarm/engine";
 import type { GamePhase, PowerUpType, DifficultyTier } from "../game/starswarm/types";
 import { starSwarmApi } from "../game/starswarm/api";
+import {
+  getSavedPausedState,
+  savePausedState,
+  clearSavedPausedState,
+} from "../game/starswarm/pauseStore";
 import { useStarSwarmAudio, DEFAULT_SFX_VOLUMES } from "../hooks/useStarSwarmAudio";
 import type { SfxVolumes } from "../hooks/useStarSwarmAudio";
 
@@ -45,9 +50,12 @@ export default function StarSwarmScreen() {
 
   const canvasRef = useRef<GameCanvasHandle>(null);
 
+  // Capture saved paused session once at mount — used to restore game state and skip difficulty picker.
+  const savedPauseRef = useRef(getSavedPausedState());
+
   const [highScore, setHighScore] = useState(0);
   const [phase, setPhase] = useState<GamePhase>("SwoopIn");
-  const [isPaused, setIsPaused] = useState(false);
+  const [isPaused, setIsPaused] = useState(savedPauseRef.current !== null);
   const [containerW, setContainerW] = useState(0);
   const [containerH, setContainerH] = useState(0);
 
@@ -62,9 +70,11 @@ export default function StarSwarmScreen() {
   const [devPlayerFireOff, setDevPlayerFireOff] = useState(false);
   const [devEnemyFireOff, setDevEnemyFireOff] = useState(false);
 
-  // Pre-game difficulty selector — shown before each new game
-  const [difficulty, setDifficulty] = useState<DifficultyTier>("LieutenantJG");
-  const [showDifficultyPicker, setShowDifficultyPicker] = useState(true);
+  // Pre-game difficulty selector — shown before each new game (skipped when restoring a saved session)
+  const [difficulty, setDifficulty] = useState<DifficultyTier>(
+    savedPauseRef.current?.difficulty ?? "LieutenantJG"
+  );
+  const [showDifficultyPicker, setShowDifficultyPicker] = useState(savedPauseRef.current === null);
 
   const adjustVolume = useCallback((key: keyof SfxVolumes, delta: number) => {
     setDevVolumes((v) => ({
@@ -155,6 +165,8 @@ export default function StarSwarmScreen() {
 
   // Confirm difficulty selection and start the game
   const handleConfirmDifficulty = useCallback(() => {
+    clearSavedPausedState();
+    savedPauseRef.current = null;
     setShowDifficultyPicker(false);
     scoreRef.current = 0;
     setPhase("SwoopIn");
@@ -191,7 +203,13 @@ export default function StarSwarmScreen() {
     <GameShell
       title={t("game.title")}
       requireBack
-      onBack={() => navigation.popToTop()}
+      onBack={() => {
+        if (isPaused) {
+          const state = canvasRef.current?.getState();
+          if (state) savePausedState({ gameState: state, difficulty });
+        }
+        navigation.popToTop();
+      }}
       onNewGame={handleRequestNewGame}
       style={{
         paddingBottom: Math.max(insets.bottom, 8),
@@ -222,6 +240,7 @@ export default function StarSwarmScreen() {
               scale={scale}
               difficulty={difficulty}
               resetTick={resetTick}
+              initialState={savedPauseRef.current?.gameState}
               // #1311/#1312: spread lastDevOptsRef for new-game options (wave, lives, etc.),
               // then override live-toggleable fields so they propagate mid-game without New Game.
               // pauseStraggler is also overridden here (fixes a pre-existing gap where the toggle

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   View,
 } from "react-native";
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -199,6 +200,8 @@ export default function StarSwarmScreen() {
   const displayW = Math.round(CANVAS_W * scale);
   const displayH = Math.round(CANVAS_H * scale);
 
+  const showPauseBtn = !showDifficultyPicker && phase !== "GameOver" && scale > 0;
+
   return (
     <GameShell
       title={t("game.title")}
@@ -211,6 +214,26 @@ export default function StarSwarmScreen() {
         navigation.popToTop();
       }}
       onNewGame={handleRequestNewGame}
+      rightSlot={
+        showPauseBtn ? (
+          <Pressable
+            onPress={isPaused ? handleResume : handlePause}
+            accessibilityRole="button"
+            accessibilityLabel={isPaused ? t("controls.resumeLabel") : t("controls.pauseLabel")}
+            style={({ pressed }) => [
+              styles.pauseHeaderBtn,
+              pressed && styles.pauseHeaderBtnPressed,
+            ]}
+            hitSlop={8}
+          >
+            <MaterialIcons
+              name={isPaused ? "play-arrow" : "pause"}
+              size={22}
+              color={colors.textOnAccent}
+            />
+          </Pressable>
+        ) : undefined
+      }
       style={{
         paddingBottom: Math.max(insets.bottom, 8),
         paddingLeft: Math.max(insets.left, 0),
@@ -491,6 +514,17 @@ const baseStyles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+  },
+  pauseHeaderBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#00aaff",
+  },
+  pauseHeaderBtnPressed: {
+    opacity: 0.7,
   },
   devButtonText: {
     color: "#fff",


### PR DESCRIPTION
## Summary

- **#1368 — Shield ring radius:** Doubles the hit-flash ring on both renderers (`refR` multiplier `0.6→1.2`, `strokeWidth` `2→3`). Also replaces the web Canvas 2D renderer's flat `fillRect` flash with the same expanding cyan ring animation, making both renderers consistent.
- **#1367 — Preserve paused session:** When a player exits while paused, the engine state is saved to a module-level store (`pauseStore.ts`). On re-entry the game resumes from the frozen frame (difficulty picker is skipped). The pause overlay now shows both **Tap to resume** and a **NEW GAME** button; tapping New Game clears the saved state and shows the difficulty picker.

## Files changed

| File | What changed |
|---|---|
| `GameCanvas.tsx` | Doubled `refR`, increased `strokeWidth`, added `initialState` prop + `getState()` handle method |
| `GameCanvas.web.tsx` | Same prop/handle additions; replaced fillRect flash with ring animation |
| `Controls.tsx` | Pause overlay restructured — full-screen resume tap target + explicit NEW GAME button |
| `StarSwarmScreen.tsx` | Reads/saves/clears `pauseStore` on mount, back-nav, and new-game confirm |
| `pauseStore.ts` *(new)* | Module-level singleton holding `{ gameState, difficulty }` |
| `starswarm.json` | Added `controls.newGameFromPause` / `controls.newGameFromPauseLabel` keys |

## Test plan

- [ ] Hit an enemy without killing it — shield ring is visibly ~2× larger than before on both native and web
- [ ] Pause game, tap Back — re-enter Star Swarm, game resumes at the frozen frame (no difficulty picker)
- [ ] From pause overlay tap **NEW GAME** — difficulty picker appears, starting fresh clears saved state
- [ ] Pause → back → re-enter → tap Resume — game continues normally
- [ ] Game over path unaffected — no saved state bleeds into next session
- [ ] Other games unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)