### PR TITLE
fix(hearts): guard adversarial targeting to playerIndex !== 0 + fix simulator

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -2019,4 +2019,28 @@ describe("selectCardToPlay — Hard difficulty, adversarial void discard (edge c
     expect(pick.suit).not.toBe("hearts");
     expect(pick).not.toEqual(c("spades", 12));
   });
+
+  it("does not apply adversarial targeting when Hard is seat 0 (never happens in real game)", () => {
+    // Regression: Hard at seat 0 must NOT save Q♠ waiting for a 'seat 0 win' that can never
+    // fire from its own void plays — it would hold Q♠ indefinitely and hurt its own score.
+    // Hard at seat 0 should dump Q♠ normally (chooseDiscard) regardless of who is winning.
+    const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
+    const trick: TrickCard[] = [
+      { card: c("clubs", 3), playerIndex: 1 },
+      { card: c("clubs", 13), playerIndex: 2 }, // seat 2 winning — not seat 0
+    ];
+    const state = mkState({
+      playerHands: [hand, [], [], []],
+      currentTrick: trick,
+      tricksPlayedInHand: 3,
+      currentPlayerIndex: 0,
+      heartsBroken: true,
+      handScores: [0, 0, 0, 0],
+      wonCards: [[], [], [], []],
+      cumulativeScores: [10, 10, 10, 10],
+    });
+    const pick = selectCardToPlay(hand, trick, state, 0, "hard");
+    // Adversarial targeting inactive for playerIndex=0; chooseDiscard dumps Q♠ normally.
+    expect(pick).toEqual(c("spades", 12));
+  });
 });

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -658,7 +658,10 @@ function selectCardToPlayHard(
 
   // Adversarial targeting (#1638): when void in led suit, prefer dumping Q♠/high hearts on
   // seat 0 (human). When another AI is winning the trick, save Q♠/hearts for seat 0's tricks.
-  if (!isMoonAttempt && !inEndgame && !isLeading) {
+  // Guard playerIndex !== 0: in the real game Hard is never seat 0 (human); without this guard
+  // a simulation placing Hard at seat 0 causes Hard to withhold Q♠ indefinitely (no seat-0
+  // trick ever fires for Hard's own void plays), tanking its own score.
+  if (!isMoonAttempt && !inEndgame && !isLeading && playerIndex !== 0) {
     const first = trick[0];
     if (first) {
       const followSuit = valid.filter((c) => c.suit === first.card.suit);

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -85,7 +85,7 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
       for (let i = 0; i < 4; i++) {
         const diff = difficulties[i]!;
         const hand = [...(state.playerHands[i] ?? [])];
-        const cards = selectCardsToPass(hand, state.passDirection, diff);
+        const cards = selectCardsToPass(hand, state.passDirection, diff, i);
         for (const card of cards) {
           state = selectPassCard(state, i, card);
         }
@@ -177,7 +177,7 @@ function simulateGameLogged(difficulties: Difficulties, seed: number): GameLog {
       for (let i = 0; i < 4; i++) {
         const diff = difficulties[i]!;
         const hand = [...(state.playerHands[i] ?? [])];
-        const cards = selectCardsToPass(hand, state.passDirection, diff);
+        const cards = selectCardsToPass(hand, state.passDirection, diff, i);
         pendingPasses[i] = cards;
         for (const card of cards) {
           state = selectPassCard(state, i, card);


### PR DESCRIPTION
## Summary

Caught by post-merge simulation run against baseline.

- **Bug**: adversarial void-discard block (from #1638) fires for all Hard players, including seat 0. When Hard is placed at seat 0 (only in simulation batches — never in the real game), the `winner !== 0` branch withholds Q♠ indefinitely waiting for a seat-0 trick that can never fire from Hard's own void plays. Result: Hard's win rate dropped from ~50% to **39.5%** vs Medium.
- **Fix**: add `playerIndex !== 0` guard. In production Hard is always seats 1–3; the guard is a no-op in the real game.
- **Simulator fix**: `simulate-hearts.ts` was calling `selectCardsToPass` without `playerIndex`, so the adversarial passing-phase targeting never fired in simulation.

## Simulation results before fix (Hard at seat 0 regression)
```
Hard vs Medium + 2 Easy neutrals (player 0 = Hard)
  Player 0 Win Rate: 39.5%   ← was ~50% before #1638
```

## Test plan

- [ ] 93 AI unit tests pass
- [ ] New regression test: Hard at seat 0 dumps Q♠ via normal `chooseDiscard` (adversarial block skipped)
- [ ] Re-run simulation after merge to verify Hard win rate restores to ~50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)