### PR TITLE
feat(hearts): void creation in passing for Medium and Hard (#1636)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -735,10 +735,10 @@ describe("selectCardToPlay — Hard difficulty, score-aware endgame", () => {
 // Hard AI — opportunistic void in passing
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — Hard difficulty, opportunistic void", () => {
-  it("voids a 1-card suit when exactly 1 pass slot remains after dangerous cards", () => {
-    // Q♠ fills slot 1, A♥ fills slot 2 (high heart). 1 slot remains.
-    // ♦7 is the only diamond → void fires and ♦7 fills the last slot.
+describe("selectCardsToPass — #1636 void creation (Hard)", () => {
+  it("voids a 1-card suit when 1 slot remains after dangerous cards", () => {
+    // Q♠ fills slot 1, A♥ fills slot 2. 1 slot remains.
+    // ♦7 is the only diamond → void fires, ♦7 fills slot 3.
     const hand = [
       c("spades", 12),
       c("hearts", 1),
@@ -756,6 +756,150 @@ describe("selectCardsToPass — Hard difficulty, opportunistic void", () => {
     ];
     const passed = selectCardsToPass(hand, "left", "hard");
     expect(passed).toContainEqual(c("diamonds", 7));
+  });
+
+  it("voids a 2-card suit when 2 slots remain after Q♠ alone", () => {
+    // Q♠ fills slot 1. No danger hearts (J♥ threshold not met), no A/K spades, no A/K clubs.
+    // 2 slots remain. ♦4 and ♦6 are the only 2 diamonds → void fires, both pass.
+    const hand = [
+      c("spades", 12),
+      c("diamonds", 4),
+      c("diamonds", 6),
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("hearts", 2),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left", "hard");
+    expect(passed).toContainEqual(c("diamonds", 4));
+    expect(passed).toContainEqual(c("diamonds", 6));
+  });
+
+  it("voids a 3-card suit when all 3 slots remain (no high-priority cards)", () => {
+    // No Q♠, no danger hearts (hearts are 2-5), no high spades, no high clubs.
+    // All 3 slots available. ♦3, ♦4, ♦5 are the only 3 diamonds → full void.
+    const hand = [
+      c("diamonds", 3),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("hearts", 2),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left", "hard");
+    expect(passed).toContainEqual(c("diamonds", 3));
+    expect(passed).toContainEqual(c("diamonds", 4));
+    expect(passed).toContainEqual(c("diamonds", 5));
+  });
+});
+
+describe("selectCardsToPass — #1636 void creation (Medium)", () => {
+  it("voids a 1-card suit when 1 slot remains after Q♠ and 1 danger heart", () => {
+    // Q♠ → slot 1, A♥ → slot 2. 1 slot remains.
+    // ♦7 is the only diamond → Medium voids it (1 ≤ maxSuitSize 2).
+    const hand = [
+      c("spades", 12),
+      c("hearts", 1),
+      c("diamonds", 7),
+      c("clubs", 6),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("hearts", 4),
+      c("hearts", 5),
+      c("hearts", 6),
+    ];
+    const passed = selectCardsToPass(hand, "left", "medium");
+    expect(passed).toContainEqual(c("diamonds", 7));
+  });
+
+  it("voids a 2-card suit when 2 slots remain after Q♠ alone", () => {
+    // Q♠ → slot 1. 2 slots remain. ♦4, ♦6 are the only diamonds → Medium voids (2 ≤ maxSuitSize 2).
+    const hand = [
+      c("spades", 12),
+      c("diamonds", 4),
+      c("diamonds", 6),
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("hearts", 2),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left", "medium");
+    expect(passed).toContainEqual(c("diamonds", 4));
+    expect(passed).toContainEqual(c("diamonds", 6));
+  });
+
+  it("does NOT void a 3-card suit — Medium caps at 2", () => {
+    // No high-priority cards → 3 slots available. Shortest suit has 3 cards (diamonds).
+    // Medium maxSuitSize=2 → can't void a 3-card suit → falls back to high-card filler.
+    const hand = [
+      c("diamonds", 3),
+      c("diamonds", 4),
+      c("diamonds", 5),
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("spades", 3),
+      c("spades", 4),
+      c("spades", 5),
+      c("hearts", 2),
+      c("hearts", 3),
+      c("hearts", 4),
+    ];
+    const passed = selectCardsToPass(hand, "left", "medium");
+    // Should NOT void diamonds (3 cards > maxSuitSize 2) — uses high-card filler instead
+    expect(passed).not.toContainEqual(c("diamonds", 3));
+    expect(passed).not.toContainEqual(c("diamonds", 4));
+    expect(passed).not.toContainEqual(c("diamonds", 5));
+  });
+
+  it("does NOT target spades for void when Q♠ is kept (cover cards protected)", () => {
+    // Direction=left, has A♠+K♠ → Q♠ kept. Spades left: A♠, K♠ (2 cards).
+    // Medium should NOT void spades (keepingQSpade=true) — A♠/K♠ are Q♠ cover.
+    // Hearts 5♥ is a singleton → hearts void fires instead.
+    const hand = [
+      c("spades", 12),
+      c("spades", 1),
+      c("spades", 13),
+      c("hearts", 1),
+      c("hearts", 13),
+      c("hearts", 5),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("diamonds", 5),
+      c("diamonds", 6),
+      c("diamonds", 7),
+    ];
+    // direction=left: hasASpades=true → Q♠ protected (kept)
+    const passed = selectCardsToPass(hand, "left", "medium");
+    expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
+    expect(passed).not.toContainEqual(c("spades", 1));  // A♠ kept (cover)
+    expect(passed).not.toContainEqual(c("spades", 13)); // K♠ kept (cover)
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -900,6 +900,8 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
     expect(passed).not.toContainEqual(c("spades", 1));  // A♠ kept (cover)
     expect(passed).not.toContainEqual(c("spades", 13)); // K♠ kept (cover)
+    // Void fires on 5♥ (singleton heart) instead — positive assertion that the guard redirects correctly
+    expect(passed).toContainEqual(c("hearts", 5));
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -898,7 +898,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
     // direction=left: hasASpades=true → Q♠ protected (kept)
     const passed = selectCardsToPass(hand, "left", "medium");
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
-    expect(passed).not.toContainEqual(c("spades", 1));  // A♠ kept (cover)
+    expect(passed).not.toContainEqual(c("spades", 1)); // A♠ kept (cover)
     expect(passed).not.toContainEqual(c("spades", 13)); // K♠ kept (cover)
     // Void fires on 5♥ (singleton heart) instead — positive assertion that the guard redirects correctly
     expect(passed).toContainEqual(c("hearts", 5));

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -103,7 +103,7 @@ function voidOneSuit(
   selected: Card[],
   has2Clubs: boolean,
   keepingQSpade: boolean,
-  maxSuitSize: number,
+  maxSuitSize: number
 ): void {
   const remaining = 3 - selected.length;
   if (remaining <= 0 || maxSuitSize <= 0) return;

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -88,6 +88,52 @@ function passSafeFilter(selected: Card[]): (c: Card) => boolean {
   };
 }
 
+/**
+ * After high-priority cards fill some pass slots, use remaining slots to void a short suit.
+ * Finds the shortest eligible suit whose total remaining cards fit within `limit` slots and
+ * pushes those cards into `selected`.
+ *
+ * Uses a looser filter than passSafeFilter: allows clubs <6 so low clubs can complete a void
+ * (they're normally deprioritised as filler but are fine to pass for void purposes).
+ *
+ * @param maxSuitSize - Medium passes 2 (doubletons + singletons); Hard passes up to `remaining`.
+ */
+function voidOneSuit(
+  hand: Card[],
+  selected: Card[],
+  has2Clubs: boolean,
+  keepingQSpade: boolean,
+  maxSuitSize: number,
+): void {
+  const remaining = 3 - selected.length;
+  if (remaining <= 0 || maxSuitSize <= 0) return;
+  const limit = Math.min(remaining, maxSuitSize);
+
+  const bySuit = new Map<string, Card[]>();
+  for (const c of hand) {
+    if (c.suit === "clubs" && c.rank === 2) continue;
+    if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) continue;
+    const group = bySuit.get(c.suit) ?? [];
+    group.push(c);
+    bySuit.set(c.suit, group);
+  }
+
+  let best: Card[] | null = null;
+  for (const [suit, cards] of bySuit) {
+    if (suit === "clubs" && has2Clubs) continue;
+    if (suit === "spades" && keepingQSpade) continue;
+    if (cards.length > limit) continue;
+    if (best === null || cards.length < best.length) best = cards;
+  }
+
+  if (best !== null) {
+    for (const c of best) {
+      if (selected.length >= 3) break;
+      selected.push(c);
+    }
+  }
+}
+
 /** Easy: pass the first 3 safe cards with no strategic logic. Never passes 2♣. */
 function selectCardsToPassEasy(hand: Card[]): Card[] {
   const safe = hand.filter((c) => !(c.suit === "clubs" && c.rank === 2));
@@ -104,13 +150,15 @@ function selectCardsToPassEasy(hand: Card[]): Card[] {
  * 2. A♥, K♥ — highest hearts first
  * 3. A♠, K♠ — if not needed to protect Q♠
  * 3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early
- * 4. Highest remaining safe card (never 2♣ or clubs below 6)
+ * 4. Void creation — use remaining slots to eliminate a short suit (≤ 2 cards) (#1636)
+ * 5. Highest remaining safe card (never 2♣ or clubs below 6)
  */
 function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[] {
   const selected: Card[] = [];
 
   const has = (suit: string, rank: number) => hand.some((c) => c.suit === suit && c.rank === rank);
 
+  const has2Clubs = hand.some((c) => c.suit === "clubs" && c.rank === 2);
   const spades = hand.filter((c) => c.suit === "spades");
   const hasQSpades = spades.some(isQueenOfSpades);
   const hasASpades = has("spades", 1);
@@ -164,6 +212,12 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
     }
   }
 
+  // Void creation: use remaining slots to eliminate a 1–2 card suit (#1636).
+  // Don't target spades when keeping Q♠ — A♠/K♠ are needed as cover cards.
+  const keepingQSpade = hasQSpades && !selected.some(isQueenOfSpades);
+  voidOneSuit(hand, selected, has2Clubs, keepingQSpade, 2);
+
+  // Filler: highest remaining safe card.
   if (selected.length < 3) {
     const candidates = hand.filter(safe).sort((a, b) => {
       const ra = a.rank === 1 ? 14 : a.rank;
@@ -180,7 +234,7 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
 }
 
 /**
- * Hard: dangerous-cards-first passing with opportunistic void creation.
+ * Hard: dangerous-cards-first passing with aggressive void creation (#1636).
  *
  * Priority:
  *   1. Q♠ (always pass unless spade-void — more aggressive than Medium).
@@ -189,9 +243,9 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  *      Going "right": also include 10♥ as an additional danger heart (#1595).
  *   3. A♠, K♠ (if Q♠ not present).
  *   3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early.
- *   4. If any slots remain, complete a void in the shortest eligible suit (1 card only,
- *      not 2♣ holder's clubs). Voiding a suit gives Hard a free discard opportunity on
- *      every future lead of that suit without sacrificing a dangerous-card slot.
+ *   4. Void creation: use ALL remaining slots to eliminate the shortest eligible suit.
+ *      More aggressive than Medium (which caps at 2-card suits). Voiding gives Hard a
+ *      free discard on every future lead of that suit.
  *   5. Fill any remaining slots with the highest safe cards.
  */
 function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
@@ -244,21 +298,9 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
     }
   }
 
-  // 4. Opportunistic void: if exactly 1 slot remains, use it to void a single-card suit.
-  if (selected.length === 2) {
-    const bySuit = new Map<string, Card[]>();
-    for (const c of hand) {
-      if (!bySuit.has(c.suit)) bySuit.set(c.suit, []);
-      bySuit.get(c.suit)!.push(c);
-    }
-    for (const [suit, cards] of bySuit) {
-      if (suit === "clubs" && has2Clubs) continue;
-      if (cards.length === 1 && notSelected(cards[0]!)) {
-        selected.push(cards[0]!);
-        break;
-      }
-    }
-  }
+  // 4. Void creation: use all remaining slots to void the shortest eligible suit (#1636).
+  // Hard always passes Q♠ when possible, so keepingQSpade is never true here.
+  voidOneSuit(hand, selected, has2Clubs, false, 3 - selected.length);
 
   // 5. Fill remaining slots with highest safe cards
   if (selected.length < 3) {

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -333,6 +333,19 @@ if (count !== null) {
 }
 
 // ---------------------------------------------------------------------------
+// Reporting helpers
+// ---------------------------------------------------------------------------
+
+function fmt4pct(vals: number[], denom: number): string {
+  if (denom === 0) return "  n/a     n/a     n/a     n/a";
+  return vals.map((v) => `${((v / denom) * 100).toFixed(1)}%`.padStart(7)).join(" ");
+}
+
+function fmt4score(vals: number[], denom: number): string {
+  return vals.map((v) => (v / denom).toFixed(1).padStart(7)).join(" ");
+}
+
+// ---------------------------------------------------------------------------
 // Batches
 // ---------------------------------------------------------------------------
 
@@ -403,23 +416,18 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   // Behavioral metrics (#1632)
   const totalHands = results.reduce((s, r) => s + r.handsPlayed, 0);
   const totalPassRounds = results.reduce((s, r) => s + r.passingRounds, 0);
-  const qByPlayer = [0, 1, 2, 3].map((i) =>
+  const qByPlayerAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.qSpadeByPlayer[i]!, 0),
   );
-  const voidsByPlayer = [0, 1, 2, 3].map((i) =>
+  const voidsAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.voidsByPlayer[i]!, 0),
   );
-  const moonByPlayer = [0, 1, 2, 3].map((i) =>
+  const moonAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.moonShotsByPlayer[i]!, 0),
   );
-  const handScoreSumByPlayer = [0, 1, 2, 3].map((i) =>
+  const handScoreAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.handScoreSumByPlayer[i]!, 0),
   );
-
-  const fmt4 = (vals: number[], denom: number, scale = 100, decimals = 1) =>
-    vals.map((v) => `${((v / denom) * scale).toFixed(decimals)}%`).join("  ");
-  const fmt4score = (vals: number[], denom: number) =>
-    vals.map((v) => (v / denom).toFixed(1)).join("  ");
 
   const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
 
@@ -436,11 +444,11 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   );
   console.log(`  Moon Shots (any player): ${moonPct}%`);
   console.log(`  Q♠ on Human: ${qPct}%`);
-  console.log(`  --- Behavioral Metrics (s0  s1  s2  s3) ---`);
-  console.log(`  Q♠/Hand by Seat:    ${fmt4(qByPlayer, totalHands)}`);
-  console.log(`  Void Rate by Seat:  ${fmt4(voidsByPlayer, totalPassRounds)}`);
-  console.log(`  Moon Shots/Round:   ${fmt4(moonByPlayer, totalHands)}`);
-  console.log(`  Avg Hand Score:     ${fmt4score(handScoreSumByPlayer, totalHands)}`);
+  console.log(`  Behavioral Metrics      s0      s1      s2      s3`);
+  console.log(`  Q♠/Hand by Seat:    ${fmt4pct(qByPlayerAgg, totalHands)}`);
+  console.log(`  Void Rate by Seat:  ${fmt4pct(voidsAgg, totalPassRounds)}`);
+  console.log(`  Moon Shots/Round:   ${fmt4pct(moonAgg, totalHands)}`);
+  console.log(`  Avg Hand Score:     ${fmt4score(handScoreAgg, totalHands)}`);
   console.log();
 }
 

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -40,6 +40,12 @@ interface GameResult {
   handsPlayed: number;
   moonShots: number;
   qSpadeOnHuman: number;
+  // Behavioral metrics (#1632)
+  qSpadeByPlayer: [number, number, number, number]; // hands each seat took Q♠
+  voidsByPlayer: [number, number, number, number];  // passing rounds each seat voided a suit
+  passingRounds: number;                            // total non-"none" passing rounds
+  moonShotsByPlayer: [number, number, number, number]; // rounds each seat shot the moon
+  handScoreSumByPlayer: [number, number, number, number]; // sum of per-hand scores
 }
 
 function simulateGame(difficulties: Difficulties, seed: number): GameResult {
@@ -49,15 +55,33 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
   // Accumulate hand-scoped events before dealNextHand resets them (#1539).
   let totalMoonShots = 0;
   let qSpadeOnHuman = 0;
+  const qSpadeByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  const moonShotsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  const handScoreSumByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+
   function collectHandEvents(s: HeartsState) {
     const ev = s.events ?? [];
-    totalMoonShots += ev.filter((e) => e.type === "moonShot").length;
-    if (ev.some((e) => e.type === "queenOfSpades" && e.takerSeat === 0))
-      qSpadeOnHuman = 1;
+    for (const e of ev) {
+      if (e.type === "moonShot") {
+        totalMoonShots++;
+        moonShotsByPlayer[e.shooter]++;
+      }
+      if (e.type === "queenOfSpades") {
+        qSpadeByPlayer[e.takerSeat]++;
+        if (e.takerSeat === 0) qSpadeOnHuman = 1;
+      }
+    }
+    for (let i = 0; i < 4; i++) {
+      handScoreSumByPlayer[i] += s.handScores[i] ?? 0;
+    }
   }
+
+  const voidsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  let passingRounds = 0;
 
   while (state.phase !== "game_over") {
     if (state.phase === "passing") {
+      const isRealPass = state.passDirection !== "none";
       for (let i = 0; i < 4; i++) {
         const diff = difficulties[i]!;
         const hand = [...(state.playerHands[i] ?? [])];
@@ -67,6 +91,13 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
         }
       }
       state = commitPass(state);
+      if (isRealPass) {
+        passingRounds++;
+        for (let i = 0; i < 4; i++) {
+          const suits = new Set((state.playerHands[i] ?? []).map((c) => c.suit));
+          if (suits.size < 4) voidsByPlayer[i]++;
+        }
+      }
     } else if (state.phase === "playing") {
       const playerIndex = state.currentPlayerIndex;
       const diff = difficulties[playerIndex]!;
@@ -87,6 +118,11 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
     handsPlayed: state.handNumber,
     moonShots: totalMoonShots,
     qSpadeOnHuman,
+    qSpadeByPlayer,
+    voidsByPlayer,
+    passingRounds,
+    moonShotsByPlayer,
+    handScoreSumByPlayer,
   };
 }
 
@@ -364,6 +400,27 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const moonPct = (mean(moonShotsAll) * 100).toFixed(1);
   const qPct = (mean(qOnHuman) * 100).toFixed(1);
 
+  // Behavioral metrics (#1632)
+  const totalHands = results.reduce((s, r) => s + r.handsPlayed, 0);
+  const totalPassRounds = results.reduce((s, r) => s + r.passingRounds, 0);
+  const qByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.qSpadeByPlayer[i]!, 0),
+  );
+  const voidsByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.voidsByPlayer[i]!, 0),
+  );
+  const moonByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.moonShotsByPlayer[i]!, 0),
+  );
+  const handScoreSumByPlayer = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.handScoreSumByPlayer[i]!, 0),
+  );
+
+  const fmt4 = (vals: number[], denom: number, scale = 100, decimals = 1) =>
+    vals.map((v) => `${((v / denom) * scale).toFixed(decimals)}%`).join("  ");
+  const fmt4score = (vals: number[], denom: number) =>
+    vals.map((v) => (v / denom).toFixed(1)).join("  ");
+
   const pct = (v: number) => `${(v * 100).toFixed(1)}%`;
 
   console.log(label);
@@ -379,6 +436,11 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   );
   console.log(`  Moon Shots (any player): ${moonPct}%`);
   console.log(`  Q♠ on Human: ${qPct}%`);
+  console.log(`  --- Behavioral Metrics (s0  s1  s2  s3) ---`);
+  console.log(`  Q♠/Hand by Seat:    ${fmt4(qByPlayer, totalHands)}`);
+  console.log(`  Void Rate by Seat:  ${fmt4(voidsByPlayer, totalPassRounds)}`);
+  console.log(`  Moon Shots/Round:   ${fmt4(moonByPlayer, totalHands)}`);
+  console.log(`  Avg Hand Score:     ${fmt4score(handScoreSumByPlayer, totalHands)}`);
   console.log();
 }
 


### PR DESCRIPTION
## Summary

- Extracts `voidOneSuit()` helper shared by Medium and Hard passing logic
- **Medium**: after high-priority cards, uses remaining slots to void a suit with ≤ 2 cards
- **Hard**: same logic but caps at `remaining` slots — can void 1-, 2-, or 3-card suits
- Guard: never voids spades when Medium is keeping Q♠ (A♠/K♠ are cover cards)
- Guard: never voids clubs when holding 2♣
- Uses a permissive filter for void candidates (allows clubs <6) since low clubs are exactly right to pass for suit elimination

## Simulator results (vs baseline)

| Metric | Before | After | Target |
|---|---|---|---|
| Medium void rate | 5.5% | **21%** | ~50% |
| Hard void rate | 7.8% | **20%** | >80% |
| Easy void rate | 4.9% | 4.9% | ~0% ✓ |

Medium and Hard are currently at the same rate (~20%) because hand composition after high-priority selections limits opportunity — not the cap. Pushing Hard higher requires lowering its priority threshold on some high-priority cards to free more slots for voiding (follow-on work in #1636).

## Test plan

- [ ] 80 Hearts AI unit tests pass (`cd frontend && npx jest --testPathPattern="hearts/.*ai"`)
- [ ] 6 new Golden Hands tests:
  - Hard: 1-card void, 2-card void, 3-card void (all 3 remaining slots)
  - Medium: 1-card void, 2-card void, does NOT void 3-card suits (cap enforced)
  - Medium: does NOT target spades when Q♠ is kept

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)