### PR TITLE
fix(hearts): AI play/lead bug fixes (#1592, #1593, #1594)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1151,3 +1151,189 @@ describe("chooseFollow — last to play, covering card (#1525)", () => {
     expect(pick).not.toEqual(c("spades", 12));
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1592 — Easy AI: basic moon blocking
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
+  it("dumps highest point card when an opponent is threatening a moon", () => {
+    // Player 0 has taken all 5 points — potential moon detected.
+    // Player 3 (Easy) is void in spades; should dump hearts 9 to disrupt.
+    const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 4), playerIndex: 0 },
+      { card: c("spades", 5), playerIndex: 1 },
+      { card: c("spades", 6), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      handScores: [5, 0, 0, 0],
+      wonCards: [allHearts5, [], [], []],
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    expect(pick).toEqual(c("hearts", 9));
+  });
+
+  it("dumps A♥ before lower hearts when blocking a moon", () => {
+    const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const hand = [c("hearts", 1), c("hearts", 3), c("diamonds", 4)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 4), playerIndex: 0 },
+      { card: c("spades", 5), playerIndex: 1 },
+      { card: c("spades", 6), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 5,
+      handScores: [5, 0, 0, 0],
+      wonCards: [allHearts5, [], [], []],
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    expect(pick).toEqual(c("hearts", 1));
+  });
+
+  it("plays normally (lowest) when no moon threat", () => {
+    const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 4), playerIndex: 0 },
+      { card: c("spades", 5), playerIndex: 1 },
+      { card: c("spades", 6), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], [], [], hand],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+      currentPlayerIndex: 3,
+    });
+    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    // No moon threat → Easy dumps lowest card
+    expect(pick).toEqual(c("diamonds", 3));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1593 — Hard AI: moonshot extended tracking + tricks-remaining guard
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
+  it("stays in moon-attempt mode when AI has collected all points so far (5+ tricks left)", () => {
+    // AI (player 1) has already won 2 hearts; still holds 8 hearts + Q♠ + 1 club.
+    // aiHasAllPoints: handScores[1]=2 === totalPointsTaken=2. hand.length=10 >= 5.
+    const heartsInHand = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const heartsAlreadyWon = [c("hearts", 10), c("hearts", 11)];
+    const hand = [...heartsInHand, c("spades", 12), c("clubs", 7)]; // 10 cards
+    const trick: TrickCard[] = [{ card: c("diamonds", 3), playerIndex: 0 }]; // AI void in diamonds
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      handScores: [0, 2, 0, 0],
+      wonCards: [[], heartsAlreadyWon, [], []],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Moon attempt active: discard highest non-hearts/non-Q♠ = clubs 7
+    expect(pick).toEqual(c("clubs", 7));
+  });
+
+  it("does not enter moon-attempt mode when fewer than 5 tricks remain", () => {
+    // AI (player 1) has already won 6 hearts; holds 2 hearts + Q♠ + 1 diamond in hand (4 cards).
+    // hand.length=4 < 5 → not feasible → isMoonAttempt=false → normal discard fires (Q♠ first).
+    const heartsInHand = [c("hearts", 2), c("hearts", 3)];
+    const heartsAlreadyWon = Array.from({ length: 6 }, (_, i) => c("hearts", (i + 4) as Rank));
+    const hand = [...heartsInHand, c("spades", 12), c("diamonds", 7)]; // 4 cards
+    const trick: TrickCard[] = [{ card: c("clubs", 3), playerIndex: 0 }]; // AI void in clubs
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 9,
+      currentPlayerIndex: 1,
+      handScores: [0, 6, 0, 0],
+      wonCards: [[], heartsAlreadyWon, [], []],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Not in moon mode → chooseDiscard fires → dumps Q♠ first
+    expect(pick).toEqual(c("spades", 12));
+  });
+
+  it("exits moon-attempt mode when another player also has points (split points)", () => {
+    // AI has 3 hearts in hand + 5 won; opponent also has 2 points → aiHasAllPoints=false.
+    const heartsInHand = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const heartsAlreadyWon = [c("hearts", 10), c("hearts", 11)];
+    const hand = [...heartsInHand, c("spades", 12), c("clubs", 7)];
+    const trick: TrickCard[] = [{ card: c("diamonds", 3), playerIndex: 0 }];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      handScores: [0, 2, 2, 0], // player 2 also has points — AI doesn't have all points
+      wonCards: [[], heartsAlreadyWon, [c("hearts", 12), c("hearts", 13)], []],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Not in moon mode (split points) → void in diamonds → chooseDiscard → dumps Q♠
+    expect(pick).toEqual(c("spades", 12));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1594 — Hard AI: chooseLeadHard never leads Q♠ as fallback
+// ---------------------------------------------------------------------------
+
+describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
+  it("leads a low heart before Q♠ when safe pool is exhausted and spades outnumber hearts", () => {
+    // valid = [Q♠, K♠, 2♥]: Q♠ not gone → K♠ unsafe → safe=[]. pool=valid.
+    // Before fix: bySuitDescending picks spades(2) over hearts(1) → lowest spade = Q♠. Bug.
+    // After fix: strip Q♠ first → pick from [K♠, 2♥] → not Q♠.
+    const hand = [c("spades", 12), c("spades", 13), c("hearts", 2)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 8,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+      wonCards: [[], [], [], []], // Q♠ not yet played
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    expect(pick).not.toEqual(c("spades", 12));
+  });
+
+  it("leads Q♠ only when it is the sole remaining card", () => {
+    const hand = [c("spades", 12)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 12,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+      wonCards: [[], [], [], []],
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    expect(pick).toEqual(c("spades", 12));
+  });
+
+  it("does not lead Q♠ when low hearts are available in the fallback pool", () => {
+    // safe is empty (all hearts + Q♠ + K♠ unsafe); pool=valid=[Q♠, K♠, 3♥, 5♥].
+    // Should pick from hearts or K♠, never Q♠.
+    const hand = [c("spades", 12), c("spades", 13), c("hearts", 3), c("hearts", 5)];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 5,
+      heartsBroken: true,
+      currentPlayerIndex: 0,
+      wonCards: [[], [], [], []],
+    });
+    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    expect(pick).not.toEqual(c("spades", 12));
+  });
+});

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1199,6 +1199,24 @@ describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
     expect(pick).toEqual(c("hearts", 1));
   });
 
+  it("dumps a point card when LEADING and an opponent is threatening a moon", () => {
+    // Easy AI (player 1) is leading its turn. Player 0 has all 5 points — moon threat.
+    // Hearts are broken, so hearts 9 is a valid lead and the moon-block should fire.
+    const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 1) as Rank));
+    const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: [],
+      tricksPlayedInHand: 5,
+      heartsBroken: true,
+      handScores: [5, 0, 0, 0],
+      wonCards: [allHearts5, [], [], []],
+      currentPlayerIndex: 1,
+    });
+    const pick = selectCardToPlay(hand, [], state, 1, "easy");
+    expect(pick).toEqual(c("hearts", 9));
+  });
+
   it("plays normally (lowest) when no moon threat", () => {
     const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
     const trick: TrickCard[] = [
@@ -1265,8 +1283,30 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
     expect(pick).toEqual(c("spades", 12));
   });
 
+  it("maintains moon-attempt mode when Q♠ is already in wonCards (not in hand)", () => {
+    // AI (player 1) has already won Q♠ + 5 hearts; still holds 8 hearts + 2 clubs.
+    // myHasQ = true via wonCards. totalHearts = 8+5 = 13. hand.length = 10 >= 5.
+    // handScores[1] = 18 (13+5) === totalPointsTaken = 18 → aiHasAllPoints.
+    const heartsInHand = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
+    const heartsWon = [c("hearts", 10), c("hearts", 11), c("hearts", 12), c("hearts", 13), c("hearts", 1)];
+    const alreadyWon = [c("spades", 12), ...heartsWon]; // Q♠ + 5 hearts
+    const hand = [...heartsInHand, c("clubs", 7), c("clubs", 8)]; // 10 cards
+    const trick: TrickCard[] = [{ card: c("diamonds", 3), playerIndex: 0 }]; // AI void in diamonds
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      handScores: [0, 18, 0, 0],
+      wonCards: [[], alreadyWon, [], []],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Moon attempt active: void in diamonds → discard highest non-hearts/non-Q♠ = clubs 8
+    expect(pick).toEqual(c("clubs", 8));
+  });
+
   it("exits moon-attempt mode when another player also has points (split points)", () => {
-    // AI has 3 hearts in hand + 5 won; opponent also has 2 points → aiHasAllPoints=false.
+    // AI has 8 hearts in hand + 2 won; opponent also has 2 points → aiHasAllPoints=false.
     const heartsInHand = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
     const heartsAlreadyWon = [c("hearts", 10), c("hearts", 11)];
     const hand = [...heartsInHand, c("spades", 12), c("clubs", 7)];
@@ -1290,10 +1330,11 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
 // ---------------------------------------------------------------------------
 
 describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
-  it("leads a low heart before Q♠ when safe pool is exhausted and spades outnumber hearts", () => {
-    // valid = [Q♠, K♠, 2♥]: Q♠ not gone → K♠ unsafe → safe=[]. pool=valid.
-    // Before fix: bySuitDescending picks spades(2) over hearts(1) → lowest spade = Q♠. Bug.
-    // After fix: strip Q♠ first → pick from [K♠, 2♥] → not Q♠.
+  it("leads K♠ (not Q♠) when safe pool is exhausted and spades outnumber hearts", () => {
+    // valid = [Q♠, K♠, 2♥]: Q♠ not gone → K♠ and hearts both unsafe → safe=[]. pool=valid.
+    // Before fix: bySuitDescending picks spades(2 cards) over hearts(1) → lowest spade = Q♠. Bug.
+    // After fix: strip Q♠ first → pickFrom=[K♠, 2♥]. spades(1) tied with hearts(1);
+    //   map preserves insertion order → spades first → lowest([K♠]) = K♠.
     const hand = [c("spades", 12), c("spades", 13), c("hearts", 2)];
     const state = mkState({
       playerHands: [hand, [], [], []],
@@ -1305,6 +1346,7 @@ describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
     });
     const pick = selectCardToPlay(hand, [], state, 0, "hard");
     expect(pick).not.toEqual(c("spades", 12));
+    expect(pick).toEqual(c("spades", 13)); // K♠: lowest of longest group after Q♠ stripped
   });
 
   it("leads Q♠ only when it is the sole remaining card", () => {
@@ -1321,9 +1363,9 @@ describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
     expect(pick).toEqual(c("spades", 12));
   });
 
-  it("does not lead Q♠ when low hearts are available in the fallback pool", () => {
-    // safe is empty (all hearts + Q♠ + K♠ unsafe); pool=valid=[Q♠, K♠, 3♥, 5♥].
-    // Should pick from hearts or K♠, never Q♠.
+  it("leads lowest heart (not Q♠) when hearts outnumber other unsafe cards in fallback pool", () => {
+    // valid = [Q♠, K♠, 3♥, 5♥]: safe=[]. poolWithoutQ=[K♠, 3♥, 5♥].
+    // bySuitDescending: hearts(2) > spades(1) → longestGroup = hearts → lowest = 3♥.
     const hand = [c("spades", 12), c("spades", 13), c("hearts", 3), c("hearts", 5)];
     const state = mkState({
       playerHands: [hand, [], [], []],
@@ -1335,5 +1377,6 @@ describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
     });
     const pick = selectCardToPlay(hand, [], state, 0, "hard");
     expect(pick).not.toEqual(c("spades", 12));
+    expect(pick).toEqual(c("hearts", 3)); // lowest of longest group (hearts) after Q♠ stripped
   });
 });

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1288,7 +1288,13 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
     // myHasQ = true via wonCards. totalHearts = 8+5 = 13. hand.length = 10 >= 5.
     // handScores[1] = 18 (13+5) === totalPointsTaken = 18 → aiHasAllPoints.
     const heartsInHand = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
-    const heartsWon = [c("hearts", 10), c("hearts", 11), c("hearts", 12), c("hearts", 13), c("hearts", 1)];
+    const heartsWon = [
+      c("hearts", 10),
+      c("hearts", 11),
+      c("hearts", 12),
+      c("hearts", 13),
+      c("hearts", 1),
+    ];
     const alreadyWon = [c("spades", 12), ...heartsWon]; // Q♠ + 5 hearts
     const hand = [...heartsInHand, c("clubs", 7), c("clubs", 8)]; // 10 cards
     const trick: TrickCard[] = [{ card: c("diamonds", 3), playerIndex: 0 }]; // AI void in diamonds

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -417,11 +417,13 @@ function selectCardToPlayHard(
   const heartsInHand = hand.filter((c) => c.suit === "hearts").length;
   const heartsWon = (state.wonCards[playerIndex] ?? []).filter((c) => c.suit === "hearts").length;
   const totalHearts = heartsInHand + heartsWon;
-  const myHasQ = hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
+  const myHasQ =
+    hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
   const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
   const myPoints = state.handScores[playerIndex] ?? 0;
   // 5-trick minimum: in the final 4 tricks, completing the moon becomes speculative (#1593).
-  const isMoonAttempt = totalHearts >= 8 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
+  const isMoonAttempt =
+    totalHearts >= 8 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
 
   // Moon blocking (skip if we're the one attempting)
   if (moonTarget !== null && moonTarget !== playerIndex && !isMoonAttempt) {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -301,7 +301,7 @@ export function detectPotentialMoon(state: HeartsState): number | null {
 // Play strategy
 // ---------------------------------------------------------------------------
 
-/** Easy: always play the lowest valid card; no strategic logic. */
+/** Easy: always play the lowest valid card; blocks obvious moonshot attempts. */
 function selectCardToPlayEasy(
   hand: Card[],
   trick: TrickCard[],
@@ -311,6 +311,16 @@ function selectCardToPlayEasy(
   void hand;
   const valid = getValidPlays(state, playerIndex);
   if (valid.length === 1) return valid[0]!;
+
+  const moonTarget = detectPotentialMoon(state);
+
+  // Basic moon blocking — dump highest point card when an opponent is threatening
+  if (moonTarget !== null && moonTarget !== playerIndex) {
+    const pointCards = valid
+      .filter((c) => cardPoints(c) > 0)
+      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+    if (pointCards.length > 0) return pointCards[0]!;
+  }
 
   const isLeading = trick.length === 0;
 
@@ -383,8 +393,9 @@ function selectCardToPlayMedium(
 
 /**
  * Hard: extends Medium with moon-attempt mode and card counting.
- * When the AI holds 8+ hearts and Q♠ with no points yet taken, it switches
- * to moon-shot mode: preserve hearts/Q♠ and discard everything else.
+ * Moon-attempt fires when the AI has accumulated 8+ hearts total (in hand or
+ * already won) plus Q♠, holds all collected points, and ≥5 tricks remain.
+ * Tracking across wonCards lets the attempt persist after winning the first hearts.
  * Card counting: infers seen cards from wonCards + currentTrick to identify
  * safe spade leads once all high spades have been played.
  */
@@ -400,11 +411,16 @@ function selectCardToPlayHard(
   const moonTarget = detectPotentialMoon(state);
   const isLeading = trick.length === 0;
 
-  // Detect if this AI player should attempt a moon shot
-  const myHearts = hand.filter((c) => c.suit === "hearts").length;
-  const myHasQ = hand.some(isQueenOfSpades);
+  // Detect if this AI player should attempt a moon shot.
+  // Track hearts + Q♠ across both hand and already-won cards so moon mode persists
+  // through tricks the AI wins. Require 5+ tricks remaining for feasibility.
+  const heartsInHand = hand.filter((c) => c.suit === "hearts").length;
+  const heartsWon = (state.wonCards[playerIndex] ?? []).filter((c) => c.suit === "hearts").length;
+  const totalHearts = heartsInHand + heartsWon;
+  const myHasQ = hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
   const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
-  const isMoonAttempt = myHearts >= 8 && myHasQ && totalPointsTaken === 0;
+  const myPoints = state.handScores[playerIndex] ?? 0;
+  const isMoonAttempt = totalHearts >= 8 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
 
   // Moon blocking (skip if we're the one attempting)
   if (moonTarget !== null && moonTarget !== playerIndex && !isMoonAttempt) {
@@ -551,14 +567,18 @@ function chooseLeadHard(valid: Card[], seenKeys: Set<string>): Card {
   });
   const pool = safe.length > 0 ? safe : valid;
 
-  const suitGroups = bySuitDescending(pool);
+  // Q♠ is last resort — exclude it so it never surfaces as the lowest of any group.
+  const poolWithoutQ = pool.filter((c) => !isQueenOfSpades(c));
+  const pickFrom = poolWithoutQ.length > 0 ? poolWithoutQ : pool;
+
+  const suitGroups = bySuitDescending(pickFrom);
   const longestGroup = suitGroups[0];
   if (longestGroup) {
     const card = lowest(longestGroup[1]);
     if (card) return card;
   }
 
-  return lowest(pool) ?? valid[0]!;
+  return lowest(pickFrom) ?? valid[0]!;
 }
 
 /** Lowest card scoring 0 points, or undefined if every card in the array scores points. */

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -420,6 +420,7 @@ function selectCardToPlayHard(
   const myHasQ = hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
   const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
   const myPoints = state.handScores[playerIndex] ?? 0;
+  // 5-trick minimum: in the final 4 tricks, completing the moon becomes speculative (#1593).
   const isMoonAttempt = totalHearts >= 8 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
 
   // Moon blocking (skip if we're the one attempting)


### PR DESCRIPTION
## Summary

- **#1592 Easy AI moon blocking**: `selectCardToPlayEasy` now calls `detectPotentialMoon` and dumps the highest available point card when an opponent is threatening a shoot-the-moon. Previously Easy AI was completely blind to moon threats.

- **#1593 Hard AI moonshot feasibility guard**: `isMoonAttempt` now tracks hearts across both the current hand *and* already-won cards (`wonCards`), so moon-attempt mode persists through tricks the AI wins rather than exiting the moment it collects its first heart. Added a `hand.length >= 5` guard that prevents entering moon mode when too few tricks remain to complete the shot.

- **#1594 `chooseLeadHard` Q♠ fallback**: When the safe lead pool is empty and the fallback falls back to all valid cards, Q♠ is now stripped from the candidate pool before suit-grouping and lowest-pick. Q♠ is led only if it is the sole remaining card.

> **Note:** All three issues reference `backend/hearts/module.py` as the relevant code, but the Hearts AI actually lives client-side in `frontend/src/game/hearts/ai.ts` (consistent with the client-side engine architecture). Function names in the issues (e.g. `chooseCardEasy`, `shouldAttemptMoon`) also differ from the actual TypeScript names.

## Test plan

- [ ] `cd frontend && npx jest src/game/hearts/__tests__/ai.test.ts` → 65 tests pass (9 new: 3 per issue)
- [ ] Verify Easy AI blocks a moon shot in-game at Easy difficulty
- [ ] Verify Hard AI stays in moon-attempt mode across multiple winning tricks
- [ ] Verify Hard AI does not lead Q♠ from a hand of [Q♠, K♠, 2♥] at Hard difficulty

🤖 Generated with [Claude Code](https://claude.com/claude-code)