### PR TITLE
Fix bottle sort flash: drive state update from animation callback

### DIFF
--- a/frontend/src/game/sort/components/SortBoard.tsx
+++ b/frontend/src/game/sort/components/SortBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AccessibilityInfo, StyleSheet, useWindowDimensions, View } from "react-native";
 import Animated, {
   cancelAnimation,
@@ -37,6 +37,8 @@ export interface SortBoardProps {
   readonly availableHeight?: number;
   /** Total flow duration in ms (POUR_PER_UNIT_MS × unitCount); computed by SortScreen. */
   readonly pourHoldMs?: number;
+  /** Called when the pour animation fully completes (ghost returns to origin). */
+  readonly onPourComplete?: () => void;
 }
 
 interface GhostInfo {
@@ -85,6 +87,7 @@ export default function SortBoard({
   pouringTo = null,
   availableHeight,
   pourHoldMs = POUR_PER_UNIT_MS,
+  onPourComplete,
 }: SortBoardProps) {
   const { t } = useTranslation("sort");
   const { width: screenW } = useWindowDimensions();
@@ -156,6 +159,14 @@ export default function SortBoard({
     rx: splashRx.value,
     opacity: splashOpacity.value,
   }));
+
+  // Stable wrapper so the worklet can invoke onPourComplete via runOnJS without
+  // capturing a stale closure — the ref is updated on every render.
+  const onPourCompleteRef = useRef(onPourComplete);
+  onPourCompleteRef.current = onPourComplete;
+  const notifyPourComplete = useCallback(() => {
+    onPourCompleteRef.current?.();
+  }, []);
 
   // Stable ref for values read inside the effect (avoids stale closure without
   // adding them to the dep array, which would re-trigger on every state change)
@@ -250,6 +261,7 @@ export default function SortBoard({
                 if (!finished) return;
                 runOnJS(setGhost)(null);
                 runOnJS(setUnitsEmitted)(0);
+                runOnJS(notifyPourComplete)();
               });
             }
           );

--- a/frontend/src/game/sort/components/__tests__/SortBoard.test.tsx
+++ b/frontend/src/game/sort/components/__tests__/SortBoard.test.tsx
@@ -85,4 +85,26 @@ describe("SortBoard", () => {
     );
     expect(UNSAFE_getAllByType(Svg).length).toBeGreaterThan(0);
   });
+
+  it("accepts onPourComplete prop and does not call it on initial render", () => {
+    // Guards that the prop exists in the interface and is not spuriously invoked.
+    // The Reanimated jest mock does not execute animation callbacks, so the actual
+    // call-through (runOnJS(notifyPourComplete)() at animation end) is covered by
+    // the SortScreen regression test for issue #1567.
+    const onPourComplete = jest.fn();
+    const state = mkState([["red", "red", "blue", "blue"], []]);
+    render(
+      withTheme(
+        <SortBoard
+          state={state}
+          onBottleTap={jest.fn()}
+          pouringFrom={0}
+          pouringTo={1}
+          pourHoldMs={380}
+          onPourComplete={onPourComplete}
+        />
+      )
+    );
+    expect(onPourComplete).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -30,12 +30,7 @@ import {
 } from "../game/sort/engine";
 import { getNextHint } from "../game/sort/solver";
 import type { Color, SortState } from "../game/sort/types";
-import SortBoard, {
-  POUR_LIFT_MS,
-  POUR_TILT_MS,
-  POUR_PER_UNIT_MS,
-  POUR_RETURN_MS,
-} from "../game/sort/components/SortBoard";
+import SortBoard, { POUR_PER_UNIT_MS } from "../game/sort/components/SortBoard";
 import { TILT_IN_MS, TILT_HOLD_MS, TILT_OUT_MS } from "../game/sort/components/BottleView";
 import LevelSelectScreen from "../game/sort/components/LevelSelectScreen";
 import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
@@ -85,6 +80,7 @@ export default function SortScreen() {
   const [isPouring, setIsPouring] = useState(false);
   const [boardHeight, setBoardHeight] = useState(0);
   const pourTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPourRef = useRef<{ snapshot: SortState; from: number; to: number } | null>(null);
   const [reduceMotion, setReduceMotion] = useState(false);
 
   // Win modal
@@ -182,6 +178,20 @@ export default function SortScreen() {
   // Game handlers
   // ---------------------------------------------------------------------------
 
+  const handlePourComplete = useCallback(() => {
+    const pending = pendingPourRef.current;
+    if (!pending) return;
+    pendingPourRef.current = null;
+    const nextState = applyPour(pending.snapshot, pending.from, pending.to);
+    setGameState(nextState);
+    setIsPouring(false);
+    setPouringFrom(null);
+    setPouringTo(null);
+    if (nextState.isComplete) {
+      audio.playWin();
+    }
+  }, [audio]);
+
   function handleBottleTap(index: number) {
     if (!gameState || gameState.isComplete || isPouring) return;
     const { selectedBottleIndex } = gameState;
@@ -202,10 +212,6 @@ export default function SortScreen() {
       const snapshot = gameState;
       const units = pourUnits(gameState.bottles[selectedBottleIndex]!, gameState.bottles[index]!);
       const holdMs = POUR_PER_UNIT_MS * units;
-      // Reduce-motion: BottleView does a fixed tilt-only animation (no ghost overlay).
-      const totalMs = reduceMotion
-        ? TILT_IN_MS + TILT_HOLD_MS + TILT_OUT_MS + 50
-        : POUR_LIFT_MS + POUR_TILT_MS + holdMs + POUR_RETURN_MS + 50;
       setHistory((h) => [...h, snapshot]);
       setIsPouring(true);
       setPouringFrom(selectedBottleIndex);
@@ -213,16 +219,26 @@ export default function SortScreen() {
       setPourHoldMs(holdMs);
       setGameState({ ...gameState, selectedBottleIndex: null });
       audio.playPour();
-      pourTimerRef.current = setTimeout(() => {
-        const nextState = applyPour(snapshot, selectedBottleIndex, index);
-        setGameState(nextState);
-        setIsPouring(false);
-        setPouringFrom(null);
-        setPouringTo(null);
-        if (nextState.isComplete) {
-          audio.playWin();
-        }
-      }, totalMs);
+      if (reduceMotion) {
+        // Reduce-motion: BottleView does a tilt-only animation with no ghost overlay,
+        // so there is no onPourComplete callback from SortBoard — drive state update
+        // with a timer instead.
+        const totalMs = TILT_IN_MS + TILT_HOLD_MS + TILT_OUT_MS + 50;
+        pourTimerRef.current = setTimeout(() => {
+          const nextState = applyPour(snapshot, selectedBottleIndex, index);
+          setGameState(nextState);
+          setIsPouring(false);
+          setPouringFrom(null);
+          setPouringTo(null);
+          if (nextState.isComplete) {
+            audio.playWin();
+          }
+        }, totalMs);
+      } else {
+        // Full animation: state update is driven by onPourComplete fired from SortBoard
+        // the moment the ghost overlay is removed, so both happen in the same render.
+        pendingPourRef.current = { snapshot, from: selectedBottleIndex, to: index };
+      }
     } else {
       setGameState({ ...gameState, selectedBottleIndex: null });
     }
@@ -646,6 +662,7 @@ export default function SortScreen() {
             pouringTo={pouringTo}
             availableHeight={boardHeight}
             pourHoldMs={pourHoldMs}
+            onPourComplete={handlePourComplete}
           />
         )}
       </View>

--- a/frontend/src/screens/__tests__/SortScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SortScreen.test.tsx
@@ -245,9 +245,13 @@ describe("SortScreen — pour completion callback (regression #1567)", () => {
     // Select bottle 1 (["red","blue"], 2 balls), then pour into bottle 3 (empty).
     // This sets pendingPourRef so onPourComplete can apply the state update.
     const bottle1 = await findByLabelText(/^Bottle 1, 2 of/);
-    await act(async () => { fireEvent.press(bottle1); });
+    await act(async () => {
+      fireEvent.press(bottle1);
+    });
     const bottle3 = await findByLabelText("Bottle 3, empty");
-    await act(async () => { fireEvent.press(bottle3); });
+    await act(async () => {
+      fireEvent.press(bottle3);
+    });
 
     // Simulate the moment SortBoard's return animation finishes and fires
     // onPourComplete (in production this is via runOnJS inside the worklet;

--- a/frontend/src/screens/__tests__/SortScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SortScreen.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { act, fireEvent, render } from "@testing-library/react-native";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import SortScreen from "../SortScreen";
+import SortBoard from "../../game/sort/components/SortBoard";
 
 // ---------------------------------------------------------------------------
 // Mocks — factories must be self-contained (jest.mock is hoisted)
@@ -215,5 +216,70 @@ describe("SortScreen — leaderboard tab", () => {
       fireEvent.press(leaderboardTab);
     });
     expect(await findByText("No scores yet.")).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: source bottle flash after pour (issue #1567)
+//
+// The bug: setGhost(null) fired from the Reanimated animation callback while
+// setGameState(nextState) was on a separate setTimeout ~50ms later. Between
+// those two calls there was a render where the ghost was gone but the stale
+// bottle state was still visible — causing a brief flash of the poured color.
+//
+// The fix: onPourComplete drives the state update from inside SortBoard's
+// animation callback so both calls land in the same render. The test below
+// guards that contract: calling onPourComplete immediately produces the
+// post-pour state without needing any timer to fire.
+// ---------------------------------------------------------------------------
+
+describe("SortScreen — pour completion callback (regression #1567)", () => {
+  it("updates bottle state immediately when onPourComplete fires — no timer needed", async () => {
+    const { findByLabelText, UNSAFE_getByType } = renderScreen();
+
+    const levelCard = await findByLabelText("Level 1");
+    await act(async () => {
+      fireEvent.press(levelCard);
+    });
+
+    // Select bottle 1 (["red","blue"], 2 balls), then pour into bottle 3 (empty).
+    // This sets pendingPourRef so onPourComplete can apply the state update.
+    const bottle1 = await findByLabelText(/^Bottle 1, 2 of/);
+    await act(async () => { fireEvent.press(bottle1); });
+    const bottle3 = await findByLabelText("Bottle 3, empty");
+    await act(async () => { fireEvent.press(bottle3); });
+
+    // Simulate the moment SortBoard's return animation finishes and fires
+    // onPourComplete (in production this is via runOnJS inside the worklet;
+    // here we call it directly because Reanimated's jest mock does not invoke
+    // animation callbacks).
+    const board = UNSAFE_getByType(SortBoard);
+    await act(async () => {
+      board.props.onPourComplete?.();
+    });
+
+    // Bottle 1 should now show 1 ball ("red" remains; "blue" was poured out).
+    // If the bug is present (state update only on a setTimeout), this label
+    // won't exist yet and the test fails.
+    expect(await findByLabelText(/^Bottle 1, 1 of/)).toBeTruthy();
+    expect(await findByLabelText(/^Bottle 3, 1 of/)).toBeTruthy();
+  });
+
+  it("is a no-op when onPourComplete fires with no pending pour", async () => {
+    const { findByLabelText, UNSAFE_getByType } = renderScreen();
+
+    const levelCard = await findByLabelText("Level 1");
+    await act(async () => {
+      fireEvent.press(levelCard);
+    });
+
+    // Call onPourComplete without initiating any pour first.
+    const board = UNSAFE_getByType(SortBoard);
+    await act(async () => {
+      board.props.onPourComplete?.();
+    });
+
+    // Original state should be unchanged.
+    expect(await findByLabelText(/^Bottle 1, 2 of/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Eliminates the brief flash of the poured color on the source bottle after each pour animation completes
- Adds `onPourComplete` callback to `SortBoard` fired via `runOnJS` alongside `setGhost(null)`, so ghost removal and state update land in the same React render
- Keeps the `setTimeout` path only for the reduce-motion fallback (which has no ghost overlay)

## Root cause

There was a ~50ms gap between two independent async operations:

1. `runOnJS(setGhost)(null)` — fired from the Reanimated worklet when the return animation finished, removing the ghost overlay
2. `setGameState(nextState)` — fired from a separate `setTimeout` 50ms later

During that gap, React re-rendered the source bottle with the ghost gone but using stale state (still containing the poured color), causing the visible flash.

## Test plan

- [ ] Play any Bottle Sort level and pour a color — source bottle should settle cleanly with no flash
- [ ] Verify undo still works correctly after a pour
- [ ] Verify win detection still fires after a completing pour
- [ ] Enable Reduce Motion (device accessibility settings) and verify pours still complete correctly via the timer path
- [ ] `SortScreen` regression test: `onPourComplete` immediately updates bottle state without a timer
- [ ] `SortBoard` smoke test: `onPourComplete` prop is accepted and not spuriously called on render

Closes #1567

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjRXhQCTfoGTjDQboPThf3)_