### PR TITLE
fix(hearts): exclude Ace of Clubs from low-club pass guard in AI

### DIFF
--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -83,7 +83,7 @@ function passSafeFilter(selected: Card[]): (c: Card) => boolean {
   return (c: Card) => {
     if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) return false;
     if (c.suit === "clubs" && c.rank === 2) return false;
-    if (c.suit === "clubs" && c.rank < 6) return false;
+    if (c.suit === "clubs" && c.rank > 1 && c.rank < 6) return false;
     return true;
   };
 }


### PR DESCRIPTION
Closes #1522

## Summary

- `passSafeFilter` in `ai.ts` used `c.rank < 6` to block AI from passing low clubs (2♣–5♣), but the Ace is stored as `rank === 1`, so `1 < 6` caught it too — the AI could never pass the Ace of Clubs
- Fix: change to `c.rank > 1 && c.rank < 6` so only ranks 2–5 are blocked, matching the stated intent "clubs below 6"

## Test plan

- [ ] Play a Hearts game and observe the Ace of Clubs appearing in the passing exchange in some hands
- [ ] Verify AI still never passes 2♣, 3♣, 4♣, or 5♣
- [ ] Verify no regression in existing Hearts engine and AI test suites

https://claude.ai/code/session_017MKw8jpucgf7NykzsNKuVT

---
_Generated by [Claude Code](https://claude.ai/code/session_017MKw8jpucgf7NykzsNKuVT)_