### PR TITLE
fix(starswarm): eliminate corner dead-zone that made ship feel stuck

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -5,7 +5,7 @@ import * as Haptics from "expo-haptics";
 import { useTranslation } from "react-i18next";
 import type { GameCanvasHandle } from "./GameCanvas";
 import type { GamePhase } from "../../game/starswarm/types";
-import { CANVAS_W, CANVAS_H } from "../../game/starswarm/engine";
+import { CANVAS_W, CANVAS_H, PLAYER_W } from "../../game/starswarm/engine";
 
 const DRAG_ZONE_Y_RATIO = 0.6; // bottom 40% is the drag zone
 
@@ -68,7 +68,9 @@ export default function Controls({
     .onChange((e) => {
       if (!activeDragRef.current) return;
       // newX = shipX_at_touch_start + (currentTouchX - touchStartX)
-      const newX = clamp(shipXAtDragStartRef.current + e.translationX / scale, 0, CANVAS_W);
+      // Clamp to engine's half-width margins so playerXRef never diverges from the rendered position.
+      const hw = PLAYER_W / 2;
+      const newX = clamp(shipXAtDragStartRef.current + e.translationX / scale, hw, CANVAS_W - hw);
       playerXRef.current = newX;
       canvasRef.current?.setPlayerX(newX);
     })
@@ -94,7 +96,8 @@ export default function Controls({
       if (held.size > 0) {
         const dx = (held.has("ArrowRight") ? STEP : 0) - (held.has("ArrowLeft") ? STEP : 0);
         if (dx !== 0) {
-          playerXRef.current = clamp(playerXRef.current + dx, 0, CANVAS_W);
+          const hw = PLAYER_W / 2;
+          playerXRef.current = clamp(playerXRef.current + dx, hw, CANVAS_W - hw);
           canvasRef.current?.setPlayerX(playerXRef.current);
         }
       }

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -25,6 +25,7 @@ import {
   difficultyLabel,
   BOSS_BULLET_VY,
   BULLET_E_VY,
+  PLAYER_W,
 } from "../engine";
 import type { Bullet, DifficultyTier, StarSwarmInput, StarSwarmState } from "../types";
 
@@ -91,6 +92,48 @@ describe("initStarSwarm", () => {
   it("player starts near bottom of canvas", () => {
     const s = initStarSwarm(CANVAS_W, CANVAS_H);
     expect(s.player.y).toBeGreaterThan(CANVAS_H * 0.8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Player boundary clamping — regression for corner-stuck bug
+// Controls.tsx previously clamped playerXRef to [0, CANVAS_W] while the engine
+// clamps to [PLAYER_W/2, CANVAS_W - PLAYER_W/2], creating a dead zone at edges.
+// ---------------------------------------------------------------------------
+
+describe("player boundary clamping", () => {
+  const hw = PLAYER_W / 2; // 17
+
+  it("clamps player to right edge (CANVAS_W - hw) when input exceeds canvas width", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    const next = tick(s, 16, { playerX: CANVAS_W, fire: false });
+    expect(next.player.x).toBe(CANVAS_W - hw);
+  });
+
+  it("clamps player to left edge (hw) when input is 0", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    const next = tick(s, 16, { playerX: 0, fire: false });
+    expect(next.player.x).toBe(hw);
+  });
+
+  it("does not over-clamp when input is exactly at the right boundary", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    const next = tick(s, 16, { playerX: CANVAS_W - hw, fire: false });
+    expect(next.player.x).toBe(CANVAS_W - hw);
+  });
+
+  it("does not over-clamp when input is exactly at the left boundary", () => {
+    const s = initStarSwarm(CANVAS_W, CANVAS_H);
+    const next = tick(s, 16, { playerX: hw, fire: false });
+    expect(next.player.x).toBe(hw);
+  });
+
+  it("consecutive right-edge inputs do not push ship beyond CANVAS_W - hw", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H);
+    for (let i = 0; i < 5; i++) {
+      s = tick(s, 16, { playerX: CANVAS_W, fire: false });
+    }
+    expect(s.player.x).toBe(CANVAS_W - hw);
   });
 });
 

--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -21,7 +21,7 @@ import type {
 export const CANVAS_W = 360;
 export const CANVAS_H = 640;
 
-const PLAYER_W = 34;
+export const PLAYER_W = 34;
 const PLAYER_H = 34;
 const PLAYER_Y_FROM_BOTTOM = 72;
 const PLAYER_SHOOT_COOLDOWN = 280; // ms


### PR DESCRIPTION
Closes #1504

## Summary

- `Controls.tsx` clamped `playerXRef` to `[0, 360]`; the engine clamps `player.x` to `[17, 343]`. The 17px gap at each edge created a drag dead-zone where the ship appeared frozen in the corner.
- Export `PLAYER_W` from `engine.ts` and align both clamp sites in `Controls.tsx` (drag gesture + keyboard loop) to `[PLAYER_W/2, CANVAS_W - PLAYER_W/2]`.
- Five regression tests added under `"player boundary clamping"` in `engine.test.ts`.

## Test plan

- [ ] Drag ship hard into the right corner and immediately drag left — ship should respond immediately with no dead-zone
- [ ] Same test at the left corner
- [ ] Arrow-key: hold right until ship hits edge, then press left — ship should move on the first frame
- [ ] Run `./node_modules/.bin/jest --testPathPattern="engine.test" --no-coverage` — all 920 tests pass