### PR TITLE
feat(mahjong): hint button — highlights a valid free pair for 2 s

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -214,14 +214,18 @@ function hitTest(
 interface Props {
   state: MahjongState;
   camera: BoardCamera;
+  hintIds?: ReadonlySet<number>;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
 }
 
+const EMPTY_SET: ReadonlySet<number> = new Set();
+
 export default function GameCanvas({
   state,
   camera,
+  hintIds = EMPTY_SET,
   onTilePress,
   onShufflePress,
   onNewGamePress,
@@ -292,7 +296,7 @@ export default function GameCanvas({
           // 2 px border on selected for visibility at small tile sizes.
           const borderInset = isSelected ? 2 : 1;
 
-          const isHint = matchingIds.has(tile.id);
+          const isHint = matchingIds.has(tile.id) || hintIds.has(tile.id);
           const borderColor = isSelected ? BORDER_SELECTED : isHint ? BORDER_HINT : BORDER_NORMAL;
           const faceColor = isSelected ? TILE_FACE_SELECTED : isFree ? TILE_FACE : TILE_FACE_LOCKED;
 

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -209,14 +209,18 @@ function drawBoard(
 interface Props {
   state: MahjongState;
   camera: BoardCamera;
+  hintIds?: ReadonlySet<number>;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
 }
 
+const EMPTY_SET: ReadonlySet<number> = new Set();
+
 export default function GameCanvas({
   state,
   camera,
+  hintIds = EMPTY_SET,
   onTilePress,
   onShufflePress,
   onNewGamePress,
@@ -239,6 +243,13 @@ export default function GameCanvas({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const matchingIds = useMemo(() => getMatchingFreeTileIds(state), [state.tiles, state.selected]);
+
+  const allHintIds = useMemo(() => {
+    if (hintIds.size === 0) return matchingIds;
+    const merged = new Set(matchingIds);
+    for (const id of hintIds) merged.add(id);
+    return merged as ReadonlySet<number>;
+  }, [matchingIds, hintIds]);
 
   const noFreePairs = useMemo(
     () => !state.isComplete && !hasFreePairs(state.tiles),
@@ -335,12 +346,12 @@ export default function GameCanvas({
       ctx,
       state,
       freeTiles,
-      matchingIds,
+      allHintIds,
       tileImagesRef.current,
       camera,
       feltPatternRef.current
     );
-  }, [state, freeTiles, matchingIds, imagesVersion, camera]);
+  }, [state, freeTiles, allHintIds, imagesVersion, camera]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -8,6 +8,7 @@ import {
   createGame,
   createSeededRng,
   elapsedMs,
+  getAnyFreePair,
   getMatchingFreeTileIds,
   hasFreePairs,
   isFreeTile,
@@ -672,6 +673,41 @@ describe("hasFreePairs", () => {
     const c: SlotTile = { id: 2, suit: "dragons", rank: 1, faceId: 1, col: 0, row: 0, layer: 1 };
     // a is covered by c, b is free. But the pair (a,b) can't form since a is not free.
     expect(hasFreePairs([a, b, c])).toBe(false);
+  });
+});
+
+describe("getAnyFreePair", () => {
+  it("returns null for an empty board", () => {
+    expect(getAnyFreePair([])).toBeNull();
+  });
+
+  it("returns the two IDs when a matching free pair exists", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const result = getAnyFreePair([a, b]);
+    expect(result).not.toBeNull();
+    expect(result!.sort()).toEqual([0, 1]);
+  });
+
+  it("returns null when no matching free pair exists", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "circles", rank: 2, faceId: 18, col: 2, row: 0, layer: 0 };
+    expect(getAnyFreePair([a, b])).toBeNull();
+  });
+
+  it("returns null when the only matching pair is blocked", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const c: SlotTile = { id: 2, suit: "dragons", rank: 1, faceId: 1, col: 0, row: 0, layer: 1 };
+    expect(getAnyFreePair([a, b, c])).toBeNull();
+  });
+
+  it("returns flower IDs for a matching flower pair", () => {
+    const a: SlotTile = { id: 10, suit: "flowers", rank: 1, faceId: 37, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 11, suit: "flowers", rank: 2, faceId: 38, col: 2, row: 0, layer: 0 };
+    const result = getAnyFreePair([a, b]);
+    expect(result).not.toBeNull();
+    expect(result!.sort()).toEqual([10, 11]);
   });
 });
 

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -113,6 +113,17 @@ export function hasFreePairs(tiles: readonly SlotTile[]): boolean {
   return false;
 }
 
+/** Returns the IDs of one valid free pair, or null when none exists. Used by the hint button. */
+export function getAnyFreePair(tiles: readonly SlotTile[]): [number, number] | null {
+  const free = tiles.filter((t) => isFreeTile(t, tiles));
+  for (let i = 0; i < free.length; i++) {
+    for (let j = i + 1; j < free.length; j++) {
+      if (tilesMatch(free[i]!, free[j]!)) return [free[i]!.id, free[j]!.id];
+    }
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Elapsed time helper
 // ---------------------------------------------------------------------------

--- a/frontend/src/i18n/locales/ar/mahjong.json
+++ b/frontend/src/i18n/locales/ar/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/de/mahjong.json
+++ b/frontend/src/i18n/locales/de/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/en/mahjong.json
+++ b/frontend/src/i18n/locales/en/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "Shuffle remaining tiles into a new solvable arrangement",
   "action.undo": "UNDO",
   "action.undoLabel": "Undo last matched pair",
+  "action.hint": "HINT",
+  "action.hintLabel": "Show a hint — highlights one valid pair for 2 seconds",
   "overlay.noMoves": "NO MOVES",
   "overlay.noMovesDetail": "No matches available. Shuffle to continue.",
   "overlay.deadlocked": "NO MORE MOVES",

--- a/frontend/src/i18n/locales/es/mahjong.json
+++ b/frontend/src/i18n/locales/es/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/fr-CA/mahjong.json
+++ b/frontend/src/i18n/locales/fr-CA/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/he/mahjong.json
+++ b/frontend/src/i18n/locales/he/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/hi/mahjong.json
+++ b/frontend/src/i18n/locales/hi/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ja/mahjong.json
+++ b/frontend/src/i18n/locales/ja/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ko/mahjong.json
+++ b/frontend/src/i18n/locales/ko/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/nl/mahjong.json
+++ b/frontend/src/i18n/locales/nl/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/pt/mahjong.json
+++ b/frontend/src/i18n/locales/pt/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ru/mahjong.json
+++ b/frontend/src/i18n/locales/ru/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/zh/mahjong.json
+++ b/frontend/src/i18n/locales/zh/mahjong.json
@@ -13,6 +13,8 @@
   "action.shuffleLabel": "__NEEDS_TRANSLATION__",
   "action.undo": "__NEEDS_TRANSLATION__",
   "action.undoLabel": "__NEEDS_TRANSLATION__",
+  "action.hint": "__NEEDS_TRANSLATION__",
+  "action.hintLabel": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -52,7 +52,14 @@ import { OfflineBanner } from "../components/shared/OfflineBanner";
 import GameCanvas from "../components/mahjong/GameCanvas";
 import { useMahjongCamera } from "../game/mahjong/layout";
 import type { BoardCamera } from "../game/mahjong/layout";
-import { createGame, elapsedMs, selectTile, shuffleBoard, undoMove } from "../game/mahjong/engine";
+import {
+  createGame,
+  elapsedMs,
+  getAnyFreePair,
+  selectTile,
+  shuffleBoard,
+  undoMove,
+} from "../game/mahjong/engine";
 import { TURTLE_LAYOUT } from "../game/mahjong/layouts/turtle";
 import type { MahjongState, SlotTile } from "../game/mahjong/types";
 import {
@@ -202,6 +209,10 @@ export default function MahjongScreen() {
     gamesPlayed: 0,
     gamesWon: 0,
   });
+
+  // Hint state — IDs of the pair currently being highlighted; auto-clears after 2 s.
+  const [hintIds, setHintIds] = useState<ReadonlySet<number>>(new Set());
+  const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Animation state
   const [flyingPairs, setFlyingPairs] = useState<FlyingPairData[]>([]);
@@ -486,6 +497,11 @@ export default function MahjongScreen() {
 
   const handleTilePress = useCallback(
     (tileId: number) => {
+      if (hintTimerRef.current) {
+        clearTimeout(hintTimerRef.current);
+        hintTimerRef.current = null;
+      }
+      setHintIds(new Set());
       setState((prev) => {
         if (!prev) return prev;
         const next = selectTile(prev, tileId);
@@ -495,6 +511,22 @@ export default function MahjongScreen() {
       });
     },
     [ensureSyncStarted]
+  );
+
+  const handleHint = useCallback(() => {
+    if (!state) return;
+    const pair = getAnyFreePair(state.tiles);
+    if (!pair) return;
+    if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
+    setHintIds(new Set(pair));
+    hintTimerRef.current = setTimeout(() => setHintIds(new Set()), 2000);
+  }, [state]);
+
+  useEffect(
+    () => () => {
+      if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
+    },
+    []
   );
 
   const handleShuffle = useCallback(() => {
@@ -584,6 +616,22 @@ export default function MahjongScreen() {
             <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
               {t("hud.deal")} #{state.dealId}
             </Text>
+            <Pressable
+              onPress={handleHint}
+              disabled={state.isComplete || state.isDeadlocked}
+              style={[
+                styles.headerBtn,
+                {
+                  borderColor: "#5dbcd2",
+                  opacity: state.isComplete || state.isDeadlocked ? 0.3 : 1,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={t("action.hintLabel")}
+              accessibilityState={{ disabled: state.isComplete || state.isDeadlocked }}
+            >
+              <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
+            </Pressable>
           </View>
 
           {/* Viewport container — clips the board during zoom/pan */}
@@ -606,6 +654,7 @@ export default function MahjongScreen() {
                   <GameCanvas
                     state={state}
                     camera={camera}
+                    hintIds={hintIds}
                     onTilePress={handleTilePress}
                     onShufflePress={handleShuffle}
                     onNewGamePress={startNewGame}


### PR DESCRIPTION
## Summary

- **`getAnyFreePair(tiles)`** added to engine — pure function returning one matching free pair's IDs, or null. Sibling to `hasFreePairs`, no state mutation.
- **GameCanvas (web + native)**: new optional `hintIds` prop merged with `matchingIds` at render time; hint tiles get the same blue border + glow as selection-matching tiles.
- **MahjongScreen HUD**: HINT button (cyan, styled like the UNDO header button) triggers a 2 s highlight then auto-clears. Button disabled when game is over/deadlocked. Timer cancelled on tile tap so it doesn't linger after the player finds the move themselves.
- **i18n**: `action.hint` / `action.hintLabel` added to English locale and all 12 other locales (`__NEEDS_TRANSLATION__`).

## Test plan
- [x] 2484/2484 tests pass (5 new `getAnyFreePair` unit tests)
- [ ] Visual: HINT button visible in HUD during active play
- [ ] Tapping HINT highlights two tiles in blue for ~2 s then clears
- [ ] Tapping a tile before 2 s clears the highlight immediately
- [ ] Button shows as greyed/disabled on win/deadlock screens

Closes #1468
Part of epic #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)