### PR TITLE
feat(bottle-sort): realistic pour animation — diagonal lift, progressive tilt, curved stream

### DIFF
--- a/frontend/src/game/sort/components/BottleView.tsx
+++ b/frontend/src/game/sort/components/BottleView.tsx
@@ -72,10 +72,10 @@ export const DEFAULT_BOTTLE_HEIGHT = 156;
 export const BOTTLE_WIDTH = DEFAULT_BOTTLE_WIDTH;
 export const BOTTLE_HEIGHT = DEFAULT_BOTTLE_HEIGHT;
 
-// Pour animation timing (ms)
-const TILT_IN_MS = 250;
+// Pour animation timing (ms) — used by reduce-motion fallback in SortScreen
+export const TILT_IN_MS = 250;
 export const TILT_HOLD_MS = 150;
-const TILT_OUT_MS = 200;
+export const TILT_OUT_MS = 200;
 export const TILT_DEG = 62;
 
 export interface BottleViewProps {

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -161,11 +161,11 @@ export default function SortBoard({
     const isRight = pouringFrom < pouringTo;
     const tiltSign: 1 | -1 = isRight ? 1 : -1;
 
-    // Spout pivot: outer neck edge scaled from viewBox coords to bottleW/bottleH
+    // Spout pivot: outer neck edge scaled from viewBox coords to bottleW
     const pivotLocalX = ((isRight ? NECK_RIGHT_VB : NECK_LEFT_VB) / VB_W) * bottleW;
-    const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
 
     // Diagonal lift target: move spout to center-top of destination opening
+    // liftDy aligns bottle tops (pivotLocalY cancels: dstNeckY - srcNeckY = dstY - srcY)
     const liftDx = (dstPos.x + bottleW / 2) - (srcPos.x + pivotLocalX);
     const liftDy = dstPos.y - srcPos.y;
 

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -42,8 +42,6 @@ interface GhostInfo {
   startY: number;
   dstX: number;
   dstY: number;
-  liftDx: number;
-  liftDy: number;
   tiltSign: 1 | -1;
   dstBottleLength: number;
 }
@@ -148,8 +146,6 @@ export default function SortBoard({
       ghostTiltDeg.value = 0;
       ghostStreamOpacity.value = 0;
       setGhost(null);
-      emitTimersRef.current.forEach(clearTimeout);
-      emitTimersRef.current = [];
       setUnitsEmitted(0);
       return;
     }
@@ -175,8 +171,6 @@ export default function SortBoard({
 
     const unitCount = Math.max(1, Math.round(pourHoldMs / POUR_PER_UNIT_MS));
 
-    emitTimersRef.current.forEach(clearTimeout);
-    emitTimersRef.current = [];
     setUnitsEmitted(0);
 
     ghostDx.value = 0;
@@ -191,8 +185,6 @@ export default function SortBoard({
       startY: srcPos.y,
       dstX: dstPos.x,
       dstY: dstPos.y,
-      liftDx,
-      liftDy,
       tiltSign,
       dstBottleLength: dstBottle?.length ?? 0,
     });
@@ -261,21 +253,21 @@ export default function SortBoard({
   );
 
   // Stream arc geometry — computed from ghost snapshot each render.
-  const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
-  const unitH_px = (INNER_H_VB / VB_H / BOTTLE_DEPTH) * bottleH;
-
   let streamPath = '';
   let streamColor = 'transparent';
   if (ghost !== null) {
+    const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
+    const unitHPx = (INNER_H_VB / VB_H / BOTTLE_DEPTH) * bottleH;
     // After diagonal lift the spout sits just above the destination neck opening
     const spoutX = ghost.dstX + bottleW / 2;
     const spoutY = ghost.dstY + pivotLocalY;
-    // Destination fill level at the start of the pour (stream falls into liquid)
+    // Fill level at pour start — endpoint stays fixed during the pour (simplification:
+    // rising fill as units land is not tracked; the visual impact is minor)
     const dstFillTopY = ghost.dstY + (BODY_BOTTOM_VB / VB_H) * bottleH -
-      ghost.dstBottleLength * unitH_px;
+      ghost.dstBottleLength * unitHPx;
     const streamEndY = Math.max(spoutY + 10, dstFillTopY);
-    // Slight curve in the pour direction for a natural arc
-    const ctrlX = spoutX - ghost.tiltSign * 6;
+    // Control point curves in the pour direction (matches the tilted bottle's arc)
+    const ctrlX = spoutX + ghost.tiltSign * 6;
     const ctrlY = spoutY + (streamEndY - spoutY) * 0.3;
     streamPath = `M ${spoutX} ${spoutY} Q ${ctrlX} ${ctrlY} ${spoutX} ${streamEndY}`;
     const topColor = ghost.bottle[ghost.bottle.length - 1];

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -10,13 +10,14 @@ import Animated, {
   withSpring,
   withTiming,
 } from "react-native-reanimated";
+import Svg, { Path } from "react-native-svg";
 import { useTranslation } from "react-i18next";
 import type { Bottle, SortState } from "../types";
+import { BOTTLE_DEPTH } from "../types";
 import BottleView, {
   DEFAULT_BOTTLE_HEIGHT,
   DEFAULT_BOTTLE_WIDTH,
   LIQUID_COLORS,
-  TILT_DEG,
 } from "./BottleView";
 
 const BOTTLE_GAP = 12;
@@ -30,7 +31,7 @@ export interface SortBoardProps {
   readonly pouringTo?: number | null;
   /** Height of the board container in pixels — used to scale bottles to fit. */
   readonly availableHeight?: number;
-  /** Tilt-hold duration in ms; defaults to TILT_HOLD_MS_PER_UNIT (1 unit). */
+  /** Total flow duration in ms (POUR_PER_UNIT_MS × unitCount); computed by SortScreen. */
   readonly pourHoldMs?: number;
 }
 
@@ -41,19 +42,31 @@ interface GhostInfo {
   startY: number;
   dstX: number;
   dstY: number;
+  liftDx: number;
+  liftDy: number;
+  tiltSign: 1 | -1;
+  dstBottleLength: number;
 }
 
-// Ghost animation timing constants (ms) — exported so SortScreen can compute total timeout
-export const LIFT_MS = 150;
-export const TRAVEL_MS = 150;
-export const TILT_IN_MS = 250;
-export const TILT_OUT_MS = 200;
-export const TILT_HOLD_MS_PER_UNIT = 150; // scaled by # of sections poured
+// Pour animation timing (ms) — exported so SortScreen can compute total timeout
+export const POUR_LIFT_MS = 240;       // diagonal lift+travel phase
+export const POUR_TILT_MS = 220;       // tilt from 0° to TILT_START_DEG
+export const POUR_PER_UNIT_MS = 380;   // per-unit progressive tilt + stream
+export const POUR_RETURN_MS = 320;     // simultaneous untilt + return
 
-// Ghost rises just enough to clear the target bottle's opening
-const LIFT_HEIGHT = 40;
+// Tilt progresses from start angle to peak as the bottle empties
+const TILT_START_DEG = 50;
+const TILT_PEAK_DEG = 95;
 
-// Stream dimensions — 7px renders reliably on iOS at all display densities
+// BottleView SVG proportions — used to compute pivot/spout position
+const VB_W = 56;
+const VB_H = 168;
+const NECK_TOP_VB = 14;    // PAD_TOP in BottleView
+const NECK_LEFT_VB = 12;   // left outer neck edge in viewBox
+const NECK_RIGHT_VB = 44;  // right outer neck edge in viewBox
+const BODY_BOTTOM_VB = 166;
+const INNER_H_VB = BODY_BOTTOM_VB - NECK_TOP_VB; // 152
+
 const STREAM_WIDTH = 7;
 
 export default function SortBoard({
@@ -63,7 +76,7 @@ export default function SortBoard({
   pouringFrom = null,
   pouringTo = null,
   availableHeight,
-  pourHoldMs = TILT_HOLD_MS_PER_UNIT,
+  pourHoldMs = POUR_PER_UNIT_MS,
 }: SortBoardProps) {
   const { t } = useTranslation("sort");
   const { width: screenW } = useWindowDimensions();
@@ -97,15 +110,15 @@ export default function SortBoard({
   const bottlePositionsRef = useRef<{ x: number; y: number }[]>([]);
 
   // Ghost shared values — always allocated (hooks can't be conditional)
-  const ghostLiftY = useSharedValue(0);
-  const ghostTravelX = useSharedValue(0);
+  const ghostDy = useSharedValue(0);
+  const ghostDx = useSharedValue(0);
   const ghostTiltDeg = useSharedValue(0);
   const ghostStreamOpacity = useSharedValue(0);
 
   const ghostAnimStyle = useAnimatedStyle(() => ({
     transform: [
-      { translateY: ghostLiftY.value },
-      { translateX: ghostTravelX.value },
+      { translateX: ghostDx.value },
+      { translateY: ghostDy.value },
       { rotate: `${ghostTiltDeg.value}deg` },
     ],
   }));
@@ -116,6 +129,8 @@ export default function SortBoard({
 
   // Ghost React state (drives overlay visibility and bottle capture)
   const [ghost, setGhost] = useState<GhostInfo | null>(null);
+  const [unitsEmitted, setUnitsEmitted] = useState(0);
+  const emitTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 
   // Stable ref for values read inside the effect (avoids stale closure without
   // adding them to the dep array, which would re-trigger on every state change)
@@ -124,30 +139,48 @@ export default function SortBoard({
 
   useEffect(() => {
     if (pouringFrom === null || pouringTo === null || reduceMotion) {
-      cancelAnimation(ghostLiftY);
-      cancelAnimation(ghostTravelX);
+      cancelAnimation(ghostDy);
+      cancelAnimation(ghostDx);
       cancelAnimation(ghostTiltDeg);
       cancelAnimation(ghostStreamOpacity);
-      ghostLiftY.value = 0;
-      ghostTravelX.value = 0;
+      ghostDy.value = 0;
+      ghostDx.value = 0;
       ghostTiltDeg.value = 0;
       ghostStreamOpacity.value = 0;
       setGhost(null);
+      emitTimersRef.current.forEach(clearTimeout);
+      emitTimersRef.current = [];
+      setUnitsEmitted(0);
       return;
     }
 
     const srcPos = bottlePositionsRef.current[pouringFrom];
     const dstPos = bottlePositionsRef.current[pouringTo];
-    if (!srcPos || !dstPos) return; // layout not measured yet — silent fallback
-
-    const dx = dstPos.x - srcPos.x;
-    const tiltAngle = pouringFrom < pouringTo ? TILT_DEG : -TILT_DEG;
+    if (!srcPos || !dstPos) return;
 
     const sourceBottle = stateRef.current.bottles[pouringFrom];
+    const dstBottle = stateRef.current.bottles[pouringTo];
     if (!sourceBottle) return;
 
-    ghostLiftY.value = 0;
-    ghostTravelX.value = 0;
+    const isRight = pouringFrom < pouringTo;
+    const tiltSign: 1 | -1 = isRight ? 1 : -1;
+
+    // Spout pivot: outer neck edge scaled from viewBox coords to bottleW/bottleH
+    const pivotLocalX = ((isRight ? NECK_RIGHT_VB : NECK_LEFT_VB) / VB_W) * bottleW;
+    const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
+
+    // Diagonal lift target: move spout to center-top of destination opening
+    const liftDx = (dstPos.x + bottleW / 2) - (srcPos.x + pivotLocalX);
+    const liftDy = dstPos.y - srcPos.y;
+
+    const unitCount = Math.max(1, Math.round(pourHoldMs / POUR_PER_UNIT_MS));
+
+    emitTimersRef.current.forEach(clearTimeout);
+    emitTimersRef.current = [];
+    setUnitsEmitted(0);
+
+    ghostDx.value = 0;
+    ghostDy.value = 0;
     ghostTiltDeg.value = 0;
     ghostStreamOpacity.value = 0;
 
@@ -158,40 +191,55 @@ export default function SortBoard({
       startY: srcPos.y,
       dstX: dstPos.x,
       dstY: dstPos.y,
+      liftDx,
+      liftDy,
+      tiltSign,
+      dstBottleLength: dstBottle?.length ?? 0,
     });
 
-    // Lift → travel → tilt in → hold → tilt out → return travel → lower.
-    // Ghost clears at end; SortScreen commits state 50ms later.
-    ghostLiftY.value = withTiming(-LIFT_HEIGHT, { duration: LIFT_MS }, (finished) => {
+    // Phase 1: Diagonal lift+travel simultaneously (POUR_LIFT_MS)
+    ghostDx.value = withTiming(liftDx, { duration: POUR_LIFT_MS });
+    ghostDy.value = withTiming(liftDy, { duration: POUR_LIFT_MS }, (finished) => {
       if (!finished) return;
-      ghostTravelX.value = withTiming(dx, { duration: TRAVEL_MS }, (finished) => {
+      // Phase 2: Tilt to TILT_START_DEG
+      ghostTiltDeg.value = withTiming(tiltSign * TILT_START_DEG, { duration: POUR_TILT_MS }, (finished) => {
         if (!finished) return;
-        ghostTiltDeg.value = withTiming(tiltAngle, { duration: TILT_IN_MS }, (finished) => {
+        // Phase 3: Progressive tilt to TILT_PEAK_DEG over full pour
+        ghostTiltDeg.value = withTiming(tiltSign * TILT_PEAK_DEG, { duration: pourHoldMs }, (finished) => {
           if (!finished) return;
-          ghostTiltDeg.value = withDelay(
-            pourHoldMs,
-            withTiming(0, { duration: TILT_OUT_MS }, (finished) => {
-              if (!finished) return;
-              ghostTravelX.value = withTiming(0, { duration: TRAVEL_MS }, (finished) => {
-                if (!finished) return;
-                ghostLiftY.value = withTiming(0, { duration: LIFT_MS }, () => {
-                  runOnJS(setGhost)(null);
-                });
-              });
-            })
-          );
+          // Phase 4: Simultaneous untilt + diagonal return
+          ghostTiltDeg.value = withTiming(0, { duration: POUR_RETURN_MS });
+          ghostDx.value = withTiming(0, { duration: POUR_RETURN_MS });
+          ghostDy.value = withTiming(0, { duration: POUR_RETURN_MS }, (finished) => {
+            if (!finished) return;
+            runOnJS(setGhost)(null);
+            runOnJS(setUnitsEmitted)(0);
+          });
         });
       });
     });
 
-    // Stream fades in at tilt-in start, holds, fades out at tilt-out start.
+    // Stream fades in as tilt starts, fades out when return begins
     ghostStreamOpacity.value = withDelay(
-      LIFT_MS + TRAVEL_MS,
+      POUR_LIFT_MS,
       withSequence(
-        withTiming(1, { duration: TILT_IN_MS }),
-        withDelay(pourHoldMs, withTiming(0, { duration: TILT_OUT_MS }))
+        withTiming(1, { duration: POUR_TILT_MS }),
+        withDelay(pourHoldMs, withTiming(0, { duration: POUR_RETURN_MS / 2 }))
       )
     );
+
+    // Schedule per-unit ghost content draining
+    const flowStart = POUR_LIFT_MS + POUR_TILT_MS;
+    for (let i = 1; i <= unitCount; i++) {
+      const emitAt = flowStart + (i - 1) * POUR_PER_UNIT_MS + POUR_PER_UNIT_MS * 0.6;
+      const captured = i;
+      emitTimersRef.current.push(setTimeout(() => setUnitsEmitted(captured), emitAt));
+    }
+
+    return () => {
+      emitTimersRef.current.forEach(clearTimeout);
+      emitTimersRef.current = [];
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pouringFrom, pouringTo, reduceMotion, pourHoldMs]);
 
@@ -212,13 +260,32 @@ export default function SortBoard({
     [state.bottles.length, onBottleTap]
   );
 
-  // Stream geometry — derived from ghost snapshot; stable for the life of each pour.
-  const streamTopColor =
-    ghost !== null && ghost.bottle.length > 0 ? ghost.bottle[ghost.bottle.length - 1] : null;
-  const streamColor = streamTopColor ? LIQUID_COLORS[streamTopColor] : "transparent";
-  const streamTop = ghost !== null ? ghost.startY - LIFT_HEIGHT : 0;
-  const streamHeight = ghost !== null ? Math.max(0, ghost.dstY - ghost.startY + LIFT_HEIGHT) : 0;
-  const streamLeft = ghost !== null ? ghost.dstX + (bottleW - STREAM_WIDTH) / 2 : 0;
+  // Stream arc geometry — computed from ghost snapshot each render.
+  const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
+  const unitH_px = (INNER_H_VB / VB_H / BOTTLE_DEPTH) * bottleH;
+
+  let streamPath = '';
+  let streamColor = 'transparent';
+  if (ghost !== null) {
+    // After diagonal lift the spout sits just above the destination neck opening
+    const spoutX = ghost.dstX + bottleW / 2;
+    const spoutY = ghost.dstY + pivotLocalY;
+    // Destination fill level at the start of the pour (stream falls into liquid)
+    const dstFillTopY = ghost.dstY + (BODY_BOTTOM_VB / VB_H) * bottleH -
+      ghost.dstBottleLength * unitH_px;
+    const streamEndY = Math.max(spoutY + 10, dstFillTopY);
+    // Slight curve in the pour direction for a natural arc
+    const ctrlX = spoutX - ghost.tiltSign * 6;
+    const ctrlY = spoutY + (streamEndY - spoutY) * 0.3;
+    streamPath = `M ${spoutX} ${spoutY} Q ${ctrlX} ${ctrlY} ${spoutX} ${streamEndY}`;
+    const topColor = ghost.bottle[ghost.bottle.length - 1];
+    streamColor = topColor ? LIQUID_COLORS[topColor] : 'transparent';
+  }
+
+  // Draining ghost contents: slice from top as units emit
+  const ghostBottle = ghost !== null
+    ? ghost.bottle.slice(0, Math.max(0, ghost.bottle.length - unitsEmitted))
+    : [];
 
   return (
     <View accessibilityLabel={t("a11y.boardRegion")} accessibilityRole="none" style={styles.board}>
@@ -270,20 +337,18 @@ export default function SortBoard({
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
         >
-          {streamHeight > 0 && (
-            <Animated.View
-              style={[
-                styles.stream,
-                {
-                  left: streamLeft,
-                  top: streamTop,
-                  width: STREAM_WIDTH,
-                  height: streamHeight,
-                  backgroundColor: streamColor,
-                },
-                ghostStreamStyle,
-              ]}
-            />
+          {streamPath !== '' && (
+            <Animated.View style={[StyleSheet.absoluteFill, ghostStreamStyle]} pointerEvents="none">
+              <Svg width="100%" height="100%">
+                <Path
+                  d={streamPath}
+                  stroke={streamColor}
+                  strokeWidth={STREAM_WIDTH}
+                  fill="none"
+                  strokeLinecap="round"
+                />
+              </Svg>
+            </Animated.View>
           )}
           <Animated.View
             style={[
@@ -298,7 +363,7 @@ export default function SortBoard({
             ]}
           >
             <BottleView
-              bottle={ghost.bottle}
+              bottle={ghostBottle}
               index={ghost.bottleIndex}
               isGhost
               colorblindMode={colorblindMode}
@@ -449,10 +514,6 @@ const styles = StyleSheet.create({
   },
   ghostBottle: {
     position: "absolute",
-  },
-  stream: {
-    position: "absolute",
-    borderRadius: STREAM_WIDTH / 2,
   },
   particle: { position: "absolute", width: 20, height: 20, borderRadius: 10, top: 0 },
   p0: { left: "8%" },

--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -47,10 +47,10 @@ interface GhostInfo {
 }
 
 // Pour animation timing (ms) — exported so SortScreen can compute total timeout
-export const POUR_LIFT_MS = 240;       // diagonal lift+travel phase
-export const POUR_TILT_MS = 220;       // tilt from 0° to TILT_START_DEG
-export const POUR_PER_UNIT_MS = 380;   // per-unit progressive tilt + stream
-export const POUR_RETURN_MS = 320;     // simultaneous untilt + return
+export const POUR_LIFT_MS = 240; // diagonal lift+travel phase
+export const POUR_TILT_MS = 220; // tilt from 0° to TILT_START_DEG
+export const POUR_PER_UNIT_MS = 380; // per-unit progressive tilt + stream
+export const POUR_RETURN_MS = 320; // simultaneous untilt + return
 
 // Tilt progresses from start angle to peak as the bottle empties
 const TILT_START_DEG = 50;
@@ -59,9 +59,9 @@ const TILT_PEAK_DEG = 95;
 // BottleView SVG proportions — used to compute pivot/spout position
 const VB_W = 56;
 const VB_H = 168;
-const NECK_TOP_VB = 14;    // PAD_TOP in BottleView
-const NECK_LEFT_VB = 12;   // left outer neck edge in viewBox
-const NECK_RIGHT_VB = 44;  // right outer neck edge in viewBox
+const NECK_TOP_VB = 14; // PAD_TOP in BottleView
+const NECK_LEFT_VB = 12; // left outer neck edge in viewBox
+const NECK_RIGHT_VB = 44; // right outer neck edge in viewBox
 const BODY_BOTTOM_VB = 166;
 const INNER_H_VB = BODY_BOTTOM_VB - NECK_TOP_VB; // 152
 
@@ -166,7 +166,7 @@ export default function SortBoard({
 
     // Diagonal lift target: move spout to center-top of destination opening
     // liftDy aligns bottle tops (pivotLocalY cancels: dstNeckY - srcNeckY = dstY - srcY)
-    const liftDx = (dstPos.x + bottleW / 2) - (srcPos.x + pivotLocalX);
+    const liftDx = dstPos.x + bottleW / 2 - (srcPos.x + pivotLocalX);
     const liftDy = dstPos.y - srcPos.y;
 
     const unitCount = Math.max(1, Math.round(pourHoldMs / POUR_PER_UNIT_MS));
@@ -194,21 +194,29 @@ export default function SortBoard({
     ghostDy.value = withTiming(liftDy, { duration: POUR_LIFT_MS }, (finished) => {
       if (!finished) return;
       // Phase 2: Tilt to TILT_START_DEG
-      ghostTiltDeg.value = withTiming(tiltSign * TILT_START_DEG, { duration: POUR_TILT_MS }, (finished) => {
-        if (!finished) return;
-        // Phase 3: Progressive tilt to TILT_PEAK_DEG over full pour
-        ghostTiltDeg.value = withTiming(tiltSign * TILT_PEAK_DEG, { duration: pourHoldMs }, (finished) => {
+      ghostTiltDeg.value = withTiming(
+        tiltSign * TILT_START_DEG,
+        { duration: POUR_TILT_MS },
+        (finished) => {
           if (!finished) return;
-          // Phase 4: Simultaneous untilt + diagonal return
-          ghostTiltDeg.value = withTiming(0, { duration: POUR_RETURN_MS });
-          ghostDx.value = withTiming(0, { duration: POUR_RETURN_MS });
-          ghostDy.value = withTiming(0, { duration: POUR_RETURN_MS }, (finished) => {
-            if (!finished) return;
-            runOnJS(setGhost)(null);
-            runOnJS(setUnitsEmitted)(0);
-          });
-        });
-      });
+          // Phase 3: Progressive tilt to TILT_PEAK_DEG over full pour
+          ghostTiltDeg.value = withTiming(
+            tiltSign * TILT_PEAK_DEG,
+            { duration: pourHoldMs },
+            (finished) => {
+              if (!finished) return;
+              // Phase 4: Simultaneous untilt + diagonal return
+              ghostTiltDeg.value = withTiming(0, { duration: POUR_RETURN_MS });
+              ghostDx.value = withTiming(0, { duration: POUR_RETURN_MS });
+              ghostDy.value = withTiming(0, { duration: POUR_RETURN_MS }, (finished) => {
+                if (!finished) return;
+                runOnJS(setGhost)(null);
+                runOnJS(setUnitsEmitted)(0);
+              });
+            }
+          );
+        }
+      );
     });
 
     // Stream fades in as tilt starts, fades out when return begins
@@ -253,8 +261,8 @@ export default function SortBoard({
   );
 
   // Stream arc geometry — computed from ghost snapshot each render.
-  let streamPath = '';
-  let streamColor = 'transparent';
+  let streamPath = "";
+  let streamColor = "transparent";
   if (ghost !== null) {
     const pivotLocalY = (NECK_TOP_VB / VB_H) * bottleH;
     const unitHPx = (INNER_H_VB / VB_H / BOTTLE_DEPTH) * bottleH;
@@ -263,21 +271,20 @@ export default function SortBoard({
     const spoutY = ghost.dstY + pivotLocalY;
     // Fill level at pour start — endpoint stays fixed during the pour (simplification:
     // rising fill as units land is not tracked; the visual impact is minor)
-    const dstFillTopY = ghost.dstY + (BODY_BOTTOM_VB / VB_H) * bottleH -
-      ghost.dstBottleLength * unitHPx;
+    const dstFillTopY =
+      ghost.dstY + (BODY_BOTTOM_VB / VB_H) * bottleH - ghost.dstBottleLength * unitHPx;
     const streamEndY = Math.max(spoutY + 10, dstFillTopY);
     // Control point curves in the pour direction (matches the tilted bottle's arc)
     const ctrlX = spoutX + ghost.tiltSign * 6;
     const ctrlY = spoutY + (streamEndY - spoutY) * 0.3;
     streamPath = `M ${spoutX} ${spoutY} Q ${ctrlX} ${ctrlY} ${spoutX} ${streamEndY}`;
     const topColor = ghost.bottle[ghost.bottle.length - 1];
-    streamColor = topColor ? LIQUID_COLORS[topColor] : 'transparent';
+    streamColor = topColor ? LIQUID_COLORS[topColor] : "transparent";
   }
 
   // Draining ghost contents: slice from top as units emit
-  const ghostBottle = ghost !== null
-    ? ghost.bottle.slice(0, Math.max(0, ghost.bottle.length - unitsEmitted))
-    : [];
+  const ghostBottle =
+    ghost !== null ? ghost.bottle.slice(0, Math.max(0, ghost.bottle.length - unitsEmitted)) : [];
 
   return (
     <View accessibilityLabel={t("a11y.boardRegion")} accessibilityRole="none" style={styles.board}>
@@ -329,7 +336,7 @@ export default function SortBoard({
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
         >
-          {streamPath !== '' && (
+          {streamPath !== "" && (
             <Animated.View style={[StyleSheet.absoluteFill, ghostStreamStyle]} pointerEvents="none">
               <Svg width="100%" height="100%">
                 <Path

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -31,13 +31,12 @@ import {
 import { getNextHint } from "../game/sort/solver";
 import type { Color, SortState } from "../game/sort/types";
 import SortBoard, {
-  LIFT_MS,
-  TRAVEL_MS,
-  TILT_IN_MS,
-  TILT_OUT_MS,
-  TILT_HOLD_MS_PER_UNIT,
+  POUR_LIFT_MS,
+  POUR_TILT_MS,
+  POUR_PER_UNIT_MS,
+  POUR_RETURN_MS,
 } from "../game/sort/components/SortBoard";
-import { TILT_HOLD_MS } from "../game/sort/components/BottleView";
+import { TILT_IN_MS, TILT_HOLD_MS, TILT_OUT_MS } from "../game/sort/components/BottleView";
 import LevelSelectScreen from "../game/sort/components/LevelSelectScreen";
 import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
 import { loadProgress, saveProgress, type SortProgress } from "../game/sort/storage";
@@ -82,7 +81,7 @@ export default function SortScreen() {
   // Pour animation state
   const [pouringFrom, setPouringFrom] = useState<number | null>(null);
   const [pouringTo, setPouringTo] = useState<number | null>(null);
-  const [pourHoldMs, setPourHoldMs] = useState(TILT_HOLD_MS_PER_UNIT);
+  const [pourHoldMs, setPourHoldMs] = useState(POUR_PER_UNIT_MS);
   const [isPouring, setIsPouring] = useState(false);
   const [boardHeight, setBoardHeight] = useState(0);
   const pourTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -202,11 +201,11 @@ export default function SortScreen() {
     if (isValidPour(gameState.bottles[selectedBottleIndex], gameState.bottles[index])) {
       const snapshot = gameState;
       const units = pourUnits(gameState.bottles[selectedBottleIndex]!, gameState.bottles[index]!);
-      const holdMs = TILT_HOLD_MS_PER_UNIT * units;
-      // Reduce-motion skips the ghost; BottleView does a fixed tilt-only animation (no scaling).
+      const holdMs = POUR_PER_UNIT_MS * units;
+      // Reduce-motion: BottleView does a fixed tilt-only animation (no ghost overlay).
       const totalMs = reduceMotion
         ? TILT_IN_MS + TILT_HOLD_MS + TILT_OUT_MS + 50
-        : LIFT_MS + TRAVEL_MS + TILT_IN_MS + holdMs + TILT_OUT_MS + TRAVEL_MS + LIFT_MS + 50;
+        : POUR_LIFT_MS + POUR_TILT_MS + holdMs + POUR_RETURN_MS + 50;
       setHistory((h) => [...h, snapshot]);
       setIsPouring(true);
       setPouringFrom(selectedBottleIndex);


### PR DESCRIPTION
## Summary

Closes #1393. Replaces the current lift→travel→fixed-tilt ghost animation with a physics-inspired four-phase pour derived from the BC Arcade design file (`ui_kits/arcade-app/Screens.jsx`, chat7).

- **Diagonal lift** — source bottle now moves diagonally to position its spout above the destination opening, instead of lifting straight up then sliding over
- **Progressive tilt** — angle increases from 50° → 95° as liquid drains (rather than snapping to a fixed 62°), so the bottle tips further as it empties
- **Curved stream** — replaced the flat rectangle stream with an SVG quadratic bezier arc that curves naturally in the pour direction
- **Draining ghost** — ghost bottle contents shrink unit-by-unit during the pour via scheduled timeouts

### Timing changes (per unit: 150ms → 380ms for a more deliberate feel)

| Phase | Before | After |
|---|---|---|
| Lift + travel | 150 + 150ms (sequential) | 240ms (simultaneous diagonal) |
| Tilt in | 250ms to fixed 62° | 220ms to 50°, then 380ms/unit up to 95° |
| Return | 200 + 150 + 150ms | 320ms (simultaneous) |

## Test plan

- [ ] Tap a bottle, tap another — verify bottle moves diagonally, tilts progressively, stream arcs, ghost contents drain
- [ ] Pour single unit vs multi-unit — verify tilt progression scales with count
- [ ] Left-to-right and right-to-left pours both work (arc curves in correct direction)
- [ ] Enable Reduce Motion in accessibility settings — verify fallback tilt-only animation still plays
- [ ] All 73 sort/bottle tests pass (`npx jest --testPathPattern="sort|Sort|bottle|Bottle"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)