### PR TITLE
chore: wire check-build-env.js into Render build for prod and staging

### DIFF
--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -83,6 +83,22 @@ describe("httpClient — BASE_URL configuration", () => {
     }
   });
 
+  it("does not throw and suppresses Sentry when EXPO_PUBLIC_TEST_HOOKS=1 and localhost URL", () => {
+    process.env.EXPO_PUBLIC_API_URL = "http://localhost:8000";
+    process.env.EXPO_PUBLIC_TEST_HOOKS = "1";
+    const g = globalThis as { __DEV__?: boolean };
+    const originalDev = g.__DEV__;
+    g.__DEV__ = false;
+    try {
+      expect(() => loadClient()).not.toThrow();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require("@sentry/react-native");
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    } finally {
+      g.__DEV__ = originalDev;
+    }
+  });
+
   it("throws at module load when EXPO_PUBLIC_API_URL is not set in a non-dev build (#511)", () => {
     delete process.env.EXPO_PUBLIC_API_URL;
     const g = globalThis as { __DEV__?: boolean };
@@ -297,6 +313,25 @@ describe("httpClient — Sentry reporting (#513)", () => {
     // __DEV__ is true in the test environment — network failures are
     // suppressed to avoid flooding Sentry with dev-mode localhost noise.
     expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("network failure skips captureMessage in test builds (EXPO_PUBLIC_TEST_HOOKS=1)", async () => {
+    process.env.EXPO_PUBLIC_API_URL = "http://localhost:8000";
+    process.env.EXPO_PUBLIC_TEST_HOOKS = "1";
+    const g = globalThis as { __DEV__?: boolean };
+    const originalDev = g.__DEV__;
+    g.__DEV__ = false;
+    try {
+      mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+      const request = makeRequest();
+      await expect(request("/x")).rejects.toThrow("Failed to fetch");
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    } finally {
+      g.__DEV__ = originalDev;
+      delete process.env.EXPO_PUBLIC_TEST_HOOKS;
+      delete process.env.EXPO_PUBLIC_API_URL;
+    }
   });
 
   it("genuine unexpected JS error (non-Api, non-Type) is captured as an exception with stack", async () => {

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -58,15 +58,15 @@ function resolveBaseUrl(): string {
   if (raw) {
     const resolved = raw.startsWith("http") ? raw : `https://${raw}`;
     if (!__DEV__ && isLocalhost(resolved)) {
-      const msg = isTestBuild
-        ? "EXPO_PUBLIC_TEST_HOOKS=1 is set and EXPO_PUBLIC_API_URL resolves to localhost. " +
-          "If this is a production or staging build, remove EXPO_PUBLIC_TEST_HOOKS from the Render service env vars."
-        : "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build. " +
+      if (isTestBuild) {
+        // Expected in E2E test environments — localhost backend is intentional.
+        // Sentry reporting suppressed; console.warn is enough for local debugging.
+        console.warn("[httpClient] localhost API URL in test build:", resolved);
+      } else {
+        const msg =
+          "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build. " +
           "This means the env var was set to a local address at bundle time. " +
           "Set EXPO_PUBLIC_API_URL to the production API URL on the Render service.";
-      if (isTestBuild) {
-        console.warn("[httpClient]", msg);
-      } else {
         Sentry.captureMessage(msg, {
           level: "fatal",
           tags: { subsystem: "httpClient", issue: "localhost-in-prod" },

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -40,6 +40,10 @@ export class ApiError extends Error {
  * a clear message instead of pretending to work and then breaking on every
  * score submit.
  */
+// Baked in at export time — true only in E2E test builds. Used to suppress
+// Sentry noise from intentional localhost API usage during tests.
+const isTestBuild = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
+
 function isLocalhost(url: string): boolean {
   try {
     const { hostname } = new URL(url);
@@ -53,7 +57,6 @@ function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
   if (raw) {
     const resolved = raw.startsWith("http") ? raw : `https://${raw}`;
-    const isTestBuild = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
     if (!__DEV__ && isLocalhost(resolved)) {
       const msg = isTestBuild
         ? "EXPO_PUBLIC_TEST_HOOKS=1 is set and EXPO_PUBLIC_API_URL resolves to localhost. " +
@@ -61,15 +64,14 @@ function resolveBaseUrl(): string {
         : "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build. " +
           "This means the env var was set to a local address at bundle time. " +
           "Set EXPO_PUBLIC_API_URL to the production API URL on the Render service.";
-      Sentry.captureMessage(msg, {
-        level: isTestBuild ? "warning" : "fatal",
-        tags: {
-          subsystem: "httpClient",
-          issue: isTestBuild ? "test-hooks-localhost" : "localhost-in-prod",
-        },
-        extra: { raw, isTestBuild },
-      });
-      if (!isTestBuild) {
+      if (isTestBuild) {
+        console.warn("[httpClient]", msg);
+      } else {
+        Sentry.captureMessage(msg, {
+          level: "fatal",
+          tags: { subsystem: "httpClient", issue: "localhost-in-prod" },
+          extra: { raw },
+        });
         throw new Error(msg);
       }
     }
@@ -175,7 +177,7 @@ export function createGameClient(options: HttpClientOptions) {
         // In dev mode, network failures against localhost are expected
         // (backend not running) — skip Sentry to avoid flooding the
         // dashboard with dev noise (#571).
-        if (!__DEV__) {
+        if (!__DEV__ && !isTestBuild) {
           Sentry.captureMessage(`API ${apiTag} network failure: ${method} ${path}`, {
             level: "warning",
             tags: { api: apiTag, errorType: "network" },

--- a/frontend/src/game/_shared/syncApi.ts
+++ b/frontend/src/game/_shared/syncApi.ts
@@ -15,6 +15,8 @@ import { Platform } from "react-native";
 
 import { getOrCreateSessionId } from "./session";
 
+const isTestBuild = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
+
 export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
 export interface SyncResponse {
@@ -41,7 +43,6 @@ function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
   if (raw) {
     const resolved = raw.startsWith("http") ? raw : `https://${raw}`;
-    const isTestBuild = process.env.EXPO_PUBLIC_TEST_HOOKS === "1";
     if (!__DEV__ && !isTestBuild && isLocalhost(resolved)) {
       const msg =
         "EXPO_PUBLIC_API_URL resolves to localhost in a non-dev build (syncApi). " +

--- a/render.yaml
+++ b/render.yaml
@@ -40,9 +40,11 @@ services:
     branch: main
     rootDir: frontend
     autoDeploy: true
-    buildCommand: npm ci && node scripts/fetch-render-env.js && npx expo export --platform web
+    buildCommand: npm ci && node scripts/fetch-render-env.js && node scripts/check-build-env.js && npx expo export --platform web
     staticPublishPath: dist
     envVars:
+      - key: APP_ENV
+        value: production
       - key: EXPO_PUBLIC_API_URL
         value: "https://games-api.buffingchi.com"
       - key: EXPO_PUBLIC_SENTRY_DSN
@@ -92,9 +94,11 @@ services:
     rootDir: frontend
     # fetch-render-env.js merges EXPO_PUBLIC_API_URL (and SENTRY_DSN if set)
     # into .env before Expo bakes them into the static bundle.
-    buildCommand: npm ci && node scripts/fetch-render-env.js && npx expo export --platform web
+    buildCommand: npm ci && node scripts/fetch-render-env.js && node scripts/check-build-env.js && npx expo export --platform web
     staticPublishPath: dist
     envVars:
+      - key: APP_ENV
+        value: staging
       - key: EXPO_PUBLIC_API_URL
         value: "https://dev-games-api.buffingchi.com"
       - key: EXPO_PUBLIC_SENTRY_DSN

--- a/render.yaml
+++ b/render.yaml
@@ -43,6 +43,9 @@ services:
     buildCommand: npm ci && node scripts/fetch-render-env.js && node scripts/check-build-env.js && npx expo export --platform web
     staticPublishPath: dist
     envVars:
+      # APP_ENV is read by check-build-env.js from process.env (not from the
+      # .env file that fetch-render-env.js writes). Must be set here so the
+      # isProduction guard in the script fires during the Render build.
       - key: APP_ENV
         value: production
       - key: EXPO_PUBLIC_API_URL
@@ -97,6 +100,9 @@ services:
     buildCommand: npm ci && node scripts/fetch-render-env.js && node scripts/check-build-env.js && npx expo export --platform web
     staticPublishPath: dist
     envVars:
+      # APP_ENV is read by check-build-env.js from process.env (not from the
+      # .env file that fetch-render-env.js writes). Must be set here so the
+      # isProduction guard in the script fires during the Render build.
       - key: APP_ENV
         value: staging
       - key: EXPO_PUBLIC_API_URL


### PR DESCRIPTION
## Summary

- Suppresses Sentry noise from E2E test builds: when `EXPO_PUBLIC_TEST_HOOKS=1` is baked into the bundle, `httpClient.ts` now `console.warn`s instead of calling `Sentry.captureMessage` for the localhost-URL warning and network failures. These events were flooding the production Sentry project (4.4K+ events, issues #1532 / #1533) because E2E builds intentionally point at `localhost:8000` but the production DSN is baked in from `.env`.
- Wires `check-build-env.js` into both Render frontend build commands and adds `APP_ENV` so the script's `isProduction` guard fires — previously the script was never invoked, allowing a misconfigured env var to ship silently.

Closes #1532, #1533, #1534

## Root cause

The events were not from a leaked Render env var. They came from local/CI E2E test builds that run `expo export` with `EXPO_PUBLIC_TEST_HOOKS=1` + `EXPO_PUBLIC_API_URL=http://localhost:8000` — but the production Sentry DSN baked in from `.env` sent all failures to the production project.

## Test plan

- [ ] Run an E2E build locally with `EXPO_PUBLIC_TEST_HOOKS=1 EXPO_PUBLIC_API_URL=http://localhost:8000` — confirm no new Sentry events appear in the production project
- [ ] Confirm `check-build-env.js` exits non-zero: `APP_ENV=production EXPO_PUBLIC_TEST_HOOKS=1 node frontend/scripts/check-build-env.js`
- [ ] Verify next Render deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)