### PR TITLE
fix(cascade): apply radial pop impulse to neighbors on merge (#1399)

### DIFF
--- a/frontend/__mocks__/@dimforge/rapier2d-compat.ts
+++ b/frontend/__mocks__/@dimforge/rapier2d-compat.ts
@@ -11,6 +11,7 @@ export class MockRigidBody {
   _vx = 0;
   _vy = 0;
   _wakeUpCount = 0;
+  _impulses: Array<{ x: number; y: number }> = [];
   _colliders: MockCollider[] = [];
 
   constructor(handle: number, x: number, y: number) {
@@ -34,6 +35,10 @@ export class MockRigidBody {
   }
   wakeUp() {
     this._wakeUpCount++;
+  }
+  applyImpulse(impulse: { x: number; y: number }, wakeUp: boolean) {
+    this._impulses.push({ ...impulse });
+    if (wakeUp) this._wakeUpCount++;
   }
   numColliders() {
     return this._colliders.length;

--- a/frontend/src/game/cascade/__tests__/engine.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.test.ts
@@ -880,11 +880,11 @@ describe("body sleeping — canSleep", () => {
 // ---------------------------------------------------------------------------
 
 describe("body sleeping — neighbor wake", () => {
-  it("calls wakeUp() on bodies within 2× spawn radius after a merge", async () => {
+  it("applies radial pop impulse and wakes bodies within 2× spawn radius after a merge", async () => {
     const handle = await buildEngine();
     const world = getWorld();
 
-    // Drop 3 fruits: two will merge (1003/1004), one nearby (1005) that should be woken.
+    // Drop 3 fruits: two will merge (1003/1004), one nearby (1005) that should receive the impulse.
     handle.drop(fruit(2), fruitSet.id, 100, 300); // body 0, collider 1003
     handle.drop(fruit(2), fruitSet.id, 110, 300); // body 1, collider 1004
     handle.drop(fruit(0), fruitSet.id, 105, 310); // body 2, collider 1005 — nearby
@@ -895,7 +895,9 @@ describe("body sleeping — neighbor wake", () => {
 
     const nearbyBody = world._bodies.get(2);
     expect(nearbyBody).toBeDefined();
+    // applyImpulse(impulse, wakeUp=true) increments _wakeUpCount and records the impulse
     expect(nearbyBody!._wakeUpCount).toBeGreaterThan(0);
+    expect(nearbyBody!._impulses.length).toBeGreaterThan(0);
   });
 });
 

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -14,6 +14,7 @@ export {
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   WALL_FRICTION,
+  POP_IMPULSE_SCALE,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -44,6 +45,7 @@ import {
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   WALL_FRICTION,
+  POP_IMPULSE_SCALE,
   FIXED_STEP_MS,
   MATTER_POSITION_ITERATIONS,
   MATTER_VELOCITY_ITERATIONS,
@@ -250,8 +252,8 @@ export async function createEngine(
             Math.min(H - WALL_THICKNESS - nextDef.radius, midY)
           );
           const newFb = spawnAt(nextDef, fruitSet.id, spawnX, spawnY, SPAWN_GRACE_TICKS);
-          // Wake sleeping neighbors within 2× spawn radius so they react to the new body.
-          // Iterate fruitMap (only live fruits) to mirror Rapier's neighbor-wake logic.
+          // Wake neighbors within 2× spawn radius and apply radial pop impulse to push
+          // them out of the merge zone, preventing stuck overlaps after spawn.
           // Build an id→body map first (O(M)) so fruitMap lookups are O(1), not O(M) each.
           const wakeRadiusSq = (nextDef.radius * 2) ** 2;
           const bodyById = new Map(Matter.Composite.allBodies(world).map((b) => [b.id, b]));
@@ -261,7 +263,13 @@ export async function createEngine(
             if (!b) return;
             const dx = b.position.x - midX;
             const dy = b.position.y - midY;
-            if (dx * dx + dy * dy < wakeRadiusSq) {
+            const distSq = dx * dx + dy * dy;
+            if (distSq < wakeRadiusSq) {
+              const dist = Math.sqrt(distSq);
+              if (dist > 0) {
+                const mag = nextDef.radius * POP_IMPULSE_SCALE;
+                Matter.Body.applyForce(b, b.position, { x: (dx / dist) * mag, y: (dy / dist) * mag });
+              }
               Matter.Sleeping.set(b, false);
             }
           });

--- a/frontend/src/game/cascade/engine.native.ts
+++ b/frontend/src/game/cascade/engine.native.ts
@@ -268,7 +268,10 @@ export async function createEngine(
               const dist = Math.sqrt(distSq);
               if (dist > 0) {
                 const mag = nextDef.radius * POP_IMPULSE_SCALE;
-                Matter.Body.applyForce(b, b.position, { x: (dx / dist) * mag, y: (dy / dist) * mag });
+                Matter.Body.applyForce(b, b.position, {
+                  x: (dx / dist) * mag,
+                  y: (dy / dist) * mag,
+                });
               }
               Matter.Sleeping.set(b, false);
             }

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -24,6 +24,8 @@ export const FRUIT_RESTITUTION = 0.1;
 export const FRUIT_FRICTION = 0.08;
 /** Wall/floor friction (spec: ~0.2) — higher than fruit friction so fruits grip walls but slide freely on each other. */
 export const WALL_FRICTION = 0.2;
+/** Radial pop impulse applied to neighbors on merge: magnitude = nextTierRadius × this. Tunable. */
+export const POP_IMPULSE_SCALE = 2.0;
 export const FRUIT_DENSITY = 1.0;
 
 // --- Rapier-specific constants (used only by engine.ts / web) ---

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -13,6 +13,7 @@ export {
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   WALL_FRICTION,
+  POP_IMPULSE_SCALE,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -42,6 +43,7 @@ import {
   FRUIT_RESTITUTION,
   FRUIT_FRICTION,
   WALL_FRICTION,
+  POP_IMPULSE_SCALE,
   FRUIT_DENSITY,
   SCALE,
   GRAVITY_Y,
@@ -290,7 +292,8 @@ export async function createEngine(
         const nextDef = fruitSet.fruits[(tier + 1) as FruitTier];
         if (nextDef !== undefined) {
           const newFb = spawnAt(nextDef, fruitSet.id, midX, midY, SPAWN_GRACE_TICKS);
-          // Wake any sleeping neighbors within 2× spawn radius so they react to the new body.
+          // Wake neighbors within 2× spawn radius and apply radial pop impulse to push
+          // them out of the merge zone, preventing stuck overlaps after spawn.
           const wakeRadiusSq = (nextDef.radius * 2) ** 2;
           fruitMap.forEach((_fb2, wHandle) => {
             if (wHandle === newFb.handle) return;
@@ -299,8 +302,15 @@ export async function createEngine(
             const wpos = wrb.translation();
             const dx = wpos.x / SCALE - midX;
             const dy = wpos.y / SCALE - midY;
-            if (dx * dx + dy * dy < wakeRadiusSq) {
-              wrb.wakeUp();
+            const distSq = dx * dx + dy * dy;
+            if (distSq < wakeRadiusSq) {
+              const dist = Math.sqrt(distSq);
+              if (dist > 0) {
+                const mag = nextDef.radius * POP_IMPULSE_SCALE * SCALE;
+                wrb.applyImpulse({ x: (dx / dist) * mag, y: (dy / dist) * mag }, true);
+              } else {
+                wrb.wakeUp();
+              }
             }
           });
         }


### PR DESCRIPTION
## Summary

Replaces the bare `wakeUp()` neighbor scan with a radial outward impulse applied to every body within 2× the spawned fruit's radius, preventing stuck overlaps when the tier+1 fruit materialises at the merge midpoint.

- **`engine.shared.ts`**: adds `POP_IMPULSE_SCALE = 2.0` (tunable constant)
- **`engine.ts` (Rapier)**: `rb.applyImpulse({ x, y }, true)` — magnitude `nextRadius × POP_IMPULSE_SCALE × SCALE`; the `wakeUp=true` flag replaces the previous explicit `wakeUp()` call. Falls back to `wakeUp()` only for the degenerate `dist=0` case
- **`engine.native.ts` (Matter.js)**: `Body.applyForce(b, b.position, { x, y })` at the body centroid (no torque) followed by `Sleeping.set(b, false)` — magnitude `nextRadius × POP_IMPULSE_SCALE`
- **Rapier mock**: adds `applyImpulse()` stub that records applied impulses in `_impulses[]` and increments `_wakeUpCount` when `wakeUp=true`
- **engine.test.ts**: updates the wake test to also assert `_impulses.length > 0`

Closes #1399.

## Test plan

- [x] 309 Cascade frontend unit tests pass
- [ ] Manual play: verify visible outward pop on merge, no stuck overlaps in dense stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)