### PR TITLE
feat(mahjong): fit-to-screen initial camera scale (#1453)

### DIFF
--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -4,7 +4,7 @@
  * Pure functions tested in isolation (no hooks, no React).
  */
 
-import { calculateMahjongLayout, makeBoardCamera } from "../layout";
+import { calculateMahjongLayout, fitToScreen, makeBoardCamera } from "../layout";
 
 const TURTLE = { boardRows: 8, boardCols: 12, boardLayers: 4 };
 
@@ -129,6 +129,56 @@ describe("calculateMahjongLayout", () => {
   });
 });
 
+describe("fitToScreen", () => {
+  it("returns scale=1 when board fits within viewport minus margin", () => {
+    const { scale } = fitToScreen(400, 300, 800, 600, 16);
+    expect(scale).toBe(1);
+  });
+
+  it("scales down when board is larger than viewport minus margin", () => {
+    const { scale } = fitToScreen(800, 600, 400, 300, 0);
+    expect(scale).toBeCloseTo(0.5, 5);
+  });
+
+  it("is constrained by the tighter dimension and capped at 1", () => {
+    // board (100×200) fits inside viewport (200×300) — uncapped would be 1.5 but cap applies
+    const { scale } = fitToScreen(100, 200, 200, 300, 0);
+    expect(scale).toBe(1);
+    // verify the width dimension actually constrains when height has more room
+    const { scale: s2 } = fitToScreen(800, 200, 400, 300, 0);
+    // scaleX = 400/800 = 0.5, scaleY = 300/200 = 1.5 → min = 0.5
+    expect(s2).toBeCloseTo(0.5, 5);
+  });
+
+  it("never exceeds 1 even when board is much smaller than viewport", () => {
+    const { scale } = fitToScreen(200, 150, 1366, 1024, 16);
+    expect(scale).toBe(1);
+  });
+
+  it("centers the board horizontally and vertically", () => {
+    const boardWidth = 400;
+    const boardHeight = 300;
+    const viewportWidth = 500;
+    const viewportHeight = 400;
+    const { scale, offsetX, offsetY } = fitToScreen(
+      boardWidth,
+      boardHeight,
+      viewportWidth,
+      viewportHeight,
+      0
+    );
+    expect(offsetX).toBeCloseTo((viewportWidth - boardWidth * scale) / 2, 5);
+    expect(offsetY).toBeCloseTo((viewportHeight - boardHeight * scale) / 2, 5);
+  });
+
+  it("applies margin symmetrically", () => {
+    const margin = 20;
+    const { scale } = fitToScreen(400, 300, 400, 300, margin);
+    const expectedScale = Math.min((400 - margin * 2) / 400, (300 - margin * 2) / 300);
+    expect(scale).toBeCloseTo(expectedScale, 5);
+  });
+});
+
 describe("makeBoardCamera", () => {
   const layout = calculateMahjongLayout({
     screenWidth: 800,
@@ -172,5 +222,22 @@ describe("makeBoardCamera", () => {
   it("exposes boardWidth and boardHeight matching the source layout", () => {
     expect(cam.boardWidth).toBe(layout.boardWidth);
     expect(cam.boardHeight).toBe(layout.boardHeight);
+  });
+
+  it("defaults to scale=1 and zero offsets when no viewport args are given", () => {
+    expect(cam.scale).toBe(1);
+    expect(cam.offsetX).toBe(0);
+    expect(cam.offsetY).toBe(0);
+    expect(cam.viewportWidth).toBe(layout.boardWidth);
+    expect(cam.viewportHeight).toBe(layout.boardHeight);
+  });
+
+  it("computes fit-to-screen scale when viewport and margin are provided", () => {
+    const fitCam = makeBoardCamera(layout, layout.boardWidth * 2, layout.boardHeight * 2, 0);
+    // Viewport is 2× the board — scale capped at 1
+    expect(fitCam.scale).toBe(1);
+    // Viewport is half the board — scale = 0.5
+    const smallCam = makeBoardCamera(layout, layout.boardWidth / 2, layout.boardHeight / 2, 0);
+    expect(smallCam.scale).toBeCloseTo(0.5, 5);
   });
 });

--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -156,19 +156,11 @@ describe("fitToScreen", () => {
   });
 
   it("centers the board horizontally and vertically", () => {
-    const boardWidth = 400;
-    const boardHeight = 300;
-    const viewportWidth = 500;
-    const viewportHeight = 400;
-    const { scale, offsetX, offsetY } = fitToScreen(
-      boardWidth,
-      boardHeight,
-      viewportWidth,
-      viewportHeight,
-      0
-    );
-    expect(offsetX).toBeCloseTo((viewportWidth - boardWidth * scale) / 2, 5);
-    expect(offsetY).toBeCloseTo((viewportHeight - boardHeight * scale) / 2, 5);
+    // board (400×300) fits inside viewport (500×400) with no margin → scale=1
+    // offsetX = (500 - 400) / 2 = 50, offsetY = (400 - 300) / 2 = 50
+    const { offsetX, offsetY } = fitToScreen(400, 300, 500, 400, 0);
+    expect(offsetX).toBe(50);
+    expect(offsetY).toBe(50);
   });
 
   it("applies margin symmetrically", () => {

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -24,6 +24,8 @@ export interface MahjongLayout {
   padY: number;
   boardWidth: number;
   boardHeight: number;
+  availWidth: number;
+  availHeight: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -31,6 +33,30 @@ export interface MahjongLayout {
 // Future implementations can swap tileToScreen to add zoom/pan without
 // touching any rendering or hit-test code.
 // ---------------------------------------------------------------------------
+
+export interface CameraState {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+export function fitToScreen(
+  boardWidth: number,
+  boardHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin = 16
+): CameraState {
+  const scaleX = (viewportWidth - margin * 2) / boardWidth;
+  const scaleY = (viewportHeight - margin * 2) / boardHeight;
+  // Cap at 1 — never scale up beyond natural tile size; user zooms in via gesture (#1454).
+  const scale = Math.min(1, scaleX, scaleY);
+  return {
+    scale,
+    offsetX: (viewportWidth - boardWidth * scale) / 2,
+    offsetY: (viewportHeight - boardHeight * scale) / 2,
+  };
+}
 
 export interface BoardCamera {
   tileToScreen(col: number, row: number, layer: number): { x: number; y: number };
@@ -41,9 +67,20 @@ export interface BoardCamera {
   sideWidth: number;
   boardWidth: number;
   boardHeight: number;
+  // Camera transform — applied to the canvas container by MahjongScreen.
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  viewportWidth: number;
+  viewportHeight: number;
 }
 
-export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
+export function makeBoardCamera(
+  layout: MahjongLayout,
+  viewportWidth = layout.boardWidth,
+  viewportHeight = layout.boardHeight,
+  margin = 0
+): BoardCamera {
   const {
     tileWidth,
     tileHeight,
@@ -55,6 +92,13 @@ export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
     boardWidth,
     boardHeight,
   } = layout;
+  const { scale, offsetX, offsetY } = fitToScreen(
+    boardWidth,
+    boardHeight,
+    viewportWidth,
+    viewportHeight,
+    margin
+  );
   return {
     tileToScreen(col, row, layer) {
       return {
@@ -69,6 +113,11 @@ export function makeBoardCamera(layout: MahjongLayout): BoardCamera {
     sideWidth,
     boardWidth,
     boardHeight,
+    scale,
+    offsetX,
+    offsetY,
+    viewportWidth,
+    viewportHeight,
   };
 }
 
@@ -140,6 +189,8 @@ export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout
     padY,
     boardWidth,
     boardHeight,
+    availWidth: availW,
+    availHeight: availH,
   };
 }
 
@@ -170,5 +221,8 @@ export function useMahjongCanvasLayout(): MahjongLayout {
 
 export function useMahjongCamera(): BoardCamera {
   const layout = useMahjongCanvasLayout();
-  return useMemo(() => makeBoardCamera(layout), [layout]);
+  return useMemo(
+    () => makeBoardCamera(layout, layout.availWidth, layout.availHeight, 16),
+    [layout]
+  );
 }

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -50,7 +50,8 @@ export function fitToScreen(
   const scaleX = (viewportWidth - margin * 2) / boardWidth;
   const scaleY = (viewportHeight - margin * 2) / boardHeight;
   // Cap at 1 — never scale up beyond natural tile size; user zooms in via gesture (#1454).
-  const scale = Math.min(1, scaleX, scaleY);
+  // Floor at 0.01 — guards against negative scale when margin > viewport/2.
+  const scale = Math.max(0.01, Math.min(1, scaleX, scaleY));
   return {
     scale,
     offsetX: (viewportWidth - boardWidth * scale) / 2,
@@ -68,6 +69,10 @@ export interface BoardCamera {
   boardWidth: number;
   boardHeight: number;
   // Camera transform — applied to the canvas container by MahjongScreen.
+  // tileToScreen() returns world-space coords (pre-transform); MahjongScreen
+  // applies scale via a View transform and centers via flexbox, so offsetX/offsetY
+  // are reserved for the gesture-driven zoom/pan layer (#1454) and not used for
+  // static positioning.
   scale: number;
   offsetX: number;
   offsetY: number;

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -524,33 +524,44 @@ export default function MahjongScreen() {
             </Text>
           </View>
 
-          {/* Board container — overflow:hidden clips FlyingPair animations */}
+          {/* Viewport container — clips the scaled board */}
           <View
             style={{
-              width: camera.boardWidth,
-              height: camera.boardHeight,
+              width: camera.viewportWidth,
+              height: camera.viewportHeight,
               overflow: "hidden",
               alignSelf: "center",
+              alignItems: "center",
+              justifyContent: "center",
             }}
           >
-            <Animated.View style={boardAnimStyle}>
-              <GameCanvas
-                state={state}
-                camera={camera}
-                onTilePress={handleTilePress}
-                onShufflePress={handleShuffle}
-                onNewGamePress={startNewGame}
-              />
-            </Animated.View>
-            {flyingPairs.map((pair) => (
-              <FlyingPair
-                key={pair.id}
-                {...pair}
-                camera={camera}
-                color={colors.accent + "99"}
-                onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
-              />
-            ))}
+            {/* Camera scale transform — fits board in viewport */}
+            <View
+              style={{
+                width: camera.boardWidth,
+                height: camera.boardHeight,
+                transform: [{ scale: camera.scale }],
+              }}
+            >
+              <Animated.View style={boardAnimStyle}>
+                <GameCanvas
+                  state={state}
+                  camera={camera}
+                  onTilePress={handleTilePress}
+                  onShufflePress={handleShuffle}
+                  onNewGamePress={startNewGame}
+                />
+              </Animated.View>
+              {flyingPairs.map((pair) => (
+                <FlyingPair
+                  key={pair.id}
+                  {...pair}
+                  camera={camera}
+                  color={colors.accent + "99"}
+                  onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
+                />
+              ))}
+            </View>
           </View>
         </ScrollView>
       )}


### PR DESCRIPTION
## Summary

- Adds `CameraState` interface and `fitToScreen()` pure function — computes the scale and centering offsets needed to fit a board bounding box within a viewport with a configurable margin
- Extends `BoardCamera` with `scale`, `offsetX`, `offsetY`, `viewportWidth`, `viewportHeight`
- `makeBoardCamera()` now accepts optional viewport dimensions; defaults to scale=1 (no-op) when omitted, preserving all existing callers
- `MahjongLayout` gains `availWidth`/`availHeight` (returned by `calculateMahjongLayout`) so `useMahjongCamera` can compute fit state without duplicating chrome-height math
- `MahjongScreen` board container is now viewport-sized; a plain `View` with `transform: [{ scale: camera.scale }]` wraps the canvas and `FlyingPair` animations together so world-space positions stay correct through the transform

## Why

Boards previously touched the viewport edges on small devices. With fit-to-screen, there's always 16 px breathing room on each side and the board is centered regardless of device. Scale is capped at 1.0 — tiles never exceed natural size. User-driven zoom-in comes in #1454.

Part of the Mahjong camera/navigation epic (#1451).

## Test plan

- [x] 119 mahjong tests pass (`npx jest --testPathPattern="mahjong"`)
- [x] 6 new `fitToScreen` tests: scale clamping at 1, scale-down, tighter-dimension constraint, centering invariant, margin symmetry
- [x] 2 new `makeBoardCamera` tests: default scale=1 with no viewport args, fit-with-viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)