### PR TITLE
fix(space-swarm): add Resume button and shrink New Game on pause screen

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -233,6 +233,8 @@ const styles = StyleSheet.create({
   pauseNewGameBtnText: {
     color: "rgba(255,255,255,0.55)",
     fontSize: 12,
+    fontWeight: "normal",
+    letterSpacing: 0,
   },
   gameOverActions: {
     position: "absolute",

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -153,7 +153,9 @@ export default function Controls({
               accessibilityLabel={t("controls.newGameFromPauseLabel")}
               accessibilityRole="button"
             >
-              <Text style={[styles.newGameBtnText, styles.pauseNewGameBtnText]}>{t("controls.newGameFromPause")}</Text>
+              <Text style={[styles.newGameBtnText, styles.pauseNewGameBtnText]}>
+                {t("controls.newGameFromPause")}
+              </Text>
             </Pressable>
           </View>
         )}

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -145,7 +145,7 @@ export default function Controls({
               accessibilityLabel={t("controls.resumeLabel")}
               accessibilityRole="button"
             >
-              <Text style={styles.pauseHint}>{t("controls.tapToResume")}</Text>
+              <Text style={styles.pauseResumeBtnText}>{t("controls.resume")}</Text>
             </Pressable>
             <Pressable
               style={[styles.newGameBtn, styles.pauseNewGameBtn]}
@@ -153,7 +153,7 @@ export default function Controls({
               accessibilityLabel={t("controls.newGameFromPauseLabel")}
               accessibilityRole="button"
             >
-              <Text style={styles.newGameBtnText}>{t("controls.newGameFromPause")}</Text>
+              <Text style={[styles.newGameBtnText, styles.pauseNewGameBtnText]}>{t("controls.newGameFromPause")}</Text>
             </Pressable>
           </View>
         )}
@@ -210,16 +210,29 @@ const styles = StyleSheet.create({
     letterSpacing: 3,
   },
   pauseResumeBtn: {
-    marginTop: 12,
-    paddingVertical: 8,
-    paddingHorizontal: 24,
+    marginTop: 16,
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 8,
+    backgroundColor: "#00ffcc",
   },
-  pauseHint: {
-    color: "rgba(255,255,255,0.6)",
-    fontSize: 13,
+  pauseResumeBtnText: {
+    color: "#000010",
+    fontWeight: "bold",
+    fontSize: 16,
+    letterSpacing: 1,
   },
   pauseNewGameBtn: {
-    marginTop: 24,
+    marginTop: 20,
+    backgroundColor: "transparent",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.35)",
+    paddingHorizontal: 18,
+    paddingVertical: 7,
+  },
+  pauseNewGameBtnText: {
+    color: "rgba(255,255,255,0.55)",
+    fontSize: 12,
   },
   gameOverActions: {
     position: "absolute",

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -13,7 +13,6 @@
   "score.display": "Score: {{score}}",
   "controls.chargeShotLabel": "Charge shot — hold and release to fire",
   "controls.paused": "PAUSED",
-  "controls.tapToResume": "Tap to resume",
   "controls.resume": "RESUME",
   "controls.pauseLabel": "Pause game",
   "controls.resumeLabel": "Resume game",

--- a/frontend/src/i18n/locales/en/starswarm.json
+++ b/frontend/src/i18n/locales/en/starswarm.json
@@ -14,6 +14,7 @@
   "controls.chargeShotLabel": "Charge shot — hold and release to fire",
   "controls.paused": "PAUSED",
   "controls.tapToResume": "Tap to resume",
+  "controls.resume": "RESUME",
   "controls.pauseLabel": "Pause game",
   "controls.resumeLabel": "Resume game",
   "controls.newGame": "NEW GAME",


### PR DESCRIPTION
Closes #1530

## Summary

- **RESUME button**: replaces the dim "Tap to resume" hint text with a full cyan button (same size/shape as the game-over NEW GAME button) — the primary action is now visually obvious
- **NEW GAME shrunk**: reduced padding (`18×7` vs `32×14`), smaller font (12px vs 16px), outline style (transparent bg + faint border + muted text) so it reads clearly as a secondary/destructive action
- Tap-anywhere-to-resume invisible overlay is preserved

## Test plan

- [ ] Pause mid-game — RESUME button is prominent (cyan, same size as game-over NEW GAME)
- [ ] Tap RESUME → game unpauses
- [ ] Tap anywhere else on overlay → game unpauses
- [ ] NEW GAME is visibly smaller and outlined — harder to fat-finger
- [ ] Tap NEW GAME → difficulty picker appears as before
- [ ] Game-over NEW GAME button is unchanged (full cyan, full size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)