### PR TITLE
feat(yacht): add AiDifficulty type and Game route param (#1598)

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -68,7 +68,7 @@ export type RootStackParamList = {
 
 export type HomeStackParamList = {
   Home: undefined;
-  Game: { initialState: GameState; aiDifficulty?: AiDifficulty | null };
+  Game: { initialState: GameState; aiDifficulty?: AiDifficulty };
   Cascade: undefined;
   StarSwarm: undefined;
   BlackjackBetting: undefined;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -23,7 +23,7 @@ import LockedGameScreen from "./src/screens/LockedGameScreen";
 import GameScreen from "./src/screens/GameScreen";
 import ProfileScreen from "./src/screens/ProfileScreen";
 import BottomTabBar from "./src/components/shared/BottomTabBar";
-import { GameState } from "./src/game/yacht/types";
+import { AiDifficulty, GameState } from "./src/game/yacht/types";
 import { ThemeProvider } from "./src/theme/ThemeContext";
 import { useHtmlAttributes } from "./src/i18n/useHtmlAttributes";
 import { NetworkProvider } from "./src/game/_shared/NetworkContext";
@@ -68,7 +68,7 @@ export type RootStackParamList = {
 
 export type HomeStackParamList = {
   Home: undefined;
-  Game: { initialState: GameState };
+  Game: { initialState: GameState; aiDifficulty?: AiDifficulty | null };
   Cascade: undefined;
   StarSwarm: undefined;
   BlackjackBetting: undefined;

--- a/frontend/src/game/yacht/types.ts
+++ b/frontend/src/game/yacht/types.ts
@@ -4,6 +4,7 @@
 
 import type { GameOutcome, GameSession } from "../_shared/types";
 
+/** Difficulty tier for the Yacht AI opponent. Governs hold and scoring strategy. */
 export type AiDifficulty = "easy" | "medium" | "hard";
 
 export type GameEvent =

--- a/frontend/src/game/yacht/types.ts
+++ b/frontend/src/game/yacht/types.ts
@@ -4,6 +4,8 @@
 
 import type { GameOutcome, GameSession } from "../_shared/types";
 
+export type AiDifficulty = "easy" | "medium" | "hard";
+
 export type GameEvent =
   | { readonly type: "diceRoll"; readonly rolledIndices: readonly number[] }
   | { readonly type: "dieHold"; readonly index: number }


### PR DESCRIPTION
## Summary

- Adds `AiDifficulty = 'easy' | 'medium' | 'hard'` to `frontend/src/game/yacht/types.ts`
- Threads an optional `aiDifficulty?: AiDifficulty | null` param through the `Game` navigation route in `App.tsx` so `HomeScreen` can signal VS-CPU mode when navigating

## Why
Foundation for epic #1596 — the AI engine (#1599), difficulty selector (#1600), and game loop all need this type. Adding it here keeps the type definition close to the Yacht domain rather than scattered across files.

## Test plan
- [ ] TypeScript compiles without new errors (`cd frontend && npx tsc --noEmit`)
- [ ] Navigating to the Yacht game (solo) still works — `aiDifficulty` is optional so existing solo flow is unaffected

Closes #1598
Part of epic #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)