### PR TITLE
feat(simulator): behavioral metrics for Hearts difficulty validation (#1632)

### DIFF
--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -333,6 +333,19 @@ if (count !== null) {
 }
 
 // ---------------------------------------------------------------------------
+// Reporting helpers
+// ---------------------------------------------------------------------------
+
+function fmt4pct(vals: number[], denom: number): string {
+  if (denom === 0) return "  n/a     n/a     n/a     n/a";
+  return vals.map((v) => `${((v / denom) * 100).toFixed(1)}%`.padStart(7)).join(" ");
+}
+
+function fmt4score(vals: number[], denom: number): string {
+  return vals.map((v) => (v / denom).toFixed(1).padStart(7)).join(" ");
+}
+
+// ---------------------------------------------------------------------------
 // Batches
 // ---------------------------------------------------------------------------
 
@@ -403,23 +416,18 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   // Behavioral metrics (#1632)
   const totalHands = results.reduce((s, r) => s + r.handsPlayed, 0);
   const totalPassRounds = results.reduce((s, r) => s + r.passingRounds, 0);
-  const qByPlayer = [0, 1, 2, 3].map((i) =>
+  const qByPlayerAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.qSpadeByPlayer[i]!, 0),
   );
-  const voidsByPlayer = [0, 1, 2, 3].map((i) =>
+  const voidsAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.voidsByPlayer[i]!, 0),
   );
-  const moonByPlayer = [0, 1, 2, 3].map((i) =>
+  const moonAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.moonShotsByPlayer[i]!, 0),
   );
-  const handScoreSumByPlayer = [0, 1, 2, 3].map((i) =>
+  const handScoreAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.handScoreSumByPlayer[i]!, 0),
   );
-
-  const fmt4 = (vals: number[], denom: number, scale = 100, decimals = 1) =>
-    vals.map((v) => `${((v / denom) * scale).toFixed(decimals)}%`).join("  ");
-  const fmt4score = (vals: number[], denom: number) =>
-    vals.map((v) => (v / denom).toFixed(1)).join("  ");
 
   const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
 
@@ -436,11 +444,11 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   );
   console.log(`  Moon Shots (any player): ${moonPct}%`);
   console.log(`  Q♠ on Human: ${qPct}%`);
-  console.log(`  --- Behavioral Metrics (s0  s1  s2  s3) ---`);
-  console.log(`  Q♠/Hand by Seat:    ${fmt4(qByPlayer, totalHands)}`);
-  console.log(`  Void Rate by Seat:  ${fmt4(voidsByPlayer, totalPassRounds)}`);
-  console.log(`  Moon Shots/Round:   ${fmt4(moonByPlayer, totalHands)}`);
-  console.log(`  Avg Hand Score:     ${fmt4score(handScoreSumByPlayer, totalHands)}`);
+  console.log(`  Behavioral Metrics      s0      s1      s2      s3`);
+  console.log(`  Q♠/Hand by Seat:    ${fmt4pct(qByPlayerAgg, totalHands)}`);
+  console.log(`  Void Rate by Seat:  ${fmt4pct(voidsAgg, totalPassRounds)}`);
+  console.log(`  Moon Shots/Round:   ${fmt4pct(moonAgg, totalHands)}`);
+  console.log(`  Avg Hand Score:     ${fmt4score(handScoreAgg, totalHands)}`);
   console.log();
 }
 

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -40,6 +40,12 @@ interface GameResult {
   handsPlayed: number;
   moonShots: number;
   qSpadeOnHuman: number;
+  // Behavioral metrics (#1632)
+  qSpadeByPlayer: [number, number, number, number]; // hands each seat took Q♠
+  voidsByPlayer: [number, number, number, number];  // passing rounds each seat voided a suit
+  passingRounds: number;                            // total non-"none" passing rounds
+  moonShotsByPlayer: [number, number, number, number]; // rounds each seat shot the moon
+  handScoreSumByPlayer: [number, number, number, number]; // sum of per-hand scores
 }
 
 function simulateGame(difficulties: Difficulties, seed: number): GameResult {
@@ -49,15 +55,33 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
   // Accumulate hand-scoped events before dealNextHand resets them (#1539).
   let totalMoonShots = 0;
   let qSpadeOnHuman = 0;
+  const qSpadeByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  const moonShotsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  const handScoreSumByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+
   function collectHandEvents(s: HeartsState) {
     const ev = s.events ?? [];
-    totalMoonShots += ev.filter((e) => e.type === "moonShot").length;
-    if (ev.some((e) => e.type === "queenOfSpades" && e.takerSeat === 0))
-      qSpadeOnHuman = 1;
+    for (const e of ev) {
+      if (e.type === "moonShot") {
+        totalMoonShots++;
+        moonShotsByPlayer[e.shooter]++;
+      }
+      if (e.type === "queenOfSpades") {
+        qSpadeByPlayer[e.takerSeat]++;
+        if (e.takerSeat === 0) qSpadeOnHuman = 1;
+      }
+    }
+    for (let i = 0; i < 4; i++) {
+      handScoreSumByPlayer[i] += s.handScores[i] ?? 0;
+    }
   }
+
+  const voidsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  let passingRounds = 0;
 
   while (state.phase !== "game_over") {
     if (state.phase === "passing") {
+      const isRealPass = state.passDirection !== "none";
       for (let i = 0; i < 4; i++) {
         const diff = difficulties[i]!;
         const hand = [...(state.playerHands[i] ?? [])];
@@ -67,6 +91,13 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
         }
       }
       state = commitPass(state);
+      if (isRealPass) {
+        passingRounds++;
+        for (let i = 0; i < 4; i++) {
+          const suits = new Set((state.playerHands[i] ?? []).map((c) => c.suit));
+          if (suits.size < 4) voidsByPlayer[i]++;
+        }
+      }
     } else if (state.phase === "playing") {
       const playerIndex = state.currentPlayerIndex;
       const diff = difficulties[playerIndex]!;
@@ -87,6 +118,11 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
     handsPlayed: state.handNumber,
     moonShots: totalMoonShots,
     qSpadeOnHuman,
+    qSpadeByPlayer,
+    voidsByPlayer,
+    passingRounds,
+    moonShotsByPlayer,
+    handScoreSumByPlayer,
   };
 }
 
@@ -364,6 +400,27 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const moonPct = (mean(moonShotsAll) * 100).toFixed(1);
   const qPct = (mean(qOnHuman) * 100).toFixed(1);
 
+  // Behavioral metrics (#1632)
+  const totalHands = results.reduce((s, r) => s + r.handsPlayed, 0);
+  const totalPassRounds = results.reduce((s, r) => s + r.passingRounds, 0);
+  const qByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.qSpadeByPlayer[i]!, 0),
+  );
+  const voidsByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.voidsByPlayer[i]!, 0),
+  );
+  const moonByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.moonShotsByPlayer[i]!, 0),
+  );
+  const handScoreSumByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.handScoreSumByPlayer[i]!, 0),
+  );
+
+  const fmt4 = (vals: number[], denom: number, scale = 100, decimals = 1) =>
+    vals.map((v) => `${((v / denom) * scale).toFixed(decimals)}%`).join("  ");
+  const fmt4score = (vals: number[], denom: number) =>
+    vals.map((v) => (v / denom).toFixed(1)).join("  ");
+
   const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
 
   console.log(label);
@@ -379,6 +436,11 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   );
   console.log(`  Moon Shots (any player): ${moonPct}%`);
   console.log(`  Q♠ on Human: ${qPct}%`);
+  console.log(`  --- Behavioral Metrics (s0  s1  s2  s3) ---`);
+  console.log(`  Q♠/Hand by Seat:    ${fmt4(qByPlayer, totalHands)}`);
+  console.log(`  Void Rate by Seat:  ${fmt4(voidsByPlayer, totalPassRounds)}`);
+  console.log(`  Moon Shots/Round:   ${fmt4(moonByPlayer, totalHands)}`);
+  console.log(`  Avg Hand Score:     ${fmt4score(handScoreSumByPlayer, totalHands)}`);
   console.log();
 }
 


### PR DESCRIPTION
## Summary

Adds four new per-seat behavioral metrics to `scripts/simulate-hearts.ts` so we can validate the behavioral signatures defined for each AI difficulty tier:

- **Q♠/Hand by Seat** — rate each seat takes the Queen of Spades (uses existing `queenOfSpades.takerSeat` event, extended to all 4 seats)
- **Void Rate by Seat** — rate each seat voids a suit after passing (checked from hand composition post-`commitPass`, non-"none" rounds only)
- **Moon Shots/Round by Seat** — rate each seat shoots the moon (uses existing `moonShot.shooter` event)
- **Avg Hand Score by Seat** — average per-hand points taken (from `handScores` collected at hand boundaries)

All existing batch output is preserved. New metrics appear as a `--- Behavioral Metrics ---` block per batch.

## Baseline findings

Running the simulator with the new metrics immediately reveals that Medium and Hard are behaviorally identical on every tracked dimension — void rates 5–8% (target: Medium 50%, Hard >80%), moon shots 0.1–0.2%/round (target: Hard ~10%), identical avg hand scores. This baseline is documented in #1632 and will guide the next phase of difficulty tier implementation.

## Test plan

- [ ] `npx tsx scripts/simulate-hearts.ts` runs without error and outputs all 6 batches with behavioral metric rows
- [ ] Easy baseline symmetric: all 4 seats show ~25% Q♠/hand, ~5% void, ~0.2% moon, ~6.5 avg score
- [ ] Medium/Hard seats show lower Q♠/hand and lower avg score than Easy seat in mixed batches

Closes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)