### PR TITLE
Blackjack: remove dealer rule label; fix sub-minimum bet limbo

### DIFF
--- a/frontend/src/components/blackjack/BettingPanel.tsx
+++ b/frontend/src/components/blackjack/BettingPanel.tsx
@@ -35,6 +35,8 @@ export default function BettingPanel({
   const { t } = useTranslation("blackjack");
   const { colors } = useTheme();
   const maxBet = Math.min(betMax, chips);
+  const effectiveMin = Math.min(betMin, chips);
+  const effectiveDenominations = chips < betMin ? [chips] : chipDenominations;
   const [bet, setBet] = useState<number>(0);
   const [rulesOpen, setRulesOpen] = useState(false);
 
@@ -46,7 +48,7 @@ export default function BettingPanel({
     setBet(0);
   }
 
-  const canDeal = bet >= betMin && bet <= maxBet && !loading;
+  const canDeal = bet >= effectiveMin && bet <= maxBet && !loading;
   const resolvedAccent = accentColor ?? colors.accent;
 
   const chipColors = [colors.accent, colors.secondary, colors.tertiary, colors.secondary] as const;
@@ -64,7 +66,7 @@ export default function BettingPanel({
 
       {/* Chip denomination row */}
       <View style={styles.chipRow}>
-        {chipDenominations.map((denom, i) => (
+        {effectiveDenominations.map((denom, i) => (
           <ChipButton
             key={denom}
             amount={denom}

--- a/frontend/src/game/blackjack/engine.ts
+++ b/frontend/src/game/blackjack/engine.ts
@@ -434,8 +434,9 @@ function settleWith(s: EngineState, outcome: "blackjack" | "win" | "lose" | "pus
 
 export function placeBet(s: EngineState, amount: number): EngineState {
   if (s.phase !== "betting") throw new Error("Not in betting phase.");
-  if (amount < s.betMin || amount > s.betMax) {
-    throw new Error(`Bet must be between ${s.betMin} and ${s.betMax}.`);
+  const effectiveMin = s.chips < s.betMin ? s.chips : s.betMin;
+  if (amount < effectiveMin || amount > s.betMax) {
+    throw new Error(`Bet must be between ${effectiveMin} and ${s.betMax}.`);
   }
   if (amount > s.chips) throw new Error("Insufficient chips.");
 

--- a/frontend/src/screens/BlackjackBettingScreen.tsx
+++ b/frontend/src/screens/BlackjackBettingScreen.tsx
@@ -118,13 +118,6 @@ export default function BlackjackBettingScreen({ navigation }: Props) {
               handOutcomes={state.hand_outcomes}
             />
           </View>
-          <Text style={[styles.dealerRule, { color: colors.textMuted }]}>
-            {t(
-              `blackjack:rules.${state.rules.hit_soft_17 ? "h17Label" : "s17Label"}` as Parameters<
-                typeof t
-              >[0]
-            )}
-          </Text>
         </View>
       )}
 
@@ -195,12 +188,6 @@ const styles = StyleSheet.create({
     opacity: 0.4,
     width: "100%",
     alignItems: "center",
-  },
-  dealerRule: {
-    fontSize: 12,
-    textTransform: "uppercase",
-    letterSpacing: 0.8,
-    fontWeight: "500",
   },
   controls: {
     alignItems: "center",


### PR DESCRIPTION
Closes #1493

## Summary

- Removes the static "DEALER STANDS ON SOFT 17" text from the betting screen — the collapsible TABLE RULES section in `BettingPanel` already covers this
- Fixes the limbo state when `chips < betMin`: effective minimum is lowered to the player's remaining chips, a single all-in chip button is shown, and `placeBet` in the engine accepts the bet

## Test plan

- [ ] Verify "DEALER STANDS ON SOFT 17" no longer appears on the betting screen; TABLE RULES toggle still works
- [ ] Start a Beginner run, lose chips down to below 5 — confirm a single chip button appears showing remaining balance and Deal becomes enabled
- [ ] Confirm normal chip denominations still appear when chips ≥ betMin

https://claude.ai/code/session_01GdDdWtmrZSRX3zRrFBjYtF

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdDdWtmrZSRX3zRrFBjYtF)_