### PR TITLE
fix(hearts): reset fanfare flags on next hand to prevent repeat animation

### DIFF
--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -368,6 +368,9 @@ export default function HeartsScreen() {
   function handleNextHand() {
     if (!gameState) return;
     setLastTrick(null);
+    setShowMoonShot(false);
+    setShowHeartsBroken(false);
+    setShowQueenOfSpades(false);
     const next = dealNextHand(gameState);
     setGameState(next);
     void saveGame(next);
@@ -391,6 +394,9 @@ export default function HeartsScreen() {
 
   function handleStartGame(difficulty: AiDifficulty) {
     setLastTrick(null);
+    setShowMoonShot(false);
+    setShowHeartsBroken(false);
+    setShowQueenOfSpades(false);
     setSubmitState("idle");
     setPlayerName("");
     loopActiveRef.current = false;
@@ -402,6 +408,9 @@ export default function HeartsScreen() {
 
   function handlePlayAgain() {
     setLastTrick(null);
+    setShowMoonShot(false);
+    setShowHeartsBroken(false);
+    setShowQueenOfSpades(false);
     setSubmitState("idle");
     setPlayerName("");
     loopActiveRef.current = false;


### PR DESCRIPTION
showMoonShot, showHeartsBroken, and showQueenOfSpades are now cleared in
handleNextHand, handleStartGame, and handlePlayAgain so a fanfare triggered
in one hand cannot bleed into subsequent hands when the player advances
before the 2.2s animation completes.

Fixes #1413

https://claude.ai/code/session_01DyQCtqYxwpvFCGNyZz2UZB