### PR TITLE
Hearts AI: prioritize A♣/K♣ in pass selection for Medium and Hard

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -198,6 +198,55 @@ describe("selectCardsToPass", () => {
 });
 
 // ---------------------------------------------------------------------------
+// selectCardsToPass — Medium difficulty, high clubs (A♣/K♣)
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass — Medium difficulty, high clubs", () => {
+  it("passes A♣ when slots remain after higher-priority cards", () => {
+    // Q♠ → slot 1, A♥ → slot 2, A♣ → slot 3 (step 3.5).
+    // Confirms rank 1 is not caught by the 'clubs below 6' guard (which checks rank > 1).
+    const hand = [
+      c("spades", 12),
+      c("hearts", 1),
+      c("clubs", 1),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).toContainEqual(c("clubs", 1));
+  });
+
+  it("passes K♣ when slots remain after higher-priority cards", () => {
+    // Q♠ → slot 1, A♥ → slot 2, K♣ → slot 3 (step 3.5).
+    const hand = [
+      c("spades", 12),
+      c("hearts", 1),
+      c("clubs", 13),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left");
+    expect(passed).toContainEqual(c("clubs", 13));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // selectCardToPlay — void (discarding)
 // ---------------------------------------------------------------------------
 
@@ -707,6 +756,55 @@ describe("selectCardsToPass — Hard difficulty, opportunistic void", () => {
     ];
     const passed = selectCardsToPass(hand, "left", "hard");
     expect(passed).toContainEqual(c("diamonds", 7));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hard AI — high clubs in passing (A♣/K♣)
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass — Hard difficulty, high clubs", () => {
+  it("passes A♣ before opportunistic void creation", () => {
+    // Q♠ → slot 1, A♥ → slot 2, A♣ → slot 3 (step 3.5 fires before step 4).
+    // ♦7 is the sole diamond and would be a void candidate, but A♣ fills the slot first.
+    const hand = [
+      c("spades", 12),
+      c("hearts", 1),
+      c("clubs", 1),
+      c("diamonds", 7),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("hearts", 3),
+      c("hearts", 4),
+      c("hearts", 5),
+      c("hearts", 6),
+    ];
+    const passed = selectCardsToPass(hand, "left", "hard");
+    expect(passed).toContainEqual(c("clubs", 1));
+  });
+
+  it("passes K♣ when slots remain after higher-priority cards", () => {
+    // Q♠ → slot 1, A♥ → slot 2, K♣ → slot 3 (step 3.5).
+    const hand = [
+      c("spades", 12),
+      c("hearts", 1),
+      c("clubs", 13),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left", "hard");
+    expect(passed).toContainEqual(c("clubs", 13));
   });
 });
 

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -219,7 +219,9 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   if (selected.length < 3) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
-      const card = hand.find((c) => c.suit === "clubs" && c.rank === rank && safe(c) && notSelected(c));
+      const card = hand.find(
+        (c) => c.suit === "clubs" && c.rank === rank && safe(c) && notSelected(c)
+      );
       if (card) selected.push(card);
     }
   }

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -99,8 +99,8 @@ function selectCardsToPassEasy(hand: Card[]): Card[] {
  * 1. Q♠ — unless protected (holding A♠ + K♠) or void in spades
  * 2. A♥, K♥ — highest hearts first
  * 3. A♠, K♠ — if not needed to protect Q♠
- * 4. High cards of suit being voided (longest suit)
- * 5. Never pass: 2♣ or clubs below 6
+ * 3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early
+ * 4. Highest remaining safe card (never 2♣ or clubs below 6)
  */
 function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[] {
   void direction;
@@ -141,14 +141,20 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
     }
   }
 
+  // High clubs: A♣ and K♣ are dangerous to hold because clubs are led early.
+  if (selected.length < 3) {
+    for (const rank of [1, 13] as const) {
+      if (selected.length >= 3) break;
+      const card = hand.find((c) => c.suit === "clubs" && c.rank === rank && safe(c));
+      if (card) selected.push(card);
+    }
+  }
+
   if (selected.length < 3) {
     const candidates = hand.filter(safe).sort((a, b) => {
       const ra = a.rank === 1 ? 14 : a.rank;
       const rb = b.rank === 1 ? 14 : b.rank;
-      if (rb !== ra) return rb - ra;
-      if (a.suit === "clubs" && b.suit !== "clubs") return 1;
-      if (b.suit === "clubs" && a.suit !== "clubs") return -1;
-      return 0;
+      return rb - ra;
     });
     for (const c of candidates) {
       if (selected.length >= 3) break;
@@ -166,6 +172,7 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  *   1. Q♠ (always pass, even when protected — unlike Medium).
  *   2. A♥, K♥, Q♥, J♥ (high hearts, highest first).
  *   3. A♠, K♠ (if Q♠ not present).
+ *   3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early.
  *   4. If any slots remain, complete a void in the shortest eligible suit (1 card only,
  *      not 2♣ holder's clubs). Voiding a suit gives Hard a free discard opportunity on
  *      every future lead of that suit without sacrificing a dangerous-card slot.
@@ -208,6 +215,15 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
 
   const notSelected = (c: Card) => !selected.some((s) => s.suit === c.suit && s.rank === c.rank);
 
+  // 3.5. High clubs: A♣ and K♣ are dangerous to hold because clubs are led early.
+  if (selected.length < 3) {
+    for (const rank of [1, 13] as const) {
+      if (selected.length >= 3) break;
+      const card = hand.find((c) => c.suit === "clubs" && c.rank === rank && safe(c) && notSelected(c));
+      if (card) selected.push(card);
+    }
+  }
+
   // 4. Opportunistic void: if exactly 1 slot remains, use it to void a single-card suit.
   if (selected.length === 2) {
     const bySuit = new Map<string, Card[]>();
@@ -228,13 +244,7 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   if (selected.length < 3) {
     const candidates = hand
       .filter((c) => safe(c) && notSelected(c))
-      .sort((a, b) => {
-        const diff = aceHigh(b.rank) - aceHigh(a.rank);
-        if (diff !== 0) return diff;
-        if (a.suit === "clubs" && b.suit !== "clubs") return 1;
-        if (b.suit === "clubs" && a.suit !== "clubs") return -1;
-        return 0;
-      });
+      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
       if (selected.length >= 3) break;
       selected.push(c);


### PR DESCRIPTION
## Summary

Fixes #1584

High clubs (A♣, K♣) were being actively de-prioritized in the "fill remaining slots" sort in both Medium and Hard pass strategies, even though they're among the riskiest cards to hold going into a round — 2♣ is always led on trick 1 and clubs cycle heavily in early tricks before hearts are broken.

- **Medium:** Added explicit A♣/K♣ sub-step after the high-spades step, before the generic fill fallback. Removed the `suit === "clubs"` de-prioritization from the fill sort.
- **Hard:** Added explicit A♣/K♣ tier (step 3.5) between high spades and opportunistic void creation. Removed the same anti-club bias from the step-5 fill sort.

The existing `passSafeFilter` already excludes 2♣ and clubs below rank 6, so those constraints are respected naturally.

## Test plan

- [x] All 52 existing Hearts AI unit tests pass (`npx jest src/game/hearts/__tests__/ai.test.ts --no-coverage`)
- [ ] Run `npx tsx scripts/simulate-hearts.ts` before/after and confirm lower average points per hand for the AI

---
_Generated by [Claude Code](https://claude.ai/code/session_011fvK2xaqRZ1FcukKe5ooAh)_