### PR TITLE
feat(mahjong): soft tile shadows + wider board padding

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -149,10 +149,6 @@ function drawBoard(
     const faceColor = isSelected ? TILE_FACE_SELECTED : isFree ? TILE_FACE : TILE_FACE_LOCKED;
     const suitColor = SUIT_COLOR[tile.suit] ?? "#888888";
 
-    // Drop shadow
-    ctx.fillStyle = "rgba(0,0,0,0.35)";
-    ctx.fillRect(x + sideWidth + 2 + liftX, y + sideWidth + 2 + liftY, faceWidth, faceHeight);
-
     // Right 3-D side
     ctx.fillStyle = SIDE_R;
     ctx.fillRect(x + faceWidth + liftX, y + sideWidth + liftY, sideWidth, faceHeight);
@@ -161,21 +157,29 @@ function drawBoard(
     ctx.fillStyle = SIDE_B;
     ctx.fillRect(x + sideWidth + liftX, y + faceHeight + liftY, faceWidth, sideWidth);
 
-    // Glow behind selected (gold) or hint (blue) tile.
+    // Shadow/glow on the border rect: selected → gold glow, hint → blue glow,
+    // normal → soft feathered drop shadow (replaces the old hard-rect shadow).
     if (isSelected) {
       ctx.shadowColor = MAHJONG_GLOW_SHADOW;
       ctx.shadowBlur = 10;
     } else if (isHint) {
       ctx.shadowColor = MAHJONG_HINT_GLOW_SHADOW;
       ctx.shadowBlur = 8;
+    } else {
+      ctx.shadowColor = "rgba(0,0,0,0.35)";
+      ctx.shadowBlur = 5;
+      ctx.shadowOffsetX = sideWidth + 2;
+      ctx.shadowOffsetY = sideWidth + 2;
     }
 
     // Border
     ctx.fillStyle = borderColor;
     ctx.fillRect(x + liftX, y + liftY, faceWidth, faceHeight);
 
-    // Clear glow before drawing face so inner fills stay crisp.
+    // Clear shadow before drawing face so inner fills stay crisp.
     ctx.shadowBlur = 0;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
 
     // Face
     ctx.fillStyle = faceColor;

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -134,8 +134,8 @@ const MAX_TILE_W = 56;
 const SIDE_R = 5 / 44;
 const LAYER_DX_R = 6 / 44;
 const LAYER_DY_R = 5 / 44;
-const PAD_X_R = 6 / 44;
-const PAD_Y_R = 10 / 44;
+const PAD_X_R = 10 / 44;
+const PAD_Y_R = 14 / 44;
 
 // Keep APP_HEADER_H in sync with AppHeader.APP_HEADER_HEIGHT
 const APP_HEADER_H = 64;
@@ -144,7 +144,7 @@ const MIN_BOTTOM_PAD = 16;
 // App header + HUD row + bottom padding = 116
 const MAHJONG_CHROME_H = APP_HEADER_H + HUD_ROW_H + MIN_BOTTOM_PAD;
 // Minimum horizontal margin on each side when safe-area insets are absent
-const MIN_HORIZ_MARGIN = 4;
+const MIN_HORIZ_MARGIN = 8;
 
 export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout {
   const {


### PR DESCRIPTION
## Summary

Closes #1475 and #1476. Two visual-comfort changes from the eye-fatigue epic (#1477).

### Shadow softening (#1475)
Replaces the hard `rgba(0,0,0,0.35)` filled rectangle used as each tile's drop shadow with a `ctx.shadowBlur = 5` approach applied directly to the border rect draw. Shadow position is preserved (`shadowOffsetX/Y = sideWidth + 2`) — only the edges feather.

The existing selected-tile gold glow and hint-tile blue glow are unified into the same conditional block, so the overall structure is simpler (one shadow/glow setup → border draw → clear, instead of a separate shadow rect + a separate glow block).

### Viewport padding (#1476)
| Constant | Before | After |
|---|---|---|
| `PAD_X_R` | `6/44` (~13.6%) | `10/44` (~22.7%) |
| `PAD_Y_R` | `10/44` (~22.7%) | `14/44` (~31.8%) |
| `MIN_HORIZ_MARGIN` | `4px` | `8px` |

Tiles shrink slightly on unconstrained screens; `MIN_TILE_W = 28px` is not reached on a 390px viewport (`rawTileW ≈ 28.8px`). Layout solver handles the change automatically via `widthFactor`.

## Test plan
- [x] 2484/2484 tests pass (layout tests verify structural invariants, not pixel values)
- [ ] Visual: tile shadows have feathered edges — no hard black blocks
- [ ] Visual: board has visible margin on all sides
- [ ] Selected tile gold glow and hint tile blue glow unaffected
- [ ] No tile flush against screen edge on iPhone SE (390px)

Closes #1475, closes #1476
Part of epic #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)