### PR TITLE
feat(mahjong): shuffle token button in HUD — proactive use

### DIFF
--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -618,7 +618,7 @@ export default function MahjongScreen() {
                 {
                   borderColor: "#ffd700",
                   opacity:
-                    state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked ? 0.3 : 1,
+                    state.shufflesLeft > 0 && !state.isComplete && !state.isDeadlocked ? 1 : 0.3,
                 },
               ]}
               accessibilityRole="button"

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -610,9 +610,27 @@ export default function MahjongScreen() {
             <Text style={[styles.hudText, { color: colors.textMuted }]}>
               {t("hud.pairs")} {state.pairsRemoved}/72
             </Text>
-            <Text style={[styles.hudText, { color: colors.textMuted }]}>
-              {t("action.shuffle")} {state.shufflesLeft}
-            </Text>
+            <Pressable
+              onPress={handleShuffle}
+              disabled={state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked}
+              style={[
+                styles.headerBtn,
+                {
+                  borderColor: "#ffd700",
+                  opacity:
+                    state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked ? 0.3 : 1,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={t("action.shuffleLabel")}
+              accessibilityState={{
+                disabled: state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked,
+              }}
+            >
+              <Text style={[styles.headerBtnText, { color: "#ffd700" }]}>
+                {t("action.shuffle")} {state.shufflesLeft}
+              </Text>
+            </Pressable>
             <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
               {t("hud.deal")} #{state.dealId}
             </Text>


### PR DESCRIPTION
## Summary

Replaces the plain `SHUFFLE {N}` text in the HUD with a tappable button (gold border, same style as HINT/UNDO).

**Behaviour change:** shuffle is now usable proactively at any time while `shufflesLeft > 0`. No moves-stuck state is no longer required. Costs a token, so there's a resource tradeoff.

- Disabled (greyed 30%) when `shufflesLeft === 0`, `isComplete`, or `isDeadlocked`
- Existing no-moves overlay in GameCanvas preserved — still shows as a CTA when the board is stuck
- No engine changes: `shuffleBoard()` only guards `shufflesLeft === 0`, so proactive use already worked

## Test plan
- [x] 2484/2484 tests pass (no new logic, pure UI change)
- [ ] Visual: SHUFFLE N button visible in HUD throughout play
- [ ] Tapping at any point with shuffles remaining triggers the shuffle animation/SFX
- [ ] Count decrements: 3 → 2 → 1 → 0 (button greys out at 0)
- [ ] Button disabled on win/deadlock screens

Closes #1469
Part of epic #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)