### PR TITLE
fix(mahjong): prevent shuffle from stacking matching tiles at same (col, row)

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -392,7 +392,17 @@ export default function GameCanvas({
           `[mahjong] slow drawBoard: ${elapsed.toFixed(1)}ms for ${state.tiles.length} tiles`
         );
     }
-  }, [state, freeTiles, allHintIds, imagesVersion, camera, boardWidth, boardHeight, debugShowFree, dpr]);
+  }, [
+    state,
+    freeTiles,
+    allHintIds,
+    imagesVersion,
+    camera,
+    boardWidth,
+    boardHeight,
+    debugShowFree,
+    dpr,
+  ]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -392,7 +392,7 @@ export default function GameCanvas({
           `[mahjong] slow drawBoard: ${elapsed.toFixed(1)}ms for ${state.tiles.length} tiles`
         );
     }
-  }, [state, freeTiles, allHintIds, imagesVersion, camera, debugShowFree, dpr]);
+  }, [state, freeTiles, allHintIds, imagesVersion, camera, boardWidth, boardHeight, debugShowFree, dpr]);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -528,10 +528,7 @@ describe("shuffleBoard", () => {
     const shuffled = shuffleBoard(state);
     const byKey = new Map<string, SlotTile[]>();
     for (const t of shuffled.tiles) {
-      const key =
-        t.suit === "flowers" || t.suit === "seasons"
-          ? t.suit
-          : `${t.suit}:${t.rank}`;
+      const key = t.suit === "flowers" || t.suit === "seasons" ? t.suit : `${t.suit}:${t.rank}`;
       const g = byKey.get(key) ?? [];
       g.push(t);
       byKey.set(key, g);

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -522,6 +522,28 @@ describe("shuffleBoard", () => {
     const shuffled = shuffleBoard(state);
     expect(shuffled.undoStack.length).toBe(1);
   });
+
+  it("never places both tiles of a pair at the same (col, row)", () => {
+    const state = createGame(TURTLE_LAYOUT);
+    const shuffled = shuffleBoard(state);
+    const byKey = new Map<string, SlotTile[]>();
+    for (const t of shuffled.tiles) {
+      const key =
+        t.suit === "flowers" || t.suit === "seasons"
+          ? t.suit
+          : `${t.suit}:${t.rank}`;
+      const g = byKey.get(key) ?? [];
+      g.push(t);
+      byKey.set(key, g);
+    }
+    for (const group of byKey.values()) {
+      for (let i = 0; i + 1 < group.length; i += 2) {
+        const a = group[i]!;
+        const b = group[i + 1]!;
+        expect(a.col === b.col && a.row === b.row).toBe(false);
+      }
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -542,7 +542,14 @@ export function shuffleBoard(state: MahjongState): MahjongState {
       candidate.push({ ...pair[0], id: id++, col: sA.col, row: sA.row, layer: sA.layer });
       candidate.push({ ...pair[1], id: id++, col: sB.col, row: sB.row, layer: sB.layer });
     }
-    if (hasFreePairs(candidate)) {
+    // Reject if any matching pair shares (col, row): removing the top tile
+    // would leave the bottom tile with no partner, making the game unwinnable.
+    const hasStackedMatch = shuffledPairs.some((_, i) => {
+      const sA = shuffledSlots[i * 2]!;
+      const sB = shuffledSlots[i * 2 + 1]!;
+      return sA.col === sB.col && sA.row === sB.row;
+    });
+    if (!hasStackedMatch && hasFreePairs(candidate)) {
       newTiles = candidate;
       break;
     }


### PR DESCRIPTION
A shuffle could place the two tiles of a matching pair directly on top of
each other, making the game permanently unwinnable: removing the top tile
left the bottom tile with no partner. The retry loop now rejects any
candidate where a pair's two slots share (col, row).

https://claude.ai/code/session_01GJoeycoFamHv9gv2Pt34ae