### PR TITLE
fix(mahjong): add pan gesture threshold to unblock shuffle/overlay buttons

### DIFF
--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -369,6 +369,11 @@ export default function MahjongScreen() {
   const panGesture = Gesture.Pan()
     .minPointers(1)
     .maxPointers(1)
+    // Only activate after an intentional drag so simple taps on overlay buttons
+    // (CTA shuffle, deadlock new-game, win new-game) are not intercepted by the
+    // gesture recognizer before Pressable.onPress can fire.
+    .activeOffsetX([-8, 8])
+    .activeOffsetY([-8, 8])
     .onUpdate((e) => {
       translateX.value = baseTranslateX.value + e.translationX;
       translateY.value = baseTranslateY.value + e.translationY;


### PR DESCRIPTION
## Summary

- Adds `.activeOffsetX([-8, 8]).activeOffsetY([-8, 8])` to `panGesture` in `MahjongScreen.tsx`

Fixes #1528

The 1-finger pan gesture introduced in #1495 had no activation threshold, so RNGH entered its "began" state on every pointer-down — including simple taps. This raced with `Pressable.onPress` for buttons rendered inside the `GestureDetector` (shuffle CTA, deadlock new-game, win new-game overlays), preventing `onPress` from firing reliably.

The 8 px offset means the gesture only activates after an intentional drag, so taps fall through to `Pressable` cleanly. Board pan and pinch-to-zoom are unaffected.

## Test plan

- [ ] Start a Mahjong game; verify the HUD `SHUFFLE N` button decrements the counter and rearranges tiles
- [ ] Play until no free pairs remain; verify the "No Moves / Shuffle (N)" CTA overlay appears and its button shuffles the board
- [ ] Verify single-finger board panning still works
- [ ] Verify pinch-to-zoom still works
- [ ] Verify the win and deadlock overlay "New Game" buttons still work

https://claude.ai/code/session_01S6u9VbQVkdLoq7M3XPLSne

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6u9VbQVkdLoq7M3XPLSne)_