### PR TITLE
fix(yacht): center fanfare dice around badge (#1378)

### DIFF
--- a/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
+++ b/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
@@ -107,8 +107,8 @@ export function YachtCelebrationAnimation({ visible, onDismiss, variant = "yacht
               {
                 left: "50%",
                 top: "50%",
-                marginLeft: offset.x,
-                marginTop: offset.y,
+                marginLeft: offset.x - 16,
+                marginTop: offset.y - 16,
               },
               faceStyles[i],
             ]}


### PR DESCRIPTION
## Summary
- Subtracts half the die glyph size (16 px) from `marginLeft` and `marginTop` in `YachtCelebrationAnimation.tsx`
- Fixes all 8 fanfare dice appearing ~16 px right and ~16 px down from their intended radial positions
- Animation timing and both `yacht`/`joker` variants are unchanged

Closes #1378

## Test plan
- [ ] Trigger a YACHT! celebration — all 8 dice appear symmetrically centered around the badge
- [ ] Trigger a JOKER! celebration — same result
- [ ] Confirm staggered spring burst + fade-out timing is unaffected
- [ ] Verify on both iOS and Android screen sizes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)