### PR TITLE
fix(solitaire): stable waste pile width + pin selection notice to bottom

### DIFF
--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -191,7 +191,7 @@ function Waste({
 
   const visibleCount = Math.min(3, waste.length);
   const visible = waste.slice(waste.length - visibleCount);
-  const containerWidth = (visibleCount - 1) * wasteFanOffset + cardWidth;
+  const containerWidth = 2 * wasteFanOffset + cardWidth;
 
   return (
     <View style={[styles.wasteFanContainer, { width: containerWidth, height: cardHeight }]}>

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -144,10 +144,9 @@ function Waste({
   const wasteFanOffset = Math.round(WASTE_FAN_OFFSET * (cardWidth / CARD_WIDTH));
 
   if (waste.length === 0) {
-    const emptyWidth = drawMode === 3 ? 2 * wasteFanOffset + cardWidth : cardWidth;
     return (
       <View
-        style={{ width: emptyWidth, height: cardHeight }}
+        style={{ width: cardWidth, height: cardHeight }}
         accessibilityRole="image"
         accessibilityLabel={t("pile.waste.empty")}
       />

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -144,9 +144,10 @@ function Waste({
   const wasteFanOffset = Math.round(WASTE_FAN_OFFSET * (cardWidth / CARD_WIDTH));
 
   if (waste.length === 0) {
+    const emptyWidth = drawMode === 3 ? 2 * wasteFanOffset + cardWidth : cardWidth;
     return (
       <View
-        style={{ width: cardWidth, height: cardHeight }}
+        style={{ width: emptyWidth, height: cardHeight }}
         accessibilityRole="image"
         accessibilityLabel={t("pile.waste.empty")}
       />

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -763,7 +763,7 @@ export default function SolitaireScreen() {
               <SolitaireWinCascade visible={cascadeVisible} />
 
               <View
-                style={styles.selectionIndicator}
+                style={[styles.selectionIndicator, { bottom: Math.max(insets.bottom, 8) }]}
                 accessibilityLiveRegion="polite"
                 pointerEvents="none"
               >
@@ -1023,7 +1023,6 @@ const styles = StyleSheet.create({
   },
   selectionIndicator: {
     position: "absolute",
-    bottom: 0,
     left: 0,
     right: 0,
     alignItems: "center",

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -728,14 +728,6 @@ export default function SolitaireScreen() {
                   </View>
                 </View>
 
-                <View style={styles.selectionIndicator} accessibilityLiveRegion="polite">
-                  {selectionLabel !== null && (
-                    <Text style={[styles.selectionIndicatorText, { color: colors.accent }]}>
-                      {selectionLabel}
-                    </Text>
-                  )}
-                </View>
-
                 <View style={[styles.tableauRow, { minHeight: cardSize.cardHeight * 3 }]}>
                   {state.tableau.map((pile, col) => (
                     <TableauPile
@@ -769,6 +761,18 @@ export default function SolitaireScreen() {
               )}
 
               <SolitaireWinCascade visible={cascadeVisible} />
+
+              <View
+                style={styles.selectionIndicator}
+                accessibilityLiveRegion="polite"
+                pointerEvents="none"
+              >
+                {selectionLabel !== null && (
+                  <Text style={[styles.selectionIndicatorText, { color: colors.accent }]}>
+                    {selectionLabel}
+                  </Text>
+                )}
+              </View>
             </DragContainer>
           </CardSizeContext.Provider>
         )}
@@ -1018,8 +1022,12 @@ const styles = StyleSheet.create({
     gap: COL_GAP,
   },
   selectionIndicator: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
     alignItems: "center",
-    paddingVertical: 4,
+    paddingVertical: 8,
   },
   selectionIndicatorText: {
     fontFamily: typography.heading,

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -696,7 +696,7 @@ export default function SolitaireScreen() {
                     onStockPress={handleStockPress}
                     onWastePress={handleWastePress}
                   />
-                  <View style={{ width: cardSize.cardWidth + COL_GAP }} />
+                  <View style={{ flex: 1 }} />
                   <View>
                     <View style={styles.foundationsRow}>
                       {SUITS.map((suit) => (


### PR DESCRIPTION
## Summary

- **#1365** — Waste pile container now always uses max fan width (`2 * wasteFanOffset + cardWidth`) in `StockWastePile.tsx`, preventing the horizontal shift during draw-3 cycling when visible card count changes 1→2→3.
- **#1366** — Selection notice moved out of the board `View` and absolutely positioned at `bottom: 0`, pinning it below the tableau as a status bar so it no longer interrupts the game layout.

## Test plan

- [ ] Draw-3 mode: cycle through the stock repeatedly and confirm the waste pile stays locked in place
- [ ] Draw-1 mode: confirm no regression (single-card waste unaffected)
- [ ] Select a card from waste, foundation, and tableau — confirm notice appears at the bottom of the screen
- [ ] Deselect — confirm notice disappears cleanly
- [ ] All 123 solitaire tests pass (`npx jest --testPathPattern="solitaire|Solitaire"`)

Closes #1365, closes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)