### PR TITLE
feat(blackjack): BJ-8 unlock system architecture — cosmetic rewards tied to run achievements

### DIFF
--- a/frontend/src/game/blackjack/BlackjackGameContext.tsx
+++ b/frontend/src/game/blackjack/BlackjackGameContext.tsx
@@ -22,6 +22,7 @@ interface BlackjackGameContextValue {
   loading: boolean;
   error: string | null;
   sessionStats: SessionStats;
+  lowestChips: number;
   apply: (fn: (s: EngineState) => EngineState, action?: PlayerActionHint) => void;
   clearEvents: () => void;
   handleRulesChange: (rules: GameRules) => void;
@@ -377,6 +378,7 @@ export function BlackjackGameProvider({ children }: { children: React.ReactNode 
         loading,
         error,
         sessionStats,
+        lowestChips: lowestChipsRef.current,
         apply,
         clearEvents,
         handleRulesChange,

--- a/frontend/src/game/blackjack/__tests__/unlocks.test.ts
+++ b/frontend/src/game/blackjack/__tests__/unlocks.test.ts
@@ -1,0 +1,247 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+import {
+  Unlock,
+  INITIAL_UNLOCKS,
+  evaluateUnlocks,
+  loadUnlocks,
+  saveUnlocks,
+  mergeUnlocks,
+} from "../unlocks";
+import { RunRecord } from "../storage";
+
+const UNLOCKS_KEY = "blackjack_unlocks_v1";
+
+const makeRun = (overrides: Partial<RunRecord> = {}): RunRecord => ({
+  table: "beginner",
+  startingChips: 100,
+  finalChips: 250,
+  runGoal: 250,
+  completed: true,
+  handsPlayed: 20,
+  biggestWin: 50,
+  lowestChips: 80,
+  startedAt: 1000000,
+  endedAt: 1002000,
+  ...overrides,
+});
+
+describe("evaluateUnlocks", () => {
+  it("returns empty array when no runs are provided", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    expect(evaluateUnlocks([], existing)).toEqual([]);
+  });
+
+  it("returns empty array when all unlocks are already unlocked", () => {
+    const existing: Unlock[] = INITIAL_UNLOCKS.map((u) => ({
+      ...u,
+      unlocked: true,
+      unlockedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    const runs = [makeRun({ table: "beginner", completed: true })];
+    expect(evaluateUnlocks(runs, existing)).toEqual([]);
+  });
+
+  it("triggers beginner table theme on a completed beginner run", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [makeRun({ table: "beginner", completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]!.id).toBe("beginner_table_theme");
+    expect(triggered[0]!.unlocked).toBe(true);
+    expect(triggered[0]!.unlockedAt).toBeDefined();
+  });
+
+  it("does not trigger unlock for an incomplete beginner run", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [makeRun({ table: "beginner", completed: false })];
+    expect(evaluateUnlocks(runs, existing)).toHaveLength(0);
+  });
+
+  it("triggers intermediate card back on a completed intermediate run", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [makeRun({ table: "intermediate", completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]!.id).toBe("intermediate_card_back");
+  });
+
+  it("triggers high roller chip style on a completed high_roller run", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [makeRun({ table: "high_roller", completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]!.id).toBe("high_roller_chip_style");
+  });
+
+  it("triggers multiple unlocks when multiple conditions are met", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [
+      makeRun({ table: "beginner", completed: true }),
+      makeRun({ table: "intermediate", completed: true }),
+    ];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(2);
+    const ids = triggered.map((u) => u.id);
+    expect(ids).toContain("beginner_table_theme");
+    expect(ids).toContain("intermediate_card_back");
+  });
+
+  it("does not re-trigger an already unlocked item", () => {
+    const existing: Unlock[] = INITIAL_UNLOCKS.map((u) => ({
+      ...u,
+      unlocked: u.id === "beginner_table_theme",
+      unlockedAt: u.id === "beginner_table_theme" ? "2026-01-01T00:00:00.000Z" : undefined,
+    }));
+    const runs = [makeRun({ table: "beginner", completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered.find((u) => u.id === "beginner_table_theme")).toBeUndefined();
+  });
+
+  it("triggers run_count unlock when run count meets threshold", () => {
+    const existing: Unlock[] = [
+      {
+        id: "veteran",
+        name: "Veteran",
+        type: "table_theme",
+        conditionType: "run_count",
+        conditionValue: 3,
+        unlocked: false,
+      },
+    ];
+    const runs = [makeRun(), makeRun(), makeRun()];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]!.id).toBe("veteran");
+  });
+
+  it("does not trigger run_count unlock below threshold", () => {
+    const existing: Unlock[] = [
+      {
+        id: "veteran",
+        name: "Veteran",
+        type: "table_theme",
+        conditionType: "run_count",
+        conditionValue: 5,
+        unlocked: false,
+      },
+    ];
+    const runs = [makeRun(), makeRun()];
+    expect(evaluateUnlocks(runs, existing)).toHaveLength(0);
+  });
+
+  it("triggers comeback unlock when a run recovered from very low chips", () => {
+    const existing: Unlock[] = [
+      {
+        id: "comeback_kid",
+        name: "Comeback Kid",
+        type: "chip_style",
+        conditionType: "comeback",
+        conditionValue: "any",
+        unlocked: false,
+      },
+    ];
+    // lowestChips = 20, startingChips = 100 → 20% which is ≤ 25%
+    const runs = [makeRun({ lowestChips: 20, startingChips: 100, completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered).toHaveLength(1);
+    expect(triggered[0]!.id).toBe("comeback_kid");
+  });
+
+  it("does not trigger comeback when lowest chips is above 25% threshold", () => {
+    const existing: Unlock[] = [
+      {
+        id: "comeback_kid",
+        name: "Comeback Kid",
+        type: "chip_style",
+        conditionType: "comeback",
+        conditionValue: "any",
+        unlocked: false,
+      },
+    ];
+    // lowestChips = 30, startingChips = 100 → 30% which is > 25%
+    const runs = [makeRun({ lowestChips: 30, startingChips: 100, completed: true })];
+    expect(evaluateUnlocks(runs, existing)).toHaveLength(0);
+  });
+
+  it("sets unlockedAt to a valid ISO date string", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const runs = [makeRun({ table: "beginner", completed: true })];
+    const triggered = evaluateUnlocks(runs, existing);
+    expect(triggered[0]!.unlockedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe("mergeUnlocks", () => {
+  it("returns the original array unchanged when no triggered unlocks", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    expect(mergeUnlocks(existing, [])).toBe(existing);
+  });
+
+  it("replaces the triggered item with its unlocked version", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const triggered: Unlock[] = [
+      { ...existing[0]!, unlocked: true, unlockedAt: "2026-01-01T00:00:00.000Z" },
+    ];
+    const merged = mergeUnlocks(existing, triggered);
+    expect(merged[0]!.unlocked).toBe(true);
+    expect(merged[0]!.unlockedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(merged[1]!.unlocked).toBe(false);
+    expect(merged[2]!.unlocked).toBe(false);
+  });
+
+  it("preserves original array length", () => {
+    const existing = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const triggered: Unlock[] = [
+      { ...existing[1]!, unlocked: true, unlockedAt: "2026-01-01T00:00:00.000Z" },
+    ];
+    expect(mergeUnlocks(existing, triggered)).toHaveLength(INITIAL_UNLOCKS.length);
+  });
+});
+
+describe("loadUnlocks / saveUnlocks", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    (Sentry.captureException as jest.Mock).mockClear();
+    (Sentry.captureMessage as jest.Mock).mockClear();
+  });
+
+  it("returns a copy of INITIAL_UNLOCKS when nothing is stored", async () => {
+    const result = await loadUnlocks();
+    expect(result).toHaveLength(INITIAL_UNLOCKS.length);
+    expect(result[0]!.unlocked).toBe(false);
+  });
+
+  it("saves and loads unlocks correctly", async () => {
+    const unlocks = INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    unlocks[0]!.unlocked = true;
+    unlocks[0]!.unlockedAt = "2026-01-01T00:00:00.000Z";
+    await saveUnlocks(unlocks);
+    const loaded = await loadUnlocks();
+    expect(loaded[0]!.unlocked).toBe(true);
+    expect(loaded[0]!.unlockedAt).toBe("2026-01-01T00:00:00.000Z");
+    expect(loaded[1]!.unlocked).toBe(false);
+  });
+
+  it("returns INITIAL_UNLOCKS and logs warning on corrupt storage", async () => {
+    await AsyncStorage.setItem(UNLOCKS_KEY, "not-valid-json{{{");
+    const result = await loadUnlocks();
+    expect(result).toHaveLength(INITIAL_UNLOCKS.length);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("corrupt payload"),
+      expect.objectContaining({ level: "warning" })
+    );
+    expect(await AsyncStorage.getItem(UNLOCKS_KEY)).toBeNull();
+  });
+
+  it("returns INITIAL_UNLOCKS and logs warning when stored value is not an array", async () => {
+    await AsyncStorage.setItem(UNLOCKS_KEY, JSON.stringify({ foo: "bar" }));
+    const result = await loadUnlocks();
+    expect(result).toHaveLength(INITIAL_UNLOCKS.length);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining("not an array"),
+      expect.objectContaining({ level: "warning" })
+    );
+    expect(await AsyncStorage.getItem(UNLOCKS_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/game/blackjack/__tests__/unlocks.test.ts
+++ b/frontend/src/game/blackjack/__tests__/unlocks.test.ts
@@ -137,7 +137,7 @@ describe("evaluateUnlocks", () => {
         name: "Comeback Kid",
         type: "chip_style",
         conditionType: "comeback",
-        conditionValue: "any",
+        conditionValue: null,
         unlocked: false,
       },
     ];
@@ -155,7 +155,7 @@ describe("evaluateUnlocks", () => {
         name: "Comeback Kid",
         type: "chip_style",
         conditionType: "comeback",
-        conditionValue: "any",
+        conditionValue: null,
         unlocked: false,
       },
     ];
@@ -243,5 +243,14 @@ describe("loadUnlocks / saveUnlocks", () => {
       expect.objectContaining({ level: "warning" })
     );
     expect(await AsyncStorage.getItem(UNLOCKS_KEY)).toBeNull();
+  });
+
+  it("saveUnlocks swallows the error and reports to Sentry on write failure", async () => {
+    jest.spyOn(AsyncStorage, "setItem").mockRejectedValueOnce(new Error("storage full"));
+    await saveUnlocks(INITIAL_UNLOCKS.map((u) => ({ ...u })));
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ tags: expect.objectContaining({ op: "saveUnlocks" }) })
+    );
   });
 });

--- a/frontend/src/game/blackjack/unlocks.ts
+++ b/frontend/src/game/blackjack/unlocks.ts
@@ -1,10 +1,3 @@
-/**
- * Unlock system for Blackjack — cosmetic rewards tied to run achievements.
- *
- * Phase 1: three placeholder unlocks (one per table) with persistence.
- * Cosmetic rendering is out of scope for this issue.
- */
-
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import { RunRecord } from "./storage";
@@ -16,7 +9,7 @@ export interface Unlock {
   name: string;
   type: "table_theme" | "card_back" | "chip_style";
   conditionType: "complete_table" | "run_count" | "comeback";
-  conditionValue: string | number;
+  conditionValue: string | number | null;
   unlocked: boolean;
   unlockedAt?: string;
 }
@@ -65,11 +58,9 @@ export function evaluateUnlocks(runHistory: RunRecord[], existingUnlocks: Unlock
     if (unlock.conditionType === "complete_table") {
       triggered = runHistory.some((r) => r.table === unlock.conditionValue && r.completed);
     } else if (unlock.conditionType === "run_count") {
-      triggered = runHistory.length >= (unlock.conditionValue as number);
+      triggered = runHistory.length >= Number(unlock.conditionValue);
     } else if (unlock.conditionType === "comeback") {
-      triggered = runHistory.some(
-        (r) => r.completed && r.lowestChips <= r.startingChips * 0.25
-      );
+      triggered = runHistory.some((r) => r.completed && r.lowestChips <= r.startingChips * 0.25);
     }
 
     if (triggered) {

--- a/frontend/src/game/blackjack/unlocks.ts
+++ b/frontend/src/game/blackjack/unlocks.ts
@@ -1,0 +1,124 @@
+/**
+ * Unlock system for Blackjack — cosmetic rewards tied to run achievements.
+ *
+ * Phase 1: three placeholder unlocks (one per table) with persistence.
+ * Cosmetic rendering is out of scope for this issue.
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+import { RunRecord } from "./storage";
+
+const UNLOCKS_KEY = "blackjack_unlocks_v1";
+
+export interface Unlock {
+  id: string;
+  name: string;
+  type: "table_theme" | "card_back" | "chip_style";
+  conditionType: "complete_table" | "run_count" | "comeback";
+  conditionValue: string | number;
+  unlocked: boolean;
+  unlockedAt?: string;
+}
+
+export const INITIAL_UNLOCKS: readonly Unlock[] = [
+  {
+    id: "beginner_table_theme",
+    name: "Felt Classic",
+    type: "table_theme",
+    conditionType: "complete_table",
+    conditionValue: "beginner",
+    unlocked: false,
+  },
+  {
+    id: "intermediate_card_back",
+    name: "Indigo Card Back",
+    type: "card_back",
+    conditionType: "complete_table",
+    conditionValue: "intermediate",
+    unlocked: false,
+  },
+  {
+    id: "high_roller_chip_style",
+    name: "Gold Chip Set",
+    type: "chip_style",
+    conditionType: "complete_table",
+    conditionValue: "high_roller",
+    unlocked: false,
+  },
+];
+
+/**
+ * Pure function. Given a run history and the current unlock state, returns
+ * only the unlocks newly triggered by those runs. Caller is responsible for
+ * merging the result back into the full unlock list before persisting.
+ */
+export function evaluateUnlocks(runHistory: RunRecord[], existingUnlocks: Unlock[]): Unlock[] {
+  const now = new Date().toISOString();
+  const newlyUnlocked: Unlock[] = [];
+
+  for (const unlock of existingUnlocks) {
+    if (unlock.unlocked) continue;
+
+    let triggered = false;
+
+    if (unlock.conditionType === "complete_table") {
+      triggered = runHistory.some((r) => r.table === unlock.conditionValue && r.completed);
+    } else if (unlock.conditionType === "run_count") {
+      triggered = runHistory.length >= (unlock.conditionValue as number);
+    } else if (unlock.conditionType === "comeback") {
+      triggered = runHistory.some(
+        (r) => r.completed && r.lowestChips <= r.startingChips * 0.25
+      );
+    }
+
+    if (triggered) {
+      newlyUnlocked.push({ ...unlock, unlocked: true, unlockedAt: now });
+    }
+  }
+
+  return newlyUnlocked;
+}
+
+export async function loadUnlocks(): Promise<Unlock[]> {
+  try {
+    const raw = await AsyncStorage.getItem(UNLOCKS_KEY);
+    if (!raw) return INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) {
+      Sentry.captureMessage("blackjack.unlocks: stored value is not an array, resetting", {
+        level: "warning",
+        tags: { subsystem: "blackjack.unlocks", op: "loadUnlocks" },
+      });
+      await AsyncStorage.removeItem(UNLOCKS_KEY).catch(() => {});
+      return INITIAL_UNLOCKS.map((u) => ({ ...u }));
+    }
+    return parsed as Unlock[];
+  } catch (e) {
+    Sentry.captureMessage("blackjack.unlocks: corrupt payload, resetting", {
+      level: "warning",
+      tags: { subsystem: "blackjack.unlocks", op: "loadUnlocks" },
+      extra: { error: String(e) },
+    });
+    await AsyncStorage.removeItem(UNLOCKS_KEY).catch(() => {});
+    return INITIAL_UNLOCKS.map((u) => ({ ...u }));
+  }
+}
+
+export async function saveUnlocks(unlocks: Unlock[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(UNLOCKS_KEY, JSON.stringify(unlocks));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "blackjack.unlocks", op: "saveUnlocks" } });
+  }
+}
+
+/**
+ * Merge newly triggered unlocks into a full unlock list, preserving order.
+ * Returns a new array with the triggered items replaced by their unlocked versions.
+ */
+export function mergeUnlocks(existing: Unlock[], triggered: Unlock[]): Unlock[] {
+  if (triggered.length === 0) return existing;
+  const triggeredById = new Map(triggered.map((u) => [u.id, u]));
+  return existing.map((u) => triggeredById.get(u.id) ?? u);
+}

--- a/frontend/src/i18n/locales/ar/blackjack.json
+++ b/frontend/src/i18n/locales/ar/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/de/blackjack.json
+++ b/frontend/src/i18n/locales/de/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/en/blackjack.json
+++ b/frontend/src/i18n/locales/en/blackjack.json
@@ -127,6 +127,7 @@
   "victory.keepPlayingLabel": "Keep Playing — continue without a goal",
   "victory.nextTable": "Play {{table}} Table",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "milestone.toast": "Milestone reached: {{chips}} chips!",
   "hud.winStreak": "{{count}}x Streak",
   "hud.winStreakAccessibilityLabel": "Win streak: {{count}} wins",

--- a/frontend/src/i18n/locales/es/blackjack.json
+++ b/frontend/src/i18n/locales/es/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/fr-CA/blackjack.json
+++ b/frontend/src/i18n/locales/fr-CA/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/he/blackjack.json
+++ b/frontend/src/i18n/locales/he/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/hi/blackjack.json
+++ b/frontend/src/i18n/locales/hi/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/ja/blackjack.json
+++ b/frontend/src/i18n/locales/ja/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/ko/blackjack.json
+++ b/frontend/src/i18n/locales/ko/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/nl/blackjack.json
+++ b/frontend/src/i18n/locales/nl/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/pt/blackjack.json
+++ b/frontend/src/i18n/locales/pt/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/ru/blackjack.json
+++ b/frontend/src/i18n/locales/ru/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/i18n/locales/zh/blackjack.json
+++ b/frontend/src/i18n/locales/zh/blackjack.json
@@ -123,6 +123,7 @@
   "victory.cashOutLabel": "Cash Out — end run and return to table selection",
   "victory.cashOut": "Cash Out",
   "victory.nextTableLabel": "Play {{table}} Table — move up to next table",
+  "victory.unlocked": "You unlocked: {{name}}",
   "victory.statsNetPLPositive": "+{{amount}} chips",
   "victory.title": "Goal Reached!",
   "victory.statsWinRate": "{{winRate}}% win rate",

--- a/frontend/src/screens/BlackjackVictoryScreen.tsx
+++ b/frontend/src/screens/BlackjackVictoryScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
@@ -8,6 +8,8 @@ import { useTheme } from "../theme/ThemeContext";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";
 import { TABLE_CONFIGS } from "../game/blackjack/tables";
 import { GameShell } from "../components/shared/GameShell";
+import { Unlock, evaluateUnlocks, loadUnlocks, mergeUnlocks, saveUnlocks } from "../game/blackjack/unlocks";
+import { loadRuns } from "../game/blackjack/storage";
 
 type Props = {
   navigation: NativeStackNavigationProp<HomeStackParamList, "BlackjackVictory">;
@@ -25,6 +27,41 @@ export default function BlackjackVictoryScreen({ navigation }: Props) {
     TABLE_CONFIGS[0]!;
   const tableIndex = TABLE_CONFIGS.indexOf(activeTable);
   const nextTable = TABLE_CONFIGS[tableIndex + 1];
+
+  const [newUnlocks, setNewUnlocks] = useState<Unlock[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    async function evaluate() {
+      const [runs, existing] = await Promise.all([loadRuns(), loadUnlocks()]);
+      // Synthesize the current completed run so evaluateUnlocks sees it even
+      // before handleCashOut persists the RunRecord to storage.
+      const currentRun = {
+        table: activeTable.id,
+        startingChips: engine?.startingChips ?? 0,
+        finalChips: engine?.chips ?? 0,
+        runGoal: engine?.runGoal ?? null,
+        completed: true,
+        handsPlayed: sessionStats.handsPlayed,
+        biggestWin: sessionStats.biggestWin,
+        lowestChips: 0,
+        startedAt: Date.now(),
+        endedAt: Date.now(),
+      };
+      const triggered = evaluateUnlocks([...runs, currentRun], existing);
+      if (!active) return;
+      if (triggered.length > 0) {
+        await saveUnlocks(mergeUnlocks(existing, triggered));
+        setNewUnlocks(triggered);
+      }
+    }
+    void evaluate();
+    return () => {
+      active = false;
+    };
+    // Intentionally no deps — evaluate once on mount when victory is confirmed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const winRate =
     sessionStats.handsPlayed > 0
@@ -126,6 +163,20 @@ export default function BlackjackVictoryScreen({ navigation }: Props) {
             </Text>
           </View>
         </View>
+
+        {/* Unlock notification */}
+        {newUnlocks.length > 0 && (
+          <View
+            style={[styles.unlockPanel, { backgroundColor: colors.surface, borderColor: colors.accent }]}
+            accessibilityLiveRegion="polite"
+          >
+            {newUnlocks.map((u) => (
+              <Text key={u.id} style={[styles.unlockText, { color: colors.text }]}>
+                {t("blackjack:victory.unlocked", { name: u.name })}
+              </Text>
+            ))}
+          </View>
+        )}
 
         {/* CTAs */}
         <View style={styles.actions}>
@@ -297,5 +348,19 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: "500",
     textDecorationLine: "underline",
+  },
+  unlockPanel: {
+    width: "100%",
+    maxWidth: 320,
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    gap: 4,
+  },
+  unlockText: {
+    fontSize: 14,
+    fontWeight: "600",
+    textAlign: "center",
   },
 });

--- a/frontend/src/screens/BlackjackVictoryScreen.tsx
+++ b/frontend/src/screens/BlackjackVictoryScreen.tsx
@@ -8,7 +8,13 @@ import { useTheme } from "../theme/ThemeContext";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";
 import { TABLE_CONFIGS } from "../game/blackjack/tables";
 import { GameShell } from "../components/shared/GameShell";
-import { Unlock, evaluateUnlocks, loadUnlocks, mergeUnlocks, saveUnlocks } from "../game/blackjack/unlocks";
+import {
+  Unlock,
+  evaluateUnlocks,
+  loadUnlocks,
+  mergeUnlocks,
+  saveUnlocks,
+} from "../game/blackjack/unlocks";
 import { loadRuns } from "../game/blackjack/storage";
 
 type Props = {
@@ -19,7 +25,7 @@ export default function BlackjackVictoryScreen({ navigation }: Props) {
   const { t } = useTranslation(["blackjack"]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
-  const { engine, sessionStats, handleCashOut, handleKeepPlaying, handleTableSelect } =
+  const { engine, sessionStats, lowestChips, handleCashOut, handleKeepPlaying, handleTableSelect } =
     useBlackjackGame();
 
   const activeTable =
@@ -44,7 +50,7 @@ export default function BlackjackVictoryScreen({ navigation }: Props) {
         completed: true,
         handsPlayed: sessionStats.handsPlayed,
         biggestWin: sessionStats.biggestWin,
-        lowestChips: 0,
+        lowestChips,
         startedAt: Date.now(),
         endedAt: Date.now(),
       };
@@ -167,7 +173,10 @@ export default function BlackjackVictoryScreen({ navigation }: Props) {
         {/* Unlock notification */}
         {newUnlocks.length > 0 && (
           <View
-            style={[styles.unlockPanel, { backgroundColor: colors.surface, borderColor: colors.accent }]}
+            style={[
+              styles.unlockPanel,
+              { backgroundColor: colors.surface, borderColor: colors.accent },
+            ]}
             accessibilityLiveRegion="polite"
           >
             {newUnlocks.map((u) => (


### PR DESCRIPTION
Implements the architecture and tracking layer for the unlock system:

- New `unlocks.ts` module: `Unlock` type, three initial unlock definitions
  (Beginner → table theme, Intermediate → card back, High Roller → chip style),
  `evaluateUnlocks()` pure function, `loadUnlocks()`/`saveUnlocks()` with
  AsyncStorage key `blackjack_unlocks_v1`, and `mergeUnlocks()` helper
- `BlackjackVictoryScreen`: evaluates unlocks on mount by synthesising the
  current completed run before `handleCashOut` persists it; displays a
  non-blocking "You unlocked: X" panel when new unlocks are triggered;
  persists updated state immediately so the BJ-2 table-select UI can read it
- i18n: adds `victory.unlocked` key to all 13 locale files
- Tests: full unit coverage of `evaluateUnlocks`, `mergeUnlocks`,
  `loadUnlocks`, and `saveUnlocks` including error/corrupt-payload paths

No cosmetic rendering in this phase — placeholder names only.

Closes #1377

https://claude.ai/code/session_01NdR5K8xapNZNXg5N7FDajQ