### PR TITLE
fix(sentry): suppress CI noise — disable Sentry in e2e builds (#1552)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
         env:
           EXPO_PUBLIC_API_URL: http://localhost:8000
           EXPO_PUBLIC_TEST_HOOKS: "1"
+          EXPO_PUBLIC_SENTRY_DSN: ""
 
       - name: Install E2E deps
         run: npm ci

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,5 @@
 EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com
 EXPO_PUBLIC_SENTRY_DSN=https://4e8b2bd816cbce3f73b0cd6923530d53@o4511129011093504.ingest.us.sentry.io/4511129020334080
+EXPO_PUBLIC_SENTRY_ENVIRONMENT=development
 
 EXPO_PUBLIC_FEEDBACK_WORKER_URL=https://feedback-worker.wcmchenry3.workers.dev

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 EXPO_PUBLIC_API_URL=https://your-api-url.example.com
 EXPO_PUBLIC_SENTRY_DSN=
+EXPO_PUBLIC_SENTRY_ENVIRONMENT=production
 EXPO_PUBLIC_FEEDBACK_WORKER_URL=https://feedback-worker.wcmchenry3.workers.dev

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,5 @@
 EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com
 EXPO_PUBLIC_SENTRY_DSN=https://4e8b2bd816cbce3f73b0cd6923530d53@o4511129011093504.ingest.us.sentry.io/4511129020334080
+EXPO_PUBLIC_SENTRY_ENVIRONMENT=production
 
 EXPO_PUBLIC_FEEDBACK_WORKER_URL=https://feedback-worker.wcmchenry3.workers.dev

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -53,6 +53,7 @@ if (!dsn) {
   try {
     Sentry.init({
       dsn,
+      environment: process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? "production",
       sendDefaultPii: true,
     });
     installSentryConsoleErrorCapture();


### PR DESCRIPTION
## Summary

- `EXPO_PUBLIC_SENTRY_DSN: ""` added to the CI `expo export` step — overrides the committed `.env` value so Sentry never initialises in e2e builds
- `EXPO_PUBLIC_SENTRY_ENVIRONMENT` wired into `Sentry.init()` (defaults to `"production"`) for future staging/prod separation
- `.env.example` updated to document the new var

Closes #1552

## Root cause

`frontend/.env` (committed) contains the real Sentry DSN. `expo export --platform web` in CI reads it and bakes the DSN into the bundle. Two e2e tests that deliberately inject corrupt storage payloads (`"garbage{not json}"`, `"not-valid-json{{{"`) then trigger the resilience-path `Sentry.captureMessage()` call — which fires real warning events to the production Sentry project with no environment label to distinguish them from real user events.

## What changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `EXPO_PUBLIC_SENTRY_DSN: ""` in the e2e build step env |
| `frontend/App.tsx` | `environment: process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? "production"` added to `Sentry.init()` |
| `frontend/.env.example` | Documents `EXPO_PUBLIC_SENTRY_ENVIRONMENT=production` |

## Test plan

- [ ] CI e2e run completes with no new Sentry events (verify in Sentry dashboard after merge)
- [ ] Production builds unaffected — DSN and environment still set from `.env.production`
- [ ] `npm test` passes (2532 tests, 146 suites) ✅
- [ ] Backend test suite passes (pre-existing coverage failures in `test_entitlement_enforcement.py` are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)