### PR TITLE
fix(hearts): prevent AI loop freeze when human taps card during trick animation (#1505)

### DIFF
--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -301,6 +301,11 @@ export default function HeartsScreen() {
   function handleCardPress(card: Card) {
     if (!gameState || gameState.currentPlayerIndex !== HUMAN || gameState.phase !== "playing")
       return;
+    // Don't accept input while the completed-trick animation is still playing.
+    // If the human taps during this window and clears lastTrick, the AI loop's
+    // pending animation-resolver promise would never be fulfilled, leaving
+    // loopActiveRef.current === true and freezing all subsequent AI turns.
+    if (lastTrick !== null) return;
     ensureSyncStarted();
     if (isQueenOfSpades(card)) {
       humanJustPlayedQSRef.current = true;

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -6,6 +6,7 @@ import { HeartsRoundsProvider } from "../../game/hearts/RoundsContext";
 import { createSeededRng, setRng } from "../../game/hearts/engine";
 import * as engine from "../../game/hearts/engine";
 import { loadGame } from "../../game/hearts/storage";
+import type { HeartsState } from "../../game/hearts/types";
 
 jest.mock("../../game/hearts/storage", () => ({
   loadGame: jest.fn().mockResolvedValue(null),
@@ -196,5 +197,87 @@ describe("HeartsScreen — playing phase (no modal)", () => {
     expect(queryByText("25")).toBeNull();
     expect(queryByText("41")).toBeNull();
     expect(queryByText("17")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: AI loop frozen when human taps card during trick animation
+// ---------------------------------------------------------------------------
+//
+// Root cause: the AI loop awaits a Promise (trickAnimResolverRef.current) while
+// showing the completed-trick animation. If the human tapped a card BEFORE the
+// animation fired handleTrickAnimationComplete, handleCardPress would call
+// setLastTrick(null) — clearing the animation — WITHOUT ever resolving the
+// Promise. This left loopActiveRef.current === true permanently, freezing all
+// subsequent AI turns.
+//
+// Fix: handleCardPress now returns early when lastTrick !== null, so the human
+// cannot interact with the hand while the animation is in progress. Once the
+// animation completes normally (handleTrickAnimationComplete → resolver →
+// setLastTrick(null)), the human can play and the AI loop is free.
+describe("HeartsScreen — AI loop frozen regression (race condition)", () => {
+  // State: trick 13 is in progress — the human has already played the leading
+  // card (♥5), and AI 1/2/3 each have one card left to follow.
+  // currentPlayerIndex === 1 (AI 1's turn), so the AI loop should run 3 turns
+  // and complete the hand (tricksPlayedInHand → 13 → phase "dealing").
+  function makeFinalTrickInProgressState(): HeartsState {
+    return {
+      _v: 3,
+      aiDifficulty: "medium",
+      phase: "playing",
+      handNumber: 1,
+      passDirection: "none",
+      cumulativeScores: [0, 0, 0, 0],
+      handScores: [0, 0, 0, 0],
+      scoreHistory: [],
+      passSelections: [[], [], [], []],
+      passingComplete: true,
+      heartsBroken: true,
+      isComplete: false,
+      winnerIndex: null,
+      events: [],
+      tricksPlayedInHand: 12, // 12 complete, trick 13 started
+      currentLeaderIndex: 0,
+      currentPlayerIndex: 1, // AI 1 to play
+      currentTrick: [
+        { card: { suit: "hearts", rank: 5 }, playerIndex: 0 }, // human led ♥5
+      ],
+      playerHands: [
+        [],                                          // human has no cards left
+        [{ suit: "diamonds", rank: 7 }],             // AI 1
+        [{ suit: "diamonds", rank: 8 }],             // AI 2
+        [{ suit: "diamonds", rank: 9 }],             // AI 3
+      ],
+      wonCards: [[], [], [], []],
+    };
+  }
+
+  beforeEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(makeFinalTrickInProgressState());
+  });
+
+  afterEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(null);
+  });
+
+  it("AI completes the final trick and the hand-end overlay appears", async () => {
+    const { getByText } = renderScreen();
+
+    // Wait for the saved game to load.
+    await waitFor(() => expect(loadGame).toHaveBeenCalled());
+
+    // Advance timers past all 3 AI delays (3 × 400 ms) plus a buffer.
+    // Before the fix, if the game reached this state after the human had tapped
+    // a card mid-animation, loopActiveRef would be stuck true and no AI turn
+    // would ever run — the game would freeze indefinitely here.
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // AI 1/2/3 each void in hearts → each plays their diamond freely.
+    // Human wins the trick (only ♥5 in the led suit).
+    // tricksPlayedInHand reaches 13 → applyHandScoring → phase "dealing"
+    // → "Hand Complete" modal rendered.
+    await waitFor(() => expect(getByText("Hand Complete")).toBeTruthy());
   });
 });

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -243,10 +243,10 @@ describe("HeartsScreen — AI loop frozen regression (race condition)", () => {
         { card: { suit: "hearts", rank: 5 }, playerIndex: 0 }, // human led ♥5
       ],
       playerHands: [
-        [],                                          // human has no cards left
-        [{ suit: "diamonds", rank: 7 }],             // AI 1
-        [{ suit: "diamonds", rank: 8 }],             // AI 2
-        [{ suit: "diamonds", rank: 9 }],             // AI 3
+        [], // human has no cards left
+        [{ suit: "diamonds", rank: 7 }], // AI 1
+        [{ suit: "diamonds", rank: 8 }], // AI 2
+        [{ suit: "diamonds", rank: 9 }], // AI 3
       ],
       wonCards: [[], [], [], []],
     };


### PR DESCRIPTION
Closes #1505

handleCardPress now returns early when `lastTrick !== null` (trick-taken animation in progress). Previously the human could tap before the animation fired `handleTrickAnimationComplete`, which called `setLastTrick(null)` without resolving the AI loop's pending Promise — leaving `loopActiveRef.current` true forever and freezing all subsequent CPU turns.

Adds a regression test: loads trick-13-in-progress state (human led, 3 AIs to follow), advances fake timers, asserts the "Hand Complete" modal appears.

https://claude.ai/code/session_01D5HqXmBnb279WP7WW4FMTS