### PR TITLE
fix(hearts-ai): shed Q♠ before K♠ when both lose the trick in chooseFollow (#1510)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -843,6 +843,48 @@ describe("chooseFollow — highest losing card (#1500)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Regression: #1510 — chooseFollow sheds Q♠ before K♠ when A♠ is played
+// ---------------------------------------------------------------------------
+describe("chooseFollow — Q♠ priority over K♠ when both lose (#1510)", () => {
+  it("sheds Q♠ before K♠ when A♠ leads and both would lose (pts > 0)", () => {
+    // A♠ leads with Q♥ already in the trick (points > 0).
+    // Player holds K♠ + Q♠ — both lose to A♠. Q♠ must be shed first.
+    const hand = [c("spades", 13), c("spades", 12)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 1), playerIndex: 0 }, // A♠ leads (ace-high wins)
+      { card: c("hearts", 12), playerIndex: 2 }, // Q♥ discarded — trick has points
+    ];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      currentPlayerIndex: 1,
+      heartsBroken: true,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    expect(pick).toEqual(c("spades", 12)); // Q♠ not K♠
+  });
+
+  it("sheds Q♠ before K♠ when A♠ leads in a 0-pt trick (no-points branch)", () => {
+    // A♠ leads, no points in trick yet, player not last to play.
+    // Player holds K♠ + Q♠ — both lose to A♠. Q♠ must still be shed first.
+    const hand = [c("spades", 13), c("spades", 12)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 1), playerIndex: 0 }, // A♠ leads
+    ];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      currentPlayerIndex: 1,
+    });
+    // Player 1 follows; players 2 and 3 still to play → not last
+    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    expect(pick).toEqual(c("spades", 12)); // Q♠ not K♠
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Regression: #1501 — medium AI avoids leading K♠/A♠ when Q♠ still live
 // ---------------------------------------------------------------------------
 describe("chooseLead — medium AI avoids risky spade leads (#1501)", () => {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -586,7 +586,9 @@ function chooseFollow(valid: Card[], trick: readonly TrickCard[], isMoonAttempt 
   if (pts > 0) {
     // Trick has points — try to lose
     if (losing.length > 0) {
-      // Play highest card that still loses
+      // Shed Q♠ before K♠: Q♠ is more dangerous even though K♠ has higher rank
+      const qSpade = losing.find(isQueenOfSpades);
+      if (qSpade) return qSpade;
       return highest(losing) ?? valid[0]!;
     }
     // Must win — play lowest to minimize damage
@@ -594,7 +596,11 @@ function chooseFollow(valid: Card[], trick: readonly TrickCard[], isMoonAttempt 
   }
 
   // No points, not last — exhaust highest card that still loses (unless moon-attempt must keep Q♠)
-  if (!isMoonAttempt && losing.length > 0) return highest(losing) ?? valid[0]!;
+  if (!isMoonAttempt && losing.length > 0) {
+    const qSpade = losing.find(isQueenOfSpades);
+    if (qSpade) return qSpade;
+    return highest(losing) ?? valid[0]!;
+  }
   return lowest(inSuit) ?? valid[0]!;
 }
 


### PR DESCRIPTION
## Summary

- `chooseFollow()` used `highest(losing)` which sorted purely by rank, causing K♠ (rank 13) to be played before Q♠ (rank 12) when both lose the trick
- When A♠ leads, both K♠ and Q♠ are "losing" — but Q♠ carries the 13-point penalty and must be shed first
- Fix adds the same Q♠-priority check already present in `chooseDiscard()` to the two `highest(losing)` call sites in `chooseFollow()` (the `pts > 0` branch and the no-points/not-last branch)

## Test plan

- [ ] 46/46 Hearts AI unit tests pass (`npx jest src/game/hearts/__tests__/ai.test.ts`)
- [ ] Two new regression tests added under `chooseFollow — Q♠ priority over K♠ when both lose (#1510)`:
  - Confirms Q♠ shed over K♠ when A♠ leads and trick has points
  - Confirms Q♠ shed over K♠ when A♠ leads and trick has no points (no-points branch)

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)