### PR TITLE
feat(starswarm): boost Boss firepower — bigger bursts, faster bullets, shorter pause (#1458)

### DIFF
--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1335,12 +1335,8 @@ describe("Boss burst-fire (#979)", () => {
       }),
     };
     s = tick(s, 16, NO_INPUT);
-    const bossBullet = s.enemyBullets.find(
-      (b) => b.vy === BOSS_BULLET_VY
-    );
-    const eliteBullet = s.enemyBullets.find(
-      (b) => b.vy === BULLET_E_VY
-    );
+    const bossBullet = s.enemyBullets.find((b) => b.vy === BOSS_BULLET_VY);
+    const eliteBullet = s.enemyBullets.find((b) => b.vy === BULLET_E_VY);
     expect(bossBullet).toBeDefined();
     expect(eliteBullet).toBeDefined();
   });
@@ -1348,9 +1344,7 @@ describe("Boss burst-fire (#979)", () => {
   it("Boss circle-phase bullet travels at BOSS_BULLET_VY", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H);
     s = advanceMs(s, 8000);
-    const bossIdx = s.enemies.findIndex(
-      (e) => e.isAlive && e.tier === "Boss"
-    );
+    const bossIdx = s.enemies.findIndex((e) => e.isAlive && e.tier === "Boss");
     if (bossIdx === -1) throw new Error("no boss");
     const cx = CANVAS_W / 2;
     const cy = CANVAS_H * 0.3;

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -23,6 +23,8 @@ import {
   difficultyMultiplier,
   difficultyParamScale,
   difficultyLabel,
+  BOSS_BULLET_VY,
+  BULLET_E_VY,
 } from "../engine";
 import type { Bullet, DifficultyTier, StarSwarmInput, StarSwarmState } from "../types";
 
@@ -1309,6 +1311,74 @@ describe("Boss burst-fire (#979)", () => {
   it("burstShotsLeft is 0 for all enemies at wave start", () => {
     const s = initStarSwarm(CANVAS_W, CANVAS_H);
     expect(s.enemies.every((e) => e.burstShotsLeft === 0)).toBe(true);
+  });
+
+  it("Boss burst bullet travels at BOSS_BULLET_VY; Elite bullet travels at BULLET_E_VY", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const bossIdx = s.enemies.findIndex(
+      (e) => e.isAlive && e.tier === "Boss" && e.phase === "Formation"
+    );
+    const eliteIdx = s.enemies.findIndex(
+      (e) => e.isAlive && e.tier === "Elite" && e.phase === "Formation"
+    );
+    if (bossIdx === -1) throw new Error("no boss in formation");
+    if (eliteIdx === -1) throw new Error("no elite in formation");
+    s = {
+      ...s,
+      bossThresholdCrossed: true,
+      enemyBullets: [],
+      enemies: s.enemies.map((e, i) => {
+        if (i === bossIdx) return { ...e, shootTimer: 0, burstShotsLeft: 0 };
+        if (i === eliteIdx) return { ...e, shootTimer: 0 };
+        return e;
+      }),
+    };
+    s = tick(s, 16, NO_INPUT);
+    const bossBullet = s.enemyBullets.find(
+      (b) => b.vy === BOSS_BULLET_VY
+    );
+    const eliteBullet = s.enemyBullets.find(
+      (b) => b.vy === BULLET_E_VY
+    );
+    expect(bossBullet).toBeDefined();
+    expect(eliteBullet).toBeDefined();
+  });
+
+  it("Boss circle-phase bullet travels at BOSS_BULLET_VY", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    s = advanceMs(s, 8000);
+    const bossIdx = s.enemies.findIndex(
+      (e) => e.isAlive && e.tier === "Boss"
+    );
+    if (bossIdx === -1) throw new Error("no boss");
+    const boss = s.enemies[bossIdx]!;
+    const cx = CANVAS_W / 2;
+    const cy = CANVAS_H * 0.3;
+    const radius = 60;
+    s = {
+      ...s,
+      bossThresholdCrossed: true,
+      enemyBullets: [],
+      enemies: s.enemies.map((e, i) =>
+        i === bossIdx
+          ? {
+              ...e,
+              phase: "Circling" as const,
+              circleCx: cx,
+              circleCy: cy,
+              circleRadius: radius,
+              circleAngle: 0,
+              circleSpeed: 0.001,
+              shootTimer: 0,
+            }
+          : e
+      ),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.enemyBullets.length).toBeGreaterThan(0);
+    const bullet = s.enemyBullets[0]!;
+    expect(bullet.vy).toBe(BOSS_BULLET_VY);
   });
 });
 

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1278,9 +1278,9 @@ describe("Boss burst-fire (#979)", () => {
     const boss = s.enemies[bossIdx]!;
     // After first burst shot, timer is either BURST_INTERVAL (more shots) or long pause (1-shot burst)
     expect(boss.shootTimer).toBeLessThanOrEqual(BURST_INTERVAL + 2);
-    // burstShotsLeft is 0 (burst complete) or 1 (one more shot coming)
+    // burstShotsLeft is 0 (burst complete) or up to 4 (3–5 shot burst, remaining after first)
     expect(boss.burstShotsLeft).toBeGreaterThanOrEqual(0);
-    expect(boss.burstShotsLeft).toBeLessThanOrEqual(2);
+    expect(boss.burstShotsLeft).toBeLessThanOrEqual(4);
   });
 
   it("Boss has long pause after burst completes (burstShotsLeft reaches 0)", () => {

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -1352,7 +1352,6 @@ describe("Boss burst-fire (#979)", () => {
       (e) => e.isAlive && e.tier === "Boss"
     );
     if (bossIdx === -1) throw new Error("no boss");
-    const boss = s.enemies[bossIdx]!;
     const cx = CANVAS_W / 2;
     const cy = CANVAS_H * 0.3;
     const radius = 60;

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -36,7 +36,7 @@ const BULLET_C_H = 22;
 
 const BULLET_E_W = 5;
 const BULLET_E_H = 10;
-const BULLET_E_VY = 0.35; // px/ms downward
+export const BULLET_E_VY = 0.35; // px/ms downward
 
 const FORMATION_COLS = 8;
 const FORMATION_COL_W = 44; // #950: was 38 — Boss (36 px) had only 1 px margin/side
@@ -66,7 +66,7 @@ export const BOSS_DIVE_THRESHOLD = 0.35; // boss unlocked when ≤35% non-boss r
 export const BURST_INTERVAL = 200; // ms between shots within a burst
 export const BURST_PAUSE_BASE = 2000; // ms cooldown after burst completes
 const BURST_PAUSE_JITTER = 1000; // ms random addend to pause
-const BOSS_BULLET_VY = 0.46; // px/ms — faster than Elite (0.35) so boss shots are harder to dodge
+export const BOSS_BULLET_VY = 0.46; // px/ms — faster than Elite (0.35) so boss shots are harder to dodge
 const BOSS_MAX_SWAY = 20; // px — Boss sways ±20px vs ±40px for other tiers
 
 const DIVE_INTERVAL_BASE = 3200; // ms between dive triggers
@@ -941,7 +941,7 @@ function tickFormation(
 function bossBurstFire(enemy: Enemy, playerX: number, playerY: number): EnemyTickResult {
   const newBurstShotsLeft =
     enemy.burstShotsLeft === 0
-      ? 2 + Math.floor(rng() * 3) // start new burst: pick 3–5 total, return remaining
+      ? 2 + Math.floor(rng() * 3) // start new burst: pick 3–5 total shots; return remaining after this shot
       : enemy.burstShotsLeft - 1;
   const newShootTimer =
     newBurstShotsLeft > 0 ? BURST_INTERVAL : BURST_PAUSE_BASE + rng() * BURST_PAUSE_JITTER;

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -64,8 +64,9 @@ export const BOSS_DIVE_THRESHOLD = 0.35; // boss unlocked when ≤35% non-boss r
 
 // #979: Boss burst-fire
 export const BURST_INTERVAL = 200; // ms between shots within a burst
-export const BURST_PAUSE_BASE = 3000; // ms cooldown after burst completes
+export const BURST_PAUSE_BASE = 2000; // ms cooldown after burst completes
 const BURST_PAUSE_JITTER = 1000; // ms random addend to pause
+const BOSS_BULLET_VY = 0.46; // px/ms — faster than Elite (0.35) so boss shots are harder to dodge
 const BOSS_MAX_SWAY = 20; // px — Boss sways ±20px vs ±40px for other tiers
 
 const DIVE_INTERVAL_BASE = 3200; // ms between dive triggers
@@ -550,21 +551,22 @@ export function bulletCap(wave: number, paramScale = 1): number {
   return Math.min(24, Math.round((3 + Math.floor((wave - 1) / 2)) * paramScale));
 }
 
-// #1314: proportional aim — keeps vy = BULLET_E_VY (same arrival time), scales vx to intersect the player.
-// vx is capped at ±BULLET_E_VY so the bullet never travels more than 45° from vertical; without the cap,
+// #1314: proportional aim — keeps vy = speed (same arrival time), scales vx to intersect the player.
+// vx is capped at ±speed so the bullet never travels more than 45° from vertical; without the cap,
 // circling enemies near the player's altitude produce extreme vx values (dy is small → dx/dy blows up).
 function aimVelocity(
   enemyX: number,
   enemyY: number,
   playerX: number,
-  playerY: number
+  playerY: number,
+  speed = BULLET_E_VY
 ): { vx: number; vy: number } {
   const dy = playerY - enemyY;
-  if (dy <= 0) return { vx: 0, vy: BULLET_E_VY }; // player at or above enemy — fire straight down
+  if (dy <= 0) return { vx: 0, vy: speed }; // player at or above enemy — fire straight down
   const dx = playerX - enemyX;
-  const rawVx = (dx / dy) * BULLET_E_VY;
-  const vx = Math.max(-BULLET_E_VY, Math.min(BULLET_E_VY, rawVx));
-  return { vx, vy: BULLET_E_VY };
+  const rawVx = (dx / dy) * speed;
+  const vx = Math.max(-speed, Math.min(speed, rawVx));
+  return { vx, vy: speed };
 }
 
 // #924/#1314: compute velocity for a Grunt enemy bullet — straight down before wave 1+;
@@ -939,12 +941,12 @@ function tickFormation(
 function bossBurstFire(enemy: Enemy, playerX: number, playerY: number): EnemyTickResult {
   const newBurstShotsLeft =
     enemy.burstShotsLeft === 0
-      ? 2 + Math.floor(rng() * 2) - 1 // start new burst: pick 2 or 3, return remaining
+      ? 2 + Math.floor(rng() * 3) // start new burst: pick 3–5 total, return remaining
       : enemy.burstShotsLeft - 1;
   const newShootTimer =
     newBurstShotsLeft > 0 ? BURST_INTERVAL : BURST_PAUSE_BASE + rng() * BURST_PAUSE_JITTER;
 
-  const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY); // #1314
+  const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY, BOSS_BULLET_VY); // #1314
   const bullet: Bullet = {
     id: nextId(),
     x: enemy.x,
@@ -1120,7 +1122,8 @@ function tickCircling(
   const shootTimer = enemy.shootTimer - dtMs;
   let bullet: Bullet | null = null;
   if (shootTimer <= 0) {
-    const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY);
+    const speed = enemy.tier === "Boss" ? BOSS_BULLET_VY : undefined;
+    const vel = aimVelocity(enemy.x, enemy.y, playerX, playerY, speed);
     bullet = {
       id: nextId(),
       x: enemy.x,


### PR DESCRIPTION
Boss burst size raised from 2–3 to 3–5 shots; BURST_PAUSE_BASE dropped from
3000 ms to 2000 ms so bursts cycle faster; Boss bullets now travel at 0.46 px/ms
(vs Elite's 0.35) across formation, dive, and circle phases. aimVelocity gains
an optional speed param to support the faster boss bullet without touching Elite
or Grunt behaviour.

https://claude.ai/code/session_01V81eUam5bZoXudJSv2c8Zw