### PR TITLE
fix(daily-word): shuffle answers list to prevent letter-streak runs

### DIFF
--- a/backend/daily_word/puzzle.py
+++ b/backend/daily_word/puzzle.py
@@ -1,13 +1,16 @@
 """Daily Word puzzle selection — deterministic, timezone-aware (#1188).
 
-Seeding: index = (int(date.strftime("%Y%m%d")) + SALT) % len(answers)
+Seeding: answers list is shuffled once at load time with random.Random(SALT),
+then index = (int(date.strftime("%Y%m%d")) + SALT) % len(answers).
 SALT comes from the DAILY_WORD_SALT env var (int, default 0).
+Changing SALT shifts the entire future word schedule.
 puzzle_id format: "YYYY-MM-DD:{lang}"
 """
 
 from __future__ import annotations
 
 import os
+import random
 import unicodedata
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -30,6 +33,12 @@ _ANSWERS_HI: list[str] = [unicodedata.normalize("NFC", w) for w in _load_list("a
 _VALID_HI: frozenset[str] = frozenset(
     unicodedata.normalize("NFC", w) for w in _load_list("valid_hi.txt")
 ) | frozenset(_ANSWERS_HI)
+
+# Shuffle each answers list so consecutive days pick pseudo-random entries rather than
+# sequential list positions. Each language uses an independent seeded RNG so their
+# schedules don't depend on each other's list length.
+random.Random(SALT).shuffle(_ANSWERS_EN)
+random.Random(SALT).shuffle(_ANSWERS_HI)
 
 _ANSWERS: dict[str, list[str]] = {"en": _ANSWERS_EN, "hi": _ANSWERS_HI}
 _VALID: dict[str, frozenset[str]] = {"en": _VALID_EN, "hi": _VALID_HI}


### PR DESCRIPTION
## Summary

Fixes #1497

- Shuffles `_ANSWERS_EN` and `_ANSWERS_HI` at module load time using `random.Random(SALT)` so consecutive days pick pseudo-random list entries instead of sequential ones
- Each language gets an independent seeded RNG instance so their schedules don't depend on each other's list length
- The index formula `(date_int + SALT) % len(answers)` is unchanged — only the traversal order is randomized
- Fully deterministic: same `DAILY_WORD_SALT` always produces the same word schedule; changing it shifts the entire future schedule

## Test plan

- [ ] `cd backend && python -m pytest tests/test_daily_word_puzzle.py tests/test_daily_word_api.py -v`
- [ ] Verify consecutive dates return unrelated words (no letter-streak runs)
- [ ] Verify same date always returns the same word (determinism)
- [ ] Verify changing `DAILY_WORD_SALT` produces a different word schedule

https://claude.ai/code/session_01XZ6YH2Mo8tbpNNGzg8Wsb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZ6YH2Mo8tbpNNGzg8Wsb1)_