### PR TITLE
feat(blackjack): progressive table tiers with lock progression (BJ-2)

### DIFF
--- a/e2e/tests/blackjack-accessibility.spec.ts
+++ b/e2e/tests/blackjack-accessibility.spec.ts
@@ -34,7 +34,7 @@ test.describe("Blackjack — accessibility", () => {
   test("bankroll has accessible label in betting phase", async ({ page }) => {
     await gotoBlackjack(page);
     await expect(
-      page.locator('[aria-label*="Bankroll: 1000 chips"]'),
+      page.locator('[aria-label*="Bankroll: 100 chips"]'),
     ).toBeVisible();
   });
 
@@ -44,9 +44,8 @@ test.describe("Blackjack — accessibility", () => {
     const bj = new BlackjackPage(page);
     await bj.goto();
     await expect(bj.chipButton(5)).toBeVisible();
+    await expect(bj.chipButton(10)).toBeVisible();
     await expect(bj.chipButton(25)).toBeVisible();
-    await expect(bj.chipButton(100)).toBeVisible();
-    await expect(bj.chipButton(500)).toBeVisible();
   });
 
   test("current bet circle has accessible label", async ({ page }) => {
@@ -61,9 +60,9 @@ test.describe("Blackjack — accessibility", () => {
   }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await expect(
-      page.getByRole("button", { name: /deal cards with 100-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 25-chip bet/i }),
     ).toBeVisible();
   });
 

--- a/e2e/tests/blackjack-betting.spec.ts
+++ b/e2e/tests/blackjack-betting.spec.ts
@@ -3,10 +3,10 @@
  *
  * Bet chip selector and Deal button interaction tests.
  *
- * BettingPanel rules:
+ * BettingPanel rules (Beginner table — selected after fresh install):
  *   - Default bet: 0 (no chips placed yet)
- *   - Chip denominations: 5, 25, 100, 500
- *   - Min bet: 5, Max bet: min(500, chips)
+ *   - Chip denominations: 5, 10, 25
+ *   - Min bet: 5, Max bet: min(25, chips)
  *   - Deal button disabled when bet < 5 or bet > chips
  *   - Clear Bet resets to 0
  */
@@ -39,17 +39,17 @@ test.describe("Blackjack — betting panel and chip selector", () => {
   test("bankroll is displayed in the header", async ({ page }) => {
     await gotoBlackjack(page);
     await expect(
-      page.locator('[aria-label*="Bankroll: 1000 chips"]'),
+      page.locator('[aria-label*="Bankroll: 100 chips"]'),
     ).toBeVisible();
   });
 
-  test("clicking 100-chip button adds 100 to bet", async ({ page }) => {
+  test("clicking 10-chip button adds 10 to bet", async ({ page }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(10).click();
 
     await expect(
-      page.getByRole("button", { name: /deal cards with 100-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 10-chip bet/i }),
     ).toBeVisible();
   });
 
@@ -66,21 +66,21 @@ test.describe("Blackjack — betting panel and chip selector", () => {
   test("multiple chip clicks accumulate the bet", async ({ page }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
-    await bj.chipButton(25).click();
+    await bj.chipButton(10).click();
+    await bj.chipButton(5).click();
 
-    // 100 + 25 = 125
+    // 10 + 5 = 15
     await expect(
-      page.getByRole("button", { name: /deal cards with 125-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 15-chip bet/i }),
     ).toBeVisible();
   });
 
   test("Clear Bet resets bet to 0 and disables Deal", async ({ page }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await expect(
-      page.getByRole("button", { name: /deal cards with 100-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 25-chip bet/i }),
     ).toBeVisible();
 
     await page.getByRole("button", { name: /clear bet/i }).click();
@@ -97,11 +97,11 @@ test.describe("Blackjack — betting panel and chip selector", () => {
     ).toBeDisabled();
   });
 
-  test("500-chip button is disabled when chips < 500", async ({ page }) => {
+  test("25-chip button is disabled when chips < 25", async ({ page }) => {
     await injectEngineState(
       page,
       playerPhaseState({
-        chips: 200,
+        chips: 10,
         bet: 0,
         phase: "betting",
         outcome: null,
@@ -115,7 +115,7 @@ test.describe("Blackjack — betting panel and chip selector", () => {
     await expect(bj.dealButton()).toBeVisible();
 
     await expect(
-      page.getByRole("button", { name: /500.*not available/i }),
+      page.getByRole("button", { name: /25.*not available/i }),
     ).toBeDisabled();
   });
 
@@ -123,13 +123,13 @@ test.describe("Blackjack — betting panel and chip selector", () => {
     page,
   }) => {
     await gotoBlackjack(page);
-    // Place 500 chips — now all chip buttons should be disabled
-    await page.getByRole("button", { name: /add 500 to bet/i }).click();
+    // Place 25 chips — at max bet for beginner table (betMax = 25)
+    await page.getByRole("button", { name: /add 25 to bet/i }).click();
 
     await expect(
-      page.getByRole("button", { name: /deal cards with 500-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 25-chip bet/i }),
     ).toBeVisible();
-    // 5-chip button should now be disabled (exact match avoids 25/500 ambiguity)
+    // 5-chip button should now be disabled (exact match avoids 25 ambiguity)
     await expect(
       page.getByRole("button", { name: "5-chip not available", exact: true }),
     ).toBeDisabled();
@@ -143,18 +143,18 @@ test.describe("Blackjack — betting panel and chip selector", () => {
   test("Deal button is enabled after placing a valid bet", async ({ page }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await expect(
-      page.getByRole("button", { name: /deal cards with 100-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 25-chip bet/i }),
     ).not.toBeDisabled();
   });
 
   test("pressing Deal with a valid bet starts the hand", async ({ page }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await page
-      .getByRole("button", { name: /deal cards with 100-chip bet/i })
+      .getByRole("button", { name: /deal cards with 25-chip bet/i })
       .click();
 
     // Either player phase or natural blackjack result

--- a/e2e/tests/blackjack-errors.spec.ts
+++ b/e2e/tests/blackjack-errors.spec.ts
@@ -76,39 +76,48 @@ test.describe("Blackjack — error paths and guardrails", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Bet stepper boundaries
+  // Bet stepper boundaries (Beginner table: betMax=25, chips=[5,10,25])
   // ---------------------------------------------------------------------------
 
-  test("chip buttons are disabled when bet would exceed max (500)", async ({
+  test("chip buttons are disabled when bet would exceed max (25)", async ({
     page,
   }) => {
     await gotoBlackjack(page);
 
-    // Place 500-chip — all chip buttons become disabled
-    await page.getByRole("button", { name: /add 500 to bet/i }).click();
+    // Place 25-chip — at max bet for Beginner table
+    await page.getByRole("button", { name: /add 25 to bet/i }).click();
 
     await expect(
-      page.getByRole("button", { name: /deal cards with 500-chip bet/i }),
+      page.getByRole("button", { name: /deal cards with 25-chip bet/i }),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "5-chip not available", exact: true }),
     ).toBeDisabled();
   });
 
-  test("500-chip button is disabled when chips cap is lower than 500", async ({
+  test("25-chip button is disabled when chips balance is below 25", async ({
     page,
   }) => {
-    const bj = new BlackjackPage(page);
-    await bj.goto();
+    // Inject a betting-phase state with only 10 chips — can't afford 25-chip
+    await injectEngineState(
+      page,
+      playerPhaseState({
+        chips: 10,
+        bet: 0,
+        phase: "betting",
+        outcome: null,
+        payout: 0,
+        player_hand: [],
+        dealer_hand: [],
+      }),
+    );
+    await page.getByRole("button", { name: "Play Blackjack" }).click();
 
-    // Place 400 chips (four 100s); now only 5 and 25 would still fit,
-    // but 500 is definitely disabled
-    for (let i = 0; i < 4; i++) {
-      await bj.chipButton(100).click();
-    }
+    const bj = new BlackjackPage(page);
+    await expect(bj.dealButton()).toBeVisible();
 
     await expect(
-      page.getByRole("button", { name: "500-chip not available", exact: true }),
+      page.getByRole("button", { name: "25-chip not available", exact: true }),
     ).toBeDisabled();
   });
 
@@ -133,7 +142,7 @@ test.describe("Blackjack — error paths and guardrails", () => {
     ).toBeVisible();
   });
 
-  test("Play Again in game-over modal starts fresh with 1000 chips", async ({
+  test("Play Again in game-over modal shows table selection then starts fresh", async ({
     page,
   }) => {
     await injectEngineState(page, gameOverState());
@@ -144,11 +153,14 @@ test.describe("Blackjack — error paths and guardrails", () => {
       .getByRole("button", { name: /start a new session with 1000 chips/i })
       .click();
 
-    // Back in betting phase with fresh chip count
+    // BJ-2: Play Again shows TableSelectPanel — select Beginner table
+    await page.getByRole("button", { name: /select beginner table/i }).click();
+
+    // Back in betting phase with Beginner chip count
     const bj = new BlackjackPage(page);
     await expect(bj.dealButton()).toBeVisible({ timeout: 5000 });
     await expect(
-      page.locator('[aria-label*="Bankroll: 1000 chips"]'),
+      page.locator('[aria-label*="Bankroll: 100 chips"]'),
     ).toBeVisible();
   });
 
@@ -180,11 +192,13 @@ test.describe("Blackjack — error paths and guardrails", () => {
     await page.goto("/");
     await page.getByRole("button", { name: "Play Blackjack" }).click();
 
-    // Should start fresh in betting phase, not crash
+    // BJ-2: fresh game shows TableSelectPanel — select Beginner
+    await page.getByRole("button", { name: /select beginner table/i }).click();
+
     const bj = new BlackjackPage(page);
     await expect(bj.dealButton()).toBeVisible({ timeout: 5000 });
     await expect(
-      page.locator('[aria-label*="Bankroll: 1000 chips"]'),
+      page.locator('[aria-label*="Bankroll: 100 chips"]'),
     ).toBeVisible();
   });
 
@@ -200,6 +214,14 @@ test.describe("Blackjack — error paths and guardrails", () => {
     );
     await page.goto("/");
     await page.getByRole("button", { name: "Play Blackjack" }).click();
+
+    // BJ-2: malformed state may show TableSelectPanel — select Beginner if present
+    const tableSelectBtn = page.getByRole("button", {
+      name: /select beginner table/i,
+    });
+    if (await tableSelectBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await tableSelectBtn.click();
+    }
 
     const bj = new BlackjackPage(page);
     await expect(bj.dealButton()).toBeVisible({ timeout: 5000 });

--- a/e2e/tests/blackjack-errors.spec.ts
+++ b/e2e/tests/blackjack-errors.spec.ts
@@ -215,13 +215,9 @@ test.describe("Blackjack — error paths and guardrails", () => {
     await page.goto("/");
     await page.getByRole("button", { name: "Play Blackjack" }).click();
 
-    // BJ-2: malformed state may show TableSelectPanel — select Beginner if present
-    const tableSelectBtn = page.getByRole("button", {
-      name: /select beginner table/i,
-    });
-    if (await tableSelectBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await tableSelectBtn.click();
-    }
+    // BJ-2: malformed state is rejected by loadGame() → falls back to null →
+    // TableSelectPanel shows (same as a fresh install) — select Beginner
+    await page.getByRole("button", { name: /select beginner table/i }).click();
 
     const bj = new BlackjackPage(page);
     await expect(bj.dealButton()).toBeVisible({ timeout: 5000 });

--- a/e2e/tests/blackjack-full-game.spec.ts
+++ b/e2e/tests/blackjack-full-game.spec.ts
@@ -30,6 +30,8 @@ test.describe("Blackjack — full happy-path game journey", () => {
     const bj = new BlackjackPage(page);
     await expect(page.getByText("BC Arcade").first()).toBeVisible();
     await page.getByRole("button", { name: "Play Blackjack" }).click();
+    // BJ-2: fresh install shows TableSelectPanel — select Beginner
+    await page.getByRole("button", { name: /select beginner table/i }).click();
     await expect(bj.dealButton()).toBeVisible();
   });
 
@@ -38,7 +40,7 @@ test.describe("Blackjack — full happy-path game journey", () => {
   }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await bj.dealButton().click();
 
     // Either player phase (Hit/Stand) or immediate result (natural BJ → Next Hand)
@@ -97,7 +99,7 @@ test.describe("Blackjack — full happy-path game journey", () => {
     for (let hand = 0; hand < 3; hand++) {
       // Betting phase
       await expect(bj.dealButton()).toBeVisible({ timeout: 10000 });
-      await bj.chipButton(100).click();
+      await bj.chipButton(5).click();
       await bj.dealButton().click();
 
       // Player or result phase

--- a/e2e/tests/blackjack-persistence.spec.ts
+++ b/e2e/tests/blackjack-persistence.spec.ts
@@ -52,7 +52,7 @@ test.describe("Blackjack — state persistence", () => {
   }) => {
     const bj = new BlackjackPage(page);
     await bj.goto();
-    await bj.chipButton(100).click();
+    await bj.chipButton(25).click();
     await bj.dealButton().click();
 
     // Wait for player or result phase

--- a/e2e/tests/helpers/blackjack.ts
+++ b/e2e/tests/helpers/blackjack.ts
@@ -13,7 +13,7 @@ export interface InjectedCard {
 export interface InjectedEngineState {
   chips: number;
   bet: number;
-  phase: "betting" | "player" | "result";
+  phase: "betting" | "player" | "result" | "victory";
   outcome: "blackjack" | "win" | "lose" | "push" | null;
   payout: number;
   deck: InjectedCard[];
@@ -28,20 +28,32 @@ export interface InjectedEngineState {
   active_hand_index: number;
   split_count: number;
   split_from_aces: boolean[];
+  // BJ-2 run-mode fields
+  runGoal?: number | null;
+  startingChips?: number;
+  betMin?: number;
+  betMax?: number;
+  lastWin?: number | null;
 }
 
 /**
  * Navigate from Home to Blackjack, clearing any saved state first.
+ * Selects the Beginner table (BJ-2: fresh install shows TableSelectPanel).
  *
  * NOTE: The Deal button will be DISABLED on arrival (bet = 0).
  * You must click a chip button before clicking Deal, or use
  * injectEngineState() to land in player/result phase directly.
+ *
+ * Beginner table: 100 starting chips, betMin=5, betMax=25,
+ * chip denominations: [5, 10, 25].
  */
 export async function gotoBlackjack(page: Page): Promise<void> {
   await page.goto("/");
   await page.evaluate(() => localStorage.removeItem("blackjack_game_v2"));
   await page.goto("/");
   await page.getByRole("button", { name: "Play Blackjack" }).click();
+  // BJ-2: fresh install shows TableSelectPanel — pick Beginner table
+  await page.getByRole("button", { name: /select beginner table/i }).click();
   // Use role selector to avoid strict-mode violations from "Dealer's Hand" / "dealer" substrings
   await page.getByRole("button", { name: /deal cards with/i }).waitFor();
 }
@@ -147,7 +159,7 @@ export class BlackjackPage {
     await gotoBlackjack(this.page);
   }
 
-  chipButton(amount: 5 | 25 | 100 | 500) {
+  chipButton(amount: 5 | 10 | 25) {
     return this.page.getByRole("button", {
       name: new RegExp(`add ${amount} to bet`, "i"),
     });

--- a/frontend/src/components/blackjack/BettingPanel.tsx
+++ b/frontend/src/components/blackjack/BettingPanel.tsx
@@ -7,13 +7,11 @@ import { GameRules } from "../../game/blackjack/types";
 import BettingCircle from "./BettingCircle";
 import ChipButton from "./ChipButton";
 
-const MIN_BET = 5;
-const MAX_BET = 500;
-
-const CHIP_DENOMINATIONS = [5, 25, 100, 500] as const;
-
 interface Props {
   chips: number;
+  betMin: number;
+  betMax: number;
+  chipDenominations: readonly number[];
   onDeal: (amount: number) => void;
   loading: boolean;
   error: string | null;
@@ -23,6 +21,9 @@ interface Props {
 
 export default function BettingPanel({
   chips,
+  betMin,
+  betMax,
+  chipDenominations,
   onDeal,
   loading,
   error,
@@ -31,7 +32,7 @@ export default function BettingPanel({
 }: Props) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
-  const maxBet = Math.min(MAX_BET, chips);
+  const maxBet = Math.min(betMax, chips);
   const [bet, setBet] = useState<number>(0);
   const [rulesOpen, setRulesOpen] = useState(false);
 
@@ -43,7 +44,7 @@ export default function BettingPanel({
     setBet(0);
   }
 
-  const canDeal = bet >= MIN_BET && bet <= maxBet && !loading;
+  const canDeal = bet >= betMin && bet <= maxBet && !loading;
 
   const chipColors = [colors.accent, colors.secondary, colors.tertiary, colors.secondary] as const;
   const chipTextColors = [
@@ -60,7 +61,7 @@ export default function BettingPanel({
 
       {/* Chip denomination row */}
       <View style={styles.chipRow}>
-        {CHIP_DENOMINATIONS.map((denom, i) => (
+        {chipDenominations.map((denom, i) => (
           <ChipButton
             key={denom}
             amount={denom}
@@ -68,14 +69,13 @@ export default function BettingPanel({
             disabled={bet + denom > maxBet || loading}
             chipColor={chipColors[i] ?? colors.accent}
             textColor={chipTextColors[i] ?? colors.textOnAccent}
-            sublabel={denom === 500 ? t("chip.vipCredits") : undefined}
           />
         ))}
       </View>
 
       {/* Table limits */}
       <Text style={[styles.limits, { color: colors.textMuted, fontFamily: typography.label }]}>
-        {t("betting.tableLimits")}: {t("betting.tableLimitsRange", { min: MIN_BET, max: MAX_BET })}
+        {t("betting.tableLimits")}: {t("betting.tableLimitsRange", { min: betMin, max: betMax })}
       </Text>
 
       {/* Action buttons */}

--- a/frontend/src/components/blackjack/HudSidebar.tsx
+++ b/frontend/src/components/blackjack/HudSidebar.tsx
@@ -7,9 +7,11 @@ import { typography } from "../../theme/typography";
 interface HudSidebarProps {
   currentPot: number;
   lastWin: number | null;
+  chips?: number;
+  runGoal?: number | null;
 }
 
-export default function HudSidebar({ currentPot, lastWin }: HudSidebarProps) {
+export default function HudSidebar({ currentPot, lastWin, chips, runGoal }: HudSidebarProps) {
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
 
@@ -62,6 +64,27 @@ export default function HudSidebar({ currentPot, lastWin }: HudSidebarProps) {
           {lastWinLabel}
         </Text>
       </View>
+
+      {/* Goal progress — only shown when table has a run goal */}
+      {runGoal != null && chips != null && (
+        <>
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <View style={styles.row}>
+            <Text style={[styles.label, { color: colors.textMuted, fontFamily: typography.label }]}>
+              {t("hud.runGoal")}
+            </Text>
+            <Text
+              style={[styles.value, { color: colors.text, fontFamily: typography.heading }]}
+              accessibilityLabel={t("hud.goalProgressAccessibilityLabel", {
+                chips,
+                goal: runGoal,
+              })}
+            >
+              {t("hud.goalProgress", { chips, goal: runGoal })}
+            </Text>
+          </View>
+        </>
+      )}
     </View>
   );
 }

--- a/frontend/src/components/blackjack/TableSelectPanel.tsx
+++ b/frontend/src/components/blackjack/TableSelectPanel.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../../theme/ThemeContext";
+import { typography } from "../../theme/typography";
+import { TABLE_CONFIGS, TableConfig, isTableUnlocked } from "../../game/blackjack/tables";
+import { RunRecord } from "../../game/blackjack/storage";
+
+interface Props {
+  runs: RunRecord[];
+  onSelectTable: (config: TableConfig) => void;
+}
+
+export default function TableSelectPanel({ runs, onSelectTable }: Props) {
+  const { t } = useTranslation("blackjack");
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, { color: colors.text, fontFamily: typography.heading }]}>
+        {t("tableSelect.title")}
+      </Text>
+
+      <View style={styles.cards}>
+        {TABLE_CONFIGS.map((config, idx) => {
+          const unlocked = isTableUnlocked(idx, runs);
+          const prevConfig = idx > 0 ? TABLE_CONFIGS[idx - 1] : null;
+
+          return (
+            <Pressable
+              key={config.id}
+              style={[
+                styles.card,
+                {
+                  backgroundColor: colors.surface,
+                  borderColor: unlocked ? colors.accent : colors.border,
+                  opacity: unlocked ? 1 : 0.55,
+                },
+              ]}
+              onPress={() => unlocked && onSelectTable(config)}
+              disabled={!unlocked}
+              accessibilityRole="button"
+              accessibilityLabel={
+                unlocked
+                  ? t("tableSelect.selectLabel", {
+                      table: t(config.labelKey as Parameters<typeof t>[0]),
+                    })
+                  : t("tableSelect.lockedLabel", {
+                      table: t(config.labelKey as Parameters<typeof t>[0]),
+                    })
+              }
+              accessibilityState={{ disabled: !unlocked }}
+            >
+              <Text
+                style={[styles.cardName, { color: unlocked ? colors.accent : colors.textMuted }]}
+              >
+                {t(config.labelKey as Parameters<typeof t>[0])}
+              </Text>
+
+              {!unlocked && prevConfig && (
+                <Text style={[styles.lockHint, { color: colors.textMuted }]}>
+                  {t("tableSelect.locked", {
+                    table: t(prevConfig.labelKey as Parameters<typeof t>[0]),
+                  })}
+                </Text>
+              )}
+
+              <View style={styles.stats}>
+                <View style={styles.statRow}>
+                  <Text style={[styles.statLabel, { color: colors.textMuted }]}>
+                    {t("tableSelect.startChips")}
+                  </Text>
+                  <Text style={[styles.statValue, { color: colors.text }]}>
+                    {config.startingChips}
+                  </Text>
+                </View>
+                <View style={styles.statRow}>
+                  <Text style={[styles.statLabel, { color: colors.textMuted }]}>
+                    {t("tableSelect.goal")}
+                  </Text>
+                  <Text style={[styles.statValue, { color: colors.text }]}>
+                    {config.runGoal}
+                  </Text>
+                </View>
+                <View style={styles.statRow}>
+                  <Text style={[styles.statLabel, { color: colors.textMuted }]}>
+                    {t("tableSelect.betRange")}
+                  </Text>
+                  <Text style={[styles.statValue, { color: colors.text }]}>
+                    {config.betMin}–{config.betMax}
+                  </Text>
+                </View>
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    gap: 20,
+    width: "100%",
+    maxWidth: 360,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  cards: {
+    width: "100%",
+    gap: 12,
+  },
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    gap: 8,
+  },
+  cardName: {
+    fontSize: 16,
+    fontWeight: "800",
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  lockHint: {
+    fontSize: 11,
+    fontStyle: "italic",
+  },
+  stats: {
+    gap: 4,
+  },
+  statRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  statLabel: {
+    fontSize: 12,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  statValue: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+});

--- a/frontend/src/components/blackjack/TableSelectPanel.tsx
+++ b/frontend/src/components/blackjack/TableSelectPanel.tsx
@@ -78,9 +78,7 @@ export default function TableSelectPanel({ runs, onSelectTable }: Props) {
                   <Text style={[styles.statLabel, { color: colors.textMuted }]}>
                     {t("tableSelect.goal")}
                   </Text>
-                  <Text style={[styles.statValue, { color: colors.text }]}>
-                    {config.runGoal}
-                  </Text>
+                  <Text style={[styles.statValue, { color: colors.text }]}>{config.runGoal}</Text>
                 </View>
                 <View style={styles.statRow}>
                   <Text style={[styles.statLabel, { color: colors.textMuted }]}>

--- a/frontend/src/components/blackjack/__tests__/BettingPanel.test.tsx
+++ b/frontend/src/components/blackjack/__tests__/BettingPanel.test.tsx
@@ -5,15 +5,32 @@ import { ThemeProvider } from "../../../theme/ThemeContext";
 import { DEFAULT_RULES } from "../../../game/blackjack/engine";
 
 function renderPanel(
-  overrides: Partial<{ chips: number; loading: boolean; error: string | null }> = {}
+  overrides: Partial<{
+    chips: number;
+    loading: boolean;
+    error: string | null;
+    betMin: number;
+    betMax: number;
+    chipDenominations: readonly number[];
+  }> = {}
 ) {
   const onDeal = jest.fn();
   const onRulesChange = jest.fn();
-  const { chips = 1000, loading = false, error = null } = overrides;
+  const {
+    chips = 1000,
+    loading = false,
+    error = null,
+    betMin = 5,
+    betMax = 25,
+    chipDenominations = [5, 10, 25],
+  } = overrides;
   const utils = render(
     <ThemeProvider>
       <BettingPanel
         chips={chips}
+        betMin={betMin}
+        betMax={betMax}
+        chipDenominations={chipDenominations}
         onDeal={onDeal}
         loading={loading}
         error={error}
@@ -39,9 +56,9 @@ describe("BettingPanel", () => {
 
   it("calls onDeal with bet amount after placing a chip", () => {
     const { getByLabelText, getByText, onDeal } = renderPanel({ chips: 1000 });
-    fireEvent.press(getByLabelText(/add 100 to bet/i));
+    fireEvent.press(getByLabelText(/add 25 to bet/i));
     fireEvent.press(getByText("Deal"));
-    expect(onDeal).toHaveBeenCalledWith(100);
+    expect(onDeal).toHaveBeenCalledWith(25);
   });
 
   it("does not call onDeal when loading", () => {
@@ -58,34 +75,33 @@ describe("BettingPanel", () => {
   it("renders chip denomination buttons", () => {
     const { getByLabelText } = renderPanel();
     expect(getByLabelText(/add 5 to bet/i)).toBeTruthy();
+    expect(getByLabelText(/add 10 to bet/i)).toBeTruthy();
     expect(getByLabelText(/add 25 to bet/i)).toBeTruthy();
-    expect(getByLabelText(/add 100 to bet/i)).toBeTruthy();
-    expect(getByLabelText(/add 500 to bet/i)).toBeTruthy();
   });
 
   it("chip click adds denomination to displayed bet", () => {
     const { getByLabelText } = renderPanel({ chips: 1000 });
-    fireEvent.press(getByLabelText(/add 100 to bet/i));
-    expect(getByLabelText(/deal cards with 100-chip bet/i)).toBeTruthy();
+    fireEvent.press(getByLabelText(/add 25 to bet/i));
+    expect(getByLabelText(/deal cards with 25-chip bet/i)).toBeTruthy();
   });
 
   it("multiple chip clicks accumulate", () => {
     const { getByLabelText } = renderPanel({ chips: 1000 });
-    fireEvent.press(getByLabelText(/add 100 to bet/i));
-    fireEvent.press(getByLabelText(/add 25 to bet/i));
-    expect(getByLabelText(/deal cards with 125-chip bet/i)).toBeTruthy();
+    fireEvent.press(getByLabelText(/add 10 to bet/i));
+    fireEvent.press(getByLabelText(/add 5 to bet/i));
+    expect(getByLabelText(/deal cards with 15-chip bet/i)).toBeTruthy();
   });
 
   it("Clear Bet button resets bet to 0", () => {
     const { getByLabelText } = renderPanel({ chips: 1000 });
-    fireEvent.press(getByLabelText(/add 100 to bet/i));
+    fireEvent.press(getByLabelText(/add 5 to bet/i));
     fireEvent.press(getByLabelText(/clear bet/i));
     expect(getByLabelText(/deal cards with 0-chip bet/i)).toBeTruthy();
   });
 
-  it("500 chip is disabled when chips < 500", () => {
-    const { getByLabelText } = renderPanel({ chips: 200 });
-    const btn = getByLabelText(/500.*not available/i);
+  it("25 chip is disabled when chips < 25", () => {
+    const { getByLabelText } = renderPanel({ chips: 10 });
+    const btn = getByLabelText(/25.*not available/i);
     expect(btn.props.accessibilityState.disabled).toBe(true);
   });
 });

--- a/frontend/src/game/blackjack/BlackjackGameContext.tsx
+++ b/frontend/src/game/blackjack/BlackjackGameContext.tsx
@@ -4,6 +4,7 @@ import { GameRules } from "./types";
 import { saveGame, loadGame, clearGame, saveRun, loadRuns } from "./storage";
 import { SessionStats, initialSessionStats, reduceHandResolved } from "./sessionStats";
 import { useGameSync } from "../_shared/useGameSync";
+import { TableConfig } from "./tables";
 
 /** Hint passed to apply() so the context can emit a typed player_action. */
 export type PlayerActionHint = "hit" | "stand" | "double" | "split" | null;
@@ -17,6 +18,7 @@ interface BlackjackGameContextValue {
   clearEvents: () => void;
   handleRulesChange: (rules: GameRules) => void;
   handlePlayAgain: () => void;
+  handleTableSelect: (config: TableConfig) => void;
 }
 
 function activeHand(s: EngineState, idx: number): Card[] {
@@ -50,7 +52,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
   }, [engine]);
 
   const startSession = useCallback(
-    async (startingChips: number, resuming = false) => {
+    async (startingChips: number, resuming = false, tableId?: string) => {
       sessionStartedAtRef.current = Date.now();
       totalHandsRef.current = 0;
       lowestChipsRef.current = startingChips;
@@ -58,7 +60,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
       setSessionStats(initialSessionStats(startingChips));
       // Load run history to compute aggregate metadata for the backend game row.
       // Runs saved in the *previous* endSession call are included because saveRun
-      // is awaited before startSession is invoked from handlePlayAgain, and because
+      // is awaited before startSession is invoked from handleTableSelect, and because
       // the initial-load path never has a preceding saveRun. The minor race that
       // can occur if endSession fires saveRun fire-and-forget (chips=0 path) means
       // the newly-completed run may not yet appear — off by one, self-corrects next
@@ -74,7 +76,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
           best_run_chips: bestRunChips,
           total_runs: totalRuns,
           runs_completed: runsCompleted,
-          current_table: "beginner",
+          current_table: (tableId ?? "beginner") as "beginner" | "intermediate" | "high_roller",
         }
       );
       // Mark the session as already started when resuming a mid-game save.
@@ -125,10 +127,13 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
         const next = saved ?? newGame();
         setEngine(next);
         if (!saved) saveGame(next);
-        // Start an instrumented session unless the loaded state is already
-        // a chips-exhausted game-over state. Pass resuming=true for saved
-        // mid-game states so syncMarkStarted fires after syncStart.
-        if (!(next.chips === 0 && next.phase === "result")) {
+        // Fresh game with no table selected yet — session starts after table pick.
+        const tableSelectPending =
+          !saved && next.runGoal === null && next.chips === next.startingChips && next.bet === 0;
+        // Start an instrumented session unless table selection is pending or the
+        // loaded state is already a chips-exhausted game-over state. Pass
+        // resuming=true for saved mid-game states so syncMarkStarted fires after syncStart.
+        if (!tableSelectPending && !(next.chips === 0 && next.phase === "result")) {
           void startSession(next.chips, !!saved);
         }
       })
@@ -310,14 +315,31 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
     // game_ended was already emitted by emitTransitionEvents — syncComplete
     // is idempotent and the guard in useGameSync makes this a no-op.
     // Otherwise we're mid-game and the user pressed New Game (abandon).
-    // Await so saveRun completes before startSession loads runs for metadata.
     await endSession("abandoned");
+    // Create a fresh engine in table-select-pending state (runGoal=null).
+    // startSession is deferred to handleTableSelect after the user picks a table.
     const fresh = newGame(undefined, { rules: engine?.rules ?? DEFAULT_RULES });
     setEngine(fresh);
     saveGame(fresh);
     setError(null);
-    void startSession(fresh.chips);
-  }, [engine, endSession, startSession]);
+  }, [engine, endSession]);
+
+  const handleTableSelect = useCallback(
+    (config: TableConfig) => {
+      const fresh = newGame(undefined, {
+        startingChips: config.startingChips,
+        runGoal: config.runGoal,
+        betMin: config.betMin,
+        betMax: config.betMax,
+        rules: engine?.rules ?? DEFAULT_RULES,
+      });
+      setEngine(fresh);
+      saveGame(fresh);
+      setError(null);
+      void startSession(fresh.chips, false, config.id);
+    },
+    [engine, startSession]
+  );
 
   return (
     <BlackjackGameContext.Provider
@@ -330,6 +352,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
         clearEvents,
         handleRulesChange,
         handlePlayAgain,
+        handleTableSelect,
       }}
     >
       {children}

--- a/frontend/src/game/blackjack/tables.ts
+++ b/frontend/src/game/blackjack/tables.ts
@@ -1,0 +1,48 @@
+import { RunRecord } from "./storage";
+
+export interface TableConfig {
+  readonly id: "beginner" | "intermediate" | "high_roller";
+  readonly labelKey: string;
+  readonly startingChips: number;
+  readonly runGoal: number;
+  readonly betMin: number;
+  readonly betMax: number;
+  readonly chipDenominations: readonly number[];
+}
+
+export const TABLE_CONFIGS: readonly TableConfig[] = [
+  {
+    id: "beginner",
+    labelKey: "table.beginner",
+    startingChips: 100,
+    runGoal: 250,
+    betMin: 5,
+    betMax: 25,
+    chipDenominations: [5, 10, 25],
+  },
+  {
+    id: "intermediate",
+    labelKey: "table.intermediate",
+    startingChips: 250,
+    runGoal: 750,
+    betMin: 10,
+    betMax: 50,
+    chipDenominations: [10, 25, 50],
+  },
+  {
+    id: "high_roller",
+    labelKey: "table.highRoller",
+    startingChips: 500,
+    runGoal: 1500,
+    betMin: 25,
+    betMax: 200,
+    chipDenominations: [25, 50, 100, 200],
+  },
+] as const;
+
+/** Returns true if the table at tableIndex has been unlocked. */
+export function isTableUnlocked(tableIndex: number, runs: RunRecord[]): boolean {
+  if (tableIndex === 0) return true;
+  const prev = TABLE_CONFIGS[tableIndex - 1];
+  return prev !== undefined && runs.some((r) => r.table === prev.id && r.completed);
+}

--- a/frontend/src/i18n/locales/ar/blackjack.json
+++ b/frontend/src/i18n/locales/ar/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "الأيدي الفائزة",
   "score.handsLost": "الأيدي الخاسرة",
   "score.blackjacks": "البلاك جاك",
-  "score.busts": "الإفلاس"
+  "score.busts": "الإفلاس",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/de/blackjack.json
+++ b/frontend/src/i18n/locales/de/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Gewonnene Hände",
   "score.handsLost": "Verlorene Hände",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Überkauft"
+  "score.busts": "Überkauft",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Hands Won",
   "score.handsLost": "Hands Lost",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Busts"
+  "score.busts": "Busts",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/es/blackjack.json
+++ b/frontend/src/i18n/locales/es/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Manos ganadas",
   "score.handsLost": "Manos perdidas",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Pasadas"
+  "score.busts": "Pasadas",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/fr-CA/blackjack.json
+++ b/frontend/src/i18n/locales/fr-CA/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Mains gagnées",
   "score.handsLost": "Mains perdues",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Sautes"
+  "score.busts": "Sautes",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/he/blackjack.json
+++ b/frontend/src/i18n/locales/he/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "ידיים שזכו",
   "score.handsLost": "ידיים שהפסידו",
   "score.blackjacks": "בלאקג׳ק",
-  "score.busts": "פיצוצים"
+  "score.busts": "פיצוצים",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/hi/blackjack.json
+++ b/frontend/src/i18n/locales/hi/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "जीते हाथ",
   "score.handsLost": "हारे हाथ",
   "score.blackjacks": "ब्लैकजैक",
-  "score.busts": "बस्ट"
+  "score.busts": "बस्ट",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "勝ちハンド",
   "score.handsLost": "負けハンド",
   "score.blackjacks": "ブラックジャック",
-  "score.busts": "バースト"
+  "score.busts": "バースト",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/ko/blackjack.json
+++ b/frontend/src/i18n/locales/ko/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "이긴 핸드",
   "score.handsLost": "진 핸드",
   "score.blackjacks": "블랙잭",
-  "score.busts": "버스트"
+  "score.busts": "버스트",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/nl/blackjack.json
+++ b/frontend/src/i18n/locales/nl/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Gewonnen handen",
   "score.handsLost": "Verloren handen",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Gebust"
+  "score.busts": "Gebust",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/pt/blackjack.json
+++ b/frontend/src/i18n/locales/pt/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Mãos ganhas",
   "score.handsLost": "Mãos perdidas",
   "score.blackjacks": "Blackjacks",
-  "score.busts": "Estouros"
+  "score.busts": "Estouros",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/ru/blackjack.json
+++ b/frontend/src/i18n/locales/ru/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "Выигранные руки",
   "score.handsLost": "Проигранные руки",
   "score.blackjacks": "Блэкджеки",
-  "score.busts": "Перебор"
+  "score.busts": "Перебор",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/i18n/locales/zh/blackjack.json
+++ b/frontend/src/i18n/locales/zh/blackjack.json
@@ -95,5 +95,18 @@
   "score.handsWon": "赢的手数",
   "score.handsLost": "输的手数",
   "score.blackjacks": "黑杰克",
-  "score.busts": "爆牌"
+  "score.busts": "爆牌",
+  "hud.runGoal": "Goal",
+  "hud.goalProgress": "{{chips}}/{{goal}}",
+  "hud.goalProgressAccessibilityLabel": "Goal progress: {{chips}} of {{goal}} chips",
+  "table.beginner": "Beginner",
+  "table.intermediate": "Intermediate",
+  "table.highRoller": "High Roller",
+  "tableSelect.title": "Choose Your Table",
+  "tableSelect.startChips": "Start",
+  "tableSelect.goal": "Goal",
+  "tableSelect.betRange": "Bets",
+  "tableSelect.locked": "Complete {{table}} first",
+  "tableSelect.selectLabel": "Select {{table}} table",
+  "tableSelect.lockedLabel": "{{table}} table locked"
 }

--- a/frontend/src/screens/BlackjackBettingScreen.tsx
+++ b/frontend/src/screens/BlackjackBettingScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
@@ -7,7 +7,10 @@ import { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { placeBet as enginePlaceBet, toViewState, DEFAULT_RULES } from "../game/blackjack/engine";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";
+import { loadRuns, RunRecord } from "../game/blackjack/storage";
+import { TABLE_CONFIGS } from "../game/blackjack/tables";
 import BettingPanel from "../components/blackjack/BettingPanel";
+import TableSelectPanel from "../components/blackjack/TableSelectPanel";
 import BlackjackTable from "../components/blackjack/BlackjackTable";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 
@@ -19,7 +22,26 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
   const { t } = useTranslation(["blackjack", "common"]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
-  const { engine, loading, error, apply, handleRulesChange, handlePlayAgain } = useBlackjackGame();
+  const { engine, loading, error, apply, handleRulesChange, handlePlayAgain, handleTableSelect } =
+    useBlackjackGame();
+  const [runs, setRuns] = useState<RunRecord[]>([]);
+
+  useEffect(() => {
+    loadRuns().then(setRuns).catch(() => {});
+  }, []);
+
+  // Show table selection when the engine is in "pending table" state:
+  // fresh game (runGoal=null) that hasn't had any chips committed yet.
+  const showTableSelect =
+    engine !== null &&
+    engine.runGoal === null &&
+    engine.chips === engine.startingChips &&
+    engine.bet === 0;
+
+  // Derive active table config from engine's betMin/betMax (set by handleTableSelect).
+  const activeTable =
+    TABLE_CONFIGS.find((t) => t.betMin === engine?.betMin && t.betMax === engine?.betMax) ??
+    TABLE_CONFIGS[0]!;
 
   // Redirect to TableScreen if loaded mid-hand (app restart, or injected state).
   useEffect(() => {
@@ -109,16 +131,23 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
         </View>
       )}
 
-      {/* Betting controls */}
+      {/* Table selection or betting controls */}
       <View style={styles.controls}>
-        <BettingPanel
-          chips={state?.chips ?? 1000}
-          onDeal={handleDeal}
-          loading={false}
-          error={error}
-          rules={state?.rules ?? DEFAULT_RULES}
-          onRulesChange={handleRulesChange}
-        />
+        {showTableSelect ? (
+          <TableSelectPanel runs={runs} onSelectTable={handleTableSelect} />
+        ) : (
+          <BettingPanel
+            chips={state?.chips ?? activeTable.startingChips}
+            betMin={engine?.betMin ?? activeTable.betMin}
+            betMax={engine?.betMax ?? activeTable.betMax}
+            chipDenominations={activeTable.chipDenominations}
+            onDeal={handleDeal}
+            loading={false}
+            error={error}
+            rules={state?.rules ?? DEFAULT_RULES}
+            onRulesChange={handleRulesChange}
+          />
+        )}
       </View>
     </View>
   );

--- a/frontend/src/screens/BlackjackBettingScreen.tsx
+++ b/frontend/src/screens/BlackjackBettingScreen.tsx
@@ -27,7 +27,9 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
   const [runs, setRuns] = useState<RunRecord[]>([]);
 
   useEffect(() => {
-    loadRuns().then(setRuns).catch(() => {});
+    loadRuns()
+      .then(setRuns)
+      .catch(() => {});
   }, []);
 
   // Show table selection when the engine is in "pending table" state:

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -193,7 +193,12 @@ export default function BlackjackTableScreen({ navigation }: Props) {
         <View style={styles.tableRow}>
           {/* Left sidebar HUD */}
           <View style={styles.sidebarLeft}>
-            <HudSidebar currentPot={state.bet} lastWin={state.last_win} />
+            <HudSidebar
+              currentPot={state.bet}
+              lastWin={state.last_win}
+              chips={engine?.chips}
+              runGoal={engine?.runGoal}
+            />
           </View>
 
           <View style={styles.tableArea}>

--- a/frontend/src/screens/__tests__/BlackjackBettingScreen.test.tsx
+++ b/frontend/src/screens/__tests__/BlackjackBettingScreen.test.tsx
@@ -17,7 +17,7 @@ jest.mock("expo-blur", () => ({
 jest.mock("../../game/blackjack/storage", () => ({
   saveGame: jest.fn(),
   clearGame: jest.fn(),
-  loadGame: jest.fn().mockResolvedValue(null),
+  loadGame: jest.fn(),
   saveRun: jest.fn().mockResolvedValue(undefined),
   loadRuns: jest.fn().mockResolvedValue([]),
 }));
@@ -40,8 +40,13 @@ function renderScreen(nav = mockNav()) {
   );
 }
 
+// Default: return a beginner-table-selected game so most tests see the betting panel.
+const beginnerGame = () =>
+  newGame(undefined, { startingChips: 100, runGoal: 250, betMin: 5, betMax: 25 });
+
 beforeEach(() => {
   jest.clearAllMocks();
+  (loadGame as jest.Mock).mockResolvedValue(beginnerGame());
 });
 
 // ---------------------------------------------------------------------------
@@ -49,9 +54,18 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("BlackjackBettingScreen — initial load", () => {
-  it("renders BettingPanel after mount (no saved game)", async () => {
+  it("renders BettingPanel when a table-selected game is loaded", async () => {
     renderScreen();
     expect(await screen.findByText("Deal")).toBeTruthy();
+  });
+
+  it("renders TableSelectPanel when no saved game exists (fresh install)", async () => {
+    (loadGame as jest.Mock).mockResolvedValueOnce(null);
+    renderScreen();
+    expect(await screen.findByText("Choose Your Table")).toBeTruthy();
+    expect(screen.getByText("Beginner")).toBeTruthy();
+    expect(screen.getByText("Intermediate")).toBeTruthy();
+    expect(screen.getByText("High Roller")).toBeTruthy();
   });
 });
 
@@ -113,12 +127,12 @@ describe("BlackjackBettingScreen — phase redirect", () => {
     const nav = mockNav();
     renderScreen(nav);
     await screen.findByText("Deal");
-    // Place a chip first so Deal becomes enabled
+    // Place a chip first so Deal becomes enabled (beginner table: max bet 25)
     await act(async () => {
-      fireEvent.press(screen.getByLabelText(/add 100 to bet/i));
+      fireEvent.press(screen.getByLabelText(/add 25 to bet/i));
     });
     await act(async () => {
-      fireEvent.press(screen.getByLabelText(/deal cards with 100-chip bet/i));
+      fireEvent.press(screen.getByLabelText(/deal cards with 25-chip bet/i));
     });
     await waitFor(() => {
       expect(nav.replace).toHaveBeenCalledWith("BlackjackTable");
@@ -134,7 +148,8 @@ describe("BlackjackBettingScreen — chip balance visibility (GH #227)", () => {
   it("bankroll is visible in header during betting phase", async () => {
     renderScreen();
     await screen.findByText("Deal");
-    expect(screen.getByLabelText(/bankroll: 1000 chips/i)).toBeTruthy();
+    // Beginner table starts with 100 chips
+    expect(screen.getByLabelText(/bankroll: 100 chips/i)).toBeTruthy();
   });
 });
 

--- a/frontend/src/screens/__tests__/BlackjackTableScreen.test.tsx
+++ b/frontend/src/screens/__tests__/BlackjackTableScreen.test.tsx
@@ -240,6 +240,7 @@ describe("BlackjackTableScreen — new game redirect (#498)", () => {
 // ---------------------------------------------------------------------------
 
 import { useBlackjackGame, PlayerActionHint } from "../../game/blackjack/BlackjackGameContext";
+import { TableConfig } from "../../game/blackjack/tables";
 import {
   hit,
   doubleDown,
@@ -276,6 +277,7 @@ function getCtx(): {
   engine: EngineState | null;
   apply: (fn: (s: EngineState) => EngineState, action?: PlayerActionHint) => void;
   handlePlayAgain: () => void;
+  handleTableSelect: (config: TableConfig) => void;
 } {
   return (window as unknown as { __bj: ReturnType<typeof useBlackjackGame> }).__bj;
 }
@@ -291,12 +293,15 @@ function card(rank: string, suit = "♠"): Card {
 }
 
 describe("BlackjackGameContext — gameEventClient instrumentation (#370)", () => {
+  // A game with runGoal set (non-null) so startSession fires on mount.
+  const tableSelectedGame = () => engineNewGame(undefined, { runGoal: 2500 });
+
   beforeEach(() => {
     mockStartGame.mockReset();
     mockStartGame.mockReturnValue("game-uuid-test");
     mockEnqueueEvent.mockReset();
     mockCompleteGame.mockReset();
-    (loadGame as jest.Mock).mockResolvedValue(null);
+    (loadGame as jest.Mock).mockResolvedValue(tableSelectedGame());
   });
 
   it("calls startGame('blackjack') with starting_chips on mount", async () => {
@@ -516,6 +521,21 @@ describe("BlackjackGameContext — gameEventClient instrumentation (#370)", () =
 
     expect(mockCompleteGame).toHaveBeenCalledTimes(1);
     expect(mockCompleteGame.mock.calls[0]?.[1]?.outcome).toBe("abandoned");
+
+    // handlePlayAgain defers startSession to handleTableSelect (BJ-2 table selection flow).
+    const fakeConfig: TableConfig = {
+      id: "beginner",
+      labelKey: "table.beginner",
+      startingChips: 1000,
+      runGoal: 2500,
+      betMin: 5,
+      betMax: 500,
+      chipDenominations: [5, 25, 100, 500],
+    };
+    act(() => {
+      getCtx().handleTableSelect(fakeConfig);
+    });
+
     await waitFor(() => {
       expect(mockStartGame).toHaveBeenCalledWith(
         "blackjack",


### PR DESCRIPTION
## Summary

- Adds three explicit blackjack tables: **Beginner** (100→250 chips, 5–25 bets), **Intermediate** (250→750, 10–50), **High Roller** (500→1500, 25–200)
- New `TableSelectPanel` shown before each run; Intermediate and High Roller are locked until the previous tier has a completed run
- `BettingPanel` now accepts `betMin`, `betMax`, `chipDenominations` props — denominations are table-specific instead of hardcoded
- `HudSidebar` shows goal progress row (`chips/goal`) when table has a `runGoal`
- `BlackjackGameContext` defers `startSession` to `handleTableSelect` so the backend gets `current_table` metadata
- All i18n locale files updated with table/tableSelect/hud.goal* keys

## Test plan

- [ ] `test-frontend`: `BettingPanel.test.tsx` and `BlackjackBettingScreen.test.tsx` updated for new props and beginner-table denominations
- [ ] Fresh install flow: no saved game → TableSelectPanel shown, select Beginner → BettingPanel with 5/10/25 chips
- [ ] Completed run → Intermediate unlocks in next TableSelectPanel
- [ ] High Roller locked until Intermediate completed
- [ ] HudSidebar goal progress row visible during a hand at Beginner table
- [ ] All other CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)