### PR TITLE
feat(yacht): backend leaderboard module (#1597)

### DIFF
--- a/backend/games/registry.py
+++ b/backend/games/registry.py
@@ -13,10 +13,10 @@ from cascade.module import module as cascade_module
 from daily_word.module import module as daily_word_module
 from hearts.module import module as hearts_module
 from mahjong.module import module as mahjong_module
-from yacht.module import module as yacht_module
 from solitaire.module import module as solitaire_module
 from sort.module import module as sort_module
 from sudoku.module import module as sudoku_module
+from yacht.module import module as yacht_module
 
 from games.protocol import GameModule
 

--- a/backend/games/registry.py
+++ b/backend/games/registry.py
@@ -13,6 +13,7 @@ from cascade.module import module as cascade_module
 from daily_word.module import module as daily_word_module
 from hearts.module import module as hearts_module
 from mahjong.module import module as mahjong_module
+from yacht.module import module as yacht_module
 from solitaire.module import module as solitaire_module
 from sort.module import module as sort_module
 from sudoku.module import module as sudoku_module
@@ -30,6 +31,7 @@ _REGISTRY: dict[str, GameModule] = {
     solitaire_module.game_type.value: solitaire_module,
     sort_module.game_type.value: sort_module,
     sudoku_module.game_type.value: sudoku_module,
+    yacht_module.game_type.value: yacht_module,
 }
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,11 +27,11 @@ from daily_word.router import router as daily_word_router
 from freecell.router import router as freecell_router
 from hearts.router import router as hearts_router
 from mahjong.router import router as mahjong_router
-from yacht.router import router as yacht_router
 from solitaire.router import router as solitaire_router
 from sort.router import router as sort_router
-from sudoku.router import router as sudoku_router
 from starswarm.router import router as starswarm_router
+from sudoku.router import router as sudoku_router
+from yacht.router import router as yacht_router
 from entitlements.router import router as entitlements_router
 from games.router import router as games_router
 from logs.router import router as logs_router
@@ -67,11 +67,11 @@ app.include_router(daily_word_router, prefix="/daily-word")
 app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")
 app.include_router(mahjong_router, prefix="/mahjong")
-app.include_router(yacht_router, prefix="/yacht")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(sort_router, prefix="/sort")
-app.include_router(sudoku_router, prefix="/sudoku")
 app.include_router(starswarm_router, prefix="/starswarm")
+app.include_router(sudoku_router, prefix="/sudoku")
+app.include_router(yacht_router, prefix="/yacht")
 app.include_router(games_router, prefix="/games")
 app.include_router(logs_router, prefix="/logs")
 app.include_router(stats_router, prefix="/stats")

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from daily_word.router import router as daily_word_router
 from freecell.router import router as freecell_router
 from hearts.router import router as hearts_router
 from mahjong.router import router as mahjong_router
+from yacht.router import router as yacht_router
 from solitaire.router import router as solitaire_router
 from sort.router import router as sort_router
 from sudoku.router import router as sudoku_router
@@ -66,6 +67,7 @@ app.include_router(daily_word_router, prefix="/daily-word")
 app.include_router(freecell_router, prefix="/freecell")
 app.include_router(hearts_router, prefix="/hearts")
 app.include_router(mahjong_router, prefix="/mahjong")
+app.include_router(yacht_router, prefix="/yacht")
 app.include_router(solitaire_router, prefix="/solitaire")
 app.include_router(sort_router, prefix="/sort")
 app.include_router(sudoku_router, prefix="/sudoku")

--- a/backend/tests/test_game_metadata.py
+++ b/backend/tests/test_game_metadata.py
@@ -269,8 +269,8 @@ def test_create_game_request_invalid_sudoku_metadata_raises_422() -> None:
 
 
 def test_create_game_request_unregistered_game_type_skips_validation() -> None:
-    # yacht/twenty48 are in GameType but not yet in the registry — should not raise
-    req = CreateGameRequest(game_type="yacht", metadata={"anything": True})
+    # twenty48 is in GameType but not yet in the registry — should not raise
+    req = CreateGameRequest(game_type="twenty48", metadata={"anything": True})
     assert req.metadata == {"anything": True}
 
 

--- a/backend/tests/test_yacht_api.py
+++ b/backend/tests/test_yacht_api.py
@@ -1,0 +1,241 @@
+"""Tests for /yacht/score and /yacht/scores (#1597).
+
+Mirrors test_hearts_api.py. Score transform is max(0, 400 - raw_score)
+so higher transformed score = better performance.
+"""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+import yacht.router as yacht_router_module
+from db.base import get_session_factory
+from db.models import GameEntitlement
+from main import app
+
+client = TestClient(app)
+
+_SID = str(uuid.uuid4())
+_HEADERS = {"X-Session-ID": _SID}
+
+
+async def _grant(session_id: str, game_slug: str) -> None:
+    factory = get_session_factory()
+    async with factory() as db:
+        db.add(GameEntitlement(session_id=session_id, game_slug=game_slug))
+        await db.commit()
+
+
+@pytest.fixture(autouse=True)
+async def _yacht_entitlement():
+    await _grant(_SID, "yacht")
+
+
+@pytest.fixture(autouse=True)
+def reset_leaderboard():
+    yacht_router_module.reset_leaderboard()
+    yield
+    yacht_router_module.reset_leaderboard()
+
+
+def _submit(player_name: str, score: int, difficulty: str = "easy"):
+    return client.post(
+        "/yacht/score",
+        json={"player_name": player_name, "score": score, "difficulty": difficulty},
+        headers=_HEADERS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /yacht/score
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitScore:
+    def test_valid_submission_returns_201(self):
+        res = _submit("Alice", 200)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["player_name"] == "Alice"
+        assert body["rank"] == 1
+
+    def test_zero_score_accepted(self):
+        res = _submit("Alice", 0)
+        assert res.status_code == 201
+
+    def test_missing_player_name_returns_422(self):
+        res = client.post("/yacht/score", json={"score": 200, "difficulty": "easy"}, headers=_HEADERS)
+        assert res.status_code == 422
+
+    def test_missing_score_returns_422(self):
+        res = client.post(
+            "/yacht/score", json={"player_name": "Bob", "difficulty": "easy"}, headers=_HEADERS
+        )
+        assert res.status_code == 422
+
+    def test_empty_player_name_returns_422(self):
+        res = _submit("", 200)
+        assert res.status_code == 422
+
+    def test_name_too_long_returns_422(self):
+        res = _submit("x" * 33, 200)
+        assert res.status_code == 422
+
+    def test_negative_score_returns_422(self):
+        res = _submit("Alice", -1)
+        assert res.status_code == 422
+
+    def test_invalid_difficulty_returns_422(self):
+        res = client.post(
+            "/yacht/score",
+            json={"player_name": "Alice", "score": 200, "difficulty": "legendary"},
+            headers=_HEADERS,
+        )
+        assert res.status_code == 422
+
+    def test_difficulty_stored_and_returned(self):
+        res = _submit("Alice", 200, difficulty="hard")
+        assert res.status_code == 201
+        assert res.json()["difficulty"] == "hard"
+
+
+# ---------------------------------------------------------------------------
+# Score transform
+# ---------------------------------------------------------------------------
+
+
+class TestScoreTransform:
+    def test_raw_300_transforms_to_100(self):
+        res = _submit("Alice", 300)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["raw_score"] == 300
+        assert body["score"] == 100
+
+    def test_raw_0_transforms_to_400(self):
+        res = _submit("Alice", 0)
+        assert res.status_code == 201
+        body = res.json()
+        assert body["raw_score"] == 0
+        assert body["score"] == 400
+
+    def test_transform_capped_at_400(self):
+        # Any raw_score >= 400 transforms to 0 (not negative)
+        res = _submit("Alice", 400)
+        assert res.status_code == 201
+        assert res.json()["score"] == 0
+
+    def test_transform_appears_in_leaderboard(self):
+        _submit("Alice", 300)
+        scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
+        assert scores[0]["raw_score"] == 300
+        assert scores[0]["score"] == 100
+
+
+# ---------------------------------------------------------------------------
+# GET /yacht/scores
+# ---------------------------------------------------------------------------
+
+
+class TestGetScores:
+    def test_empty_initially(self):
+        res = client.get("/yacht/scores", headers=_HEADERS)
+        assert res.status_code == 200
+        assert res.json()["scores"] == []
+
+    def test_returns_submitted_entries(self):
+        _submit("Alice", 200)
+        _submit("Bob", 250)
+        scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
+        assert len(scores) == 2
+
+    def test_ordered_by_transformed_score_descending(self):
+        # Lower raw score = higher transformed score = ranked first
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Carol", 300)   # transformed 100
+        limiter.reset()
+        _submit("Alice", 100)   # transformed 300
+        limiter.reset()
+        _submit("Bob", 200)     # transformed 200
+        scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
+        assert [s["score"] for s in scores] == [300, 200, 100]
+
+    def test_capped_at_ten_entries(self):
+        from limiter import limiter
+
+        for i in range(11):
+            limiter.reset()
+            _submit(f"Player{i}", i * 10)
+        scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
+        assert len(scores) == 10
+        # Top entry: raw=0 → transformed=400
+        assert scores[0]["score"] == 400
+        # Lowest included: raw=90 → transformed=310; raw=100 → 300 is excluded
+        assert scores[-1]["score"] == 310
+
+
+# ---------------------------------------------------------------------------
+# Rank in submission response
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitRank:
+    def test_first_submission_rank_1(self):
+        assert _submit("Alice", 100).json()["rank"] == 1
+
+    def test_lower_raw_score_ranked_higher(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 100)   # transformed 300
+        limiter.reset()
+        body = _submit("Bob", 200).json()   # transformed 200 → rank 2
+        assert body["rank"] == 2
+
+    def test_off_leaderboard_returns_rank_11(self):
+        from limiter import limiter
+
+        for i in range(10):
+            limiter.reset()
+            _submit(f"Top{i}", 0)   # all transformed to 400
+        limiter.reset()
+        body = _submit("Lowly", 399).json()   # transformed 1 → off board
+        assert body["rank"] == 11
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    def test_sixth_submission_returns_429(self):
+        from limiter import limiter
+
+        for i in range(5):
+            assert _submit(f"Player{i}", i * 10).status_code == 201
+
+        assert _submit("Excess", 999).status_code == 429
+        limiter.reset()
+
+
+# ---------------------------------------------------------------------------
+# Tie-break ordering — older entry wins
+# ---------------------------------------------------------------------------
+
+
+class TestTieBreak:
+    def test_older_score_ranks_higher_on_tie(self):
+        from limiter import limiter
+
+        limiter.reset()
+        _submit("Alice", 200)   # transformed 200, submitted first
+        limiter.reset()
+        _submit("Bob", 200)     # transformed 200, submitted second
+
+        scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
+        assert scores[0]["player_name"] == "Alice"
+        assert scores[1]["player_name"] == "Bob"

--- a/backend/tests/test_yacht_api.py
+++ b/backend/tests/test_yacht_api.py
@@ -59,6 +59,7 @@ class TestSubmitScore:
         body = res.json()
         assert body["player_name"] == "Alice"
         assert body["rank"] == 1
+        assert "timestamp" in body
 
     def test_zero_score_accepted(self):
         res = _submit("Alice", 0)
@@ -92,6 +93,18 @@ class TestSubmitScore:
             json={"player_name": "Alice", "score": 200, "difficulty": "legendary"},
             headers=_HEADERS,
         )
+        assert res.status_code == 422
+
+    def test_missing_difficulty_returns_422(self):
+        res = client.post(
+            "/yacht/score",
+            json={"player_name": "Alice", "score": 200},
+            headers=_HEADERS,
+        )
+        assert res.status_code == 422
+
+    def test_score_over_400_returns_422(self):
+        res = _submit("Alice", 401)
         assert res.status_code == 422
 
     def test_difficulty_stored_and_returned(self):
@@ -173,8 +186,9 @@ class TestGetScores:
         assert len(scores) == 10
         # Top entry: raw=0 → transformed=400
         assert scores[0]["score"] == 400
-        # Lowest included: raw=90 → transformed=310; raw=100 → 300 is excluded
+        # Lowest included: raw=90 → transformed=310; raw=100 → 300 excluded
         assert scores[-1]["score"] == 310
+        assert all(s["score"] != 300 for s in scores)
 
 
 # ---------------------------------------------------------------------------
@@ -218,7 +232,7 @@ class TestRateLimit:
         for i in range(5):
             assert _submit(f"Player{i}", i * 10).status_code == 201
 
-        assert _submit("Excess", 999).status_code == 429
+        assert _submit("Excess", 99).status_code == 429
         limiter.reset()
 
 

--- a/backend/tests/test_yacht_api.py
+++ b/backend/tests/test_yacht_api.py
@@ -66,7 +66,9 @@ class TestSubmitScore:
         assert res.status_code == 201
 
     def test_missing_player_name_returns_422(self):
-        res = client.post("/yacht/score", json={"score": 200, "difficulty": "easy"}, headers=_HEADERS)
+        res = client.post(
+            "/yacht/score", json={"score": 200, "difficulty": "easy"}, headers=_HEADERS
+        )
         assert res.status_code == 422
 
     def test_missing_score_returns_422(self):
@@ -168,11 +170,11 @@ class TestGetScores:
         from limiter import limiter
 
         limiter.reset()
-        _submit("Carol", 300)   # transformed 100
+        _submit("Carol", 300)  # transformed 100
         limiter.reset()
-        _submit("Alice", 100)   # transformed 300
+        _submit("Alice", 100)  # transformed 300
         limiter.reset()
-        _submit("Bob", 200)     # transformed 200
+        _submit("Bob", 200)  # transformed 200
         scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
         assert [s["score"] for s in scores] == [300, 200, 100]
 
@@ -204,9 +206,9 @@ class TestSubmitRank:
         from limiter import limiter
 
         limiter.reset()
-        _submit("Alice", 100)   # transformed 300
+        _submit("Alice", 100)  # transformed 300
         limiter.reset()
-        body = _submit("Bob", 200).json()   # transformed 200 → rank 2
+        body = _submit("Bob", 200).json()  # transformed 200 → rank 2
         assert body["rank"] == 2
 
     def test_off_leaderboard_returns_rank_11(self):
@@ -214,9 +216,9 @@ class TestSubmitRank:
 
         for i in range(10):
             limiter.reset()
-            _submit(f"Top{i}", 0)   # all transformed to 400
+            _submit(f"Top{i}", 0)  # all transformed to 400
         limiter.reset()
-        body = _submit("Lowly", 399).json()   # transformed 1 → off board
+        body = _submit("Lowly", 399).json()  # transformed 1 → off board
         assert body["rank"] == 11
 
 
@@ -246,9 +248,9 @@ class TestTieBreak:
         from limiter import limiter
 
         limiter.reset()
-        _submit("Alice", 200)   # transformed 200, submitted first
+        _submit("Alice", 200)  # transformed 200, submitted first
         limiter.reset()
-        _submit("Bob", 200)     # transformed 200, submitted second
+        _submit("Bob", 200)  # transformed 200, submitted second
 
         scores = client.get("/yacht/scores", headers=_HEADERS).json()["scores"]
         assert scores[0]["player_name"] == "Alice"

--- a/backend/yacht/models.py
+++ b/backend/yacht/models.py
@@ -1,0 +1,28 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+AiDifficulty = Literal["easy", "medium", "hard"]
+
+
+class YachtMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    difficulty: AiDifficulty = Field(default="easy")
+
+
+class YachtScoreSubmitRequest(BaseModel):
+    player_name: str = Field(..., min_length=1, max_length=32)
+    score: int = Field(..., ge=0)
+    difficulty: AiDifficulty
+
+
+class ScoreEntry(BaseModel):
+    player_name: str
+    raw_score: int
+    score: int
+    difficulty: str
+    rank: int
+
+
+class LeaderboardResponse(BaseModel):
+    scores: list[ScoreEntry]

--- a/backend/yacht/models.py
+++ b/backend/yacht/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -12,7 +13,7 @@ class YachtMetadata(BaseModel):
 
 class YachtScoreSubmitRequest(BaseModel):
     player_name: str = Field(..., min_length=1, max_length=32)
-    score: int = Field(..., ge=0)
+    score: int = Field(..., ge=0, le=400)
     difficulty: AiDifficulty
 
 
@@ -20,7 +21,8 @@ class ScoreEntry(BaseModel):
     player_name: str
     raw_score: int
     score: int
-    difficulty: str
+    difficulty: AiDifficulty
+    timestamp: datetime
     rank: int
 
 

--- a/backend/yacht/module.py
+++ b/backend/yacht/module.py
@@ -1,0 +1,23 @@
+"""Yacht GameModule descriptor.
+
+Satisfies the ``GameModule`` Protocol from ``games/protocol.py`` via
+structural subtyping — no inheritance required.
+"""
+
+from __future__ import annotations
+
+from vocab import GameType
+from yacht.models import YachtMetadata
+
+
+class YachtModule:
+    """GameModule implementation for Yacht."""
+
+    game_type = GameType.YACHT
+    metadata_model = YachtMetadata
+
+    def stats_shape(self, raw_stats: dict) -> dict:
+        return {k: v for k, v in raw_stats.items() if k != "latest_score"}
+
+
+module = YachtModule()

--- a/backend/yacht/router.py
+++ b/backend/yacht/router.py
@@ -72,7 +72,8 @@ async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
                 player_name=str(name),
                 raw_score=raw,
                 score=int(g.final_score or 0),
-                difficulty=diff,
+                difficulty=diff,  # type: ignore[arg-type]
+                timestamp=g.completed_at,
                 rank=i + 1,
             )
         )
@@ -83,6 +84,7 @@ async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
 @limiter.limit("5/minute")
 async def submit_score(request: Request, body: YachtScoreSubmitRequest) -> ScoreEntry:
     transformed = _transform_score(body.score)
+    submitted_at = datetime.now(timezone.utc)
     factory = get_session_factory()
     async with factory() as db:
         gt_id = await _yacht_game_type_id(db)
@@ -90,7 +92,7 @@ async def submit_score(request: Request, body: YachtScoreSubmitRequest) -> Score
             session_id=_YACHT_SESSION,
             game_type_id=gt_id,
             final_score=transformed,
-            completed_at=datetime.now(timezone.utc),
+            completed_at=submitted_at,
             game_metadata={
                 "player_name": body.player_name,
                 "raw_score": body.score,
@@ -114,6 +116,7 @@ async def submit_score(request: Request, body: YachtScoreSubmitRequest) -> Score
         raw_score=body.score,
         score=transformed,
         difficulty=body.difficulty,
+        timestamp=submitted_at,
         rank=LEADERBOARD_LIMIT + 1,
     )
 

--- a/backend/yacht/router.py
+++ b/backend/yacht/router.py
@@ -1,0 +1,132 @@
+"""Yacht leaderboard — score submission and top-10 board.
+
+POST /yacht/score applies max(0, 400 − raw_score) and persists the result.
+GET /yacht/scores returns the top 10 entries sorted by transformed score
+descending (older entries break ties).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_session_factory
+from db.models import Game, GameType
+from entitlements.dependencies import require_entitlement
+from limiter import limiter
+from vocab import GameType as GameTypeEnum
+
+from .models import LeaderboardResponse, ScoreEntry, YachtScoreSubmitRequest
+
+router = APIRouter(dependencies=[Depends(require_entitlement("yacht"))])
+
+LEADERBOARD_LIMIT = 10
+_YACHT_SESSION = "yacht-anon"
+
+
+def _transform_score(raw_score: int) -> int:
+    return max(0, 400 - raw_score)
+
+
+async def _yacht_game_type_id(db: AsyncSession) -> int:
+    row = (
+        await db.execute(select(GameType.id).where(GameType.name == GameTypeEnum.YACHT))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="yacht game_type missing — run alembic migrations.",
+        )
+    return row
+
+
+async def _top_scores(db: AsyncSession) -> list[ScoreEntry]:
+    gt_id = await _yacht_game_type_id(db)
+    rows = (
+        (
+            await db.execute(
+                select(Game)
+                .where(
+                    Game.game_type_id == gt_id,
+                    Game.final_score.is_not(None),
+                )
+                .order_by(desc(Game.final_score), Game.completed_at.asc())
+                .limit(LEADERBOARD_LIMIT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    entries: list[ScoreEntry] = []
+    for i, g in enumerate(rows):
+        meta = g.game_metadata or {}
+        name = meta.get("player_name") or "anon"
+        raw = int(meta.get("raw_score", 0))
+        diff = str(meta.get("difficulty", "easy"))
+        entries.append(
+            ScoreEntry(
+                player_name=str(name),
+                raw_score=raw,
+                score=int(g.final_score or 0),
+                difficulty=diff,
+                rank=i + 1,
+            )
+        )
+    return entries
+
+
+@router.post("/score", response_model=ScoreEntry, status_code=201)
+@limiter.limit("5/minute")
+async def submit_score(request: Request, body: YachtScoreSubmitRequest) -> ScoreEntry:
+    transformed = _transform_score(body.score)
+    factory = get_session_factory()
+    async with factory() as db:
+        gt_id = await _yacht_game_type_id(db)
+        game = Game(
+            session_id=_YACHT_SESSION,
+            game_type_id=gt_id,
+            final_score=transformed,
+            completed_at=datetime.now(timezone.utc),
+            game_metadata={
+                "player_name": body.player_name,
+                "raw_score": body.score,
+                "difficulty": body.difficulty,
+            },
+        )
+        db.add(game)
+        await db.commit()
+
+        top = await _top_scores(db)
+
+    for entry in top:
+        if (
+            entry.player_name == body.player_name
+            and entry.raw_score == body.score
+            and entry.difficulty == body.difficulty
+        ):
+            return entry
+    return ScoreEntry(
+        player_name=body.player_name,
+        raw_score=body.score,
+        score=transformed,
+        difficulty=body.difficulty,
+        rank=LEADERBOARD_LIMIT + 1,
+    )
+
+
+@router.get("/scores", response_model=LeaderboardResponse)
+@limiter.limit("60/minute")
+async def get_scores(request: Request) -> LeaderboardResponse:
+    factory = get_session_factory()
+    async with factory() as db:
+        scores = await _top_scores(db)
+    return LeaderboardResponse(scores=scores)
+
+
+def reset_leaderboard() -> None:
+    """Test helper — no-op. DB isolation handled by conftest ``clean_db_tables``."""
+    return None


### PR DESCRIPTION
## Summary
- Adds `YachtModule`, `YachtMetadata`, and `YachtScoreSubmitRequest` models mirroring the Hearts pattern
- `POST /yacht/score` applies `max(0, 400 − raw_score)` transform, stores raw score + difficulty in `game_metadata`, rate-limited to 5/min
- `GET /yacht/scores` returns top 10 entries sorted by transformed score descending, includes `raw_score`, `score`, `difficulty`, and `rank`
- Registers `YachtModule` in `games/registry.py` and mounts router in `main.py`

## Test plan
- [x] `python -m pytest tests/test_yacht_api.py -v` — 22 tests, all passing
- [x] Score transform verified: raw 300 → 100, raw 0 → 400, raw ≥ 400 → 0
- [x] Top-10 cap: 11th submission is excluded from leaderboard
- [x] Rate limit: 6th submission in one minute returns 429
- [x] Tie-break: older entry wins at equal score
- [x] Difficulty round-trips correctly (`easy` / `medium` / `hard`)

Closes #1597
Part of #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)