### PR TITLE
fix(mahjong): retina rendering — DPR backing buffer, image smoothing, pixel snapping

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -94,7 +94,9 @@ function drawBoard(
   for (const tile of sorted) {
     ctx.save();
 
-    const { x, y } = cam.tileToScreen(tile.col, tile.row, tile.layer);
+    const { x: rawX, y: rawY } = cam.tileToScreen(tile.col, tile.row, tile.layer);
+    const x = Math.round(rawX);
+    const y = Math.round(rawY);
     const isSelected = tile.id === selectedId;
     const isFree = freeTiles.has(tile.id);
     const isHint = matchingIds.has(tile.id);
@@ -257,10 +259,28 @@ export default function GameCanvas({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+
+    // Scale the backing buffer to physical pixels so the canvas is crisp on
+    // high-DPI / Retina screens. CSS display size stays at logical pixels.
+    const dpr = window.devicePixelRatio ?? 1;
+    const physW = Math.round(boardWidth * dpr);
+    const physH = Math.round(boardHeight * dpr);
+    canvas.style.width = `${boardWidth}px`;
+    canvas.style.height = `${boardHeight}px`;
+    if (canvas.width !== physW) canvas.width = physW;
+    if (canvas.height !== physH) canvas.height = physH;
+
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
+
+    // Map all drawing coordinates to physical pixels and use high-quality
+    // filtering when scaling SVG art.
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+
     drawBoard(ctx, state, freeTiles, matchingIds, tileImagesRef.current, camera);
-  }, [state, freeTiles, matchingIds, imagesVersion, camera]);
+  }, [state, freeTiles, matchingIds, imagesVersion, camera, boardWidth, boardHeight]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -280,7 +280,7 @@ export default function GameCanvas({
     ctx.imageSmoothingQuality = "high";
 
     drawBoard(ctx, state, freeTiles, matchingIds, tileImagesRef.current, camera);
-  }, [state, freeTiles, matchingIds, imagesVersion, camera, boardWidth, boardHeight]);
+  }, [state, freeTiles, matchingIds, imagesVersion, camera]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {


### PR DESCRIPTION
## Summary

- **Confirmed Retina bug (#1471):** The canvas backing buffer had no `devicePixelRatio` compensation. On 2× Retina screens every tile rendered at half native resolution. Each draw pass now sizes the buffer to physical pixels, applies a DPR transform, and sets `imageSmoothingQuality = "high"` (was browser default `"low"`).
- **Pixel snapping (#1472):** Wraps `tileToScreen()` output in `Math.round()` before every `fillRect`/`drawImage` to prevent sub-pixel interpolation on tile borders, especially at non-integer DPR values (e.g. 1.5×, 2.25×).

## Changes

`frontend/src/components/mahjong/GameCanvas.web.tsx` only — no logic, no engine, no native renderer touched.

**Draw effect:**
```typescript
const dpr = window.devicePixelRatio ?? 1;
canvas.style.width  = `${boardWidth}px`;   // CSS display stays logical
canvas.style.height = `${boardHeight}px`;
canvas.width  = Math.round(boardWidth  * dpr); // backing buffer = physical px
canvas.height = Math.round(boardHeight * dpr);
ctx.setTransform(dpr, 0, 0, dpr, 0, 0);       // draw in logical coords
ctx.imageSmoothingEnabled = true;
ctx.imageSmoothingQuality = "high";
```

**Draw loop (per tile):**
```typescript
const { x: rawX, y: rawY } = cam.tileToScreen(...);
const x = Math.round(rawX);
const y = Math.round(rawY);
```

Hit-testing is unaffected: the existing `rect.width / camera.boardWidth` scale correction already normalises click coordinates to logical pixels regardless of DPR.

## Test plan

- [x] 139/139 mahjong tests pass
- [ ] Visually verify tile art is crisp on a 2× Retina screen (before: blurry, after: sharp)
- [ ] Verify tile selection / hit-testing still works correctly
- [ ] Check at browser zoom 150% (DPR = 1.5) — no half-pixel border artifacts

Closes #1471, closes #1472
Part of epic #1477