### PR TITLE
fix(cascade): add final_score guard and structured error handling in PATCH /cascade/score

### DIFF
--- a/backend/cascade/router.py
+++ b/backend/cascade/router.py
@@ -7,10 +7,12 @@ GET /cascade/scores returns the top 10 scores for the leaderboard display.
 
 from __future__ import annotations
 
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy import and_, desc, func, or_, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_session_factory
@@ -23,6 +25,8 @@ from vocab import GameType as GameTypeEnum
 from .models import LeaderboardResponse, ScoreEntry, SetPlayerNameRequest
 
 router = APIRouter(dependencies=[Depends(require_entitlement("cascade"))])
+
+logger = logging.getLogger(__name__)
 
 LEADERBOARD_LIMIT = 10
 
@@ -86,30 +90,41 @@ async def set_player_name(
         if game is None:
             raise HTTPException(status_code=404, detail="Game not found.")
 
+        if game.final_score is None:
+            raise HTTPException(status_code=400, detail="Game has no final score.")
+
         metadata = dict(game.game_metadata or {})
         metadata["player_name"] = body.player_name
         game.game_metadata = metadata
-        await db.commit()
+        try:
+            await db.commit()
+        except SQLAlchemyError as exc:
+            logger.error("cascade score commit failed for game %s: %s", game_id, exc)
+            raise HTTPException(status_code=500, detail="Failed to save player name.")
 
         # Rank = 1 + count of games that outrank this one.
         # Tie-break: equal scores rank older completed_at first (same order as
         # the leaderboard GET), so a game ranks below existing tied entries.
         score_val = game.final_score or 0
-        count = (
-            await db.execute(
-                select(func.count()).where(
-                    Game.game_type_id == gt_id,
-                    Game.final_score.is_not(None),
-                    or_(
-                        Game.final_score > score_val,
-                        and_(
-                            Game.final_score == score_val,
-                            Game.completed_at < game.completed_at,
+        try:
+            count = (
+                await db.execute(
+                    select(func.count()).where(
+                        Game.game_type_id == gt_id,
+                        Game.final_score.is_not(None),
+                        or_(
+                            Game.final_score > score_val,
+                            and_(
+                                Game.final_score == score_val,
+                                Game.completed_at < game.completed_at,
+                            ),
                         ),
-                    ),
+                    )
                 )
-            )
-        ).scalar()
+            ).scalar()
+        except SQLAlchemyError as exc:
+            logger.error("cascade rank query failed for game %s: %s", game_id, exc)
+            raise HTTPException(status_code=500, detail="Failed to calculate rank.")
 
     rank = int(count or 0) + 1
     return ScoreEntry(

--- a/backend/tests/test_cascade_api.py
+++ b/backend/tests/test_cascade_api.py
@@ -298,3 +298,62 @@ class TestDuplicateNames:
         scores = client.get("/cascade/scores", headers=SESSION_HEADERS).json()["scores"]
         alice_scores = [s["score"] for s in scores if s["player_name"] == "Alice"]
         assert alice_scores == [200, 100]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths:
+    def test_no_final_score_returns_400(self):
+        """PATCH /cascade/score fails with 400 when the game has no final_score."""
+        gid = _create_game()
+        # Deliberately skip _complete_game so final_score stays None.
+        res = _set_name(gid, "Alice")
+        assert res.status_code == 400
+        body = res.json()
+        assert "detail" in body
+        assert body["detail"] != "Internal Server Error"
+
+    async def test_db_commit_failure_returns_structured_500(self, monkeypatch):
+        """A SQLAlchemy error during db.commit() returns a structured 500, not a bare traceback."""
+        from sqlalchemy.exc import SQLAlchemyError
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        gid = _create_game()
+        _complete_game(gid, 500)
+
+        async def _fail_commit(self):
+            raise SQLAlchemyError("simulated commit failure")
+
+        monkeypatch.setattr(AsyncSession, "commit", _fail_commit)
+        res = _set_name(gid, "Alice")
+        assert res.status_code == 500
+        body = res.json()
+        assert "detail" in body
+        assert body["detail"] != "Internal Server Error"
+
+    async def test_rank_query_failure_returns_structured_500(self, monkeypatch):
+        """A SQLAlchemy error during the rank SELECT returns a structured 500."""
+        from sqlalchemy.exc import SQLAlchemyError
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        gid = _create_game()
+        _complete_game(gid, 500)
+
+        original_execute = AsyncSession.execute
+
+        async def _execute_fail_on_count(self, *args, **kwargs):
+            stmt = args[0] if args else None
+            # Identify the rank query by presence of COUNT in the compiled SQL.
+            if stmt is not None and "count" in str(stmt).lower():
+                raise SQLAlchemyError("simulated rank query failure")
+            return await original_execute(self, *args, **kwargs)
+
+        monkeypatch.setattr(AsyncSession, "execute", _execute_fail_on_count)
+        res = _set_name(gid, "Alice")
+        assert res.status_code == 500
+        body = res.json()
+        assert "detail" in body
+        assert body["detail"] != "Internal Server Error"


### PR DESCRIPTION
- Return 400 when game.final_score is None instead of proceeding to rank
  calculation with potentially null/zero values
- Wrap db.commit() in try/except SQLAlchemyError; return structured 500
  with detail message and log at ERROR level instead of bare traceback
- Wrap rank count query in try/except SQLAlchemyError with same treatment
- Add three new tests: no-final-score guard (400), commit failure (500),
  rank query failure (500) — all verifying structured detail in response

Closes #1554