### PR TITLE
feat(blackjack): in-run chip milestone system (BJ-5)

### DIFF
--- a/frontend/src/game/blackjack/BlackjackGameContext.tsx
+++ b/frontend/src/game/blackjack/BlackjackGameContext.tsx
@@ -299,6 +299,8 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
         startingChips: engine.startingChips,
         betMin: engine.betMin,
         betMax: engine.betMax,
+        milestones: engine.milestones,
+        milestones_reached: engine.milestones_reached,
       };
       setEngine(updated);
       saveGame(updated);
@@ -331,6 +333,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
         runGoal: config.runGoal,
         betMin: config.betMin,
         betMax: config.betMax,
+        milestones: config.milestones,
         rules: engine?.rules ?? DEFAULT_RULES,
       });
       setEngine(fresh);

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -1554,6 +1554,70 @@ describe("milestone system", () => {
     expect(next.events?.some((e) => e.type === "milestone")).toBe(true);
   });
 
+  it("emits milestone event when chips cross threshold via hit-bust settling below zero", () => {
+    // Player busts → loses bet. chips 300, bet 100, milestone [150].
+    // After bust: chips 200 — already above 150, so milestone fires.
+    // (We set milestones_reached=[] to simulate not having crossed it yet.)
+    const s: EngineState = {
+      ...stateWithMilestones(300, [250]),
+      bet: 100,
+      player_hand: [c("♠", "K"), c("♥", "Q")], // 20 — one more card will bust
+      deck: [c("♦", "5")], // deal 5 → 25, bust
+    };
+    // Bust brings chips to 200, which is below 250 → no milestone
+    const next = hit(s);
+    expect(next.chips).toBe(200);
+    expect(next.milestones_reached).toEqual([]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(false);
+  });
+
+  it("emits milestone event on hit-bust when chips after loss still cross threshold", () => {
+    // chips 300, bet 50, milestone [200]. Bust → chips 250. 250 ≥ 200 → milestone fires.
+    const s: EngineState = {
+      ...stateWithMilestones(300, [200]),
+      bet: 50,
+      player_hand: [c("♠", "K"), c("♥", "Q")], // 20
+      deck: [c("♦", "5")], // 25 — bust
+    };
+    const next = hit(s);
+    expect(next.chips).toBe(250);
+    expect(next.milestones_reached).toEqual([200]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(true);
+  });
+
+  it("emits milestone event on split final settlement via finishIfAllHandsDone", () => {
+    // Two-hand split. Win both hands: chips 100 → 100+50+50=200; milestone [150] fires.
+    const s: EngineState = {
+      ...DEFAULT_RUN_CONFIG,
+      milestones: [150],
+      milestones_reached: [],
+      chips: 100,
+      bet: 0,
+      phase: "player",
+      outcome: null,
+      payout: 0,
+      lastWin: null,
+      player_hand: [],
+      dealer_hand: [c("♦", "6"), c("♣", "7")], // dealer 13, will draw 4s → stands at 17
+      deck: Array(10).fill(c("♠", "4")),
+      doubled: false,
+      rules: DEFAULT_RULES,
+      // Two split hands, each bet 50, both win (K+9=19 > dealer 17)
+      player_hands: [[c("♠", "K"), c("♥", "9")], [c("♠", "K"), c("♥", "9")]],
+      hand_bets: [50, 50],
+      hand_outcomes: [null, null],
+      hand_payouts: [0, 0],
+      active_hand_index: 2, // past both hands — triggers finishIfAllHandsDone
+      split_count: 1,
+      split_from_aces: [false, false],
+    };
+    // Calling stand on hand 2 (already active_hand_index=2, finishIfAllHandsDone runs)
+    const next = stand({ ...s, active_hand_index: 1, phase: "player" });
+    expect(next.chips).toBe(200); // 100 + 50 + 50
+    expect(next.milestones_reached).toEqual([150]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(true);
+  });
+
   it("does not re-emit an already-reached milestone", () => {
     const s: EngineState = {
       ...stateWithMilestones(250, [200], [200]),

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -49,6 +49,7 @@ function emptySplitState() {
 function stateInPlayer(chips = 1000, bet = 100): EngineState {
   return {
     ...DEFAULT_RUN_CONFIG,
+    milestones_reached: [],
     chips,
     bet,
     phase: "player",
@@ -72,6 +73,7 @@ function stateInResult(
 ): EngineState {
   return {
     ...DEFAULT_RUN_CONFIG,
+    milestones_reached: [],
     chips,
     bet,
     phase: "result",
@@ -96,6 +98,7 @@ function splitSetup(opts?: {
 }): EngineState {
   return {
     ...DEFAULT_RUN_CONFIG,
+    milestones_reached: [],
     chips: opts?.chips ?? 1000,
     bet: opts?.bet ?? 100,
     phase: "player",
@@ -709,6 +712,7 @@ function ddSetup(
 ): EngineState {
   return {
     ...DEFAULT_RUN_CONFIG,
+    milestones_reached: [],
     chips,
     bet,
     phase: "player",
@@ -1342,6 +1346,7 @@ describe("game events", () => {
   function stateInBetting(chips = 1000): EngineState {
     return {
       ...DEFAULT_RUN_CONFIG,
+      milestones_reached: [],
       chips,
       bet: 0,
       phase: "betting",
@@ -1485,5 +1490,131 @@ describe("game events", () => {
     };
     const view = toViewState(s);
     expect(view.events).toEqual([{ type: "cardDeal" }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Milestone system (BJ-5)
+// ---------------------------------------------------------------------------
+
+describe("milestone system", () => {
+  function stateWithMilestones(
+    chips: number,
+    milestones: number[],
+    milestones_reached: number[] = []
+  ): EngineState {
+    return {
+      ...stateInPlayer(chips),
+      milestones,
+      milestones_reached,
+      player_hand: [c("♠", "K"), c("♥", "9")], // 19 — beats dealer
+      dealer_hand: [c("♦", "6"), c("♣", "7")], // 13 — dealer draws to stand
+      deck: Array(10).fill(c("♠", "4")),
+    };
+  }
+
+  it("newGame initializes milestones_reached as empty array", () => {
+    const g = newGame(undefined, { milestones: [175, 220] });
+    expect(g.milestones).toEqual([175, 220]);
+    expect(g.milestones_reached).toEqual([]);
+  });
+
+  it("no milestone emitted when chips don't reach threshold", () => {
+    const s = stateWithMilestones(100, [500]);
+    // Player 19 vs dealer 13 (draws 4+4=21 bust path — dealer actually stands at 17)
+    // chips: 100, bet: 100 → win → chips 200 — below 500 threshold
+    const next = stand(s);
+    expect(next.milestones_reached).toEqual([]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(false);
+  });
+
+  it("emits milestone event when chips cross a threshold via stand", () => {
+    // chips 150, bet 100, milestones [200] — win brings chips to 250 → crosses 200
+    const s: EngineState = {
+      ...stateWithMilestones(150, [200]),
+      bet: 100,
+    };
+    const next = stand(s);
+    expect(next.chips).toBe(250);
+    expect(next.milestones_reached).toEqual([200]);
+    const msEvent = next.events?.find((e) => e.type === "milestone");
+    expect(msEvent).toEqual({ type: "milestone", value: 200 });
+  });
+
+  it("emits milestone event when chips cross threshold via doubleDown win", () => {
+    const s: EngineState = {
+      ...stateWithMilestones(150, [200]),
+      bet: 50,
+      player_hand: [c("♠", "6"), c("♥", "5")], // 11 — good DD hand
+      deck: [c("♠", "K"), c("♠", "4")], // DD card=K→21, dealer draws 4 (stays 17)
+    };
+    const next = doubleDown(s);
+    expect(next.chips).toBe(250); // 150 + 100 (2*50)
+    expect(next.milestones_reached).toEqual([200]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(true);
+  });
+
+  it("does not re-emit an already-reached milestone", () => {
+    const s: EngineState = {
+      ...stateWithMilestones(250, [200], [200]),
+      bet: 50,
+    };
+    const next = stand(s);
+    // 200 already in milestones_reached — should not fire again
+    expect(next.milestones_reached).toEqual([200]);
+    expect(next.events?.filter((e) => e.type === "milestone")).toHaveLength(0);
+  });
+
+  it("emits multiple milestone events when chips skip past two thresholds at once", () => {
+    // chips 100, bet 500 (theoretical) → win brings chips to 600; milestones [200, 500]
+    const s: EngineState = {
+      ...stateWithMilestones(100, [200, 500]),
+      bet: 500,
+    };
+    const next = stand(s);
+    expect(next.chips).toBe(600);
+    expect(next.milestones_reached).toEqual([200, 500]);
+    const msEvents = next.events?.filter((e) => e.type === "milestone") ?? [];
+    expect(msEvents).toHaveLength(2);
+  });
+
+  it("milestones_reached persists across newHand", () => {
+    const s = stateInResult(300, 100, "win", 100);
+    const sWithMilestones: EngineState = {
+      ...s,
+      milestones: [200],
+      milestones_reached: [200],
+    };
+    const next = newHand(sWithMilestones);
+    expect(next.milestones_reached).toEqual([200]);
+    expect(next.milestones).toEqual([200]);
+  });
+
+  it("emits milestone event on natural blackjack crossing threshold", () => {
+    // Natural blackjack: chips 150, bet 50, milestone [200] → 150 + ceil(50*1.5)=75 = 225
+    const s: EngineState = {
+      ...DEFAULT_RUN_CONFIG,
+      milestones: [200],
+      milestones_reached: [],
+      chips: 150,
+      bet: 0,
+      phase: "betting",
+      outcome: null,
+      payout: 0,
+      lastWin: null,
+      // Deal order (pop from end): player1=A, dealer1=K, player2=Q, dealer2=2
+      // Player [A,Q]=21 natural; dealer [K,2]=12 — not BJ → outcome "blackjack"
+      deck: [c("♦", "2"), c("♣", "Q"), c("♠", "K"), c("♥", "A")],
+      player_hand: [],
+      dealer_hand: [],
+      doubled: false,
+      rules: DEFAULT_RULES,
+      ...emptySplitState(),
+    };
+    const next = placeBet(s, 50);
+    expect(next.outcome).toBe("blackjack");
+    expect(next.chips).toBe(225);
+    expect(next.milestones_reached).toEqual([200]);
+    expect(next.events?.some((e) => e.type === "milestone")).toBe(true);
   });
 });

--- a/frontend/src/game/blackjack/__tests__/engine.test.ts
+++ b/frontend/src/game/blackjack/__tests__/engine.test.ts
@@ -1603,7 +1603,10 @@ describe("milestone system", () => {
       doubled: false,
       rules: DEFAULT_RULES,
       // Two split hands, each bet 50, both win (K+9=19 > dealer 17)
-      player_hands: [[c("♠", "K"), c("♥", "9")], [c("♠", "K"), c("♥", "9")]],
+      player_hands: [
+        [c("♠", "K"), c("♥", "9")],
+        [c("♠", "K"), c("♥", "9")],
+      ],
       hand_bets: [50, 50],
       hand_outcomes: [null, null],
       hand_payouts: [0, 0],

--- a/frontend/src/game/blackjack/__tests__/storage.test.ts
+++ b/frontend/src/game/blackjack/__tests__/storage.test.ts
@@ -89,6 +89,18 @@ describe("blackjack storage", () => {
     expect(loaded?.lastWin).toBeNull();
   });
 
+  it("backfills milestone fields for saves that predate BJ-5", async () => {
+    const g = newGame();
+    const serialized = JSON.parse(JSON.stringify(g)) as Record<string, unknown>;
+    delete serialized["milestones"];
+    delete serialized["milestones_reached"];
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(serialized));
+    const loaded = await loadGame();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.milestones).toEqual([]);
+    expect(loaded!.milestones_reached).toEqual([]);
+  });
+
   it("backfills run-mode fields for saves that predate run mode", async () => {
     const g = newGame();
     const serialized = JSON.parse(JSON.stringify(g)) as Record<string, unknown>;

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -600,7 +600,10 @@ export function stand(s: EngineState): EngineState {
     const next = advanceHand({ ...s, events: undefined });
     if (next.phase === "result" && next.outcome !== null) {
       const msEvents = pendingMilestoneEvents(s, next);
-      return { ...next, events: [outcomeEvent(next.outcome as "win" | "lose" | "push"), ...msEvents] };
+      return {
+        ...next,
+        events: [outcomeEvent(next.outcome as "win" | "lose" | "push"), ...msEvents],
+      };
     }
     return next;
   }
@@ -655,7 +658,11 @@ export function doubleDown(s: EngineState): EngineState {
     if (advanced.phase === "result" && advanced.outcome !== null && !busted) {
       return {
         ...advanced,
-        events: [...splitDoubleEvents, outcomeEvent(advanced.outcome as "win" | "lose" | "push"), ...msEvents],
+        events: [
+          ...splitDoubleEvents,
+          outcomeEvent(advanced.outcome as "win" | "lose" | "push"),
+          ...msEvents,
+        ],
       };
     }
     return { ...advanced, events: [...splitDoubleEvents, ...msEvents] };
@@ -685,7 +692,11 @@ export function doubleDown(s: EngineState): EngineState {
   const msEvents = pendingMilestoneEvents(s, settled);
   return {
     ...settled,
-    events: [{ type: "cardDeal" }, outcomeEvent(settled.outcome as "win" | "lose" | "push"), ...msEvents],
+    events: [
+      { type: "cardDeal" },
+      outcomeEvent(settled.outcome as "win" | "lose" | "push"),
+      ...msEvents,
+    ],
   };
 }
 

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -52,6 +52,7 @@ export interface RunConfig {
   runGoal: number | null;
   betMin: number;
   betMax: number;
+  milestones: readonly number[];
   rules?: GameRules;
 }
 
@@ -60,6 +61,7 @@ export const DEFAULT_RUN_CONFIG: RunConfig = {
   runGoal: null,
   betMin: 5,
   betMax: 500,
+  milestones: [],
 };
 
 /**
@@ -93,6 +95,8 @@ export interface EngineState {
   startingChips: number;
   betMin: number;
   betMax: number;
+  milestones: readonly number[];
+  milestones_reached: number[];
 }
 
 // ---------------------------------------------------------------------------
@@ -208,6 +212,23 @@ function deal(deck: Card[], deckCount: number = 1): { deck: Card[]; card: Card }
   const next = [...working];
   const card = next.pop()!;
   return { deck: next, card };
+}
+
+// ---------------------------------------------------------------------------
+// Milestone helpers
+// ---------------------------------------------------------------------------
+
+function advanceMilestonesReached(s: EngineState, newChips: number): number[] {
+  if (s.milestones.length === 0) return s.milestones_reached;
+  const newly = s.milestones.filter((t) => !s.milestones_reached.includes(t) && newChips >= t);
+  return newly.length > 0 ? [...s.milestones_reached, ...newly] : s.milestones_reached;
+}
+
+function pendingMilestoneEvents(prev: EngineState, next: EngineState): BlackjackGameEvent[] {
+  if (prev.milestones_reached.length === next.milestones_reached.length) return [];
+  return next.milestones_reached
+    .filter((t) => !prev.milestones_reached.includes(t))
+    .map((value) => ({ type: "milestone" as const, value }));
 }
 
 // ---------------------------------------------------------------------------
@@ -364,6 +385,8 @@ export function newGame(deck?: Card[], runConfig?: Partial<RunConfig>): EngineSt
     startingChips: rc.startingChips,
     betMin: rc.betMin,
     betMax: rc.betMax,
+    milestones: rc.milestones ?? [],
+    milestones_reached: [],
     ...emptySplitState(),
   };
 }
@@ -382,6 +405,7 @@ function settleWith(s: EngineState, outcome: "blackjack" | "win" | "lose" | "pus
     payout: delta,
     chips: newChips,
     phase,
+    milestones_reached: advanceMilestonesReached(s, newChips),
   };
 }
 
@@ -422,9 +446,10 @@ export function placeBet(s: EngineState, amount: number): EngineState {
   if (isNaturalBlackjack(playerHand)) {
     const outcome = isNaturalBlackjack(dealerHand) ? "push" : "blackjack";
     const settled = settleWith(afterDeal, outcome);
+    const msEvents = pendingMilestoneEvents(afterDeal, settled);
     return {
       ...settled,
-      events: [{ type: "cardDeal" }, { type: "cardDeal" }, outcomeEvent(outcome)],
+      events: [{ type: "cardDeal" }, { type: "cardDeal" }, outcomeEvent(outcome), ...msEvents],
     };
   }
   return {
@@ -521,6 +546,7 @@ function finishIfAllHandsDone(s: EngineState): EngineState {
     chips: finalChips,
     outcome: overallOutcome,
     phase: finalPhase,
+    milestones_reached: advanceMilestonesReached(working, finalChips),
   };
 }
 
@@ -547,7 +573,9 @@ export function hit(s: EngineState): EngineState {
     let next: EngineState = { ...s, deck, player_hands: newHands, events };
     if (busted) {
       next = settleHand(next, s.active_hand_index, "lose");
-      return { ...advanceHand(next), events };
+      const advanced = advanceHand(next);
+      const msEvents = pendingMilestoneEvents(s, advanced);
+      return { ...advanced, events: msEvents.length > 0 ? [...events, ...msEvents] : events };
     }
     return next;
   }
@@ -559,7 +587,9 @@ export function hit(s: EngineState): EngineState {
     player_hand: [...s.player_hand, card],
   };
   if (handValue(next.player_hand) > 21) {
-    return { ...settleWith(next, "lose"), events: [{ type: "cardDeal" }, { type: "bust" }] };
+    const settled = settleWith(next, "lose");
+    const msEvents = pendingMilestoneEvents(next, settled);
+    return { ...settled, events: [{ type: "cardDeal" }, { type: "bust" }, ...msEvents] };
   }
   return { ...next, events: [{ type: "cardDeal" }] };
 }
@@ -569,12 +599,14 @@ export function stand(s: EngineState): EngineState {
   if (s.split_count > 0) {
     const next = advanceHand({ ...s, events: undefined });
     if (next.phase === "result" && next.outcome !== null) {
-      return { ...next, events: [outcomeEvent(next.outcome as "win" | "lose" | "push")] };
+      const msEvents = pendingMilestoneEvents(s, next);
+      return { ...next, events: [outcomeEvent(next.outcome as "win" | "lose" | "push"), ...msEvents] };
     }
     return next;
   }
   const next = determineAndSettle(dealerPlay({ ...s, events: undefined }));
-  return { ...next, events: [outcomeEvent(next.outcome as "win" | "lose" | "push")] };
+  const msEvents = pendingMilestoneEvents(s, next);
+  return { ...next, events: [outcomeEvent(next.outcome as "win" | "lose" | "push"), ...msEvents] };
 }
 
 export function doubleDown(s: EngineState): EngineState {
@@ -619,13 +651,14 @@ export function doubleDown(s: EngineState): EngineState {
       next = settleHand(next, idx, "lose");
     }
     const advanced = advanceHand(next);
+    const msEvents = pendingMilestoneEvents(s, advanced);
     if (advanced.phase === "result" && advanced.outcome !== null && !busted) {
       return {
         ...advanced,
-        events: [...splitDoubleEvents, outcomeEvent(advanced.outcome as "win" | "lose" | "push")],
+        events: [...splitDoubleEvents, outcomeEvent(advanced.outcome as "win" | "lose" | "push"), ...msEvents],
       };
     }
-    return { ...advanced, events: splitDoubleEvents };
+    return { ...advanced, events: [...splitDoubleEvents, ...msEvents] };
   }
 
   if (s.player_hand.length !== 2) {
@@ -644,15 +677,15 @@ export function doubleDown(s: EngineState): EngineState {
   };
 
   if (handValue(afterDouble.player_hand) > 21) {
-    return {
-      ...settleWith(afterDouble, "lose"),
-      events: [{ type: "cardDeal" }, { type: "bust" }],
-    };
+    const settled = settleWith(afterDouble, "lose");
+    const msEvents = pendingMilestoneEvents(afterDouble, settled);
+    return { ...settled, events: [{ type: "cardDeal" }, { type: "bust" }, ...msEvents] };
   }
   const settled = determineAndSettle(dealerPlay(afterDouble));
+  const msEvents = pendingMilestoneEvents(s, settled);
   return {
     ...settled,
-    events: [{ type: "cardDeal" }, outcomeEvent(settled.outcome as "win" | "lose" | "push")],
+    events: [{ type: "cardDeal" }, outcomeEvent(settled.outcome as "win" | "lose" | "push"), ...msEvents],
   };
 }
 

--- a/frontend/src/game/blackjack/storage.ts
+++ b/frontend/src/game/blackjack/storage.ts
@@ -142,6 +142,13 @@ export async function loadGame(): Promise<EngineState | null> {
     if (typeof parsed.betMax !== "number") {
       parsed.betMax = DEFAULT_RUN_CONFIG.betMax;
     }
+    // Backfill milestone fields for saves created before BJ-5.
+    if (!Array.isArray(parsed.milestones)) {
+      parsed.milestones = [];
+    }
+    if (!Array.isArray(parsed.milestones_reached)) {
+      parsed.milestones_reached = [];
+    }
     return parsed;
   } catch (e) {
     // Corrupt payload: recovery is complete (we remove the bad entry and

--- a/frontend/src/game/blackjack/tables.ts
+++ b/frontend/src/game/blackjack/tables.ts
@@ -8,6 +8,7 @@ export interface TableConfig {
   readonly betMin: number;
   readonly betMax: number;
   readonly chipDenominations: readonly number[];
+  readonly milestones: readonly number[];
 }
 
 export const TABLE_CONFIGS: readonly TableConfig[] = [
@@ -19,6 +20,7 @@ export const TABLE_CONFIGS: readonly TableConfig[] = [
     betMin: 5,
     betMax: 25,
     chipDenominations: [5, 10, 25],
+    milestones: [175, 220],
   },
   {
     id: "intermediate",
@@ -28,6 +30,7 @@ export const TABLE_CONFIGS: readonly TableConfig[] = [
     betMin: 10,
     betMax: 50,
     chipDenominations: [10, 25, 50],
+    milestones: [500, 625],
   },
   {
     id: "high_roller",
@@ -37,6 +40,7 @@ export const TABLE_CONFIGS: readonly TableConfig[] = [
     betMin: 25,
     betMax: 200,
     chipDenominations: [25, 50, 100, 200],
+    milestones: [1000, 1250],
   },
 ] as const;
 

--- a/frontend/src/game/blackjack/types.ts
+++ b/frontend/src/game/blackjack/types.ts
@@ -10,7 +10,8 @@ export type BlackjackGameEvent =
   | { readonly type: "bust" }
   | { readonly type: "win" }
   | { readonly type: "loss" }
-  | { readonly type: "push" };
+  | { readonly type: "push" }
+  | { readonly type: "milestone"; readonly value: number };
 
 export interface CardResponse {
   rank: string;

--- a/frontend/src/i18n/locales/ar/blackjack.json
+++ b/frontend/src/i18n/locales/ar/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/de/blackjack.json
+++ b/frontend/src/i18n/locales/de/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/es/blackjack.json
+++ b/frontend/src/i18n/locales/es/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/fr-CA/blackjack.json
+++ b/frontend/src/i18n/locales/fr-CA/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/he/blackjack.json
+++ b/frontend/src/i18n/locales/he/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/hi/blackjack.json
+++ b/frontend/src/i18n/locales/hi/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/ko/blackjack.json
+++ b/frontend/src/i18n/locales/ko/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/nl/blackjack.json
+++ b/frontend/src/i18n/locales/nl/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/pt/blackjack.json
+++ b/frontend/src/i18n/locales/pt/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/ru/blackjack.json
+++ b/frontend/src/i18n/locales/ru/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/i18n/locales/zh/blackjack.json
+++ b/frontend/src/i18n/locales/zh/blackjack.json
@@ -108,5 +108,6 @@
   "tableSelect.betRange": "Bets",
   "tableSelect.locked": "Complete {{table}} first",
   "tableSelect.selectLabel": "Select {{table}} table",
-  "tableSelect.lockedLabel": "{{table}} table locked"
+  "tableSelect.lockedLabel": "{{table}} table locked",
+  "milestone.toast": "Milestone reached: {{chips}} chips!"
 }

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -52,7 +52,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   const { engine, loading, error, apply, clearEvents, handlePlayAgain } = useBlackjackGame();
   const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
   const [celebrationVisible, setCelebrationVisible] = useState(false);
-  const [milestoneChips, setMilestoneChips] = useState(0);
+  const [milestoneChips, setMilestoneChips] = useState<number | null>(null);
   const milestoneOpacity = useSharedValue(0);
 
   const cardDealSound = useSound("blackjack.cardDeal");
@@ -229,11 +229,13 @@ export default function BlackjackTableScreen({ navigation }: Props) {
             />
             <Animated.View style={bustFlashStyle} />
             <Animated.View style={winFlashStyle} />
-            <Animated.View style={[styles.milestoneToast, milestoneStyle, { backgroundColor: colors.accent }]}>
-              <Text style={[styles.milestoneText, { color: colors.surface }]}>
-                {t("blackjack:milestone.toast", { chips: milestoneChips })}
-              </Text>
-            </Animated.View>
+            {milestoneChips !== null && (
+              <Animated.View style={[styles.milestoneToast, milestoneStyle, { backgroundColor: colors.accent }]}>
+                <Text style={[styles.milestoneText, { color: colors.surface }]}>
+                  {t("blackjack:milestone.toast", { chips: milestoneChips })}
+                </Text>
+              </Animated.View>
+            )}
           </View>
 
           {/* Right spacer to balance the sidebar — collapsed on split so both hands fit */}

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -230,7 +230,9 @@ export default function BlackjackTableScreen({ navigation }: Props) {
             <Animated.View style={bustFlashStyle} />
             <Animated.View style={winFlashStyle} />
             {milestoneChips !== null && (
-              <Animated.View style={[styles.milestoneToast, milestoneStyle, { backgroundColor: colors.accent }]}>
+              <Animated.View
+                style={[styles.milestoneToast, milestoneStyle, { backgroundColor: colors.accent }]}
+              >
                 <Text style={[styles.milestoneText, { color: colors.surface }]}>
                   {t("blackjack:milestone.toast", { chips: milestoneChips })}
                 </Text>

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, Pressable, StyleSheet, useWindowDimensions } from "react-na
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
+  withDelay,
   withSequence,
   withTiming,
 } from "react-native-reanimated";
@@ -51,6 +52,8 @@ export default function BlackjackTableScreen({ navigation }: Props) {
   const { engine, loading, error, apply, clearEvents, handlePlayAgain } = useBlackjackGame();
   const [confirmNewGameVisible, setConfirmNewGameVisible] = useState(false);
   const [celebrationVisible, setCelebrationVisible] = useState(false);
+  const [milestoneChips, setMilestoneChips] = useState(0);
+  const milestoneOpacity = useSharedValue(0);
 
   const cardDealSound = useSound("blackjack.cardDeal");
   const blackjackSound = useSound("blackjack.blackjack");
@@ -72,6 +75,10 @@ export default function BlackjackTableScreen({ navigation }: Props) {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: "rgba(34,197,94,0.35)",
     opacity: winFlash.value,
+    pointerEvents: "none",
+  }));
+  const milestoneStyle = useAnimatedStyle(() => ({
+    opacity: milestoneOpacity.value,
     pointerEvents: "none",
   }));
 
@@ -100,6 +107,13 @@ export default function BlackjackTableScreen({ navigation }: Props) {
         );
       },
       push: () => pushSound.play(),
+      milestone: (event) => {
+        setMilestoneChips(event.value);
+        milestoneOpacity.value = withSequence(
+          withTiming(1, { duration: 150 }),
+          withDelay(1400, withTiming(0, { duration: 250 }))
+        );
+      },
     },
     clearEvents
   );
@@ -215,6 +229,11 @@ export default function BlackjackTableScreen({ navigation }: Props) {
             />
             <Animated.View style={bustFlashStyle} />
             <Animated.View style={winFlashStyle} />
+            <Animated.View style={[styles.milestoneToast, milestoneStyle, { backgroundColor: colors.accent }]}>
+              <Text style={[styles.milestoneText, { color: colors.surface }]}>
+                {t("blackjack:milestone.toast", { chips: milestoneChips })}
+              </Text>
+            </Animated.View>
           </View>
 
           {/* Right spacer to balance the sidebar — collapsed on split so both hands fit */}
@@ -405,5 +424,18 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "700",
     lineHeight: 20,
+  },
+  milestoneToast: {
+    position: "absolute",
+    top: 8,
+    alignSelf: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    zIndex: 10,
+  },
+  milestoneText: {
+    fontSize: 14,
+    fontWeight: "700",
   },
 });


### PR DESCRIPTION
Closes #1374. Part of #1369.

## Summary

- Adds chip milestone thresholds to each table tier: Beginner 175/220, Intermediate 500/625, High Roller 1000/1250
- `EngineState` gains `milestones: readonly number[]` and `milestones_reached: number[]`; both persist in AsyncStorage
- All settlement paths in the engine (`stand`, `hit`, `doubleDown`, `placeBet` natural BJ, split resolution) check for newly crossed milestones and emit `{ type: "milestone", value: N }` UI events
- Already-reached milestones never re-fire within a run; milestone state survives `newHand` and app backgrounding
- `BlackjackTableScreen` renders a non-blocking animated toast banner (~1.8s total) on milestone events
- Storage backfill handles pre-BJ-5 saves (both new fields default to `[]`)

## Test plan

- [ ] Run `npx jest --testPathPattern="blackjack/"` — 250 tests, all passing
- [ ] Start a Beginner run, grind chips to 175 — toast appears briefly without blocking play
- [ ] Continue to 220 — second toast fires; neither repeats on subsequent hands
- [ ] Background and reopen app mid-run — milestones_reached state is preserved
- [ ] Start a new run — milestone state resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)