### PR TITLE
fix(mahjong): hint button gap-blindness and silent no-op (#1591)

### DIFF
--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -180,6 +180,14 @@ describe("isFreeTile", () => {
     const otherRow = tile({ id: 1, col: 2, row: 3, layer: 0 });
     expect(isFreeTile(t, [t, otherRow])).toBe(true);
   });
+
+  it("is blocked by a tile two layers above after layer+1 is removed (gap blindness fix)", () => {
+    // layer 0 tile covered by a tile at layer 2; the layer 1 tile has been removed.
+    // Before the fix, only layer+1 was checked so the layer 0 tile was wrongly free.
+    const t = tile({ id: 0, col: 4, row: 2, layer: 0 });
+    const abovePlus2 = tile({ id: 1, col: 4, row: 2, layer: 2 });
+    expect(isFreeTile(t, [t, abovePlus2])).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -71,7 +71,7 @@ export function tilesMatch(a: SlotTile, b: SlotTile): boolean {
 export function isFreeTile(tile: SlotTile, tiles: readonly SlotTile[]): boolean {
   for (const t of tiles) {
     if (t.id === tile.id) continue;
-    if (t.layer === tile.layer + 1 && t.col === tile.col && t.row === tile.row) return false;
+    if (t.layer > tile.layer && t.col === tile.col && t.row === tile.row) return false;
   }
 
   let leftBlocked = false;

--- a/frontend/src/i18n/locales/ar/mahjong.json
+++ b/frontend/src/i18n/locales/ar/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/de/mahjong.json
+++ b/frontend/src/i18n/locales/de/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/en/mahjong.json
+++ b/frontend/src/i18n/locales/en/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "Undo last matched pair",
   "action.hint": "HINT",
   "action.hintLabel": "Show a hint — highlights one valid pair for 2 seconds",
+  "action.noHint": "No hints available",
   "overlay.noMoves": "NO MOVES",
   "overlay.noMovesDetail": "No matches available. Shuffle to continue.",
   "overlay.deadlocked": "NO MORE MOVES",

--- a/frontend/src/i18n/locales/es/mahjong.json
+++ b/frontend/src/i18n/locales/es/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/fr-CA/mahjong.json
+++ b/frontend/src/i18n/locales/fr-CA/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/he/mahjong.json
+++ b/frontend/src/i18n/locales/he/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/hi/mahjong.json
+++ b/frontend/src/i18n/locales/hi/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ja/mahjong.json
+++ b/frontend/src/i18n/locales/ja/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ko/mahjong.json
+++ b/frontend/src/i18n/locales/ko/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/nl/mahjong.json
+++ b/frontend/src/i18n/locales/nl/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/pt/mahjong.json
+++ b/frontend/src/i18n/locales/pt/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/ru/mahjong.json
+++ b/frontend/src/i18n/locales/ru/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/i18n/locales/zh/mahjong.json
+++ b/frontend/src/i18n/locales/zh/mahjong.json
@@ -15,6 +15,7 @@
   "action.undoLabel": "__NEEDS_TRANSLATION__",
   "action.hint": "__NEEDS_TRANSLATION__",
   "action.hintLabel": "__NEEDS_TRANSLATION__",
+  "action.noHint": "__NEEDS_TRANSLATION__",
   "overlay.noMoves": "__NEEDS_TRANSLATION__",
   "overlay.noMovesDetail": "__NEEDS_TRANSLATION__",
   "overlay.deadlocked": "__NEEDS_TRANSLATION__",

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -827,7 +827,7 @@ export default function MahjongScreen() {
 
           {noHintVisible && (
             <Text
-              style={[styles.noHintToast, { color: "#5dbcd2" }]}
+              style={styles.noHintToast}
               accessibilityLiveRegion="polite"
               testID="no-hint-toast"
             >
@@ -1125,6 +1125,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     letterSpacing: 0.5,
     paddingBottom: 4,
+    color: "#5dbcd2",
   },
   hudText: {
     fontFamily: typography.heading,

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -302,6 +302,8 @@ export default function MahjongScreen() {
   // Hint state — IDs of the pair currently being highlighted; auto-clears after 2 s.
   const [hintIds, setHintIds] = useState<ReadonlySet<number>>(new Set());
   const hintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [noHintVisible, setNoHintVisible] = useState(false);
+  const noHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Dev panel state — __DEV__ only; toggled via Shift+D (web) or long-press score (native).
   const [devPanelOpen, setDevPanelOpen] = useState(false);
@@ -667,7 +669,12 @@ export default function MahjongScreen() {
   const handleHint = useCallback(() => {
     if (!state) return;
     const pair = getAnyFreePair(state.tiles);
-    if (!pair) return;
+    if (!pair) {
+      if (noHintTimerRef.current) clearTimeout(noHintTimerRef.current);
+      setNoHintVisible(true);
+      noHintTimerRef.current = setTimeout(() => setNoHintVisible(false), 2000);
+      return;
+    }
     if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
     setHintIds(new Set(pair));
     hintTimerRef.current = setTimeout(() => setHintIds(new Set()), 2000);
@@ -676,6 +683,7 @@ export default function MahjongScreen() {
   useEffect(
     () => () => {
       if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
+      if (noHintTimerRef.current) clearTimeout(noHintTimerRef.current);
     },
     []
   );
@@ -816,6 +824,16 @@ export default function MahjongScreen() {
               </Pressable>
             )}
           </View>
+
+          {noHintVisible && (
+            <Text
+              style={[styles.noHintToast, { color: "#5dbcd2" }]}
+              accessibilityLiveRegion="polite"
+              testID="no-hint-toast"
+            >
+              {t("action.noHint")}
+            </Text>
+          )}
 
           {/* Viewport container — clips the board during zoom/pan */}
           <View
@@ -1101,6 +1119,12 @@ const styles = StyleSheet.create({
     alignSelf: "stretch",
     paddingHorizontal: 4,
     paddingVertical: 8,
+  },
+  noHintToast: {
+    fontFamily: typography.heading,
+    fontSize: 12,
+    letterSpacing: 0.5,
+    paddingBottom: 4,
   },
   hudText: {
     fontFamily: typography.heading,

--- a/frontend/src/screens/__tests__/MahjongScreen.test.tsx
+++ b/frontend/src/screens/__tests__/MahjongScreen.test.tsx
@@ -348,7 +348,8 @@ describe("MahjongScreen — hint button", () => {
   });
 
   it("shows the no-hint toast when no free pair is available", async () => {
-    // A state with a covered tile — the only matching tile is blocked above.
+    // id:0 (layer 0) is blocked by id:1 (layer 1); id:1 is free but has no second
+    // free match, so getAnyFreePair returns null.
     const blockedState: MahjongState = {
       _v: 1,
       tiles: [

--- a/frontend/src/screens/__tests__/MahjongScreen.test.tsx
+++ b/frontend/src/screens/__tests__/MahjongScreen.test.tsx
@@ -21,18 +21,21 @@ import type { MahjongState } from "../../game/mahjong/types";
 
 jest.mock("../../components/mahjong/GameCanvas", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { View, Pressable } = require("react-native");
+  const { View, Pressable, Text } = require("react-native");
   function MockGameCanvas({
     onNewGamePress,
+    hintIds,
   }: {
     onTilePress: (id: number) => void;
     onShufflePress: () => void;
     onNewGamePress: () => void;
+    hintIds: ReadonlySet<number>;
     layout: object;
   }) {
     return (
       <View testID="game-canvas">
         <Pressable accessibilityLabel="mock-new-game" onPress={onNewGamePress} />
+        <Text testID="hint-ids-size">{hintIds?.size ?? 0}</Text>
       </View>
     );
   }
@@ -304,6 +307,74 @@ describe("MahjongScreen — stats tracking", () => {
       const stats = raw ? JSON.parse(raw) : { gamesWon: 1 };
       expect(stats.gamesWon).toBe(1);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hint button
+// ---------------------------------------------------------------------------
+
+describe("MahjongScreen — hint button", () => {
+  /** Minimal in-progress state with two free matching tiles so getAnyFreePair returns a pair. */
+  function makeHintableState(): MahjongState {
+    return {
+      _v: 1,
+      tiles: [
+        { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 },
+        { id: 1, suit: "characters", rank: 1, faceId: 8, col: 2, row: 0, layer: 0 },
+      ] as MahjongState["tiles"],
+      selected: null,
+      pairsRemoved: 0,
+      score: 0,
+      shufflesLeft: 3,
+      undoStack: [],
+      isComplete: false,
+      isDeadlocked: false,
+      startedAt: null,
+      accumulatedMs: 0,
+      dealId: "TEST",
+    } as unknown as MahjongState;
+  }
+
+  it("passes hintIds to GameCanvas when a valid pair exists", async () => {
+    await AsyncStorage.setItem("mahjong_game", JSON.stringify(makeHintableState()));
+    const api = await mount();
+
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("action.hintLabel"));
+    });
+
+    expect(api.getByTestId("hint-ids-size").props.children).toBe(2);
+  });
+
+  it("shows the no-hint toast when no free pair is available", async () => {
+    // A state with a covered tile — the only matching tile is blocked above.
+    const blockedState: MahjongState = {
+      _v: 1,
+      tiles: [
+        { id: 0, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 0 },
+        { id: 1, suit: "characters", rank: 1, faceId: 8, col: 0, row: 0, layer: 1 },
+      ] as MahjongState["tiles"],
+      selected: null,
+      pairsRemoved: 0,
+      score: 0,
+      shufflesLeft: 3,
+      undoStack: [],
+      isComplete: false,
+      isDeadlocked: false,
+      startedAt: null,
+      accumulatedMs: 0,
+      dealId: "TEST",
+    } as unknown as MahjongState;
+    await AsyncStorage.setItem("mahjong_game", JSON.stringify(blockedState));
+    const api = await mount();
+
+    await act(async () => {
+      fireEvent.press(api.getByLabelText("action.hintLabel"));
+    });
+
+    expect(api.getByTestId("no-hint-toast")).toBeTruthy();
+    expect(api.getByTestId("hint-ids-size").props.children).toBe(0);
   });
 });
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`isFreeTile` bug fix**: Changed the above-check from `t.layer === tile.layer + 1` to `t.layer > tile.layer` so any tile at the same col/row on any higher layer correctly blocks the tile below. Previously, after a mid-layer tile was removed, a tile two or more layers above would pass the check undetected — causing `getAnyFreePair` to return `null` on boards that still had valid pairs.
- **Silent no-op fix**: `handleHint` now shows a brief "No hints available" toast (auto-clears after 2 s) when `getAnyFreePair` returns `null`, instead of silently doing nothing.
- **Tests**: Added an `isFreeTile` gap-in-layers test to `engine.test.ts` and two `MahjongScreen` tests verifying `hintIds` propagation and the no-hint toast.

## Test plan

- [ ] Press Hint on a normal in-progress board — two tiles should glow blue for 2 seconds
- [ ] Remove tiles from a mid-layer stack, then press Hint — should still find valid pairs (not silently no-op)
- [ ] Press Hint when no free pairs exist (e.g., only blocked tiles remain) — "No hints available" toast should appear briefly
- [ ] `engine.test.ts` — `isFreeTile` gap-in-layers case passes
- [ ] `MahjongScreen.test.tsx` — hint button tests pass

Closes #1591

https://claude.ai/code/session_01Wk94LYoXpQybuy2MaPXhSP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wk94LYoXpQybuy2MaPXhSP)_