### PR TITLE
feat(hearts): pass direction awareness for Medium and Hard AI (#1595)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1386,3 +1386,171 @@ describe("chooseLeadHard — Q♠ is last-resort fallback (#1594)", () => {
     expect(pick).toEqual(c("hearts", 3)); // lowest of longest group (hearts) after Q♠ stripped
   });
 });
+
+// ---------------------------------------------------------------------------
+// selectCardsToPass — #1595 pass direction awareness
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
+  it("passes Q♠ going right even when protected by A♠+K♠", () => {
+    // Medium normally keeps Q♠ when holding both A♠ and K♠.
+    // Going right relaxes protection — Q♠ should be passed.
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 5),
+      c("hearts", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("hearts", 2),
+    ];
+    const passed = selectCardsToPass(hand, "right", "medium");
+    expect(passed).toContainEqual(c("spades", 12));
+  });
+
+  it("keeps Q♠ going left when holding A♠ or K♠ alone", () => {
+    // Going left with A♠ alone counts as protection — Q♠ kept.
+    // A♥+K♥ fill slots 1-2 (danger hearts); A♠ fills slot 3; Q♠ never reaches filler.
+    const hand = [
+      c("spades", 12), // Q♠ — protected by A♠ going left
+      c("spades", 1), // A♠ — enough protection going left
+      c("hearts", 1), // A♥ → slot 1
+      c("hearts", 13), // K♥ → slot 2
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("hearts", 2),
+    ];
+    const passed = selectCardsToPass(hand, "left", "medium");
+    expect(passed).not.toContainEqual(c("spades", 12));
+  });
+
+  it("left vs right produce different selections for same hand when Q♠ protection differs", () => {
+    // Hand: Q♠ + A♠ (no K♠) + A♥ + K♥ (danger hearts fill slots).
+    // Left: Q♠ protected (A♠ present); [A♥, K♥, A♠] passed, Q♠ stays.
+    // Right: Q♠ not protected; [Q♠, A♥, K♥] passed, Q♠ gone.
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 1), // A♠
+      c("hearts", 1), // A♥ → danger heart
+      c("hearts", 13), // K♥ → danger heart
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("diamonds", 8),
+      c("hearts", 2),
+    ];
+    const passedLeft = selectCardsToPass(hand, "left", "medium");
+    const passedRight = selectCardsToPass(hand, "right", "medium");
+    expect(passedLeft).not.toContainEqual(c("spades", 12));
+    expect(passedRight).toContainEqual(c("spades", 12));
+  });
+});
+
+describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
+  it("passes Q♠ going right (always)", () => {
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 5),
+      c("hearts", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("hearts", 2),
+    ];
+    const passed = selectCardsToPass(hand, "right", "hard");
+    expect(passed).toContainEqual(c("spades", 12));
+  });
+
+  it("includes 10♥ as a danger heart when passing right but not left", () => {
+    // Going right: Q♠ passed (slot 1), A♥ passed (slot 2), 10♥ passes danger threshold → slot 3.
+    // Going left: Q♠ passed (slot 1), A♥ passed (slot 2), 10♥ below threshold of 11 → K♦ fills slot 3.
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 13), // K♠ (kept regardless — step 3 skipped when Q♠ in hand)
+      c("hearts", 1), // A♥ — danger both directions
+      c("hearts", 10), // 10♥ — danger only going right
+      c("diamonds", 13), // K♦ — high filler
+      c("diamonds", 9),
+      c("diamonds", 8),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("hearts", 2),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passedRight = selectCardsToPass(hand, "right", "hard");
+    const passedLeft = selectCardsToPass(hand, "left", "hard");
+    expect(passedRight).toContainEqual(c("hearts", 10));
+    expect(passedLeft).not.toContainEqual(c("hearts", 10));
+  });
+});
+
+describe("selectCardsToPass — #1595 across direction (Medium)", () => {
+  it("passes Q♠ going across even when holding A♠+K♠", () => {
+    // "across" is treated the same as "right" — Q♠ protection threshold is relaxed.
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 5),
+      c("hearts", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("hearts", 2),
+    ];
+    const passed = selectCardsToPass(hand, "across", "medium");
+    expect(passed).toContainEqual(c("spades", 12));
+    expect(passed).toHaveLength(3);
+  });
+
+  it("none direction uses baseline protection (A♠+K♠ keeps Q♠)", () => {
+    // "none" = no-pass hand; still uses baseline A♠+K♠ protection.
+    // A♥+K♥ fill slots 1-2; A♠ fills slot 3; Q♠ never reaches filler.
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 1), // A♥ → slot 1
+      c("hearts", 13), // K♥ → slot 2
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+      c("hearts", 2),
+    ];
+    const passed = selectCardsToPass(hand, "none", "medium");
+    expect(passed).not.toContainEqual(c("spades", 12));
+    expect(passed).toHaveLength(3);
+  });
+});

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1463,7 +1463,8 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
 });
 
 describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
-  it("passes Q♠ going right (always)", () => {
+  it("passes Q♠ regardless of direction (left and right both always pass Q♠)", () => {
+    // Hard is more aggressive than Medium — direction does not protect Q♠.
     const hand = [
       c("spades", 12),
       c("spades", 1),
@@ -1479,8 +1480,10 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
       c("diamonds", 7),
       c("hearts", 2),
     ];
-    const passed = selectCardsToPass(hand, "right", "hard");
-    expect(passed).toContainEqual(c("spades", 12));
+    const passedLeft = selectCardsToPass(hand, "left", "hard");
+    const passedRight = selectCardsToPass(hand, "right", "hard");
+    expect(passedLeft).toContainEqual(c("spades", 12));
+    expect(passedRight).toContainEqual(c("spades", 12));
   });
 
   it("includes 10♥ as a danger heart when passing right but not left", () => {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -97,9 +97,10 @@ function selectCardsToPassEasy(hand: Card[]): Card[] {
 /**
  * Medium: select exactly 3 cards to pass. Priority order:
  * 1. Q♠ — pass unless protected; protection threshold varies by direction (#1595):
- *    - "right"/"across": pass even with A♠ or K♠ (Q♠ travels far enough to be safe)
- *    - "left": keep Q♠ unless completely unprotected (needs both A♠ AND K♠ to protect)
- *    - "none": baseline — pass unless holding A♠ + K♠
+ *    - "right"/"across": pass even with A♠ or K♠ (Q♠ travels far enough to be safe).
+ *      Note: "right" (1 seat) and "across" (2 seats) are treated identically for simplicity.
+ *    - "left": keep Q♠ if holding either A♠ or K♠ (left neighbor plays close — higher risk)
+ *    - "none": baseline — pass unless holding both A♠ and K♠
  * 2. A♥, K♥ — highest hearts first
  * 3. A♠, K♠ — if not needed to protect Q♠
  * 3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early
@@ -117,9 +118,10 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
   const voidInSpades = spades.length === 0;
 
   // Direction changes how boldly we pass Q♠.
-  // "right"/"across": Q♠ travels far — pass if we have any high spade cover at all.
-  // "left": Q♠ may cycle back quickly — only pass if truly unprotected (neither A♠ nor K♠).
-  // "none": baseline — pass unless holding both A♠ and K♠.
+  // "right"/"across": Q♠ lands on an opponent who plays farther from us — pass freely.
+  // "left": left neighbor plays adjacent to us and gets more opportunities to dump Q♠ back;
+  //         keep Q♠ if we hold any high-spade cover (A♠ or K♠ alone suffices).
+  // "none": no pass this hand — use baseline protection (A♠ and K♠ both required).
   const qSpadeProtected =
     direction === "right" || direction === "across"
       ? false // always willing to pass Q♠ when it goes far
@@ -201,10 +203,8 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   const hasQSpades = spades.some(isQueenOfSpades);
   const voidInSpades = spades.length === 0;
 
-  // 1. Q♠ — Hard always wants to pass Q♠; only keep it when passing left AND spade-void
-  // (receiving player would be spade-void too, making Q♠ dangerous to pass there).
-  const skipQSpade = voidInSpades || (direction === "left" && voidInSpades);
-  if (hasQSpades && !skipQSpade) {
+  // 1. Q♠ — Hard always passes Q♠ regardless of direction.
+  if (hasQSpades && !voidInSpades) {
     selected.push({ suit: "spades", rank: 12 });
   }
 

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -96,14 +96,16 @@ function selectCardsToPassEasy(hand: Card[]): Card[] {
 
 /**
  * Medium: select exactly 3 cards to pass. Priority order:
- * 1. Q♠ — unless protected (holding A♠ + K♠) or void in spades
+ * 1. Q♠ — pass unless protected; protection threshold varies by direction (#1595):
+ *    - "right"/"across": pass even with A♠ or K♠ (Q♠ travels far enough to be safe)
+ *    - "left": keep Q♠ unless completely unprotected (needs both A♠ AND K♠ to protect)
+ *    - "none": baseline — pass unless holding A♠ + K♠
  * 2. A♥, K♥ — highest hearts first
  * 3. A♠, K♠ — if not needed to protect Q♠
  * 3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early
  * 4. Highest remaining safe card (never 2♣ or clubs below 6)
  */
 function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[] {
-  void direction;
   const selected: Card[] = [];
 
   const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
@@ -112,8 +114,18 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
   const hasQSpades = spades.some(isQueenOfSpades);
   const hasASpades = has("spades", 1);
   const hasKSpades = has("spades", 13);
-  const qSpadeProtected = hasASpades && hasKSpades;
   const voidInSpades = spades.length === 0;
+
+  // Direction changes how boldly we pass Q♠.
+  // "right"/"across": Q♠ travels far — pass if we have any high spade cover at all.
+  // "left": Q♠ may cycle back quickly — only pass if truly unprotected (neither A♠ nor K♠).
+  // "none": baseline — pass unless holding both A♠ and K♠.
+  const qSpadeProtected =
+    direction === "right" || direction === "across"
+      ? false // always willing to pass Q♠ when it goes far
+      : direction === "left"
+        ? hasASpades || hasKSpades // keep Q♠ if we have any high-spade protection
+        : hasASpades && hasKSpades; // "none": baseline protection check
 
   if (hasQSpades && !qSpadeProtected && !voidInSpades) {
     selected.push({ suit: "spades", rank: 12 });
@@ -169,8 +181,10 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  * Hard: dangerous-cards-first passing with opportunistic void creation.
  *
  * Priority:
- *   1. Q♠ (always pass, even when protected — unlike Medium).
+ *   1. Q♠ (always pass unless spade-void — more aggressive than Medium).
+ *      Direction does not change Q♠ behavior for Hard (always pass it) (#1595).
  *   2. A♥, K♥, Q♥, J♥ (high hearts, highest first).
+ *      Going "right": also include 10♥ as an additional danger heart (#1595).
  *   3. A♠, K♠ (if Q♠ not present).
  *   3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early.
  *   4. If any slots remain, complete a void in the shortest eligible suit (1 card only,
@@ -179,7 +193,6 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  *   5. Fill any remaining slots with the highest safe cards.
  */
 function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
-  void direction;
   const selected: Card[] = [];
 
   const has2Clubs = hand.some((c) => c.suit === "clubs" && c.rank === 2);
@@ -188,16 +201,21 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   const hasQSpades = spades.some(isQueenOfSpades);
   const voidInSpades = spades.length === 0;
 
-  // 1. Q♠ (pass even when holding A♠ + K♠)
-  if (hasQSpades && !voidInSpades) {
+  // 1. Q♠ — Hard always wants to pass Q♠; only keep it when passing left AND spade-void
+  // (receiving player would be spade-void too, making Q♠ dangerous to pass there).
+  const skipQSpade = voidInSpades || (direction === "left" && voidInSpades);
+  if (hasQSpades && !skipQSpade) {
     selected.push({ suit: "spades", rank: 12 });
   }
 
   const safe = passSafeFilter(selected);
 
-  // 2. High hearts
+  // 2. High hearts — going right, also include 10♥ as an extra danger card (#1595).
+  const heartDangerThreshold = direction === "right" ? 10 : 11;
   const dangerHearts = hand
-    .filter((c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= 11) && safe(c))
+    .filter(
+      (c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c)
+    )
     .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   for (const c of dangerHearts) {
     if (selected.length >= 3) break;


### PR DESCRIPTION
## Summary

- **Medium**: Q♠ protection threshold now varies by pass direction. Going right/across (card travels far), Q♠ is always passed even when holding A♠+K♠. Going left (card stays close), Q♠ is kept whenever any high spade (A♠ or K♠) is present. Going none (no-pass hand), baseline behavior (requires both A♠+K♠) is preserved.
- **Hard**: Includes 10♥ as a danger heart when passing right, aggressively dumping one more high heart toward opponents in the favorable direction.
- Addresses the `void direction;` stubs in `selectCardsToPassMedium` and `selectCardsToPassHard`.

## What wasn't implemented

The Cover Your Pass guard (keep a low spade when holding A♠/K♠) was specced but turns out to be dead code given the current step ordering: A♠/K♠ (ace-high = 14/13) always outrank J♠ (11) in the filler step, so J♠ is never selected while A♠/K♠ remain in hand. The guard was removed to keep the code clean.

## Test plan

- [x] `npx jest src/game/hearts/__tests__/ai.test.ts` — 74 tests, all pass
- [ ] Run `npx tsx scripts/simulate-hearts.ts` after merge and compare Hard vs Medium win rate against pre-PR2 baseline (52.2% vs 52.1%, n.s.)
- [ ] Verify CI passes (lint + prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)