### PR TITLE
fix(mahjong): restore drop shadow on selected and hint tiles (#1487)

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -158,8 +158,10 @@ function drawBoard(
     ctx.fillStyle = SIDE_B;
     ctx.fillRect(x + sideWidth + liftX, y + faceHeight + liftY, faceWidth, sideWidth);
 
-    // Shadow/glow on the border rect: selected → gold glow, hint → blue glow,
-    // normal → soft feathered drop shadow (replaces the old hard-rect shadow).
+    // Shadow/glow on the border rect: selected → gold glow + drop shadow,
+    // hint → blue glow + drop shadow, normal → soft feathered drop shadow.
+    ctx.shadowOffsetX = sideWidth + 2;
+    ctx.shadowOffsetY = sideWidth + 2;
     if (isSelected) {
       ctx.shadowColor = MAHJONG_GLOW_SHADOW;
       ctx.shadowBlur = 10;
@@ -169,8 +171,6 @@ function drawBoard(
     } else {
       ctx.shadowColor = "rgba(0,0,0,0.35)";
       ctx.shadowBlur = 5;
-      ctx.shadowOffsetX = sideWidth + 2;
-      ctx.shadowOffsetY = sideWidth + 2;
     }
 
     // Border


### PR DESCRIPTION
## Summary

- PR #1485 hoisted shadow rendering into a conditional block but only set `shadowOffsetX/Y` in the normal (`else`) branch — selected and hint tiles lost their positional drop shadow
- Fix: hoist `shadowOffsetX/Y` before the `if/else if/else` so all three branches inherit the same offset; only `shadowColor` and `shadowBlur` vary per branch

## Change

```diff
-    if (isSelected) {
-      ctx.shadowColor = MAHJONG_GLOW_SHADOW;
-      ctx.shadowBlur = 10;
-    } else if (isHint) {
-      ctx.shadowColor = MAHJONG_HINT_GLOW_SHADOW;
-      ctx.shadowBlur = 8;
-    } else {
-      ctx.shadowColor = "rgba(0,0,0,0.35)";
-      ctx.shadowBlur = 5;
-      ctx.shadowOffsetX = sideWidth + 2;
-      ctx.shadowOffsetY = sideWidth + 2;
-    }
+    ctx.shadowOffsetX = sideWidth + 2;
+    ctx.shadowOffsetY = sideWidth + 2;
+    if (isSelected) {
+      ctx.shadowColor = MAHJONG_GLOW_SHADOW;
+      ctx.shadowBlur = 10;
+    } else if (isHint) {
+      ctx.shadowColor = MAHJONG_HINT_GLOW_SHADOW;
+      ctx.shadowBlur = 8;
+    } else {
+      ctx.shadowColor = "rgba(0,0,0,0.35)";
+      ctx.shadowBlur = 5;
+    }
```

## Test plan

- [ ] 148 mahjong tests pass
- [ ] In browser: select a tile → gold glow + visible drop shadow
- [ ] In browser: press HINT → blue glow + visible drop shadow on highlighted pair
- [ ] Normal tiles still have soft feathered drop shadow

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)