### PR TITLE
fix: resolve StarSwarmScreen TDZ crash (BC_GAMES-3Q)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 .pytest_cache/
 .hypothesis/
 .coverage
+.coverage.*
 htmlcov/
 
 # Node / Expo

--- a/frontend/src/screens/BlackjackBettingScreen.tsx
+++ b/frontend/src/screens/BlackjackBettingScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, ActivityIndicator, Pressable } from "react-nati
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { placeBet as enginePlaceBet, toViewState, DEFAULT_RULES } from "../game/blackjack/engine";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";

--- a/frontend/src/screens/BlackjackStatsScreen.tsx
+++ b/frontend/src/screens/BlackjackStatsScreen.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFocusEffect } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";
 import { loadRuns, RunRecord } from "../game/blackjack/storage";

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -10,7 +10,7 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import {
   hit as engineHit,

--- a/frontend/src/screens/BlackjackVictoryScreen.tsx
+++ b/frontend/src/screens/BlackjackVictoryScreen.tsx
@@ -3,7 +3,7 @@ import { View, Text, Pressable, StyleSheet, ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { useBlackjackGame } from "../game/blackjack/BlackjackGameContext";
 import { TABLE_CONFIGS } from "../game/blackjack/tables";

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { createAudioPlayer } from "expo-audio";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { GameShell } from "../components/shared/GameShell";
 import { AnimationOverlay } from "../components/shared/AnimationOverlay";

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -46,7 +46,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { TILE_REQUIRES } from "../components/mahjong/tileAssets";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -34,7 +34,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import {

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { useTheme } from "../theme/ThemeContext";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { GameShell } from "../components/shared/GameShell";
 import GameCanvas from "../components/starswarm/GameCanvas";
 import type { GameCanvasHandle, DevOptions } from "../components/starswarm/GameCanvas";

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -35,7 +35,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -4,7 +4,7 @@ import { GestureDetector, Gesture } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
-import { HomeStackParamList } from "../../App";
+import type { HomeStackParamList } from "../../App";
 import { useTheme } from "../theme/ThemeContext";
 import { GameShell } from "../components/shared/GameShell";
 import { Twenty48State } from "../game/twenty48/types";


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes `ReferenceError: Cannot access 'Te' before initialization` crashing StarSwarmScreen on load (Sentry **BC_GAMES-3Q**, 48 events, escalating)
- Root cause: `HomeStackParamList` was imported without `type` in every lazy-loaded screen, emitting a runtime circular dependency in the webpack/Metro bundle
- Fix: add `import type` to all 12 affected lazy screen files so the bundler erases the import entirely

## Root cause

`HomeStackParamList` is declared `export type` in `App.tsx` — it exists only at the TypeScript level. Without the `type` keyword, Metro/webpack emits a live runtime `require("../../App")` inside each lazy chunk, creating a circular static→lazy dependency:

```
<lazy chunk> ──(sync import)──▶ App.tsx
App.tsx ──(React.lazy factory)──▶ <lazy chunk>
```

In webpack 5's ESM output this cycle leaves the chunk's module-level `const` bindings (e.g. `getStyles`, minified to `Te`) in the **Temporal Dead Zone** when the component function first runs. Result: the screen crashes before React can render it.

## Fix

```diff
- import { HomeStackParamList } from "../../App";
+ import type { HomeStackParamList } from "../../App";
```

Applied to all 12 lazy-loaded screens. `HomeScreen` and `GameScreen` are synchronously bundled with `App.tsx` (same chunk) and were intentionally left unchanged.

## Test plan

- [ ] Navigate to Star Swarm — screen loads without error
- [ ] Verify Sentry BC_GAMES-3Q stops receiving new events after deploy
- [ ] Spot-check other lazy screens (Cascade, Blackjack, Sudoku, etc.) load normally — no regression

https://claude.ai/code/session_01QYjHxudUuP5kbEkVNBdphr
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYjHxudUuP5kbEkVNBdphr)_