### PR TITLE
feat(mahjong): dev panel — free-pairs list, free-tile overlay, state summary (#1470)

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -215,6 +215,7 @@ interface Props {
   state: MahjongState;
   camera: BoardCamera;
   hintIds?: ReadonlySet<number>;
+  debugShowFree?: boolean;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
@@ -226,6 +227,7 @@ export default function GameCanvas({
   state,
   camera,
   hintIds = EMPTY_SET,
+  debugShowFree = false,
   onTilePress,
   onShufflePress,
   onNewGamePress,
@@ -372,6 +374,17 @@ export default function GameCanvas({
                 h={faceHeight - 4}
                 opacity={isFree ? 1 : 0.35}
               />
+              {/* Debug: green tint over free tiles when dev overlay is active */}
+              {debugShowFree && isFree && (
+                <Rect
+                  x={x + 2 + liftX}
+                  y={y + 2 + liftY}
+                  width={faceWidth - 4}
+                  height={faceHeight - 4}
+                  color="#00cc44"
+                  opacity={0.3}
+                />
+              )}
             </Group>
           );
         })}

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -110,7 +110,8 @@ function drawBoard(
   matchingIds: ReadonlySet<number>,
   tileImages: readonly (HTMLImageElement | null)[],
   cam: BoardCamera,
-  feltPattern: CanvasPattern | null
+  feltPattern: CanvasPattern | null,
+  debugShowFree: boolean
 ): void {
   const { tileWidth, tileHeight, faceWidth, faceHeight, sideWidth, boardWidth, boardHeight } = cam;
 
@@ -202,6 +203,13 @@ function drawBoard(
       ctx.fillRect(x + 8 + liftX, y + 10 + liftY, faceWidth - 16, faceHeight - 20);
     }
 
+    // Debug: green tint over free tiles when dev overlay is active.
+    if (debugShowFree && isFree) {
+      ctx.globalAlpha = 0.3;
+      ctx.fillStyle = "#00cc44";
+      ctx.fillRect(x + 2 + liftX, y + 2 + liftY, faceWidth - 4, faceHeight - 4);
+    }
+
     ctx.restore();
   }
 }
@@ -214,6 +222,7 @@ interface Props {
   state: MahjongState;
   camera: BoardCamera;
   hintIds?: ReadonlySet<number>;
+  debugShowFree?: boolean;
   onTilePress: (tileId: number) => void;
   onShufflePress: () => void;
   onNewGamePress: () => void;
@@ -225,6 +234,7 @@ export default function GameCanvas({
   state,
   camera,
   hintIds = EMPTY_SET,
+  debugShowFree = false,
   onTilePress,
   onShufflePress,
   onNewGamePress,
@@ -353,9 +363,10 @@ export default function GameCanvas({
       allHintIds,
       tileImagesRef.current,
       camera,
-      feltPatternRef.current
+      feltPatternRef.current,
+      debugShowFree
     );
-  }, [state, freeTiles, allHintIds, imagesVersion, camera]);
+  }, [state, freeTiles, allHintIds, imagesVersion, camera, debugShowFree]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -8,6 +8,7 @@ import {
   createGame,
   createSeededRng,
   elapsedMs,
+  getAllFreePairs,
   getAnyFreePair,
   getMatchingFreeTileIds,
   hasFreePairs,
@@ -673,6 +674,36 @@ describe("hasFreePairs", () => {
     const c: SlotTile = { id: 2, suit: "dragons", rank: 1, faceId: 1, col: 0, row: 0, layer: 1 };
     // a is covered by c, b is free. But the pair (a,b) can't form since a is not free.
     expect(hasFreePairs([a, b, c])).toBe(false);
+  });
+});
+
+describe("getAllFreePairs", () => {
+  it("returns empty array for an empty board", () => {
+    expect(getAllFreePairs([])).toEqual([]);
+  });
+
+  it("returns one pair when exactly one match exists", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const result = getAllFreePairs([a, b]);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.map((t) => t.id).sort()).toEqual([0, 1]);
+  });
+
+  it("returns multiple pairs when several matches exist", () => {
+    // Place pairs on separate rows so none are horizontally blocked by the other pair.
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const c: SlotTile = { id: 2, suit: "circles", rank: 2, faceId: 18, col: 0, row: 2, layer: 0 };
+    const d: SlotTile = { id: 3, suit: "circles", rank: 2, faceId: 18, col: 2, row: 2, layer: 0 };
+    expect(getAllFreePairs([a, b, c, d])).toHaveLength(2);
+  });
+
+  it("excludes blocked tiles", () => {
+    const a: SlotTile = { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 };
+    const b: SlotTile = { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 };
+    const c: SlotTile = { id: 2, suit: "dragons", rank: 1, faceId: 1, col: 0, row: 0, layer: 1 };
+    expect(getAllFreePairs([a, b, c])).toHaveLength(0);
   });
 });
 

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -113,6 +113,18 @@ export function hasFreePairs(tiles: readonly SlotTile[]): boolean {
   return false;
 }
 
+/** Returns all valid free pairs. Used by the dev panel to list every available move. */
+export function getAllFreePairs(tiles: readonly SlotTile[]): [SlotTile, SlotTile][] {
+  const free = tiles.filter((t) => isFreeTile(t, tiles));
+  const pairs: [SlotTile, SlotTile][] = [];
+  for (let i = 0; i < free.length; i++) {
+    for (let j = i + 1; j < free.length; j++) {
+      if (tilesMatch(free[i]!, free[j]!)) pairs.push([free[i]!, free[j]!]);
+    }
+  }
+  return pairs;
+}
+
 /** Returns the IDs of one valid free pair, or null when none exists. Used by the hint button. */
 export function getAnyFreePair(tiles: readonly SlotTile[]): [number, number] | null {
   const free = tiles.filter((t) => isFreeTile(t, tiles));

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -113,7 +113,7 @@ export function hasFreePairs(tiles: readonly SlotTile[]): boolean {
   return false;
 }
 
-/** Returns all valid free pairs. Used by the dev panel to list every available move. */
+/** Returns all valid free pairs. */
 export function getAllFreePairs(tiles: readonly SlotTile[]): [SlotTile, SlotTile][] {
   const free = tiles.filter((t) => isFreeTile(t, tiles));
   const pairs: [SlotTile, SlotTile][] = [];

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -14,7 +14,7 @@
  *      MatchBurst / DeadlockShake / ShufflePulse / WinModal spring.
  */
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AccessibilityInfo,
   ActivityIndicator,
@@ -55,6 +55,7 @@ import type { BoardCamera } from "../game/mahjong/layout";
 import {
   createGame,
   elapsedMs,
+  getAllFreePairs,
   getAnyFreePair,
   selectTile,
   shuffleBoard,
@@ -214,6 +215,15 @@ export default function MahjongScreen() {
   const [hintIds, setHintIds] = useState<ReadonlySet<number>>(new Set());
   const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Dev panel state — __DEV__ only; toggled via Shift+D (web) or long-press score (native).
+  const [devPanelOpen, setDevPanelOpen] = useState(false);
+  const [debugShowFree, setDebugShowFree] = useState(false);
+  const freePairs = useMemo<[SlotTile, SlotTile][]>(
+    () => (__DEV__ && state ? getAllFreePairs(state.tiles) : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [state?.tiles]
+  );
+
   // Animation state
   const [flyingPairs, setFlyingPairs] = useState<FlyingPairData[]>([]);
   const [reduceMotion, setReduceMotion] = useState(false);
@@ -328,6 +338,16 @@ export default function MahjongScreen() {
   // Reduce motion preference.
   useEffect(() => {
     AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotion);
+  }, []);
+
+  // Dev panel: Shift+D keyboard shortcut on web.
+  useEffect(() => {
+    if (!__DEV__ || Platform.OS !== "web") return;
+    function onKey(e: KeyboardEvent) {
+      if (e.shiftKey && e.key === "D") setDevPanelOpen((o) => !o);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, []);
 
   // Scoreboard snapshot — updated on every state change.
@@ -604,9 +624,14 @@ export default function MahjongScreen() {
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.hudRow} accessibilityRole="summary">
-            <Text style={[styles.hudText, { color: colors.text }]}>
-              {t("hud.score")} {state.score}
-            </Text>
+            <Pressable
+              onLongPress={__DEV__ ? () => setDevPanelOpen((o) => !o) : undefined}
+              accessibilityRole="text"
+            >
+              <Text style={[styles.hudText, { color: colors.text }]}>
+                {t("hud.score")} {state.score}
+              </Text>
+            </Pressable>
             <Text style={[styles.hudText, { color: colors.textMuted }]}>
               {t("hud.pairs")} {state.pairsRemoved}/72
             </Text>
@@ -650,6 +675,16 @@ export default function MahjongScreen() {
             >
               <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
             </Pressable>
+            {__DEV__ && (
+              <Pressable
+                onPress={() => setDevPanelOpen((o) => !o)}
+                style={[styles.headerBtn, { borderColor: "rgba(255,128,0,0.8)" }]}
+                accessibilityRole="button"
+                accessibilityLabel="Toggle dev panel"
+              >
+                <Text style={[styles.headerBtnText, { color: "rgba(255,128,0,1)" }]}>DEV</Text>
+              </Pressable>
+            )}
           </View>
 
           {/* Viewport container — clips the board during zoom/pan */}
@@ -673,6 +708,7 @@ export default function MahjongScreen() {
                     state={state}
                     camera={camera}
                     hintIds={hintIds}
+                    debugShowFree={__DEV__ && debugShowFree}
                     onTilePress={handleTilePress}
                     onShufflePress={handleShuffle}
                     onNewGamePress={startNewGame}
@@ -691,6 +727,39 @@ export default function MahjongScreen() {
             </GestureDetector>
           </View>
         </ScrollView>
+      )}
+
+      {__DEV__ && devPanelOpen && state && (
+        <View style={styles.devPanel} pointerEvents="box-none">
+          <Text style={styles.devPanelTitle}>DEV — Mahjong</Text>
+          <Text style={styles.devPanelText}>tiles: {state.tiles.length} / pairs removed: {state.pairsRemoved}</Text>
+          <Text style={styles.devPanelText}>free tiles: {new Set(freePairs.flatMap(([a, b]: [SlotTile, SlotTile]) => [a.id, b.id])).size} / free pairs: {freePairs.length}</Text>
+          <Text style={styles.devPanelText}>shuffles left: {state.shufflesLeft} / score: {state.score}</Text>
+          <Text style={styles.devPanelText}>deal #{state.dealId} / undo depth: {state.undoStack.length}</Text>
+          <Pressable
+            onPress={() => setDebugShowFree((v) => !v)}
+            style={[styles.devToggleBtn, debugShowFree && styles.devToggleBtnActive]}
+          >
+            <Text style={styles.devToggleText}>
+              {debugShowFree ? "overlay: ON" : "overlay: off"}
+            </Text>
+          </Pressable>
+          {freePairs.length > 0 && (
+            <>
+              <Text style={[styles.devPanelTitle, { marginTop: 8 }]}>free pairs</Text>
+              <ScrollView style={{ maxHeight: 140 }} showsVerticalScrollIndicator={false}>
+                {freePairs.map(([a, b]: [SlotTile, SlotTile], i: number) => (
+                  <Text key={i} style={styles.devPairText}>
+                    {a.suit[0]}{a.rank} ↔ {b.suit[0]}{b.rank} (ids {a.id},{b.id})
+                  </Text>
+                ))}
+              </ScrollView>
+            </>
+          )}
+          {freePairs.length === 0 && (
+            <Text style={[styles.devPanelText, { color: "#ff6644", marginTop: 4 }]}>no free pairs</Text>
+          )}
+        </View>
       )}
 
       {state?.isComplete && (
@@ -983,5 +1052,53 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     letterSpacing: 1,
     textTransform: "uppercase",
+  },
+  devPanel: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    width: 220,
+    backgroundColor: "rgba(0,0,0,0.82)",
+    borderLeftWidth: 1,
+    borderLeftColor: "rgba(255,128,0,0.5)",
+    padding: 10,
+  },
+  devPanelTitle: {
+    color: "rgba(255,128,0,1)",
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    marginBottom: 4,
+  },
+  devPanelText: {
+    color: "#cccccc",
+    fontSize: 10,
+    lineHeight: 16,
+    fontVariant: ["tabular-nums"],
+  },
+  devPairText: {
+    color: "#aaccaa",
+    fontSize: 10,
+    lineHeight: 15,
+    fontVariant: ["tabular-nums"],
+  },
+  devToggleBtn: {
+    marginTop: 6,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: "rgba(255,128,0,0.5)",
+    alignSelf: "flex-start",
+  },
+  devToggleBtnActive: {
+    backgroundColor: "rgba(255,128,0,0.2)",
+    borderColor: "rgba(255,128,0,1)",
+  },
+  devToggleText: {
+    color: "rgba(255,128,0,1)",
+    fontSize: 10,
+    fontWeight: "700",
   },
 });

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -732,10 +732,20 @@ export default function MahjongScreen() {
       {__DEV__ && devPanelOpen && state && (
         <View style={styles.devPanel} pointerEvents="box-none">
           <Text style={styles.devPanelTitle}>DEV — Mahjong</Text>
-          <Text style={styles.devPanelText}>tiles: {state.tiles.length} / pairs removed: {state.pairsRemoved}</Text>
-          <Text style={styles.devPanelText}>free tiles: {new Set(freePairs.flatMap(([a, b]: [SlotTile, SlotTile]) => [a.id, b.id])).size} / free pairs: {freePairs.length}</Text>
-          <Text style={styles.devPanelText}>shuffles left: {state.shufflesLeft} / score: {state.score}</Text>
-          <Text style={styles.devPanelText}>deal #{state.dealId} / undo depth: {state.undoStack.length}</Text>
+          <Text style={styles.devPanelText}>
+            tiles: {state.tiles.length} / pairs removed: {state.pairsRemoved}
+          </Text>
+          <Text style={styles.devPanelText}>
+            free tiles:{" "}
+            {new Set(freePairs.flatMap(([a, b]: [SlotTile, SlotTile]) => [a.id, b.id])).size} / free
+            pairs: {freePairs.length}
+          </Text>
+          <Text style={styles.devPanelText}>
+            shuffles left: {state.shufflesLeft} / score: {state.score}
+          </Text>
+          <Text style={styles.devPanelText}>
+            deal #{state.dealId} / undo depth: {state.undoStack.length}
+          </Text>
           <Pressable
             onPress={() => setDebugShowFree((v) => !v)}
             style={[styles.devToggleBtn, debugShowFree && styles.devToggleBtnActive]}
@@ -750,14 +760,18 @@ export default function MahjongScreen() {
               <ScrollView style={{ maxHeight: 140 }} showsVerticalScrollIndicator={false}>
                 {freePairs.map(([a, b]: [SlotTile, SlotTile], i: number) => (
                   <Text key={i} style={styles.devPairText}>
-                    {a.suit[0]}{a.rank} ↔ {b.suit[0]}{b.rank} (ids {a.id},{b.id})
+                    {a.suit[0]}
+                    {a.rank} ↔ {b.suit[0]}
+                    {b.rank} (ids {a.id},{b.id})
                   </Text>
                 ))}
               </ScrollView>
             </>
           )}
           {freePairs.length === 0 && (
-            <Text style={[styles.devPanelText, { color: "#ff6644", marginTop: 4 }]}>no free pairs</Text>
+            <Text style={[styles.devPanelText, { color: "#ff6644", marginTop: 4 }]}>
+              no free pairs
+            </Text>
           )}
         </View>
       )}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -219,9 +219,9 @@ export default function MahjongScreen() {
   const [devPanelOpen, setDevPanelOpen] = useState(false);
   const [debugShowFree, setDebugShowFree] = useState(false);
   const freePairs = useMemo<[SlotTile, SlotTile][]>(
-    () => (__DEV__ && state ? getAllFreePairs(state.tiles) : []),
+    () => (__DEV__ && devPanelOpen && state ? getAllFreePairs(state.tiles) : []),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [state?.tiles]
+    [devPanelOpen, state?.tiles]
   );
 
   // Animation state
@@ -624,14 +624,17 @@ export default function MahjongScreen() {
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.hudRow} accessibilityRole="summary">
-            <Pressable
-              onLongPress={__DEV__ ? () => setDevPanelOpen((o) => !o) : undefined}
-              accessibilityRole="text"
-            >
+            {__DEV__ ? (
+              <Pressable onLongPress={() => setDevPanelOpen((o) => !o)} accessibilityRole="none">
+                <Text style={[styles.hudText, { color: colors.text }]}>
+                  {t("hud.score")} {state.score}
+                </Text>
+              </Pressable>
+            ) : (
               <Text style={[styles.hudText, { color: colors.text }]}>
                 {t("hud.score")} {state.score}
               </Text>
-            </Pressable>
+            )}
             <Text style={[styles.hudText, { color: colors.textMuted }]}>
               {t("hud.pairs")} {state.pairsRemoved}/72
             </Text>


### PR DESCRIPTION
## Summary

- **engine**: adds `getAllFreePairs(tiles)` — returns every valid `[SlotTile, SlotTile]` pair; fixes a buggy test that used col-adjacent positions (tiles at col 2 and 4 were mutually blocked)
- **GameCanvas (web + native)**: new optional `debugShowFree?: boolean` prop; when true, draws a 30%-opacity green tint over every free tile face
- **MahjongScreen**: `__DEV__`-gated floating panel (orange accent, right-edge, follows StarSwarm pattern) with:
  - State summary: tiles remaining, free-tile count, free-pair count, shuffles left, score, deal ID, undo depth
  - Live free-pairs list (suit initial + rank + IDs for each pair)
  - "overlay: ON/off" toggle that wires `debugShowFree` into `GameCanvas`
  - Three triggers: **DEV** button in HUD, **Shift+D** on web, **long-press score** on native

## Test plan

- [ ] Run `npx jest --testPathPattern="mahjong" --no-coverage` — 148 tests pass
- [ ] Open Expo web dev build; verify DEV button appears in HUD
- [ ] Click DEV button → panel slides in on the right, shows correct counts
- [ ] Press Shift+D → panel toggles
- [ ] Toggle overlay → free tiles get green tint on canvas
- [ ] Make a match → pair count decrements live in panel
- [ ] Free pairs list scrolls when many pairs available
- [ ] Panel absent in production build (`__DEV__ === false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)