### PR TITLE
feat(mahjong): pinch-to-zoom and two-finger pan (#1454)

### DIFF
--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -38,6 +38,7 @@ import Animated, {
   runOnJS,
   Easing,
 } from "react-native-reanimated";
+import { GestureDetector, Gesture } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
@@ -69,6 +70,12 @@ import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
 
 const MAX_NAME_LENGTH = 32;
+const MAX_ZOOM = 2.5;
+
+function clamp(value: number, min: number, max: number): number {
+  "worklet";
+  return Math.min(Math.max(value, min), max);
+}
 
 // ---------------------------------------------------------------------------
 // Tile center — used by FlyingPair to compute animation start/end positions
@@ -209,6 +216,56 @@ export default function MahjongScreen() {
   const boardAnimStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: boardShakeX.value }],
     opacity: boardOpacity.value,
+  }));
+
+  // Gesture zoom/pan shared values — min zoom = camera.scale (fit-to-screen).
+  const minZoom = useSharedValue(camera.scale);
+  const zoomScale = useSharedValue(camera.scale);
+  const baseScale = useSharedValue(camera.scale);
+  const translateX = useSharedValue(0);
+  const baseTranslateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const baseTranslateY = useSharedValue(0);
+
+  // Reset gesture state when fit-to-screen scale changes (orientation / resize).
+  useEffect(() => {
+    minZoom.value = camera.scale;
+    zoomScale.value = camera.scale;
+    baseScale.value = camera.scale;
+    translateX.value = 0;
+    baseTranslateX.value = 0;
+    translateY.value = 0;
+    baseTranslateY.value = 0;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [camera.scale]);
+
+  const pinchGesture = Gesture.Pinch()
+    .onUpdate((e) => {
+      zoomScale.value = clamp(baseScale.value * e.scale, minZoom.value, MAX_ZOOM);
+    })
+    .onEnd(() => {
+      baseScale.value = zoomScale.value;
+    });
+
+  const panGesture = Gesture.Pan()
+    .minPointers(2)
+    .onUpdate((e) => {
+      translateX.value = baseTranslateX.value + e.translationX;
+      translateY.value = baseTranslateY.value + e.translationY;
+    })
+    .onEnd(() => {
+      baseTranslateX.value = translateX.value;
+      baseTranslateY.value = translateY.value;
+    });
+
+  const boardGesture = Gesture.Simultaneous(pinchGesture, panGesture);
+
+  const gestureAnimStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: zoomScale.value },
+    ],
   }));
 
   const hasLoadedRef = useRef(false);
@@ -524,7 +581,7 @@ export default function MahjongScreen() {
             </Text>
           </View>
 
-          {/* Viewport container — clips the scaled board */}
+          {/* Viewport container — clips the board during zoom/pan */}
           <View
             style={{
               width: camera.viewportWidth,
@@ -535,33 +592,34 @@ export default function MahjongScreen() {
               justifyContent: "center",
             }}
           >
-            {/* Camera scale transform — fits board in viewport */}
-            <View
-              style={{
-                width: camera.boardWidth,
-                height: camera.boardHeight,
-                transform: [{ scale: camera.scale }],
-              }}
-            >
-              <Animated.View style={boardAnimStyle}>
-                <GameCanvas
-                  state={state}
-                  camera={camera}
-                  onTilePress={handleTilePress}
-                  onShufflePress={handleShuffle}
-                  onNewGamePress={startNewGame}
-                />
+            <GestureDetector gesture={boardGesture}>
+              {/* Gesture layer — pinch-to-zoom + two-finger pan */}
+              <Animated.View
+                style={[
+                  { width: camera.boardWidth, height: camera.boardHeight },
+                  gestureAnimStyle,
+                ]}
+              >
+                <Animated.View style={boardAnimStyle}>
+                  <GameCanvas
+                    state={state}
+                    camera={camera}
+                    onTilePress={handleTilePress}
+                    onShufflePress={handleShuffle}
+                    onNewGamePress={startNewGame}
+                  />
+                </Animated.View>
+                {flyingPairs.map((pair) => (
+                  <FlyingPair
+                    key={pair.id}
+                    {...pair}
+                    camera={camera}
+                    color={colors.accent + "99"}
+                    onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
+                  />
+                ))}
               </Animated.View>
-              {flyingPairs.map((pair) => (
-                <FlyingPair
-                  key={pair.id}
-                  {...pair}
-                  camera={camera}
-                  color={colors.accent + "99"}
-                  onDone={() => setFlyingPairs((prev) => prev.filter((p) => p.id !== pair.id))}
-                />
-              ))}
-            </View>
+            </GestureDetector>
           </View>
         </ScrollView>
       )}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -595,10 +595,7 @@ export default function MahjongScreen() {
             <GestureDetector gesture={boardGesture}>
               {/* Gesture layer — pinch-to-zoom + two-finger pan */}
               <Animated.View
-                style={[
-                  { width: camera.boardWidth, height: camera.boardHeight },
-                  gestureAnimStyle,
-                ]}
+                style={[{ width: camera.boardWidth, height: camera.boardHeight }, gestureAnimStyle]}
               >
                 <Animated.View style={boardAnimStyle}>
                   <GameCanvas


### PR DESCRIPTION
## Summary

- Wraps the board container in a `GestureDetector` using `Gesture.Simultaneous(Pinch, Pan)` from `react-native-gesture-handler`
- **Pinch**: scales the board between `camera.scale` (fit-to-screen minimum) and `2.5×` maximum; `clamp` worklet enforces bounds on the UI thread
- **Pan**: restricted to `minPointers(2)` so single-finger tile taps pass through to the `Pressable` inside `GameCanvas` unchanged
- All gesture state (`zoomScale`, `translateX/Y`) lives in Reanimated `useSharedValue`s driving `useAnimatedStyle` — zero React re-renders per frame
- Shake/deadlock animation remains a separate inner `Animated.View` layer, unaffected by the gesture transform
- Resets to fit-to-screen state when `camera.scale` changes (orientation change / window resize)

## Test plan

- [ ] Single-finger tap selects tiles normally
- [ ] Two-finger pinch zooms in (up to 2.5×) and out (back to fit-to-screen)
- [ ] Two-finger drag pans the board while zoomed
- [ ] Deadlock shake animation still plays correctly during zoom
- [ ] Shuffle pulse animation still plays correctly
- [ ] Rotating device / resizing window resets zoom+pan to fit-to-screen
- [ ] All 119 mahjong tests pass (`npx jest --testPathPattern="mahjong"`)

Closes #1454

🤖 Generated with [Claude Code](https://claude.com/claude-code)