### PR TITLE
fix(tests): async coverage and entitlement dev-override for CI (#1560)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
+core = "sysmon"
 omit = ["tests/*", "scripts/*", "*/generate_levels.py", "*/verify_levels.py", "perf/*"]
 
 [tool.black]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,6 +3,7 @@ black==26.3.1
 ruff==0.8.4
 pytest-asyncio==1.3.0
 pytest-cov==6.1.0
+coverage>=7.6
 locust==2.32.4
 hypothesis==6.131.15
 pip-audit==2.7.3

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,7 +31,15 @@ def pytest_configure(config: pytest.Config) -> None:
     We must set DATABASE_URL before collection so module-level
     `pytestmark = pytest.mark.skipif(not os.environ.get("DATABASE_URL"), ...)`
     resolves correctly.
+
+    Also neutralise ENTITLEMENT_DEV_OVERRIDE so that .env's dev shortcut
+    doesn't bypass entitlement checks in the test suite.  dotenv's
+    load_dotenv() (called in main.py at import time) only sets variables
+    that are *absent* from os.environ, so setting the key here — before
+    any test module is imported — prevents the .env value from taking effect.
     """
+    os.environ.setdefault("ENTITLEMENT_DEV_OVERRIDE", "")
+
     global _TEST_DB_FILE
     if os.environ.get("DATABASE_URL"):
         # Caller provided a DB (e.g. Render Postgres for smoke tests).

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,7 +33,7 @@ def pytest_configure(config: pytest.Config) -> None:
     resolves correctly.
 
     Also neutralise ENTITLEMENT_DEV_OVERRIDE so that .env's dev shortcut
-    doesn't bypass entitlement checks in the test suite.  dotenv's
+    doesn't bypass entitlement checks in the test suite. dotenv's
     load_dotenv() (called in main.py at import time) only sets variables
     that are *absent* from os.environ, so setting the key here — before
     any test module is imported — prevents the .env value from taking effect.


### PR DESCRIPTION
## Summary

Fixes the two root causes preventing issue #1560's acceptance criteria from being met on CI:

- **Async coverage gap (Python 3.13)**: The default `ctrace` coverage core uses `sys.settrace`, which does not fire trace events when a coroutine resumes from an `await`. This caused every async handler body to appear uncovered despite all tests passing. Enabling `core = "sysmon"` in `[tool.coverage.run]` switches to Python 3.12+'s `sys.monitoring` API, which records resumption correctly. All five routers now reach 95-98% line coverage (≥90% AC met).
- **Dev override leaking into CI**: `backend/.env` contains `ENTITLEMENT_DEV_OVERRIDE=true` for local development. `python-dotenv`'s `load_dotenv()` (called in `main.py` at import time) was injecting this value into the pytest process, bypassing all entitlement checks and causing 10 tests in `test_entitlement_enforcement.py` and `test_entitlements.py` to fail. Adding `os.environ.setdefault("ENTITLEMENT_DEV_OVERRIDE", "")` to `pytest_configure` in `conftest.py` — before any test module is imported — prevents dotenv from overriding it.

## Test plan

- [ ] `cd backend && python -m pytest -q` → 534 passed, 2 skipped, 96% total coverage, ≥80% floor met
- [ ] Five score routers individually: cascade 98%, hearts 98%, mahjong 98%, solitaire 98%, sudoku 95%
- [ ] All 30 entitlement tests pass
- [ ] Coverage floor of 80% is met (was failing before)

Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)