### PR TITLE
feat(mahjong): BoardCamera abstraction for world→screen conversion (#1452)

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -20,18 +20,7 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_BG } from "../../theme/theme.constants";
-import type { MahjongLayout } from "../../game/mahjong/layout";
-
-// ---------------------------------------------------------------------------
-// Geometry helpers — accept layout so they stay pure functions
-// ---------------------------------------------------------------------------
-
-function tileX(col: number, layer: number, l: MahjongLayout): number {
-  return l.padX + (col / 2) * l.tileWidth + layer * l.layerDx;
-}
-function tileY(row: number, layer: number, l: MahjongLayout): number {
-  return l.padY + row * l.tileHeight - layer * l.layerDy;
-}
+import type { BoardCamera } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
 // Colors
@@ -203,15 +192,13 @@ function hitTest(
   tiles: readonly SlotTile[],
   tapX: number,
   tapY: number,
-  l: MahjongLayout
+  cam: BoardCamera
 ): number | null {
-  const fw = l.tileWidth - l.sideWidth;
-  const fh = l.tileHeight - l.sideWidth;
+  const { faceWidth: fw, faceHeight: fh } = cam;
   // Iterate from highest layer down so the topmost tile wins.
   const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
   for (const tile of sorted) {
-    const x = tileX(tile.col, tile.layer, l);
-    const y = tileY(tile.row, tile.layer, l);
+    const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
     if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
       return tile.id;
     }
@@ -225,7 +212,7 @@ function hitTest(
 
 interface Props {
   state: MahjongState;
-  layout: MahjongLayout;
+  camera: BoardCamera;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
@@ -233,14 +220,15 @@ interface Props {
 
 export default function GameCanvas({
   state,
-  layout,
+  camera,
   onTilePress,
   onShufflePress,
   onNewGamePress,
 }: Props) {
   const { t } = useTranslation("mahjong");
   const tileSvgs = useAllTileSVGs();
-  const { tileWidth, tileHeight, sideWidth, boardWidth, boardHeight } = layout;
+  const { tileWidth, tileHeight, faceWidth, faceHeight, sideWidth, boardWidth, boardHeight } =
+    camera;
 
   const freeTiles = useMemo(() => {
     const s = new Set<number>();
@@ -278,7 +266,7 @@ export default function GameCanvas({
   function handleTap(e: { nativeEvent: { locationX: number; locationY: number } }) {
     if (!gameActive) return;
     const { locationX, locationY } = e.nativeEvent;
-    const tileId = hitTest(state.tiles, locationX, locationY, layout);
+    const tileId = hitTest(state.tiles, locationX, locationY, camera);
     if (tileId !== null) onTilePress(tileId);
   }
 
@@ -291,12 +279,11 @@ export default function GameCanvas({
       >
         <Fill color={BG} />
         {sortedTiles.map((tile) => {
-          const x = tileX(tile.col, tile.layer, layout);
-          const y = tileY(tile.row, tile.layer, layout);
+          const { x, y } = camera.tileToScreen(tile.col, tile.row, tile.layer);
           const isSelected = tile.id === selectedId;
           const isFree = freeTiles.has(tile.id);
-          const fw = tileWidth - sideWidth;
-          const fh = tileHeight - sideWidth;
+          const fw = faceWidth;
+          const fh = faceHeight;
 
           // Lift selected tile upward/outward — scale with tile size.
           const liftX = isSelected ? Math.round(tileWidth * (4 / 44)) : 0;

--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -4,10 +4,7 @@
  * Rendered via @shopify/react-native-skia.
  * Metro automatically uses GameCanvas.web.tsx on the web platform.
  *
- * Tile geometry (grid → pixels):
- *   pixel_x = padX + (col / 2) * tileWidth + layer * layerDx
- *   pixel_y = padY + row * tileHeight − layer * layerDy
- *
+ * World→screen conversion is delegated to BoardCamera.tileToScreen().
  * Rendering order: layer ASC so higher layers appear on top.
  * Hit-testing: topmost tile (highest layer) at touch point wins.
  */
@@ -282,8 +279,6 @@ export default function GameCanvas({
           const { x, y } = camera.tileToScreen(tile.col, tile.row, tile.layer);
           const isSelected = tile.id === selectedId;
           const isFree = freeTiles.has(tile.id);
-          const fw = faceWidth;
-          const fh = faceHeight;
 
           // Lift selected tile upward/outward — scale with tile size.
           const liftX = isSelected ? Math.round(tileWidth * (4 / 44)) : 0;
@@ -303,8 +298,8 @@ export default function GameCanvas({
               <Rect
                 x={x + sideWidth + 2 + liftX}
                 y={y + sideWidth + 2 + liftY}
-                width={fw}
-                height={fh}
+                width={faceWidth}
+                height={faceHeight}
                 color={SHADOW}
               />
               {/* Gold glow behind selected tile */}
@@ -312,35 +307,41 @@ export default function GameCanvas({
                 <Rect
                   x={x + liftX - 3}
                   y={y + liftY - 3}
-                  width={fw + 6}
-                  height={fh + 6}
+                  width={faceWidth + 6}
+                  height={faceHeight + 6}
                   color={MAHJONG_GLOW_BG}
                 />
               )}
               {/* Right 3-D side */}
               <Rect
-                x={x + fw + liftX}
+                x={x + faceWidth + liftX}
                 y={y + sideWidth + liftY}
                 width={sideWidth}
-                height={fh}
+                height={faceHeight}
                 color={SIDE_R}
               />
               {/* Bottom 3-D side */}
               <Rect
                 x={x + sideWidth + liftX}
-                y={y + fh + liftY}
-                width={fw}
+                y={y + faceHeight + liftY}
+                width={faceWidth}
                 height={sideWidth}
                 color={SIDE_B}
               />
               {/* Border */}
-              <Rect x={x + liftX} y={y + liftY} width={fw} height={fh} color={borderColor} />
+              <Rect
+                x={x + liftX}
+                y={y + liftY}
+                width={faceWidth}
+                height={faceHeight}
+                color={borderColor}
+              />
               {/* Face */}
               <Rect
                 x={x + borderInset + liftX}
                 y={y + borderInset + liftY}
-                width={fw - 2 * borderInset}
-                height={fh - 2 * borderInset}
+                width={faceWidth - 2 * borderInset}
+                height={faceHeight - 2 * borderInset}
                 color={faceColor}
               />
               {/* SVG face art */}
@@ -349,8 +350,8 @@ export default function GameCanvas({
                 suit={tile.suit}
                 x={x + 2 + liftX}
                 y={y + 2 + liftY}
-                w={fw - 4}
-                h={fh - 4}
+                w={faceWidth - 4}
+                h={faceHeight - 4}
                 opacity={isFree ? 1 : 0.35}
               />
             </Group>

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -17,18 +17,7 @@ import { hasFreePairs, isFreeTile, tilesMatch } from "../../game/mahjong/engine"
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import { MAHJONG_TILE_FACE_SELECTED, MAHJONG_GLOW_SHADOW } from "../../theme/theme.constants";
-import type { MahjongLayout } from "../../game/mahjong/layout";
-
-// ---------------------------------------------------------------------------
-// Geometry helpers
-// ---------------------------------------------------------------------------
-
-function tileX(col: number, layer: number, l: MahjongLayout): number {
-  return l.padX + (col / 2) * l.tileWidth + layer * l.layerDx;
-}
-function tileY(row: number, layer: number, l: MahjongLayout): number {
-  return l.padY + row * l.tileHeight - layer * l.layerDy;
-}
+import type { BoardCamera } from "../../game/mahjong/layout";
 
 // ---------------------------------------------------------------------------
 // Colors
@@ -62,14 +51,12 @@ function hitTest(
   tiles: readonly SlotTile[],
   tapX: number,
   tapY: number,
-  l: MahjongLayout
+  cam: BoardCamera
 ): number | null {
-  const fw = l.tileWidth - l.sideWidth;
-  const fh = l.tileHeight - l.sideWidth;
+  const { faceWidth: fw, faceHeight: fh } = cam;
   const sorted = [...tiles].sort((a, b) => b.layer - a.layer);
   for (const tile of sorted) {
-    const x = tileX(tile.col, tile.layer, l);
-    const y = tileY(tile.row, tile.layer, l);
+    const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
     if (tapX >= x && tapX < x + fw && tapY >= y && tapY < y + fh) {
       return tile.id;
     }
@@ -86,9 +73,9 @@ function drawBoard(
   state: MahjongState,
   freeTiles: ReadonlySet<number>,
   tileImages: readonly (HTMLImageElement | null)[],
-  l: MahjongLayout
+  cam: BoardCamera
 ): void {
-  const { tileWidth, tileHeight, sideWidth, boardWidth, boardHeight } = l;
+  const { tileWidth, tileHeight, faceWidth, faceHeight, sideWidth, boardWidth, boardHeight } = cam;
 
   ctx.clearRect(0, 0, boardWidth, boardHeight);
 
@@ -105,16 +92,15 @@ function drawBoard(
   for (const tile of sorted) {
     ctx.save();
 
-    const x = tileX(tile.col, tile.layer, l);
-    const y = tileY(tile.row, tile.layer, l);
+    const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
     const isSelected = tile.id === selectedId;
     const isFree = freeTiles.has(tile.id);
-    const fw = tileWidth - sideWidth;
-    const fh = tileHeight - sideWidth;
+    const fw = faceWidth;
+    const fh = faceHeight;
 
     // Lift selected tile upward/outward — scale with tile size.
-    const liftX = isSelected ? Math.round(l.tileWidth * (4 / 44)) : 0;
-    const liftY = isSelected ? -Math.round(l.tileHeight * (5 / 56)) : 0;
+    const liftX = isSelected ? Math.round(tileWidth * (4 / 44)) : 0;
+    const liftY = isSelected ? -Math.round(tileHeight * (5 / 56)) : 0;
     // 2 px border on selected for visibility at small tile sizes.
     const borderInset = isSelected ? 2 : 1;
 
@@ -181,7 +167,7 @@ function drawBoard(
 
 interface Props {
   state: MahjongState;
-  layout: MahjongLayout;
+  camera: BoardCamera;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
@@ -189,13 +175,13 @@ interface Props {
 
 export default function GameCanvas({
   state,
-  layout,
+  camera,
   onTilePress,
   onShufflePress,
   onNewGamePress,
 }: Props) {
   const { t } = useTranslation("mahjong");
-  const { boardWidth, boardHeight } = layout;
+  const { boardWidth, boardHeight } = camera;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const tileImagesRef = useRef<(HTMLImageElement | null)[]>(Array(42).fill(null));
@@ -269,8 +255,8 @@ export default function GameCanvas({
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    drawBoard(ctx, state, freeTiles, tileImagesRef.current, layout);
-  }, [state, freeTiles, imagesVersion, layout]);
+    drawBoard(ctx, state, freeTiles, tileImagesRef.current, camera);
+  }, [state, freeTiles, imagesVersion, camera]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -280,14 +266,14 @@ export default function GameCanvas({
       const rect = canvas.getBoundingClientRect();
       // getBoundingClientRect reflects the parent's CSS scale transform, so
       // divide by the visual/native ratio to get canvas drawing coordinates.
-      const scaleX = rect.width / layout.boardWidth;
-      const scaleY = rect.height / layout.boardHeight;
+      const scaleX = rect.width / camera.boardWidth;
+      const scaleY = rect.height / camera.boardHeight;
       const tapX = (e.clientX - rect.left) / scaleX;
       const tapY = (e.clientY - rect.top) / scaleY;
-      const tileId = hitTest(state.tiles, tapX, tapY, layout);
+      const tileId = hitTest(state.tiles, tapX, tapY, camera);
       if (tileId !== null) onTilePress(tileId);
     },
-    [state.tiles, onTilePress, gameActive, layout]
+    [state.tiles, onTilePress, gameActive, camera]
   );
 
   return (

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -4,9 +4,7 @@
  * Rendered via HTML Canvas 2D.
  * Metro uses this file automatically on the web platform.
  *
- * Tile geometry (grid → pixels):
- *   pixel_x = padX + (col / 2) * tileWidth + layer * layerDx
- *   pixel_y = padY + row * tileHeight − layer * layerDy
+ * World→screen conversion is delegated to BoardCamera.tileToScreen().
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -95,8 +93,6 @@ function drawBoard(
     const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
     const isSelected = tile.id === selectedId;
     const isFree = freeTiles.has(tile.id);
-    const fw = faceWidth;
-    const fh = faceHeight;
 
     // Lift selected tile upward/outward — scale with tile size.
     const liftX = isSelected ? Math.round(tileWidth * (4 / 44)) : 0;
@@ -113,15 +109,15 @@ function drawBoard(
 
     // Drop shadow
     ctx.fillStyle = "rgba(0,0,0,0.35)";
-    ctx.fillRect(x + sideWidth + 2 + liftX, y + sideWidth + 2 + liftY, fw, fh);
+    ctx.fillRect(x + sideWidth + 2 + liftX, y + sideWidth + 2 + liftY, faceWidth, faceHeight);
 
     // Right 3-D side
     ctx.fillStyle = SIDE_R;
-    ctx.fillRect(x + fw + liftX, y + sideWidth + liftY, sideWidth, fh);
+    ctx.fillRect(x + faceWidth + liftX, y + sideWidth + liftY, sideWidth, faceHeight);
 
     // Bottom 3-D side
     ctx.fillStyle = SIDE_B;
-    ctx.fillRect(x + sideWidth + liftX, y + fh + liftY, fw, sideWidth);
+    ctx.fillRect(x + sideWidth + liftX, y + faceHeight + liftY, faceWidth, sideWidth);
 
     // Gold glow behind selected tile — applied to the border rect only.
     if (isSelected) {
@@ -131,7 +127,7 @@ function drawBoard(
 
     // Border
     ctx.fillStyle = borderColor;
-    ctx.fillRect(x + liftX, y + liftY, fw, fh);
+    ctx.fillRect(x + liftX, y + liftY, faceWidth, faceHeight);
 
     // Clear glow before drawing face so inner fills stay crisp.
     ctx.shadowBlur = 0;
@@ -141,8 +137,8 @@ function drawBoard(
     ctx.fillRect(
       x + borderInset + liftX,
       y + borderInset + liftY,
-      fw - 2 * borderInset,
-      fh - 2 * borderInset
+      faceWidth - 2 * borderInset,
+      faceHeight - 2 * borderInset
     );
 
     // SVG face art — fall back to suit-color rect while image is loading.
@@ -151,10 +147,10 @@ function drawBoard(
     const img = tileImages[tile.faceId - 1];
     ctx.globalAlpha = isFree ? 1 : 0.35;
     if (img !== null) {
-      ctx.drawImage(img, x + 2 + liftX, y + 2 + liftY, fw - 4, fh - 4);
+      ctx.drawImage(img, x + 2 + liftX, y + 2 + liftY, faceWidth - 4, faceHeight - 4);
     } else {
       ctx.fillStyle = suitColor;
-      ctx.fillRect(x + 8 + liftX, y + 10 + liftY, fw - 16, fh - 20);
+      ctx.fillRect(x + 8 + liftX, y + 10 + liftY, faceWidth - 16, faceHeight - 20);
     }
 
     ctx.restore();

--- a/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
+++ b/frontend/src/components/mahjong/__tests__/GameCanvas.test.tsx
@@ -11,7 +11,7 @@ import { create, act } from "react-test-renderer";
 import type { MahjongState } from "../../../game/mahjong/types";
 import { createGame } from "../../../game/mahjong/engine";
 import { TURTLE_LAYOUT } from "../../../game/mahjong/layouts/turtle";
-import { calculateMahjongLayout } from "../../../game/mahjong/layout";
+import { calculateMahjongLayout, makeBoardCamera } from "../../../game/mahjong/layout";
 
 // Skia requires a native module — stub the whole package.
 jest.mock("@shopify/react-native-skia", () => ({
@@ -39,15 +39,17 @@ jest.mock("expo-asset", () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { default: GameCanvas } = require("../GameCanvas.web");
 
-const testLayout = calculateMahjongLayout({
-  screenWidth: 768,
-  screenHeight: 1024,
-  safeAreaTop: 0,
-  safeAreaBottom: 0,
-  boardRows: 8,
-  boardCols: 12,
-  boardLayers: 4,
-});
+const testCamera = makeBoardCamera(
+  calculateMahjongLayout({
+    screenWidth: 768,
+    screenHeight: 1024,
+    safeAreaTop: 0,
+    safeAreaBottom: 0,
+    boardRows: 8,
+    boardCols: 12,
+    boardLayers: 4,
+  })
+);
 
 function makeState(overrides: Partial<MahjongState> = {}): MahjongState {
   return { ...createGame(TURTLE_LAYOUT, 12345), ...overrides };
@@ -62,7 +64,7 @@ describe("GameCanvas (web)", () => {
         create(
           <GameCanvas
             state={makeState()}
-            layout={testLayout}
+            camera={testCamera}
             onTilePress={noop}
             onShufflePress={noop}
             onNewGamePress={noop}
@@ -79,7 +81,7 @@ describe("GameCanvas (web)", () => {
       tree = create(
         <GameCanvas
           state={state}
-          layout={testLayout}
+          camera={testCamera}
           onTilePress={noop}
           onShufflePress={noop}
           onNewGamePress={noop}
@@ -98,7 +100,7 @@ describe("GameCanvas (web)", () => {
       tree = create(
         <GameCanvas
           state={state}
-          layout={testLayout}
+          camera={testCamera}
           onTilePress={noop}
           onShufflePress={noop}
           onNewGamePress={noop}
@@ -127,7 +129,7 @@ describe("GameCanvas (web)", () => {
       tree = create(
         <GameCanvas
           state={state}
-          layout={testLayout}
+          camera={testCamera}
           onTilePress={noop}
           onShufflePress={noop}
           onNewGamePress={noop}
@@ -147,7 +149,7 @@ describe("GameCanvas (web)", () => {
       tree = create(
         <GameCanvas
           state={state}
-          layout={testLayout}
+          camera={testCamera}
           onTilePress={noop}
           onShufflePress={noop}
           onNewGamePress={noop}

--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -1,10 +1,10 @@
 /**
- * Unit tests for calculateMahjongLayout.
+ * Unit tests for calculateMahjongLayout and makeBoardCamera.
  *
- * The pure function is tested in isolation (no hooks, no React).
+ * Pure functions tested in isolation (no hooks, no React).
  */
 
-import { calculateMahjongLayout } from "../layout";
+import { calculateMahjongLayout, makeBoardCamera } from "../layout";
 
 const TURTLE = { boardRows: 8, boardCols: 12, boardLayers: 4 };
 
@@ -126,5 +126,51 @@ describe("calculateMahjongLayout", () => {
       l.padY + TURTLE.boardRows * l.tileHeight + TURTLE.boardLayers * l.layerDy + l.padY;
     expect(l.boardWidth).toBe(expectedBoardWidth);
     expect(l.boardHeight).toBe(expectedBoardHeight);
+  });
+});
+
+describe("makeBoardCamera", () => {
+  const layout = calculateMahjongLayout({
+    screenWidth: 800,
+    screenHeight: 600,
+    safeAreaTop: 0,
+    safeAreaBottom: 0,
+    ...TURTLE,
+  });
+  const cam = makeBoardCamera(layout);
+
+  it("tileToScreen(0, 0, 0) returns the pad origin", () => {
+    const { x, y } = cam.tileToScreen(0, 0, 0);
+    expect(x).toBe(layout.padX);
+    expect(y).toBe(layout.padY);
+  });
+
+  it("tileToScreen advances x by tileWidth per 2 col units", () => {
+    const { x: x0 } = cam.tileToScreen(0, 0, 0);
+    const { x: x2 } = cam.tileToScreen(2, 0, 0);
+    expect(x2 - x0).toBe(layout.tileWidth);
+  });
+
+  it("tileToScreen advances y by tileHeight per row", () => {
+    const { y: y0 } = cam.tileToScreen(0, 0, 0);
+    const { y: y1 } = cam.tileToScreen(0, 1, 0);
+    expect(y1 - y0).toBe(layout.tileHeight);
+  });
+
+  it("tileToScreen shifts right and up by layer offsets", () => {
+    const { x: x0, y: y0 } = cam.tileToScreen(0, 0, 0);
+    const { x: x1, y: y1 } = cam.tileToScreen(0, 0, 1);
+    expect(x1 - x0).toBe(layout.layerDx);
+    expect(y0 - y1).toBe(layout.layerDy);
+  });
+
+  it("faceWidth and faceHeight equal tileWidth/tileHeight minus sideWidth", () => {
+    expect(cam.faceWidth).toBe(layout.tileWidth - layout.sideWidth);
+    expect(cam.faceHeight).toBe(layout.tileHeight - layout.sideWidth);
+  });
+
+  it("exposes boardWidth and boardHeight matching the source layout", () => {
+    expect(cam.boardWidth).toBe(layout.boardWidth);
+    expect(cam.boardHeight).toBe(layout.boardHeight);
   });
 });

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -2,43 +2,6 @@ import { useMemo } from "react";
 import { useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-// ---------------------------------------------------------------------------
-// Camera abstraction — authoritative world→screen converter.
-// Future implementations can swap tileToScreen to add zoom/pan without
-// touching any rendering or hit-test code.
-// ---------------------------------------------------------------------------
-
-export interface BoardCamera {
-  tileToScreen(col: number, row: number, layer: number): { x: number; y: number };
-  tileWidth: number;
-  tileHeight: number;
-  faceWidth: number;
-  faceHeight: number;
-  sideWidth: number;
-  boardWidth: number;
-  boardHeight: number;
-}
-
-export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
-  const { tileWidth, tileHeight, sideWidth, layerDx, layerDy, padX, padY, boardWidth, boardHeight } =
-    layout;
-  return {
-    tileToScreen(col, row, layer) {
-      return {
-        x: padX + (col / 2) * tileWidth + layer * layerDx,
-        y: padY + row * tileHeight - layer * layerDy,
-      };
-    },
-    tileWidth,
-    tileHeight,
-    faceWidth: tileWidth - sideWidth,
-    faceHeight: tileHeight - sideWidth,
-    sideWidth,
-    boardWidth,
-    boardHeight,
-  };
-}
-
 export interface MahjongLayoutInput {
   screenWidth: number;
   screenHeight: number;
@@ -61,6 +24,52 @@ export interface MahjongLayout {
   padY: number;
   boardWidth: number;
   boardHeight: number;
+}
+
+// ---------------------------------------------------------------------------
+// Camera abstraction — authoritative world→screen converter.
+// Future implementations can swap tileToScreen to add zoom/pan without
+// touching any rendering or hit-test code.
+// ---------------------------------------------------------------------------
+
+export interface BoardCamera {
+  tileToScreen(col: number, row: number, layer: number): { x: number; y: number };
+  tileWidth: number;
+  tileHeight: number;
+  faceWidth: number;
+  faceHeight: number;
+  sideWidth: number;
+  boardWidth: number;
+  boardHeight: number;
+}
+
+export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
+  const {
+    tileWidth,
+    tileHeight,
+    sideWidth,
+    layerDx,
+    layerDy,
+    padX,
+    padY,
+    boardWidth,
+    boardHeight,
+  } = layout;
+  return {
+    tileToScreen(col, row, layer) {
+      return {
+        x: padX + (col / 2) * tileWidth + layer * layerDx,
+        y: padY + row * tileHeight - layer * layerDy,
+      };
+    },
+    tileWidth,
+    tileHeight,
+    faceWidth: tileWidth - sideWidth,
+    faceHeight: tileHeight - sideWidth,
+    sideWidth,
+    boardWidth,
+    boardHeight,
+  };
 }
 
 const TILE_ASPECT = 56 / 44;

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -2,6 +2,43 @@ import { useMemo } from "react";
 import { useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+// ---------------------------------------------------------------------------
+// Camera abstraction — authoritative world→screen converter.
+// Future implementations can swap tileToScreen to add zoom/pan without
+// touching any rendering or hit-test code.
+// ---------------------------------------------------------------------------
+
+export interface BoardCamera {
+  tileToScreen(col: number, row: number, layer: number): { x: number; y: number };
+  tileWidth: number;
+  tileHeight: number;
+  faceWidth: number;
+  faceHeight: number;
+  sideWidth: number;
+  boardWidth: number;
+  boardHeight: number;
+}
+
+export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
+  const { tileWidth, tileHeight, sideWidth, layerDx, layerDy, padX, padY, boardWidth, boardHeight } =
+    layout;
+  return {
+    tileToScreen(col, row, layer) {
+      return {
+        x: padX + (col / 2) * tileWidth + layer * layerDx,
+        y: padY + row * tileHeight - layer * layerDy,
+      };
+    },
+    tileWidth,
+    tileHeight,
+    faceWidth: tileWidth - sideWidth,
+    faceHeight: tileHeight - sideWidth,
+    sideWidth,
+    boardWidth,
+    boardHeight,
+  };
+}
+
 export interface MahjongLayoutInput {
   screenWidth: number;
   screenHeight: number;
@@ -120,4 +157,9 @@ export function useMahjongCanvasLayout(): MahjongLayout {
       }),
     [width, height, insets.top, insets.bottom, insets.left, insets.right]
   );
+}
+
+export function useMahjongCamera(): BoardCamera {
+  const layout = useMahjongCanvasLayout();
+  return useMemo(() => makeBoardCamera(layout), [layout]);
 }

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -49,8 +49,8 @@ import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
 import GameCanvas from "../components/mahjong/GameCanvas";
-import { useMahjongCanvasLayout } from "../game/mahjong/layout";
-import type { MahjongLayout } from "../game/mahjong/layout";
+import { useMahjongCamera } from "../game/mahjong/layout";
+import type { BoardCamera } from "../game/mahjong/layout";
 import { createGame, elapsedMs, selectTile, shuffleBoard, undoMove } from "../game/mahjong/engine";
 import { TURTLE_LAYOUT } from "../game/mahjong/layouts/turtle";
 import type { MahjongState, SlotTile } from "../game/mahjong/types";
@@ -74,11 +74,9 @@ const MAX_NAME_LENGTH = 32;
 // Tile center — used by FlyingPair to compute animation start/end positions
 // ---------------------------------------------------------------------------
 
-function tileCenter(tile: SlotTile, l: MahjongLayout): { cx: number; cy: number } {
-  return {
-    cx: l.padX + (tile.col / 2) * l.tileWidth + tile.layer * l.layerDx + l.tileWidth / 2,
-    cy: l.padY + tile.row * l.tileHeight - tile.layer * l.layerDy + l.tileHeight / 2,
-  };
+function tileCenter(tile: SlotTile, cam: BoardCamera): { cx: number; cy: number } {
+  const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
+  return { cx: x + cam.tileWidth / 2, cy: y + cam.tileHeight / 2 };
 }
 
 // ---------------------------------------------------------------------------
@@ -96,12 +94,12 @@ const BURST_R = 22;
 function FlyingPair({
   tile1,
   tile2,
-  layout,
+  camera,
   color,
   onDone,
-}: FlyingPairData & { layout: MahjongLayout; color: string; onDone: () => void }) {
-  const { cx: c1x, cy: c1y } = tileCenter(tile1, layout);
-  const { cx: c2x, cy: c2y } = tileCenter(tile2, layout);
+}: FlyingPairData & { camera: BoardCamera; color: string; onDone: () => void }) {
+  const { cx: c1x, cy: c1y } = tileCenter(tile1, camera);
+  const { cx: c2x, cy: c2y } = tileCenter(tile2, camera);
   const midX = (c1x + c2x) / 2;
   const midY = (c1y + c2y) / 2;
 
@@ -133,8 +131,8 @@ function FlyingPair({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const tw = layout.tileWidth - layout.sideWidth;
-  const th = layout.tileHeight - layout.sideWidth;
+  const tw = camera.faceWidth;
+  const th = camera.faceHeight;
 
   const tile1Style = useAnimatedStyle(() => ({
     position: "absolute",
@@ -192,7 +190,7 @@ export default function MahjongScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
-  const layout = useMahjongCanvasLayout();
+  const camera = useMahjongCamera();
 
   const [state, setState] = useState<MahjongState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -529,8 +527,8 @@ export default function MahjongScreen() {
           {/* Board container — overflow:hidden clips FlyingPair animations */}
           <View
             style={{
-              width: layout.boardWidth,
-              height: layout.boardHeight,
+              width: camera.boardWidth,
+              height: camera.boardHeight,
               overflow: "hidden",
               alignSelf: "center",
             }}
@@ -538,7 +536,7 @@ export default function MahjongScreen() {
             <Animated.View style={boardAnimStyle}>
               <GameCanvas
                 state={state}
-                layout={layout}
+                camera={camera}
                 onTilePress={handleTilePress}
                 onShufflePress={handleShuffle}
                 onNewGamePress={startNewGame}
@@ -548,7 +546,7 @@ export default function MahjongScreen() {
               <FlyingPair
                 key={pair.id}
                 {...pair}
-                layout={layout}
+                camera={camera}
                 color={colors.accent + "99"}
                 onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
               />


### PR DESCRIPTION
## Summary

- Introduces `BoardCamera` interface in `layout.ts` with a single `tileToScreen(col, row, layer)` method as the authoritative world→screen converter
- Adds `makeBoardCamera(layout)` factory and `useMahjongCamera()` hook
- Replaces inline `tileX`/`tileY` helper functions in `GameCanvas.tsx`, `GameCanvas.web.tsx`, and `MahjongScreen.tsx` with `camera.tileToScreen()`
- `GameCanvas` props changed from `layout: MahjongLayout` to `camera: BoardCamera`; `FlyingPair` and board container in `MahjongScreen` updated to match

## Why

Decouples tile grid positions from pixel math. Future zoom/pan (#1454) only needs to change `makeBoardCamera`'s `tileToScreen` implementation — no rendering, hit-test, or animation code needs to change.

Part of the Mahjong camera/navigation epic (#1451).

## Test plan

- [x] All 105 mahjong tests pass (`npx jest --testPathPattern="mahjong"`)
- [x] No new TypeScript errors introduced
- [x] `GameCanvas.test.tsx` updated to use `makeBoardCamera` + `camera` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)