### PR TITLE
feat(starswarm): rework Challenging Stage — lower HP, slower swarm, conditional scoring, no power-up (#1463)

### DIFF
--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -738,10 +738,10 @@ describe("ChallengingStage off-screen cleanup", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
     expect(s.phase).toBe("ChallengingStage");
 
-    // With 40 enemies, last enemy (idx 39) has delay = 39*80/3200 = 0.975.
-    // It exits the canvas after (1 + 0.975) * 3200 ≈ 6320 ms.
+    // With 40 enemies, last enemy (idx 39) has delay = 39*400/5000 = 3.12 (×pathDuration).
+    // It exits the canvas after 39*400 + 5000 = 20600 ms.
     // Advance past that with no firing so enemies scroll off instead of being shot.
-    s = advanceMs(s, 7000, NO_INPUT);
+    s = advanceMs(s, 22000, NO_INPUT);
     expect(s.phase).toBe("WaveClear");
   });
 
@@ -1497,16 +1497,10 @@ describe("Power-up engine (#980)", () => {
     expect(s.activePowerUp).toBeNull();
   });
 
-  it("Challenging Stage spawns one lightning power-up at wave start within safe bounds (#1032)", () => {
+  it("Challenging Stage spawns no power-ups (#1463 — power-ups trivialise the perfect-clear)", () => {
     const s = initStarSwarm(CANVAS_W, CANVAS_H, 3);
     expect(s.phase).toBe("ChallengingStage");
-    expect(s.powerUps.length).toBe(1);
-    const pu = s.powerUps[0]!;
-    expect(pu.type).toBe("lightning");
-    // X randomised within safe margins (not hardcoded to center)
-    expect(pu.x).toBeGreaterThanOrEqual(12);
-    expect(pu.x).toBeLessThanOrEqual(CANVAS_W - 12);
-    expect(pu.despawnTimer).toBeGreaterThan(6000); // canvas-height-derived (~8950ms at CANVAS_H=640)
+    expect(s.powerUps.length).toBe(0);
   });
 });
 
@@ -2244,19 +2238,20 @@ describe("#1022 Challenging Stage cadence & PERFECT bonus", () => {
 
   it("challengingPerfect is false on WaveClear when enemies scroll off without being shot", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
-    // 40 enemies; last one (idx 39) exits at ≈6320ms — advance past with no firing
-    s = advanceMs(s, 7000, NO_INPUT);
+    // 40 enemies; last one (idx 39) exits at 39*400 + 5000 = 20600 ms — advance past with no firing
+    s = advanceMs(s, 22000, NO_INPUT);
     expect(s.phase).toBe("WaveClear");
     expect(s.challengingPerfect).toBe(false);
   });
 
   it("PERFECT clears add 10,000 pts bonus at Ensign ×1 (plus 40×50 hit bonus)", () => {
-    // Zero-hit path: enemies scroll off — only waveClearBonus (wave 3 × 500 × 1 = 1500)
+    // Zero-hit path: enemies scroll off — wave-clear bonus is 0 (conditional on hits, #1463)
     let noPerfect = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
-    noPerfect = advanceMs(noPerfect, 7000, NO_INPUT);
+    noPerfect = advanceMs(noPerfect, 22000, NO_INPUT);
     expect(noPerfect.phase).toBe("WaveClear");
+    expect(noPerfect.score).toBe(0); // zero kills → zero wave-clear bonus
 
-    // Full-hit path: all 40 hit + perfect → 1500 + 2000 + 10000 = 13500
+    // Full-hit path: all 40 hit + perfect → waveClear(1500) + hits(2000) + perfect(10000) = 13500
     let perfect = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
     perfect = {
       ...perfect,
@@ -2266,8 +2261,8 @@ describe("#1022 Challenging Stage cadence & PERFECT bonus", () => {
     perfect = tick(perfect, 16, NO_INPUT);
     expect(perfect.phase).toBe("WaveClear");
 
-    // Δ = 40 hits × 50 + 10,000 perfect bonus = 12,000
-    expect(perfect.score - noPerfect.score).toBe(40 * 50 + 10_000);
+    // Δ = waveClear(3×500×1) + 40×50 + 10,000 perfect bonus = 13,500
+    expect(perfect.score - noPerfect.score).toBe(3 * 500 + 40 * 50 + 10_000);
   });
 });
 

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -2264,6 +2264,20 @@ describe("#1022 Challenging Stage cadence & PERFECT bonus", () => {
     // Δ = waveClear(3×500×1) + 40×50 + 10,000 perfect bonus = 13,500
     expect(perfect.score - noPerfect.score).toBe(3 * 500 + 40 * 50 + 10_000);
   });
+
+  it("partial hit fraction (20/40 kills) gives proportional wave-clear bonus at Ensign ×1 (#1463)", () => {
+    // 20/40 = 50% hit fraction → waveClear = round(0.5 × 3 × 500 × 1) = 750
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 3, 42, "Ensign");
+    s = {
+      ...s,
+      challengingHits: 20,
+      enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })),
+    };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.phase).toBe("WaveClear");
+    // waveClear(750) + hits(20×50=1000) + no perfect bonus = 1750
+    expect(s.score).toBe(750 + 20 * 50);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -78,8 +78,8 @@ const PERFECT_BONUS = 10_000; // flat bonus for hitting all challenge enemies (#
 // #1463: reduced HP — challenging stage is a shooting gallery; multi-hit enemies are unkillable at speed
 const CHALLENGING_TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 1, Boss: 2 };
 // #1463: slower swarm — 5 s arc, 400 ms stagger → ~20.6 s total stage
-const CHALLENGE_PATH_DURATION = 5000; // ms each enemy traverses its arc
-const CHALLENGE_STAGGER_MS = 400; // ms between successive enemy entries
+const CHALLENGING_PATH_DURATION = 5000; // ms each enemy traverses its arc
+const CHALLENGING_STAGGER_MS = 400; // ms between successive enemy entries
 
 const SHOOT_INTERVAL_BASE = 2600; // ms base
 const SHOOT_INTERVAL_JITTER = 1400; // ms random addend
@@ -488,7 +488,7 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
   const size = TIER_SIZE[tier];
   const path = challengePath(idx, total, canvasW, canvasH);
   const p0 = evalCubic(path, 0);
-  const delay = (idx * CHALLENGE_STAGGER_MS) / CHALLENGE_PATH_DURATION;
+  const delay = (idx * CHALLENGING_STAGGER_MS) / CHALLENGING_PATH_DURATION;
 
   return {
     id: nextId(),
@@ -502,7 +502,7 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
     formationY: path.p3.y,
     path,
     pathT: -delay,
-    pathDuration: CHALLENGE_PATH_DURATION,
+    pathDuration: CHALLENGING_PATH_DURATION,
     vel: { x: 0, y: 0 },
     circleCx: 0,
     circleCy: 0,
@@ -1748,7 +1748,7 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
     if (!anyAlive) {
       const sm = difficultyMultiplier(state.difficulty);
       // #1463: wave-clear bonus scales with hit ratio — zero kills = zero bonus
-      const hitFraction = state.challengingHits / CHALLENGING_ENEMY_COUNT;
+      const hitFraction = Math.min(1, state.challengingHits / CHALLENGING_ENEMY_COUNT);
       const waveClearBonus = Math.round(hitFraction * state.wave * WAVE_CLEAR_BONUS_BASE * sm);
       const perfect = state.challengingHits === CHALLENGING_ENEMY_COUNT;
       const perfectBonus = perfect ? Math.round(PERFECT_BONUS * sm) : 0;

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -75,6 +75,11 @@ const WAVE_CLEAR_PAUSE = 1600; // ms
 const CHALLENGING_CLEAR_PAUSE = 2200; // ms
 const CHALLENGING_ENEMY_COUNT = 40; // classic 40-enemy Challenging Stage (#1022)
 const PERFECT_BONUS = 10_000; // flat bonus for hitting all challenge enemies (#1022)
+// #1463: reduced HP — challenging stage is a shooting gallery; multi-hit enemies are unkillable at speed
+const CHALLENGING_TIER_HP: Record<EnemyTier, number> = { Grunt: 1, Elite: 1, Boss: 2 };
+// #1463: slower swarm — 5 s arc, 400 ms stagger → ~20.6 s total stage
+const CHALLENGE_PATH_DURATION = 5000; // ms each enemy traverses its arc
+const CHALLENGE_STAGGER_MS = 400; // ms between successive enemy entries
 
 const SHOOT_INTERVAL_BASE = 2600; // ms base
 const SHOOT_INTERVAL_JITTER = 1400; // ms random addend
@@ -483,7 +488,7 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
   const size = TIER_SIZE[tier];
   const path = challengePath(idx, total, canvasW, canvasH);
   const p0 = evalCubic(path, 0);
-  const delay = (idx * 80) / 3200;
+  const delay = (idx * CHALLENGE_STAGGER_MS) / CHALLENGE_PATH_DURATION;
 
   return {
     id: nextId(),
@@ -497,7 +502,7 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
     formationY: path.p3.y,
     path,
     pathT: -delay,
-    pathDuration: 3200,
+    pathDuration: CHALLENGE_PATH_DURATION,
     vel: { x: 0, y: 0 },
     circleCx: 0,
     circleCy: 0,
@@ -506,7 +511,7 @@ function makeChallengeEnemy(idx: number, total: number, canvasW: number, canvasH
     circleSpeed: CIRCLE_SPEED,
     shootTimer: 9_999_999, // never shoots
     diveTargetX: 0,
-    hp: TIER_HP[tier],
+    hp: CHALLENGING_TIER_HP[tier],
     isAlive: true,
     hitFlashTimer: 0,
     wiggleTimer: 0,
@@ -635,18 +640,7 @@ function buildWaveState(
 
   const startingNonBossCount = enemies.filter((e) => e.tier !== "Boss").length;
 
-  // #1032: Challenging Stage power-up X is randomised (Math.random() — cosmetic, non-deterministic)
-  const challengingPowerUp: PowerUp = {
-    id: nextId(),
-    type: "lightning",
-    x: POWERUP_W / 2 + Math.random() * (canvasW - POWERUP_W),
-    y: POWERUP_H / 2,
-    vy: POWERUP_VY,
-    width: POWERUP_W,
-    height: POWERUP_H,
-    despawnTimer: powerUpDespawnMs(canvasH),
-  };
-  const powerUps: PowerUp[] = isChallengingWave(wave) ? [challengingPowerUp] : [];
+  const powerUps: PowerUp[] = [];
   const dropJitterTarget = triggerKills(wave) + Math.floor(rng() * 5) - 2;
   const paramScale = difficultyParamScale(difficulty);
   // Ensign gets gentler AI; every tier above gets straggler aggression
@@ -1753,7 +1747,9 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
     const anyAlive = liveEnemies.length > 0;
     if (!anyAlive) {
       const sm = difficultyMultiplier(state.difficulty);
-      const waveClearBonus = Math.round(state.wave * WAVE_CLEAR_BONUS_BASE * sm);
+      // #1463: wave-clear bonus scales with hit ratio — zero kills = zero bonus
+      const hitFraction = state.challengingHits / CHALLENGING_ENEMY_COUNT;
+      const waveClearBonus = Math.round(hitFraction * state.wave * WAVE_CLEAR_BONUS_BASE * sm);
       const perfect = state.challengingHits === CHALLENGING_ENEMY_COUNT;
       const perfectBonus = perfect ? Math.round(PERFECT_BONUS * sm) : 0;
       return {


### PR DESCRIPTION
Enemy HP reduced to Grunt 1 / Elite 1 / Boss 2 so the stage is a real
shooting gallery. Path duration extended from 3200 ms to 5000 ms; stagger
from 80 ms to 400 ms — total stage duration ~20.6 s (was 6.3 s). Wave-clear
bonus is now proportional to hit fraction (zero kills = zero bonus) so passive
play no longer scores nearly as much as active play. Power-up removed — any
bomb or lightning trivialises the perfect-clear target.

https://claude.ai/code/session_01V81eUam5bZoXudJSv2c8Zw