### PR TITLE
fix(hearts-analysis): correct stale Chart.js SRI hash blocking dashboard load

### DIFF
--- a/hearts-analysis/static/index.html
+++ b/hearts-analysis/static/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hearts Analysis Dashboard</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-hG6tLc9q8bFM5OQASDTJTJJg/wn8PP0PcayE3I2H1972/F7ktiSvWutAuQIkt4QUTIhiaFEnkrKea7XHUv1ugg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }


### PR DESCRIPTION
## Summary

- The `integrity` attribute for Chart.js 4.4.1 on cdnjs was stale, causing the browser to block the script with an SRI mismatch error
- This left `Chart` undefined and broke the entire dashboard (`Uncaught ReferenceError: Chart is not defined`)
- Updated the hash to match what cdnjs currently serves

## Test plan

- [ ] Open `http://localhost:8803` (or your local port) after pulling — no SRI error in console
- [ ] Charts render correctly after running a simulation

🤖 Generated with [Claude Code](https://claude.ai/code)