### PR TITLE
fix(cascade): add explicit WALL_FRICTION = 0.2 to static boundaries (#1404)

### DIFF
--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -13,6 +13,7 @@ export {
   GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
+  WALL_FRICTION,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -42,6 +43,7 @@ import {
   GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
+  WALL_FRICTION,
   FIXED_STEP_MS,
   MATTER_POSITION_ITERATIONS,
   MATTER_VELOCITY_ITERATIONS,
@@ -95,15 +97,15 @@ export async function createEngine(
   // --- Static walls and floor ---
   const floor = Matter.Bodies.rectangle(W / 2, H - WALL_THICKNESS / 2, W, WALL_THICKNESS, {
     isStatic: true,
-    friction: FRUIT_FRICTION,
+    friction: WALL_FRICTION,
   });
   const leftWall = Matter.Bodies.rectangle(WALL_THICKNESS / 2, H / 2, WALL_THICKNESS, H, {
     isStatic: true,
-    friction: FRUIT_FRICTION,
+    friction: WALL_FRICTION,
   });
   const rightWall = Matter.Bodies.rectangle(W - WALL_THICKNESS / 2, H / 2, WALL_THICKNESS, H, {
     isStatic: true,
-    friction: FRUIT_FRICTION,
+    friction: WALL_FRICTION,
   });
   Matter.Composite.add(world, [floor, leftWall, rightWall]);
 

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -22,6 +22,8 @@ export const GAME_OVER_MERGE_COOLDOWN_TICKS = 90;
 export const FRUIT_RESTITUTION = 0.1;
 /** Low friction = fruits slide and settle naturally (spec: 0.05–0.1). */
 export const FRUIT_FRICTION = 0.08;
+/** Wall/floor friction (spec: ~0.2) — higher than fruit friction so fruits grip walls but slide freely on each other. */
+export const WALL_FRICTION = 0.2;
 export const FRUIT_DENSITY = 1.0;
 
 // --- Rapier-specific constants (used only by engine.ts / web) ---

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -12,6 +12,7 @@ export {
   GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
+  WALL_FRICTION,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -40,6 +41,7 @@ import {
   GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
+  WALL_FRICTION,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -128,24 +130,21 @@ export async function createEngine(
 
   // Floor (top surface at H - WALL_THICKNESS)
   world.createCollider(
-    R.ColliderDesc.cuboid((W / 2) * SCALE, (WALL_THICKNESS / 2) * SCALE).setTranslation(
-      (W / 2) * SCALE,
-      (H - WALL_THICKNESS / 2) * SCALE
-    )
+    R.ColliderDesc.cuboid((W / 2) * SCALE, (WALL_THICKNESS / 2) * SCALE)
+      .setTranslation((W / 2) * SCALE, (H - WALL_THICKNESS / 2) * SCALE)
+      .setFriction(WALL_FRICTION)
   );
   // Left wall (inner surface at WALL_THICKNESS)
   world.createCollider(
-    R.ColliderDesc.cuboid((WALL_THICKNESS / 2) * SCALE, H * SCALE).setTranslation(
-      (WALL_THICKNESS / 2) * SCALE,
-      (H / 2) * SCALE
-    )
+    R.ColliderDesc.cuboid((WALL_THICKNESS / 2) * SCALE, H * SCALE)
+      .setTranslation((WALL_THICKNESS / 2) * SCALE, (H / 2) * SCALE)
+      .setFriction(WALL_FRICTION)
   );
   // Right wall (inner surface at W - WALL_THICKNESS)
   world.createCollider(
-    R.ColliderDesc.cuboid((WALL_THICKNESS / 2) * SCALE, H * SCALE).setTranslation(
-      (W - WALL_THICKNESS / 2) * SCALE,
-      (H / 2) * SCALE
-    )
+    R.ColliderDesc.cuboid((WALL_THICKNESS / 2) * SCALE, H * SCALE)
+      .setTranslation((W - WALL_THICKNESS / 2) * SCALE, (H / 2) * SCALE)
+      .setFriction(WALL_FRICTION)
   );
 
   const dangerY = H * DANGER_LINE_RATIO; // pixels


### PR DESCRIPTION
## Summary

- Adds `WALL_FRICTION = 0.2` constant to `engine.shared.ts`
- Rapier (`engine.ts`): chains `.setFriction(WALL_FRICTION)` onto all 3 static collider descriptors (floor, left wall, right wall) — previously no friction was set, so Rapier used its internal default
- Matter.js (`engine.native.ts`): replaces `friction: FRUIT_FRICTION` with `friction: WALL_FRICTION` on the 3 static bodies — they were incorrectly inheriting the fruit friction value (0.08)

Fruits now grip walls/floor at 0.2 while still sliding freely against each other at 0.08, matching the spec relationship defined in epic #1397.

Closes #1404. Depends on #1405 (FRUIT_FRICTION lowered to 0.08).

## Test plan

- [x] 309 Cascade frontend unit tests pass
- [ ] Manual play: verify fruits grip walls naturally without sticking to each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)