### PR TITLE
fix: suppress bomb flash when wave clears via power-up

### DIFF
--- a/frontend/src/game/starswarm/engine.ts
+++ b/frontend/src/game/starswarm/engine.ts
@@ -1762,6 +1762,7 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
         phase: "WaveClear",
         phaseTimer: CHALLENGING_CLEAR_PAUSE,
         challengingPerfect: perfect,
+        bombFlashTimer: 0,
       };
     }
     return state;
@@ -1777,6 +1778,7 @@ function checkPhaseTransitions(state: StarSwarmState): StarSwarmState {
         score: state.score + waveClearBonus,
         phase: "WaveClear",
         phaseTimer: WAVE_CLEAR_PAUSE,
+        bombFlashTimer: 0,
       };
     }
     return state;


### PR DESCRIPTION
Zeroes bombFlashTimer on both WaveClear transitions so the full-screen
white overlay doesn't play over the freeze when a bomb or laser kills
the last enemy. Closes #1543.

https://claude.ai/code/session_01Vyi2eMdRYySSorZa1qGizQ