### PR TITLE
feat(hearts): adversarial targeting — Hard routes damage toward human player (#1638)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1971,4 +1971,52 @@ describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
     expect(passed).toHaveLength(3);
     expect(passed).not.toContainEqual(c("spades", 12));
   });
+
+  it("passes Q♠ to seat 0 in moon-viable mode via across pass from seat 2", () => {
+    // Seat 2 passes across → (2+2)%4=0 → targeting seat 0.
+    const hand = [
+      c("hearts", 1),
+      c("hearts", 10),
+      c("hearts", 9),
+      c("hearts", 8),
+      c("hearts", 7),
+      c("spades", 12),
+      c("diamonds", 1),
+      c("clubs", 1),
+      c("diamonds", 8),
+      c("clubs", 8),
+      c("diamonds", 7),
+      c("clubs", 7),
+      c("diamonds", 6),
+    ];
+    const passed = selectCardsToPass(hand, "across", "hard", 2);
+    expect(passed).toHaveLength(3);
+    expect(passed).toContainEqual(c("spades", 12));
+  });
+});
+
+describe("selectCardToPlay — Hard difficulty, adversarial void discard (edge cases)", () => {
+  it("falls through to normal discard when seat 0 is winning but Hard holds no Q♠ or hearts", () => {
+    // Player 1 holds only non-point cards — nothing to target seat 0 with.
+    // Should fall through and discard normally (highest non-point card).
+    const hand = [c("diamonds", 10), c("clubs", 9), c("diamonds", 6)];
+    const trick: TrickCard[] = [
+      { card: c("spades", 13), playerIndex: 0 }, // seat 0 winning with K♠
+      { card: c("spades", 3), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      heartsBroken: true,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+      cumulativeScores: [10, 10, 10, 10],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // No Q♠ or hearts to dump — adversarial block falls through; normal discard fires.
+    expect(pick.suit).not.toBe("hearts");
+    expect(pick).not.toEqual(c("spades", 12));
+  });
 });

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -1870,3 +1870,105 @@ describe("selectCardsToPass — #1595 across direction (Medium)", () => {
     expect(passed).toHaveLength(3);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hard AI — adversarial targeting (#1638)
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — Hard difficulty, adversarial void discard", () => {
+  it("dumps Q♠ on seat 0 when seat 0 is winning the trick and Hard is void", () => {
+    // Player 1 (Hard) is void in clubs and holds Q♠ + hearts.
+    // Seat 0 is currently winning the trick with K♣.
+    const hand = [c("spades", 12), c("hearts", 5), c("hearts", 9), c("diamonds", 7)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 13), playerIndex: 0 }, // seat 0 winning
+      { card: c("clubs", 3), playerIndex: 2 },
+    ];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      heartsBroken: true,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+      cumulativeScores: [10, 10, 10, 10], // below endgame threshold
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Seat 0 is winning — adversarial: dump Q♠ on human.
+    expect(pick).toEqual(c("spades", 12));
+  });
+
+  it("saves Q♠ when an AI opponent (not seat 0) is winning the trick", () => {
+    // Player 1 (Hard) is void in clubs. Seat 2 is winning with K♣ (not seat 0).
+    // Hard holds Q♠, hearts, and a diamond — should discard the non-point card.
+    const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 0 },
+      { card: c("clubs", 13), playerIndex: 2 }, // seat 2 winning
+    ];
+    const state = mkState({
+      playerHands: [[], hand, [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 1,
+      heartsBroken: true,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+      cumulativeScores: [10, 10, 10, 10],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    // Another AI is winning — save Q♠ for seat 0; dump non-point card (7♦).
+    expect(pick).toEqual(c("diamonds", 7));
+    expect(pick).not.toEqual(c("spades", 12));
+  });
+});
+
+describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
+  it("passes Q♠ to seat 0 even in moon-viable mode (left pass from seat 3)", () => {
+    // Seat 3 passes left → recipient is seat 0. Hand is moon-viable (5+ hearts + Q♠).
+    // Without targeting, moonViable keeps Q♠; with targeting, Q♠ is passed to seat 0.
+    const hand = [
+      c("hearts", 1),
+      c("hearts", 10),
+      c("hearts", 9),
+      c("hearts", 8),
+      c("hearts", 7),
+      c("spades", 12),
+      c("diamonds", 1),
+      c("clubs", 1),
+      c("diamonds", 8),
+      c("clubs", 8),
+      c("diamonds", 7),
+      c("clubs", 7),
+      c("diamonds", 6),
+    ];
+    // playerIndex=3, direction="left" → (3+1)%4=0 → targeting seat 0
+    const passed = selectCardsToPass(hand, "left", "hard", 3);
+    expect(passed).toHaveLength(3);
+    expect(passed).toContainEqual(c("spades", 12));
+  });
+
+  it("keeps Q♠ in moon-viable mode when NOT passing to seat 0 (left pass from seat 1)", () => {
+    // Seat 1 passes left → recipient is seat 2 (not seat 0). Moon-viable should activate.
+    const hand = [
+      c("hearts", 1),
+      c("hearts", 10),
+      c("hearts", 9),
+      c("hearts", 8),
+      c("hearts", 7),
+      c("spades", 12),
+      c("diamonds", 1),
+      c("clubs", 1),
+      c("diamonds", 8),
+      c("clubs", 8),
+      c("diamonds", 7),
+      c("clubs", 7),
+      c("diamonds", 6),
+    ];
+    // playerIndex=1, direction="left" → (1+1)%4=2 → not targeting seat 0
+    const passed = selectCardsToPass(hand, "left", "hard", 1);
+    expect(passed).toHaveLength(3);
+    expect(passed).not.toContainEqual(c("spades", 12));
+  });
+});

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -271,6 +271,7 @@ function selectCardsToPassHard(
   const voidInSpades = spades.length === 0;
 
   // Adversarial targeting (#1638): when passing to seat 0, always send Q♠ — skip moon-viable.
+  // Standard mode already passes Q♠ first, so only moon-viable needs suppressing.
   const targetingHuman = passingToSeat0(playerIndex, direction);
 
   // Moon-viable passing (#1637): 5+ hearts + Q♠ → keep both, pass dangerous non-hearts.
@@ -389,6 +390,8 @@ function selectCardsToPassHard(
 /**
  * Select exactly 3 cards to pass.
  * `difficulty` defaults to "medium" (current behaviour) so existing callers are unchanged.
+ * `playerIndex` defaults to 0 (human seat) — seat 0 never passes so the default never
+ * triggers adversarial targeting; pass the actual AI seat index (1–3) for Hard targeting.
  */
 export function selectCardsToPass(
   hand: Card[],
@@ -669,6 +672,7 @@ function selectCardToPlayHard(
             .filter((c) => c.suit === "hearts")
             .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
           if (heartsDesc.length > 0) return heartsDesc[0]!;
+          // No Q♠ or hearts to target with — fall through to normal discard.
         } else {
           // Another AI is winning — prefer non-point discard; save Q♠/hearts for seat 0.
           const nonPts = valid.filter((c) => cardPoints(c) === 0);
@@ -678,9 +682,8 @@ function selectCardToPlayHard(
             .filter((c) => c.suit === "hearts")
             .sort((a, b) => aceHigh(a.rank) - aceHigh(b.rank));
           if (heartsAsc.length > 0) return heartsAsc[0]!;
-          // No hearts either — must play Q♠ (no safe alternative).
+          // No hearts either — must play Q♠ (no safe alternative); fall through.
         }
-        // Fall through to chooseDiscard via chooseFollow for remaining edge cases.
       }
     }
   }

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -79,6 +79,13 @@ function bySuitDescending(cards: Card[]): Array<[string, Card[]]> {
 // Passing strategy
 // ---------------------------------------------------------------------------
 
+/** Returns true when playerIndex's pass lands on seat 0 for the given direction. */
+function passingToSeat0(playerIndex: number, direction: PassDirection): boolean {
+  if (direction === "none") return false;
+  const offset = direction === "left" ? 1 : direction === "right" ? 3 : 2;
+  return (playerIndex + offset) % 4 === 0;
+}
+
 function passSafeFilter(selected: Card[]): (c: Card) => boolean {
   return (c: Card) => {
     if (selected.some((s) => s.suit === c.suit && s.rank === c.rank)) return false;
@@ -249,7 +256,11 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  *   4. Void creation: use ALL remaining slots to eliminate the shortest eligible suit.
  *   5. Fill any remaining slots with the highest safe cards.
  */
-function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
+function selectCardsToPassHard(
+  hand: Card[],
+  direction: PassDirection,
+  playerIndex: number
+): Card[] {
   const selected: Card[] = [];
 
   const has2Clubs = hand.some((c) => c.suit === "clubs" && c.rank === 2);
@@ -259,9 +270,12 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
   const hasQSpades = spades.some(isQueenOfSpades);
   const voidInSpades = spades.length === 0;
 
+  // Adversarial targeting (#1638): when passing to seat 0, always send Q♠ — skip moon-viable.
+  const targetingHuman = passingToSeat0(playerIndex, direction);
+
   // Moon-viable passing (#1637): 5+ hearts + Q♠ → keep both, pass dangerous non-hearts.
   const moonViable = heartsInHand >= 5 && hasQSpades; // hasQSpades implies !voidInSpades
-  if (moonViable) {
+  if (moonViable && !targetingHuman) {
     const notSel = (c: Card) => !selected.some((s) => s.suit === c.suit && s.rank === c.rank);
     const moonSafe = (c: Card) =>
       c.suit !== "hearts" &&
@@ -379,10 +393,11 @@ function selectCardsToPassHard(hand: Card[], direction: PassDirection): Card[] {
 export function selectCardsToPass(
   hand: Card[],
   direction: PassDirection,
-  difficulty: AiDifficulty = "medium"
+  difficulty: AiDifficulty = "medium",
+  playerIndex = 0
 ): Card[] {
   if (difficulty === "easy") return selectCardsToPassEasy(hand);
-  if (difficulty === "hard") return selectCardsToPassHard(hand, direction);
+  if (difficulty === "hard") return selectCardsToPassHard(hand, direction, playerIndex);
   return selectCardsToPassMedium(hand, direction);
 }
 
@@ -634,6 +649,38 @@ function selectCardToPlayHard(
           if (lowestHeart.length > 0) return lowestHeart[0]!;
           if (withoutQ.length > 0) return withoutQ[0]!;
         }
+      }
+    }
+  }
+
+  // Adversarial targeting (#1638): when void in led suit, prefer dumping Q♠/high hearts on
+  // seat 0 (human). When another AI is winning the trick, save Q♠/hearts for seat 0's tricks.
+  if (!isMoonAttempt && !inEndgame && !isLeading) {
+    const first = trick[0];
+    if (first) {
+      const followSuit = valid.filter((c) => c.suit === first.card.suit);
+      if (followSuit.length === 0) {
+        const winner = currentTrickWinner(trick);
+        if (winner === 0) {
+          // Seat 0 is winning — dump Q♠ first, then highest heart.
+          const q = valid.find(isQueenOfSpades);
+          if (q) return q;
+          const heartsDesc = valid
+            .filter((c) => c.suit === "hearts")
+            .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+          if (heartsDesc.length > 0) return heartsDesc[0]!;
+        } else {
+          // Another AI is winning — prefer non-point discard; save Q♠/hearts for seat 0.
+          const nonPts = valid.filter((c) => cardPoints(c) === 0);
+          if (nonPts.length > 0) return highest(nonPts) ?? valid[0]!;
+          // Only point cards remain — dump lowest heart, keep Q♠ in reserve.
+          const heartsAsc = valid
+            .filter((c) => c.suit === "hearts")
+            .sort((a, b) => aceHigh(a.rank) - aceHigh(b.rank));
+          if (heartsAsc.length > 0) return heartsAsc[0]!;
+          // No hearts either — must play Q♠ (no safe alternative).
+        }
+        // Fall through to chooseDiscard via chooseFollow for remaining edge cases.
       }
     }
   }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -360,7 +360,8 @@ export default function HeartsScreen() {
       const aiCards = selectCardsToPass(
         [...(s.playerHands[i] ?? [])],
         s.passDirection,
-        s.aiDifficulty
+        s.aiDifficulty,
+        i
       );
       for (const c of aiCards) {
         s = selectPassCard(s, i, c);


### PR DESCRIPTION
## Summary

- **Passing phase**: `selectCardsToPassHard` now receives `playerIndex` so it can detect when it's the seat that passes to seat 0. When that's the case, moon-viable mode is skipped and Q♠ is always passed directly to the human.
- **Discard phase**: When Hard is void in the led suit (outside endgame/moon-attempt mode), it now checks who is currently winning the trick. If seat 0 is winning → dumps Q♠ or highest heart on them. If another AI is winning → prefers non-point discards to hold Q♠/hearts in reserve for a future seat-0 trick.
- **Caller update**: `HeartsScreen.tsx` passes `i` as `playerIndex` to `selectCardsToPass`.

## Test plan

- [ ] 90 AI unit tests pass (`npx jest src/game/hearts/__tests__/ai.test.ts`)
- [ ] New void-discard test: dumps Q♠ on seat 0 when seat 0 is winning
- [ ] New void-discard test: saves Q♠ when an AI opponent is winning
- [ ] New passing test: moon-viable bypassed → Q♠ included when passing to seat 0 (seat 3, left pass)
- [ ] New passing test: moon-viable preserved → Q♠ kept when passing to seat 2 (seat 1, left pass)
- [ ] Verify Q♠-on-Human rate increases above 54.4% baseline in simulation

Closes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)