### PR TITLE
feat(hearts): raise void rate — prioritise void creation in passing (#1645)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -887,6 +887,32 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
     expect(passed).toContainEqual(c("diamonds", 4));
     expect(passed).toContainEqual(c("diamonds", 5));
   });
+
+  it("double-void — Q♠ + two singletons uses all 3 pass slots (#1645)", () => {
+    // Q♠ (slot 1); K♠ is a singleton after Q♠ excluded from spades (slot 2);
+    // 5♦ singleton fires in the second loop iteration (slot 3).
+    // 4 hearts → moon-viable mode does NOT fire (requires 5+).
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 13), // K♠ — singleton after Q♠ passes
+      c("diamonds", 5), // 5♦ — singleton
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("clubs", 11),
+      c("hearts", 4),
+      c("hearts", 5),
+      c("hearts", 6),
+      c("hearts", 7),
+    ];
+    const passed = selectCardsToPass(hand, "left", "hard");
+    expect(passed).toContainEqual(c("spades", 12)); // Q♠ passed
+    expect(passed).toContainEqual(c("spades", 13)); // K♠ (spade void)
+    expect(passed).toContainEqual(c("diamonds", 5)); // 5♦ (diamond void)
+    expect(passed).toHaveLength(3);
+  });
 });
 
 describe("selectCardsToPass — #1636 void creation (Medium)", () => {
@@ -985,6 +1011,30 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
     expect(passed).not.toContainEqual(c("spades", 13)); // K♠ kept (cover)
     // Void fires on 5♥ (singleton heart) instead — positive assertion that the guard redirects correctly
     expect(passed).toContainEqual(c("hearts", 5));
+  });
+
+  it("double-void — voids two singletons in one pass (#1645)", () => {
+    // No Q♠, no A♥ → all 3 slots available for void.
+    // Spades singleton (3♠) voids first; diamonds singleton (5♦) voids second iteration.
+    const hand = [
+      c("spades", 3), // singleton
+      c("diamonds", 5), // singleton
+      c("clubs", 6),
+      c("clubs", 7),
+      c("clubs", 8),
+      c("clubs", 9),
+      c("clubs", 10),
+      c("hearts", 4),
+      c("hearts", 5),
+      c("hearts", 6),
+      c("hearts", 7),
+      c("hearts", 8),
+      c("hearts", 9),
+    ];
+    const passed = selectCardsToPass(hand, "left", "medium");
+    expect(passed).toContainEqual(c("spades", 3));
+    expect(passed).toContainEqual(c("diamonds", 5));
+    expect(passed).toHaveLength(3);
   });
 });
 
@@ -1824,6 +1874,7 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
     const passedLeft = selectCardsToPass(hand, "left", "hard");
     expect(passedRight).toContainEqual(c("hearts", 10));
     expect(passedLeft).not.toContainEqual(c("hearts", 10));
+    expect(passedLeft).toContainEqual(c("hearts", 1)); // A♥ still passes going left
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -934,9 +934,9 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
     expect(passed).toContainEqual(c("diamonds", 6));
   });
 
-  it("does NOT void a 3-card suit — Medium caps at 2", () => {
-    // No high-priority cards → 3 slots available. Shortest suit has 3 cards (diamonds).
-    // Medium maxSuitSize=2 → can't void a 3-card suit → falls back to high-card filler.
+  it("voids a 3-card suit — Medium uses maxSuitSize=3 (#1645)", () => {
+    // No Q♠, no A♥ → 3 slots go to void. Shortest suit is diamonds (3 cards).
+    // Medium maxSuitSize=3 → voids 3-card suits aggressively (#1645 regression fix).
     const hand = [
       c("diamonds", 3),
       c("diamonds", 4),
@@ -953,10 +953,10 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("hearts", 4),
     ];
     const passed = selectCardsToPass(hand, "left", "medium");
-    // Should NOT void diamonds (3 cards > maxSuitSize 2) — uses high-card filler instead
-    expect(passed).not.toContainEqual(c("diamonds", 3));
-    expect(passed).not.toContainEqual(c("diamonds", 4));
-    expect(passed).not.toContainEqual(c("diamonds", 5));
+    // Medium DOES void the 3-card diamond suit (shortest eligible)
+    expect(passed).toContainEqual(c("diamonds", 3));
+    expect(passed).toContainEqual(c("diamonds", 4));
+    expect(passed).toContainEqual(c("diamonds", 5));
   });
 
   it("does NOT target spades for void when Q♠ is kept (cover cards protected)", () => {
@@ -1799,23 +1799,26 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
   });
 
   it("includes 10♥ as a danger heart when passing right but not left", () => {
-    // Going right: Q♠ (slot 1), A♥ (slot 2), 10♥ passes danger threshold → slot 3.
-    // Going left: Q♠ (slot 1), A♥ (slot 2), 10♥ below threshold of 11 → void/filler fills slot 3.
-    // 4 hearts total so moon-viable mode does NOT fire (requires 5+).
+    // Hand designed so no suit is voidable after Q♠ passes (all remaining suits have 3+ cards)
+    // → void creation falls through, danger hearts fill slots 2-3.
+    // Going right: Q♠ (slot 1), A♥ (slot 2), 10♥ (slot 3) — threshold=10 includes 10♥.
+    // Going left: Q♠ (slot 1), A♥ (slot 2), filler (slot 3) — threshold=11 excludes 10♥.
+    // Q♠ is the only spade (no K♠ singleton for void to consume).
+    // 4 hearts total → moon-viable mode does NOT fire (requires 5+).
     const hand = [
-      c("spades", 12), // Q♠
-      c("spades", 13), // K♠
+      c("spades", 12), // Q♠ — only spade; after passing, no spades remain for void
       c("hearts", 1), // A♥ — danger both directions
       c("hearts", 10), // 10♥ — danger only going right
       c("hearts", 2),
       c("hearts", 3),
       c("diamonds", 13), // K♦
+      c("diamonds", 12), // Q♦
       c("diamonds", 9),
-      c("diamonds", 8),
-      c("diamonds", 7),
       c("clubs", 7),
       c("clubs", 8),
       c("clubs", 9),
+      c("clubs", 10),
+      c("clubs", 11), // J♣
     ];
     const passedRight = selectCardsToPass(hand, "right", "hard");
     const passedLeft = selectCardsToPass(hand, "left", "hard");

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -364,8 +364,7 @@ function selectCardsToPassHard(
   const heartDangerThreshold = direction === "right" ? 10 : 11;
   const dangerHearts = hand
     .filter(
-      (c) =>
-        c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c)
+      (c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c)
     )
     .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   for (const c of dangerHearts) {
@@ -393,9 +392,7 @@ function selectCardsToPassHard(
 
   // 5. Fill remaining slots with highest safe cards.
   if (selected.length < 3) {
-    const candidates = hand
-      .filter(safe)
-      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+    const candidates = hand.filter(safe).sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
       if (selected.length >= 3) break;
       selected.push(c);

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -103,7 +103,8 @@ function passSafeFilter(selected: Card[]): (c: Card) => boolean {
  * Uses a looser filter than passSafeFilter: allows clubs <6 so low clubs can complete a void
  * (they're normally deprioritised as filler but are fine to pass for void purposes).
  *
- * @param maxSuitSize - Medium passes 2 (doubletons + singletons); Hard passes up to `remaining`.
+ * @param maxSuitSize - Both tiers pass `3` (Medium) or `3 - selected.length` (Hard); the binding
+ *   constraint is always `remaining = 3 - selected.length`, so the effective limit is `remaining`.
  */
 function voidOneSuit(
   hand: Card[],
@@ -347,7 +348,6 @@ function selectCardsToPassHard(
   }
 
   const safe = passSafeFilter(selected);
-  const notSelected = (c: Card) => !selected.some((s) => s.suit === c.suit && s.rank === c.rank);
 
   // 2. Void creation — immediately after Q♠; loop until no more voids fire (#1645).
   // Handles: Q♠ + two singletons (uses all 3 slots), no-Q♠ + doubleton + singleton, etc.
@@ -365,7 +365,7 @@ function selectCardsToPassHard(
   const dangerHearts = hand
     .filter(
       (c) =>
-        c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c) && notSelected(c)
+        c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c)
     )
     .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   for (const c of dangerHearts) {
@@ -377,7 +377,7 @@ function selectCardsToPassHard(
   if (selected.length < 3 && !hasQSpades) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
-      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c) && notSelected(c));
+      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c));
       if (card) selected.push(card);
     }
   }
@@ -386,9 +386,7 @@ function selectCardsToPassHard(
   if (selected.length < 3) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
-      const card = hand.find(
-        (c) => c.suit === "clubs" && c.rank === rank && safe(c) && notSelected(c)
-      );
+      const card = hand.find((c) => c.suit === "clubs" && c.rank === rank && safe(c));
       if (card) selected.push(card);
     }
   }
@@ -396,7 +394,7 @@ function selectCardsToPassHard(
   // 5. Fill remaining slots with highest safe cards.
   if (selected.length < 3) {
     const candidates = hand
-      .filter((c) => safe(c) && notSelected(c))
+      .filter(safe)
       .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
       if (selected.length >= 3) break;

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -154,11 +154,14 @@ function selectCardsToPassEasy(hand: Card[]): Card[] {
  *      Note: "right" (1 seat) and "across" (2 seats) are treated identically for simplicity.
  *    - "left": keep Q♠ if holding either A♠ or K♠ (left neighbor plays close — higher risk)
  *    - "none": baseline — pass unless holding both A♠ and K♠
- * 2. A♥, K♥ — highest hearts first
- * 3. A♠, K♠ — if not needed to protect Q♠
- * 3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early
- * 4. Void creation — use remaining slots to eliminate a short suit (≤ 2 cards) (#1636)
- * 5. Highest remaining safe card (never 2♣ or clubs below 6)
+ * 2. A♥ only (highest danger heart — always wins heart tricks, most likely to cause damage)
+ * 3. Void creation — use remaining slots to eliminate a short suit (≤ 3 cards) (#1636, #1645)
+ *    Only A♥ precedes void — K♥/Q♥/J♥ fill slots AFTER voiding. A void provides guaranteed
+ *    discard opportunities for the entire hand; a single extra danger heart is less valuable.
+ * 4. K♥, Q♥, J♥ — remaining danger hearts fill slots after void
+ * 4.5. A♠, K♠ — if not needed to protect Q♠
+ * 5. A♣, K♣ — high clubs are dangerous since clubs cycle early
+ * 6. Highest remaining safe card (never 2♣ or clubs below 6)
  */
 function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[] {
   const selected: Card[] = [];
@@ -190,18 +193,35 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
 
   const safe = passSafeFilter(selected);
 
-  const dangerHearts = hand
-    .filter((c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= 11) && safe(c))
-    .sort((a, b) => {
-      const ra = a.rank === 1 ? 14 : a.rank;
-      const rb = b.rank === 1 ? 14 : b.rank;
-      return rb - ra;
-    });
-  for (const c of dangerHearts) {
+  // 2. A♥ only — always wins heart tricks; the single most dangerous heart to hold.
+  const aceHearts = hand.filter((c) => c.suit === "hearts" && c.rank === 1 && safe(c));
+  for (const c of aceHearts) {
     if (selected.length >= 3) break;
     selected.push(c);
   }
 
+  // 3. Void creation — fires before remaining danger hearts so it gets more slots (#1645).
+  // Loop to handle e.g. singleton + doubleton in separate eligible suits.
+  // Don't target spades when keeping Q♠ — A♠/K♠ are needed as cover cards.
+  const keepingQSpade = hasQSpades && !selected.some(isQueenOfSpades);
+  {
+    let prevLen = -1;
+    while (selected.length < 3 && selected.length !== prevLen) {
+      prevLen = selected.length;
+      voidOneSuit(hand, selected, has2Clubs, keepingQSpade, 3);
+    }
+  }
+
+  // 4. Remaining danger hearts — K♥, Q♥, J♥ fill slots after void creation.
+  const remainingDangerHearts = hand
+    .filter((c) => c.suit === "hearts" && c.rank >= 11 && safe(c))
+    .sort((a, b) => b.rank - a.rank);
+  for (const c of remainingDangerHearts) {
+    if (selected.length >= 3) break;
+    selected.push(c);
+  }
+
+  // 4.5. A♠/K♠ — if not needed to protect Q♠.
   if (selected.length < 3 && !hasQSpades) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
@@ -210,7 +230,7 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
     }
   }
 
-  // High clubs: A♣ and K♣ are dangerous to hold because clubs are led early.
+  // 5. A♣/K♣ fill any remaining slots.
   if (selected.length < 3) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
@@ -219,18 +239,9 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
     }
   }
 
-  // Void creation: use remaining slots to eliminate a 1–2 card suit (#1636).
-  // Don't target spades when keeping Q♠ — A♠/K♠ are needed as cover cards.
-  const keepingQSpade = hasQSpades && !selected.some(isQueenOfSpades);
-  voidOneSuit(hand, selected, has2Clubs, keepingQSpade, 2);
-
-  // Filler: highest remaining safe card.
+  // 6. Filler: highest remaining safe card.
   if (selected.length < 3) {
-    const candidates = hand.filter(safe).sort((a, b) => {
-      const ra = a.rank === 1 ? 14 : a.rank;
-      const rb = b.rank === 1 ? 14 : b.rank;
-      return rb - ra;
-    });
+    const candidates = hand.filter(safe).sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
       if (selected.length >= 3) break;
       selected.push(c);
@@ -249,11 +260,13 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
  *
  * Standard mode priority:
  *   1. Q♠ (always pass unless spade-void).
- *   2. A♥, K♥, Q♥, J♥ (high hearts, highest first).
+ *   2. Void creation: use ALL remaining slots to eliminate the shortest eligible suit (#1645).
+ *      Immediately after Q♠ so it always gets 2 slots — enough to void a doubleton in ~87%
+ *      of hands. Danger hearts fill the slots that remain after voiding.
+ *   3. A♥, K♥, Q♥, J♥ (high hearts, highest first) — fill remaining after void.
  *      Going "right": also include 10♥ as an extra danger card (#1595).
- *   3. A♠, K♠ (if Q♠ not present).
- *   3.5. A♣, K♣ — high clubs are dangerous since clubs cycle early.
- *   4. Void creation: use ALL remaining slots to eliminate the shortest eligible suit.
+ *   4. A♠, K♠ (if Q♠ not present).
+ *   4.5. A♣, K♣ — fill remaining slots.
  *   5. Fill any remaining slots with the highest safe cards.
  */
 function selectCardsToPassHard(
@@ -334,12 +347,25 @@ function selectCardsToPassHard(
   }
 
   const safe = passSafeFilter(selected);
+  const notSelected = (c: Card) => !selected.some((s) => s.suit === c.suit && s.rank === c.rank);
 
-  // 2. High hearts — going right, also include 10♥ as an extra danger card (#1595).
+  // 2. Void creation — immediately after Q♠; loop until no more voids fire (#1645).
+  // Handles: Q♠ + two singletons (uses all 3 slots), no-Q♠ + doubleton + singleton, etc.
+  // Hard always passes Q♠ in standard mode so keepingQSpade is never true here.
+  {
+    let prevLen = -1;
+    while (selected.length < 3 && selected.length !== prevLen) {
+      prevLen = selected.length;
+      voidOneSuit(hand, selected, has2Clubs, false, 3 - selected.length);
+    }
+  }
+
+  // 3. High hearts — fill slots remaining after void. Going right, include 10♥ (#1595).
   const heartDangerThreshold = direction === "right" ? 10 : 11;
   const dangerHearts = hand
     .filter(
-      (c) => c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c)
+      (c) =>
+        c.suit === "hearts" && (c.rank === 1 || c.rank >= heartDangerThreshold) && safe(c) && notSelected(c)
     )
     .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
   for (const c of dangerHearts) {
@@ -347,18 +373,16 @@ function selectCardsToPassHard(
     selected.push(c);
   }
 
-  // 3. High spades if no Q♠
+  // 4. High spades if no Q♠.
   if (selected.length < 3 && !hasQSpades) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
-      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c));
+      const card = hand.find((c) => c.suit === "spades" && c.rank === rank && safe(c) && notSelected(c));
       if (card) selected.push(card);
     }
   }
 
-  const notSelected = (c: Card) => !selected.some((s) => s.suit === c.suit && s.rank === c.rank);
-
-  // 3.5. High clubs: A♣ and K♣ are dangerous to hold because clubs are led early.
+  // 4.5. A♣, K♣ — fill remaining slots.
   if (selected.length < 3) {
     for (const rank of [1, 13] as const) {
       if (selected.length >= 3) break;
@@ -369,11 +393,7 @@ function selectCardsToPassHard(
     }
   }
 
-  // 4. Void creation: use all remaining slots to void the shortest eligible suit (#1636).
-  // Hard always passes Q♠ in standard mode, so keepingQSpade is never true here.
-  voidOneSuit(hand, selected, has2Clubs, false, 3 - selected.length);
-
-  // 5. Fill remaining slots with highest safe cards
+  // 5. Fill remaining slots with highest safe cards.
   if (selected.length < 3) {
     const candidates = hand
       .filter((c) => safe(c) && notSelected(c))


### PR DESCRIPTION
## Summary

Closes #1645.

Reorders the passing priority chain for both Medium and Hard so void creation fires earlier and more aggressively:

- **Medium**: void now fires after A♥ only (previously after all danger hearts K♥/Q♥/J♥), `maxSuitSize` raised from 2→3, and added double-void loop
- **Hard**: void now fires immediately after Q♠ (before any danger hearts), added double-void loop so two short suits can be eliminated in one pass
- **Both tiers**: `voidOneSuit` is now called in a loop until no additional suits can be eliminated — enables cases like Q♠ + two singletons filling all 3 slots

## Simulator results (3 000-game batches, AI seats only)

| Tier | Before | After | Target |
|------|--------|-------|--------|
| Easy (baseline) | ~5% | ~5% | — |
| Medium | ~21% | ~47% | ~50% |
| Hard | ~21% | ~50% | ~80% |

The gap between Hard and the 80% target reflects a structural ceiling: ~30-35% of intentional voids are refilled by incoming cards during the exchange (measured post-exchange per simulator). Medium has nearly closed its target gap.

## Test changes

- `does NOT void a 3-card suit — Medium caps at 2` → updated to `voids a 3-card suit — Medium uses maxSuitSize=3 (#1645)` — flipped assertion to reflect new maxSuitSize=3 behavior
- `includes 10♥ as a danger heart when passing right but not left` — redesigned hand to remove an unintended K♠ singleton that void was consuming before 10♥ could fill the slot; added positive assertion that A♥ passes going left
- Added double-void test for Medium: two singletons in different suits both voided in one pass
- Added double-void test for Hard: Q♠ + two singletons fill all 3 slots across two loop iterations

## Code cleanup (review feedback)

- Removed redundant `notSelected` guard in Hard's passing function — `safe()` captures `selected` by reference and already excludes it
- Updated `voidOneSuit` `@param maxSuitSize` doc to reflect that both tiers now use `maxSuitSize ≥ remaining`, making the binding constraint always `remaining`

## Test plan

- [x] `npx jest --testPathPattern="ai.test"` — 95/95 pass
- [x] Rebased cleanly onto latest `dev` (Yacht VS mode #1641)
- [x] Simulator run confirms void rate improvement across all AI configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)