### PR TITLE
feat(hearts): rename AI difficulty labels to play-style personas (#1653)

### DIFF
--- a/e2e/tests/hearts-difficulty-select.spec.ts
+++ b/e2e/tests/hearts-difficulty-select.spec.ts
@@ -16,7 +16,7 @@ const c = (suit: string, rank: number) => ({ suit: suit, rank: rank });
 // so the state passes loadGame's bounds validation (#1540).
 const GAME_OVER_STATE = {
   _v: 3,
-  aiDifficulty: "medium",
+  aiDifficulty: "schemer",
   phase: "game_over",
   handNumber: 5,
   passDirection: "none",
@@ -42,7 +42,7 @@ const GAME_OVER_STATE = {
 };
 
 test.describe("Hearts — difficulty selector (#1168)", () => {
-  test("pre-game picker shows Easy / Medium / Hard radio buttons", async ({
+  test("pre-game picker shows Cautious / Schemer / Daring radio buttons", async ({
     page,
   }) => {
     await mockHeartsApi(page);
@@ -54,14 +54,14 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
       .getByRole("heading", { name: "Hearts", exact: true })
       .waitFor({ timeout: 10_000 });
 
-    const group = page.getByRole("radiogroup", { name: "AI Difficulty" });
+    const group = page.getByRole("radiogroup", { name: "Opponent Style" });
     await expect(group).toBeVisible({ timeout: 5_000 });
-    await expect(group.getByRole("radio", { name: "Easy" })).toBeVisible();
-    await expect(group.getByRole("radio", { name: "Medium" })).toBeVisible();
-    await expect(group.getByRole("radio", { name: "Hard" })).toBeVisible();
+    await expect(group.getByRole("radio", { name: "Cautious" })).toBeVisible();
+    await expect(group.getByRole("radio", { name: "Schemer" })).toBeVisible();
+    await expect(group.getByRole("radio", { name: "Daring" })).toBeVisible();
   });
 
-  test("selecting Easy and clicking Start Game launches a game", async ({
+  test("selecting Cautious and clicking Start Game launches a game", async ({
     page,
   }) => {
     await mockHeartsApi(page);
@@ -73,7 +73,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
       .getByRole("heading", { name: "Hearts", exact: true })
       .waitFor({ timeout: 10_000 });
 
-    await page.getByRole("radio", { name: "Easy" }).click();
+    await page.getByRole("radio", { name: "Cautious" }).click();
     await page.getByRole("button", { name: "Start Game" }).click();
 
     await expect(page.getByLabel("Your hand, 13 cards")).toBeVisible({
@@ -81,7 +81,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
     });
   });
 
-  test("selecting Hard and clicking Start Game launches a game", async ({
+  test("selecting Daring and clicking Start Game launches a game", async ({
     page,
   }) => {
     await mockHeartsApi(page);
@@ -93,7 +93,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
       .getByRole("heading", { name: "Hearts", exact: true })
       .waitFor({ timeout: 10_000 });
 
-    await page.getByRole("radio", { name: "Hard" }).click();
+    await page.getByRole("radio", { name: "Daring" }).click();
     await page.getByRole("button", { name: "Start Game" }).click();
 
     await expect(page.getByLabel("Your hand, 13 cards")).toBeVisible({
@@ -116,7 +116,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
 
     // Difficulty selector appears in game_over panel
     await expect(
-      page.getByRole("radiogroup", { name: "AI Difficulty" }),
+      page.getByRole("radiogroup", { name: "Opponent Style" }),
     ).toBeVisible({
       timeout: 3_000,
     });
@@ -124,7 +124,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
     // Click Play Again — goes back to pre-game picker
     await page.getByRole("button", { name: "Play Again" }).click();
     await expect(
-      page.getByRole("radiogroup", { name: "AI Difficulty" }),
+      page.getByRole("radiogroup", { name: "Opponent Style" }),
     ).toBeVisible({
       timeout: 5_000,
     });
@@ -133,7 +133,7 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
     ).toBeVisible();
   });
 
-  test("difficulty selector in game_over panel shows Easy / Medium / Hard", async ({
+  test("difficulty selector in game_over panel shows Cautious / Schemer / Daring", async ({
     page,
   }) => {
     await mockHeartsApi(page);
@@ -145,16 +145,16 @@ test.describe("Hearts — difficulty selector (#1168)", () => {
 
     await expect(page.getByText("Game Over")).toBeVisible({ timeout: 5_000 });
 
-    const groups = page.getByRole("radiogroup", { name: "AI Difficulty" });
+    const groups = page.getByRole("radiogroup", { name: "Opponent Style" });
     await expect(groups.first()).toBeVisible({ timeout: 3_000 });
     await expect(
-      groups.first().getByRole("radio", { name: "Easy" }),
+      groups.first().getByRole("radio", { name: "Cautious" }),
     ).toBeVisible();
     await expect(
-      groups.first().getByRole("radio", { name: "Medium" }),
+      groups.first().getByRole("radio", { name: "Schemer" }),
     ).toBeVisible();
     await expect(
-      groups.first().getByRole("radio", { name: "Hard" }),
+      groups.first().getByRole("radio", { name: "Daring" }),
     ).toBeVisible();
   });
 

--- a/e2e/tests/hearts-smoke.spec.ts
+++ b/e2e/tests/hearts-smoke.spec.ts
@@ -18,7 +18,7 @@ test.describe("Hearts — smoke tests", () => {
     await page.getByRole("button", { name: "Play Hearts" }).click();
     await page.getByRole("heading", { name: "Hearts", exact: true }).waitFor({ timeout: 10_000 });
     await expect(
-      page.getByRole("radiogroup", { name: "AI Difficulty" }),
+      page.getByRole("radiogroup", { name: "Opponent Style" }),
     ).toBeVisible({ timeout: 5_000 });
   });
 

--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -2,13 +2,19 @@ import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
-import type { AiDifficulty } from "../../game/hearts/types";
-import { AI_DIFFICULTIES } from "../../game/hearts/types";
+import type { AiPersona } from "../../game/hearts/types";
+import { AI_PERSONAS } from "../../game/hearts/types";
 
 interface Props {
-  value: AiDifficulty;
-  onChange: (d: AiDifficulty) => void;
+  value: AiPersona;
+  onChange: (d: AiPersona) => void;
 }
+
+const PERSONA_DEFAULTS: Record<AiPersona, { label: string; desc: string }> = {
+  cautious: { label: "Cautious", desc: "Plays conservatively, avoids taking points" },
+  schemer: { label: "Schemer", desc: "Creates suit voids, deflects the Queen of Spades" },
+  daring: { label: "Daring", desc: "Swings for moon shots, targets you with the Queen" },
+};
 
 export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
   const { t } = useTranslation("hearts");
@@ -17,26 +23,26 @@ export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
   return (
     <View
       accessibilityRole="radiogroup"
-      accessibilityLabel={t("difficulty.groupLabel", { defaultValue: "AI Difficulty" })}
+      accessibilityLabel={t("difficulty.groupLabel", { defaultValue: "Opponent Style" })}
       style={[styles.row, { borderColor: colors.border }]}
     >
-      {AI_DIFFICULTIES.map((d) => {
+      {AI_PERSONAS.map((d) => {
         const selected = d === value;
+        const defaults = PERSONA_DEFAULTS[d];
         return (
           <Pressable
             key={d}
             onPress={() => onChange(d)}
             accessibilityRole="radio"
-            accessibilityLabel={t(`difficulty.${d}`, {
-              defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
-            })}
+            accessibilityLabel={t(`difficulty.${d}`, { defaultValue: defaults.label })}
             accessibilityState={{ selected }}
             style={[styles.btn, { backgroundColor: selected ? colors.accent : colors.surface }]}
           >
             <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
-              {t(`difficulty.${d}`, {
-                defaultValue: d === "easy" ? "Easy" : d === "medium" ? "Medium" : "Hard",
-              })}
+              {t(`difficulty.${d}`, { defaultValue: defaults.label })}
+            </Text>
+            <Text style={[styles.desc, { color: selected ? colors.textOnAccent : colors.textMuted }]}>
+              {t(`difficulty.${d}.desc`, { defaultValue: defaults.desc })}
             </Text>
           </Pressable>
         );
@@ -55,11 +61,18 @@ const styles = StyleSheet.create({
   btn: {
     flex: 1,
     paddingVertical: 10,
+    paddingHorizontal: 6,
     alignItems: "center",
     justifyContent: "center",
+    gap: 3,
   },
   label: {
     fontSize: 15,
     fontWeight: "600",
+    textAlign: "center",
+  },
+  desc: {
+    fontSize: 11,
+    textAlign: "center",
   },
 });

--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -41,7 +41,9 @@ export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
             <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
               {t(`difficulty.${d}`, { defaultValue: defaults.label })}
             </Text>
-            <Text style={[styles.desc, { color: selected ? colors.textOnAccent : colors.textMuted }]}>
+            <Text
+              style={[styles.desc, { color: selected ? colors.textOnAccent : colors.textMuted }]}
+            >
               {t(`difficulty.${d}.desc`, { defaultValue: defaults.desc })}
             </Text>
           </Pressable>

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -27,7 +27,7 @@ function c(suit: Suit, rank: Rank): Card {
 function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
   return {
     _v: 3,
-    aiDifficulty: "medium",
+    aiDifficulty: "schemer",
     phase: "playing",
     handNumber: 1,
     passDirection: "left",
@@ -198,10 +198,10 @@ describe("selectCardsToPass", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectCardsToPass — Medium difficulty, high clubs (A♣/K♣)
+// selectCardsToPass — Schemer difficulty, high clubs (A♣/K♣)
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — Medium difficulty, high clubs", () => {
+describe("selectCardsToPass — Schemer difficulty, high clubs", () => {
   it("passes A♣ when slots remain after higher-priority cards", () => {
     // Q♠ → slot 1, A♥ → slot 2, A♣ → slot 3 (step 3.5).
     // Confirms rank 1 is not caught by the 'clubs below 6' guard (which checks rank > 1).
@@ -498,10 +498,10 @@ describe("selectCardToPlay — ace treated as high card", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Easy AI — selectCardsToPass
+// Cautious AI — selectCardsToPass
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — Easy difficulty", () => {
+describe("selectCardsToPass — Cautious difficulty", () => {
   it("always returns exactly 3 cards", () => {
     const hand = [
       c("spades", 12),
@@ -518,7 +518,7 @@ describe("selectCardsToPass — Easy difficulty", () => {
       c("diamonds", 3),
       c("hearts", 5),
     ];
-    expect(selectCardsToPass(hand, "left", "easy")).toHaveLength(3);
+    expect(selectCardsToPass(hand, "left", "cautious")).toHaveLength(3);
   });
 
   it("never passes 2♣", () => {
@@ -537,7 +537,7 @@ describe("selectCardsToPass — Easy difficulty", () => {
       c("diamonds", 8),
       c("diamonds", 9),
     ];
-    const passed = selectCardsToPass(hand, "left", "easy");
+    const passed = selectCardsToPass(hand, "left", "cautious");
     expect(passed).not.toContainEqual(c("clubs", 2));
   });
 
@@ -557,16 +557,16 @@ describe("selectCardsToPass — Easy difficulty", () => {
       c("clubs", 10),
       c("hearts", 11),
     ];
-    const passed = selectCardsToPass(hand, "right", "easy");
+    const passed = selectCardsToPass(hand, "right", "cautious");
     passed.forEach((p) => expect(hand).toContainEqual(p));
   });
 });
 
 // ---------------------------------------------------------------------------
-// Easy AI — selectCardToPlay
+// Cautious AI — selectCardToPlay
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Easy difficulty", () => {
+describe("selectCardToPlay — Cautious difficulty", () => {
   it("leads the lowest valid card", () => {
     const hand = [c("spades", 1), c("spades", 3), c("diamonds", 5)];
     const state = mkState({
@@ -576,7 +576,7 @@ describe("selectCardToPlay — Easy difficulty", () => {
       heartsBroken: true,
       currentPlayerIndex: 0,
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "easy");
+    const pick = selectCardToPlay(hand, [], state, 0, "cautious");
     // Lowest card (ace-high, so spades 3 is lowest)
     expect(pick).toEqual(c("spades", 3));
   });
@@ -594,8 +594,8 @@ describe("selectCardToPlay — Easy difficulty", () => {
       tricksPlayedInHand: 3,
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
-    // Easy dumps lowest card, not the strategic Q♠
+    const pick = selectCardToPlay(hand, trick, state, 3, "cautious");
+    // Cautious dumps lowest card, not the strategic Q♠
     expect(pick).toEqual(c("diamonds", 3));
   });
 
@@ -611,16 +611,16 @@ describe("selectCardToPlay — Easy difficulty", () => {
       tricksPlayedInHand: 3,
       currentPlayerIndex: 2,
     });
-    const pick = selectCardToPlay(hand, trick, state, 2, "easy");
+    const pick = selectCardToPlay(hand, trick, state, 2, "cautious");
     expect(pick).toEqual(c("spades", 5));
   });
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — moon attempt
+// Daring AI — moon attempt
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
+describe("selectCardToPlay — Daring difficulty, moon attempt", () => {
   it("discards non-hearts when void in led suit and holding 8+ hearts + Q♠ with no points taken", () => {
     // AI player 1 holds 8 hearts + Q♠ + two diamonds (void in clubs); no points taken
     const hearts8 = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
@@ -634,7 +634,7 @@ describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Void in clubs → can discard freely. Moon attempt: keep hearts and Q♠.
     // Should discard a diamond (highest of non-hearts/non-Q♠)
     expect(pick.suit).not.toBe("hearts");
@@ -664,9 +664,9 @@ describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 1, "hard");
+    const pick = selectCardToPlay(hand, [], state, 1, "daring");
     // Moon attempt: lead highest non-heart (A♦, aceHigh=14) to win the trick.
-    // Normal Hard would lead lowest of longest safe suit (8♦).
+    // Normal Daring would lead lowest of longest safe suit (8♦).
     expect(pick).toEqual(c("diamonds", 1));
   });
 
@@ -689,7 +689,7 @@ describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 1, "hard");
+    const pick = selectCardToPlay(hand, [], state, 1, "daring");
     // No non-hearts besides Q♠ — fall back to highest heart (10♥) to force wins.
     expect(pick).toEqual(c("hearts", 10));
   });
@@ -719,18 +719,18 @@ describe("selectCardToPlay — Hard difficulty, moon attempt", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Moon attempt: play lowest card that beats current winner (9♥) → 10♥.
-    // Normal Hard would play highest loser (8♥) to avoid winning points.
+    // Normal Daring would play highest loser (8♥) to avoid winning points.
     expect(pick).toEqual(c("hearts", 10));
   });
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — card counting (leading)
+// Daring AI — card counting (leading)
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Hard difficulty, card counting", () => {
+describe("selectCardToPlay — Daring difficulty, card counting", () => {
   it("avoids leading K♠ when Q♠ is still live", () => {
     const hand = [c("spades", 13), c("spades", 2), c("clubs", 7)];
     const state = mkState({
@@ -741,7 +741,7 @@ describe("selectCardToPlay — Hard difficulty, card counting", () => {
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []], // Q♠ not seen
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     // Should not lead K♠ since Q♠ might be discarded onto it
     expect(pick).not.toEqual(c("spades", 13));
   });
@@ -756,7 +756,7 @@ describe("selectCardToPlay — Hard difficulty, card counting", () => {
       currentPlayerIndex: 0,
       wonCards: [[c("spades", 12)], [], [], []], // Q♠ already taken
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     // Q♠ is gone — K♠ is safe to lead (lowest non-heart in safe pool)
     // clubs 7 is also safe; the algo picks lowest of longest safe suit
     // With Q♠ gone, K♠ is in the safe pool; lowest of spades=[K♠,2♠] is 2♠
@@ -767,13 +767,13 @@ describe("selectCardToPlay — Hard difficulty, card counting", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — score-aware endgame
+// Daring AI — score-aware endgame
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Hard difficulty, score-aware endgame", () => {
+describe("selectCardToPlay — Daring difficulty, score-aware endgame", () => {
   it("dumps Q♠ on score leader when void and score leader is winning the trick", () => {
     // Player 0 has the highest score (70) and is winning the trick.
-    // Hard (player 1) is void in clubs and should dump Q♠ to push player 0 toward 100.
+    // Daring (player 1) is void in clubs and should dump Q♠ to push player 0 toward 100.
     const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
     const trick: TrickCard[] = [
       { card: c("clubs", 8), playerIndex: 0 },
@@ -787,15 +787,15 @@ describe("selectCardToPlay — Hard difficulty, score-aware endgame", () => {
       currentPlayerIndex: 1,
       cumulativeScores: [70, 20, 10, 15],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     expect(pick).toEqual(c("spades", 12));
   });
 
-  it("holds Q♠ when dumping would push trick winner to 100+ and Hard is not the game leader", () => {
+  it("holds Q♠ when dumping would push trick winner to 100+ and Daring is not the game leader", () => {
     // Player 2 (score 88) is winning the trick; 88 + 13 = 101 ≥ 100 would end the game.
-    // Hard (player 1, score 50) is not the game leader (player 0 has lowest score 30).
+    // Daring (player 1, score 50) is not the game leader (player 0 has lowest score 30).
     // Player 3 is the score leader (92) but is NOT winning the trick — offensive dump doesn't fire.
-    // Hard should hold Q♠ and discard a safe card instead.
+    // Daring should hold Q♠ and discard a safe card instead.
     const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
     const trick: TrickCard[] = [
       { card: c("clubs", 4), playerIndex: 3 },
@@ -809,13 +809,13 @@ describe("selectCardToPlay — Hard difficulty, score-aware endgame", () => {
       currentPlayerIndex: 1,
       cumulativeScores: [30, 50, 88, 92],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     expect(pick).not.toEqual(c("spades", 12));
   });
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — opportunistic void in passing
+// Daring AI — opportunistic void in passing
 // ---------------------------------------------------------------------------
 
 describe("selectCardsToPass — #1636 void creation (Hard)", () => {
@@ -837,7 +837,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
       c("hearts", 5),
       c("hearts", 6),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("diamonds", 7));
   });
 
@@ -859,7 +859,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
       c("hearts", 3),
       c("hearts", 4),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("diamonds", 4));
     expect(passed).toContainEqual(c("diamonds", 6));
   });
@@ -882,7 +882,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
       c("hearts", 3),
       c("hearts", 4),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("diamonds", 3));
     expect(passed).toContainEqual(c("diamonds", 4));
     expect(passed).toContainEqual(c("diamonds", 5));
@@ -907,7 +907,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
       c("hearts", 6),
       c("hearts", 7),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("spades", 12)); // Q♠ passed
     expect(passed).toContainEqual(c("spades", 13)); // K♠ (spade void)
     expect(passed).toContainEqual(c("diamonds", 5)); // 5♦ (diamond void)
@@ -918,7 +918,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
 describe("selectCardsToPass — #1636 void creation (Medium)", () => {
   it("voids a 1-card suit when 1 slot remains after Q♠ and 1 danger heart", () => {
     // Q♠ → slot 1, A♥ → slot 2. 1 slot remains.
-    // ♦7 is the only diamond → Medium voids it (1 ≤ maxSuitSize 2).
+    // ♦7 is the only diamond → Schemer voids it (1 ≤ maxSuitSize 2).
     const hand = [
       c("spades", 12),
       c("hearts", 1),
@@ -934,12 +934,12 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("hearts", 5),
       c("hearts", 6),
     ];
-    const passed = selectCardsToPass(hand, "left", "medium");
+    const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed).toContainEqual(c("diamonds", 7));
   });
 
   it("voids a 2-card suit when 2 slots remain after Q♠ alone", () => {
-    // Q♠ → slot 1. 2 slots remain. ♦4, ♦6 are the only diamonds → Medium voids (2 ≤ maxSuitSize 2).
+    // Q♠ → slot 1. 2 slots remain. ♦4, ♦6 are the only diamonds → Schemer voids (2 ≤ maxSuitSize 2).
     const hand = [
       c("spades", 12),
       c("diamonds", 4),
@@ -955,7 +955,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("hearts", 3),
       c("hearts", 4),
     ];
-    const passed = selectCardsToPass(hand, "left", "medium");
+    const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed).toContainEqual(c("diamonds", 4));
     expect(passed).toContainEqual(c("diamonds", 6));
   });
@@ -978,8 +978,8 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("hearts", 3),
       c("hearts", 4),
     ];
-    const passed = selectCardsToPass(hand, "left", "medium");
-    // Medium DOES void the 3-card diamond suit (shortest eligible)
+    const passed = selectCardsToPass(hand, "left", "schemer");
+    // Schemer DOES void the 3-card diamond suit (shortest eligible)
     expect(passed).toContainEqual(c("diamonds", 3));
     expect(passed).toContainEqual(c("diamonds", 4));
     expect(passed).toContainEqual(c("diamonds", 5));
@@ -987,7 +987,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
 
   it("does NOT target spades for void when Q♠ is kept (cover cards protected)", () => {
     // Direction=left, has A♠+K♠ → Q♠ kept. Spades left: A♠, K♠ (2 cards).
-    // Medium should NOT void spades (keepingQSpade=true) — A♠/K♠ are Q♠ cover.
+    // Schemer should NOT void spades (keepingQSpade=true) — A♠/K♠ are Q♠ cover.
     // Hearts 5♥ is a singleton → hearts void fires instead.
     const hand = [
       c("spades", 12),
@@ -1005,7 +1005,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("diamonds", 7),
     ];
     // direction=left: hasASpades=true → Q♠ protected (kept)
-    const passed = selectCardsToPass(hand, "left", "medium");
+    const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
     expect(passed).not.toContainEqual(c("spades", 1)); // A♠ kept (cover)
     expect(passed).not.toContainEqual(c("spades", 13)); // K♠ kept (cover)
@@ -1031,7 +1031,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
       c("hearts", 8),
       c("hearts", 9),
     ];
-    const passed = selectCardsToPass(hand, "left", "medium");
+    const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed).toContainEqual(c("spades", 3));
     expect(passed).toContainEqual(c("diamonds", 5));
     expect(passed).toHaveLength(3);
@@ -1039,12 +1039,12 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — moon-viable passing (#1637)
+// Daring AI — moon-viable passing (#1637)
 // ---------------------------------------------------------------------------
 
 describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
   it("keeps Q♠ and all hearts when dealt 5+ hearts + Q♠", () => {
-    // 5 hearts + Q♠ → moon-viable. Hard passes LOWEST non-hearts (3♠, 5♠, 7♣) to
+    // 5 hearts + Q♠ → moon-viable. Daring passes LOWEST non-hearts (3♠, 5♠, 7♣) to
     // keep Aces and Kings for trick control during the moon attempt (#1647).
     const hand = [
       c("spades", 12), // Q♠ — kept for moon attempt
@@ -1061,7 +1061,7 @@ describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
       c("spades", 3),
       c("spades", 5),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
     expect(passed).not.toContainEqual(c("hearts", 1)); // A♥ kept
     expect(passed).not.toContainEqual(c("hearts", 13)); // K♥ kept
@@ -1074,7 +1074,7 @@ describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
   });
 
   it("uses standard passing when fewer than 5 hearts (no moon-viable)", () => {
-    // 4 hearts → NOT moon-viable. Standard Hard passing: Q♠ always passed.
+    // 4 hearts → NOT moon-viable. Standard Daring passing: Q♠ always passed.
     const hand = [
       c("spades", 12), // Q♠ — passed in standard mode
       c("hearts", 1),
@@ -1090,7 +1090,7 @@ describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
       c("spades", 3),
       c("spades", 5),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("spades", 12)); // Q♠ passed (standard mode)
   });
 
@@ -1112,7 +1112,7 @@ describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
       c("clubs", 4),
       c("clubs", 1), // A♣ — passable
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept
     expect(passed).not.toContainEqual(c("clubs", 2)); // 2♣ never passed
     expect(passed).toContainEqual(c("clubs", 1)); // A♣ passed (safe non-heart)
@@ -1126,10 +1126,10 @@ describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — high clubs in passing (A♣/K♣)
+// Daring AI — high clubs in passing (A♣/K♣)
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — Hard difficulty, high clubs", () => {
+describe("selectCardsToPass — Daring difficulty, high clubs", () => {
   it("passes A♣ (step 4.5) when no void creation opportunity exists", () => {
     // Q♠ → slot 1. Void creation (step 2) can't fire — 3 diamonds need 3 slots but only 2
     // remain. No high hearts (all below J♥). A♣ lands in step 4.5.
@@ -1148,7 +1148,7 @@ describe("selectCardsToPass — Hard difficulty, high clubs", () => {
       c("hearts", 4),
       c("hearts", 5),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("clubs", 1));
   });
 
@@ -1169,7 +1169,7 @@ describe("selectCardsToPass — Hard difficulty, high clubs", () => {
       c("hearts", 3),
       c("hearts", 4),
     ];
-    const passed = selectCardsToPass(hand, "left", "hard");
+    const passed = selectCardsToPass(hand, "left", "daring");
     expect(passed).toContainEqual(c("clubs", 13));
   });
 });
@@ -1285,7 +1285,7 @@ describe("chooseFollow — highest losing card (#1500)", () => {
       tricksPlayedInHand: 5,
       currentPlayerIndex: 1,
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 13));
   });
 
@@ -1301,7 +1301,7 @@ describe("chooseFollow — highest losing card (#1500)", () => {
       tricksPlayedInHand: 5,
       currentPlayerIndex: 1,
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 12)); // Q♠ dumped
   });
 });
@@ -1325,7 +1325,7 @@ describe("chooseFollow — Q♠ priority over K♠ when both lose (#1510)", () =
       currentPlayerIndex: 1,
       heartsBroken: true,
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 12)); // Q♠ not K♠
   });
 
@@ -1343,7 +1343,7 @@ describe("chooseFollow — Q♠ priority over K♠ when both lose (#1510)", () =
       currentPlayerIndex: 1,
     });
     // Player 1 follows; players 2 and 3 still to play → not last
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 12)); // Q♠ not K♠
   });
 });
@@ -1365,7 +1365,7 @@ describe("chooseFollow — protected Q♠ never self-taken when non-point winner
       currentPlayerIndex: 1,
     });
     // Player 1 follows; players 2 and 3 still to play → not last
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).not.toEqual(c("spades", 12)); // Q♠ must not be played
     expect(pick.suit).toBe("spades"); // must follow suit
     expect([1, 13]).toContain(pick.rank); // A♠ or K♠ (non-point winners)
@@ -1387,7 +1387,7 @@ describe("chooseFollow — protected Q♠ never self-taken when non-point winner
       heartsBroken: true,
     });
     // K♠ (13) and Q♠ (12) both beat 10♠; trick has points. Should play K♠ not Q♠.
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 13)); // K♠, not Q♠
   });
 
@@ -1407,7 +1407,7 @@ describe("chooseFollow — protected Q♠ never self-taken when non-point winner
       heartsBroken: true,
     });
     // trick.length === 3 → isLastToPlay = true; pts = 1 (7♥). K♠ and Q♠ both beat 6♠.
-    const pick = selectCardToPlay(hand, trick, state, 1, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 1, "schemer");
     expect(pick).toEqual(c("spades", 13)); // K♠, not Q♠
   });
 });
@@ -1425,7 +1425,7 @@ describe("chooseLead — medium AI avoids risky spade leads (#1501)", () => {
       heartsBroken: false,
       wonCards: [[], [], [], []], // Q♠ not in wonCards
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "medium");
+    const pick = selectCardToPlay(hand, [], state, 0, "schemer");
     expect(pick).not.toEqual(c("spades", 13));
   });
 
@@ -1438,7 +1438,7 @@ describe("chooseLead — medium AI avoids risky spade leads (#1501)", () => {
       heartsBroken: false,
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "medium");
+    const pick = selectCardToPlay(hand, [], state, 0, "schemer");
     expect(pick).not.toEqual(c("spades", 1));
   });
 
@@ -1452,7 +1452,7 @@ describe("chooseLead — medium AI avoids risky spade leads (#1501)", () => {
       heartsBroken: true,
       wonCards: [[c("spades", 12)], [], [], []], // Q♠ has been played
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "medium");
+    const pick = selectCardToPlay(hand, [], state, 0, "schemer");
     expect(pick).toEqual(c("spades", 13));
   });
 });
@@ -1474,7 +1474,7 @@ describe("chooseFollow — last to play, covering card (#1525)", () => {
       currentTrick: trick,
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 3, "schemer");
     expect(pick).toEqual(c("spades", 12));
   });
 
@@ -1491,13 +1491,13 @@ describe("chooseFollow — last to play, covering card (#1525)", () => {
       currentTrick: trick,
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "medium");
+    const pick = selectCardToPlay(hand, trick, state, 3, "schemer");
     expect(pick).not.toEqual(c("spades", 12));
     expect(pick).toEqual(c("spades", 7));
   });
 
   it("hard AI in moon-attempt mode does not dump Q♠ even when covering card present", () => {
-    // Hard AI holds 8 hearts + Q♠ with 0 pts taken → isMoonAttempt = true.
+    // Daring AI holds 8 hearts + Q♠ with 0 pts taken → isMoonAttempt = true.
     // A♠ is covering; Q♠ should be held to complete the moon shot.
     const hearts8 = Array.from({ length: 8 }, (_, i) => c("hearts", (i + 2) as Rank));
     const hand = [...hearts8, c("spades", 12), c("spades", 7)];
@@ -1513,13 +1513,13 @@ describe("chooseFollow — last to play, covering card (#1525)", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 3, "daring");
     expect(pick).not.toEqual(c("spades", 12));
   });
 });
 
 // ---------------------------------------------------------------------------
-// #1647 — Hard AI: chooseFollow moon-attempt 0-pt trick behaviour
+// #1647 — Daring AI: chooseFollow moon-attempt 0-pt trick behaviour
 // ---------------------------------------------------------------------------
 
 describe("chooseFollow — moon attempt, 0-pt trick (#1647)", () => {
@@ -1550,7 +1550,7 @@ describe("chooseFollow — moon attempt, 0-pt trick (#1647)", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 3, "daring");
     // Should win with lowest card above rank 8 → 9♣, not 10♣ or J♣
     expect(pick).toEqual(c("clubs", 9));
   });
@@ -1578,7 +1578,7 @@ describe("chooseFollow — moon attempt, 0-pt trick (#1647)", () => {
       handScores: [0, 0, 0, 0],
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // K♠ and A♠ both beat 5♠; Q♠ excluded (not last); lowest non-Q♠ winner = K♠
     expect(pick).not.toEqual(c("spades", 12)); // Q♠ protected
     expect(pick).toEqual(c("spades", 13)); // K♠ — lowest non-Q♠ winner
@@ -1586,13 +1586,13 @@ describe("chooseFollow — moon attempt, 0-pt trick (#1647)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// #1592 — Easy AI: basic moon blocking
+// #1592 — Cautious AI: basic moon blocking
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
+describe("selectCardToPlay — Cautious AI moon blocking (#1592)", () => {
   it("dumps highest point card when an opponent is threatening a moon", () => {
     // Player 0 has taken all 5 points — potential moon detected.
-    // Player 3 (Easy) is void in spades; should dump hearts 9 to disrupt.
+    // Player 3 (Cautious) is void in spades; should dump hearts 9 to disrupt.
     const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 1) as Rank));
     const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
     const trick: TrickCard[] = [
@@ -1608,7 +1608,7 @@ describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
       wonCards: [allHearts5, [], [], []],
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    const pick = selectCardToPlay(hand, trick, state, 3, "cautious");
     expect(pick).toEqual(c("hearts", 9));
   });
 
@@ -1628,12 +1628,12 @@ describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
       wonCards: [allHearts5, [], [], []],
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
+    const pick = selectCardToPlay(hand, trick, state, 3, "cautious");
     expect(pick).toEqual(c("hearts", 1));
   });
 
   it("dumps a point card when LEADING and an opponent is threatening a moon", () => {
-    // Easy AI (player 1) is leading its turn. Player 0 has all 5 points — moon threat.
+    // Cautious AI (player 1) is leading its turn. Player 0 has all 5 points — moon threat.
     // Hearts are broken, so hearts 9 is a valid lead and the moon-block should fire.
     const allHearts5 = Array.from({ length: 5 }, (_, i) => c("hearts", (i + 1) as Rank));
     const hand = [c("hearts", 9), c("diamonds", 3), c("diamonds", 4)];
@@ -1646,7 +1646,7 @@ describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
       wonCards: [allHearts5, [], [], []],
       currentPlayerIndex: 1,
     });
-    const pick = selectCardToPlay(hand, [], state, 1, "easy");
+    const pick = selectCardToPlay(hand, [], state, 1, "cautious");
     expect(pick).toEqual(c("hearts", 9));
   });
 
@@ -1665,17 +1665,17 @@ describe("selectCardToPlay — Easy AI moon blocking (#1592)", () => {
       wonCards: [[], [], [], []],
       currentPlayerIndex: 3,
     });
-    const pick = selectCardToPlay(hand, trick, state, 3, "easy");
-    // No moon threat → Easy dumps lowest card
+    const pick = selectCardToPlay(hand, trick, state, 3, "cautious");
+    // No moon threat → Cautious dumps lowest card
     expect(pick).toEqual(c("diamonds", 3));
   });
 });
 
 // ---------------------------------------------------------------------------
-// #1593 — Hard AI: moonshot extended tracking + tricks-remaining guard
+// #1593 — Daring AI: moonshot extended tracking + tricks-remaining guard
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
+describe("selectCardToPlay — Daring AI moonshot guard (#1593)", () => {
   it("stays in moon-attempt mode when AI has collected all points so far (5+ tricks left)", () => {
     // AI (player 1) has already won 2 hearts; still holds 8 hearts + Q♠ + 1 club.
     // aiHasAllPoints: handScores[1]=2 === totalPointsTaken=2. hand.length=10 >= 5.
@@ -1691,7 +1691,7 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
       handScores: [0, 2, 0, 0],
       wonCards: [[], heartsAlreadyWon, [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Moon attempt active: discard highest non-hearts/non-Q♠ = clubs 7
     expect(pick).toEqual(c("clubs", 7));
   });
@@ -1711,7 +1711,7 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
       handScores: [0, 6, 0, 0],
       wonCards: [[], heartsAlreadyWon, [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Not in moon mode → chooseDiscard fires → dumps Q♠ first
     expect(pick).toEqual(c("spades", 12));
   });
@@ -1739,7 +1739,7 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
       handScores: [0, 18, 0, 0],
       wonCards: [[], alreadyWon, [], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Moon attempt active: void in diamonds → discard highest non-hearts/non-Q♠ = clubs 8
     expect(pick).toEqual(c("clubs", 8));
   });
@@ -1758,14 +1758,14 @@ describe("selectCardToPlay — Hard AI moonshot guard (#1593)", () => {
       handScores: [0, 2, 2, 0], // player 2 also has points — AI doesn't have all points
       wonCards: [[], heartsAlreadyWon, [c("hearts", 12), c("hearts", 13)], []],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Not in moon mode (split points) → void in diamonds → chooseDiscard → dumps Q♠
     expect(pick).toEqual(c("spades", 12));
   });
 });
 
 // ---------------------------------------------------------------------------
-// #1594 — Hard AI: chooseLeadHard never leads Q♠ as fallback
+// #1594 — Daring AI: chooseLeadHard never leads Q♠ as fallback
 // ---------------------------------------------------------------------------
 
 describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit lead when holding Q♠ (#1646)", () => {
@@ -1781,7 +1781,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []], // Q♠ not yet played
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     expect(pick).not.toEqual(c("spades", 12));
     expect(pick).toEqual(c("hearts", 2)); // only non-spade option when holding Q♠
   });
@@ -1796,7 +1796,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     expect(pick).toEqual(c("spades", 12));
   });
 
@@ -1812,7 +1812,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     expect(pick).not.toEqual(c("spades", 12));
     expect(pick).toEqual(c("hearts", 3)); // lowest of longest group (hearts) after Q♠ stripped
   });
@@ -1836,7 +1836,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "hard");
+    const pick = selectCardToPlay(hand, [], state, 0, "daring");
     // Shortest non-spade suit is diamonds (2 cards) → lowest = 2♦
     expect(pick).toEqual(c("diamonds", 2));
   });
@@ -1859,7 +1859,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []],
     });
-    const pick = selectCardToPlay(hand, [], state, 0, "medium");
+    const pick = selectCardToPlay(hand, [], state, 0, "schemer");
     // Shortest non-spade suit is diamonds (2 cards) → lowest = 2♦
     expect(pick).toEqual(c("diamonds", 2));
   });
@@ -1875,11 +1875,11 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
       currentPlayerIndex: 0,
       wonCards: [[], [], [], []],
     });
-    // Both Hard and Medium should lead lowest of longest non-heart suit = 7♣
-    const pickHard = selectCardToPlay(hand, [], state, 0, "hard");
-    const pickMedium = selectCardToPlay(hand, [], state, 0, "medium");
-    expect(pickHard).toEqual(c("clubs", 7));
-    expect(pickMedium).toEqual(c("clubs", 7));
+    // Both Daring and Schemer should lead lowest of longest non-heart suit = 7♣
+    const pickDaring = selectCardToPlay(hand, [], state, 0, "daring");
+    const pickSchemer = selectCardToPlay(hand, [], state, 0, "schemer");
+    expect(pickDaring).toEqual(c("clubs", 7));
+    expect(pickSchemer).toEqual(c("clubs", 7));
   });
 });
 
@@ -1889,7 +1889,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
 
 describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
   it("passes Q♠ going right even when protected by A♠+K♠", () => {
-    // Medium normally keeps Q♠ when holding both A♠ and K♠.
+    // Schemer normally keeps Q♠ when holding both A♠ and K♠.
     // Going right relaxes protection — Q♠ should be passed.
     const hand = [
       c("spades", 12),
@@ -1906,7 +1906,7 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
       c("diamonds", 7),
       c("hearts", 2),
     ];
-    const passed = selectCardsToPass(hand, "right", "medium");
+    const passed = selectCardsToPass(hand, "right", "schemer");
     expect(passed).toContainEqual(c("spades", 12));
   });
 
@@ -1928,7 +1928,7 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
       c("diamonds", 8),
       c("hearts", 2),
     ];
-    const passed = selectCardsToPass(hand, "left", "medium");
+    const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed).not.toContainEqual(c("spades", 12));
   });
 
@@ -1951,8 +1951,8 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
       c("diamonds", 8),
       c("hearts", 2),
     ];
-    const passedLeft = selectCardsToPass(hand, "left", "medium");
-    const passedRight = selectCardsToPass(hand, "right", "medium");
+    const passedLeft = selectCardsToPass(hand, "left", "schemer");
+    const passedRight = selectCardsToPass(hand, "right", "schemer");
     expect(passedLeft).not.toContainEqual(c("spades", 12));
     expect(passedRight).toContainEqual(c("spades", 12));
   });
@@ -1960,7 +1960,7 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
 
 describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
   it("passes Q♠ regardless of direction (left and right both always pass Q♠)", () => {
-    // Hard is more aggressive than Medium — direction does not protect Q♠.
+    // Daring is more aggressive than Medium — direction does not protect Q♠.
     const hand = [
       c("spades", 12),
       c("spades", 1),
@@ -1976,8 +1976,8 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
       c("diamonds", 7),
       c("hearts", 2),
     ];
-    const passedLeft = selectCardsToPass(hand, "left", "hard");
-    const passedRight = selectCardsToPass(hand, "right", "hard");
+    const passedLeft = selectCardsToPass(hand, "left", "daring");
+    const passedRight = selectCardsToPass(hand, "right", "daring");
     expect(passedLeft).toContainEqual(c("spades", 12));
     expect(passedRight).toContainEqual(c("spades", 12));
   });
@@ -2004,8 +2004,8 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
       c("clubs", 10),
       c("clubs", 11), // J♣
     ];
-    const passedRight = selectCardsToPass(hand, "right", "hard");
-    const passedLeft = selectCardsToPass(hand, "left", "hard");
+    const passedRight = selectCardsToPass(hand, "right", "daring");
+    const passedLeft = selectCardsToPass(hand, "left", "daring");
     expect(passedRight).toContainEqual(c("hearts", 10));
     expect(passedLeft).not.toContainEqual(c("hearts", 10));
     expect(passedLeft).toContainEqual(c("hearts", 1)); // A♥ still passes going left
@@ -2030,7 +2030,7 @@ describe("selectCardsToPass — #1595 across direction (Medium)", () => {
       c("diamonds", 7),
       c("hearts", 2),
     ];
-    const passed = selectCardsToPass(hand, "across", "medium");
+    const passed = selectCardsToPass(hand, "across", "schemer");
     expect(passed).toContainEqual(c("spades", 12));
     expect(passed).toHaveLength(3);
   });
@@ -2053,19 +2053,19 @@ describe("selectCardsToPass — #1595 across direction (Medium)", () => {
       c("diamonds", 7),
       c("hearts", 2),
     ];
-    const passed = selectCardsToPass(hand, "none", "medium");
+    const passed = selectCardsToPass(hand, "none", "schemer");
     expect(passed).not.toContainEqual(c("spades", 12));
     expect(passed).toHaveLength(3);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Hard AI — adversarial targeting (#1638)
+// Daring AI — adversarial targeting (#1638)
 // ---------------------------------------------------------------------------
 
-describe("selectCardToPlay — Hard difficulty, adversarial void discard", () => {
-  it("dumps Q♠ on seat 0 when seat 0 is winning the trick and Hard is void", () => {
-    // Player 1 (Hard) is void in clubs and holds Q♠ + hearts.
+describe("selectCardToPlay — Daring difficulty, adversarial void discard", () => {
+  it("dumps Q♠ on seat 0 when seat 0 is winning the trick and Daring is void", () => {
+    // Player 1 (Daring) is void in clubs and holds Q♠ + hearts.
     // Seat 0 is currently winning the trick with K♣.
     const hand = [c("spades", 12), c("hearts", 5), c("hearts", 9), c("diamonds", 7)];
     const trick: TrickCard[] = [
@@ -2082,14 +2082,14 @@ describe("selectCardToPlay — Hard difficulty, adversarial void discard", () =>
       wonCards: [[], [], [], []],
       cumulativeScores: [10, 10, 10, 10], // below endgame threshold
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Seat 0 is winning — adversarial: dump Q♠ on human.
     expect(pick).toEqual(c("spades", 12));
   });
 
   it("saves Q♠ when an AI opponent (not seat 0) is winning the trick", () => {
-    // Player 1 (Hard) is void in clubs. Seat 2 is winning with K♣ (not seat 0).
-    // Hard holds Q♠, hearts, and a diamond — should discard the non-point card.
+    // Player 1 (Daring) is void in clubs. Seat 2 is winning with K♣ (not seat 0).
+    // Daring holds Q♠, hearts, and a diamond — should discard the non-point card.
     const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
     const trick: TrickCard[] = [
       { card: c("clubs", 3), playerIndex: 0 },
@@ -2105,7 +2105,7 @@ describe("selectCardToPlay — Hard difficulty, adversarial void discard", () =>
       wonCards: [[], [], [], []],
       cumulativeScores: [10, 10, 10, 10],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // Another AI is winning — save Q♠ for seat 0; dump non-point card (7♦).
     expect(pick).toEqual(c("diamonds", 7));
     expect(pick).not.toEqual(c("spades", 12));
@@ -2132,7 +2132,7 @@ describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
       c("diamonds", 6),
     ];
     // playerIndex=3, direction="left" → (3+1)%4=0 → targeting seat 0
-    const passed = selectCardsToPass(hand, "left", "hard", 3);
+    const passed = selectCardsToPass(hand, "left", "daring", 3);
     expect(passed).toHaveLength(3);
     expect(passed).toContainEqual(c("spades", 12));
   });
@@ -2155,7 +2155,7 @@ describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
       c("diamonds", 6),
     ];
     // playerIndex=1, direction="left" → (1+1)%4=2 → not targeting seat 0
-    const passed = selectCardsToPass(hand, "left", "hard", 1);
+    const passed = selectCardsToPass(hand, "left", "daring", 1);
     expect(passed).toHaveLength(3);
     expect(passed).not.toContainEqual(c("spades", 12));
   });
@@ -2177,7 +2177,7 @@ describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
       c("clubs", 7),
       c("diamonds", 6),
     ];
-    const passed = selectCardsToPass(hand, "across", "hard", 2);
+    const passed = selectCardsToPass(hand, "across", "daring", 2);
     expect(passed).toHaveLength(3);
     expect(passed).toContainEqual(c("spades", 12));
   });
@@ -2202,14 +2202,14 @@ describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
       c("clubs", 6),
     ];
     // playerIndex=3, direction="left" → (3+1)%4=0 → targeting seat 0
-    const passed = selectCardsToPass(hand, "left", "hard", 3);
+    const passed = selectCardsToPass(hand, "left", "daring", 3);
     expect(passed).toHaveLength(3);
     expect(passed).not.toContainEqual(c("spades", 12)); // Q♠ kept for moon attempt
   });
 });
 
-describe("selectCardToPlay — Hard difficulty, adversarial void discard (edge cases)", () => {
-  it("falls through to normal discard when seat 0 is winning but Hard holds no Q♠ or hearts", () => {
+describe("selectCardToPlay — Daring difficulty, adversarial void discard (edge cases)", () => {
+  it("falls through to normal discard when seat 0 is winning but Daring holds no Q♠ or hearts", () => {
     // Player 1 holds only non-point cards — nothing to target seat 0 with.
     // Should fall through and discard normally (highest non-point card).
     const hand = [c("diamonds", 10), c("clubs", 9), c("diamonds", 6)];
@@ -2227,16 +2227,16 @@ describe("selectCardToPlay — Hard difficulty, adversarial void discard (edge c
       wonCards: [[], [], [], []],
       cumulativeScores: [10, 10, 10, 10],
     });
-    const pick = selectCardToPlay(hand, trick, state, 1, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 1, "daring");
     // No Q♠ or hearts to dump — adversarial block falls through; normal discard fires.
     expect(pick.suit).not.toBe("hearts");
     expect(pick).not.toEqual(c("spades", 12));
   });
 
-  it("does not apply adversarial targeting when Hard is seat 0 (never happens in real game)", () => {
-    // Regression: Hard at seat 0 must NOT save Q♠ waiting for a 'seat 0 win' that can never
+  it("does not apply adversarial targeting when Daring is seat 0 (never happens in real game)", () => {
+    // Regression: Daring at seat 0 must NOT save Q♠ waiting for a 'seat 0 win' that can never
     // fire from its own void plays — it would hold Q♠ indefinitely and hurt its own score.
-    // Hard at seat 0 should dump Q♠ normally (chooseDiscard) regardless of who is winning.
+    // Daring at seat 0 should dump Q♠ normally (chooseDiscard) regardless of who is winning.
     const hand = [c("spades", 12), c("hearts", 5), c("diamonds", 7)];
     const trick: TrickCard[] = [
       { card: c("clubs", 3), playerIndex: 1 },
@@ -2252,7 +2252,7 @@ describe("selectCardToPlay — Hard difficulty, adversarial void discard (edge c
       wonCards: [[], [], [], []],
       cumulativeScores: [10, 10, 10, 10],
     });
-    const pick = selectCardToPlay(hand, trick, state, 0, "hard");
+    const pick = selectCardToPlay(hand, trick, state, 0, "daring");
     // Adversarial targeting inactive for playerIndex=0; chooseDiscard dumps Q♠ normally.
     expect(pick).toEqual(c("spades", 12));
   });

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -818,7 +818,7 @@ describe("selectCardToPlay — Daring difficulty, score-aware endgame", () => {
 // Daring AI — opportunistic void in passing
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — #1636 void creation (Hard)", () => {
+describe("selectCardsToPass — #1636 void creation (Daring)", () => {
   it("voids a 1-card suit when 1 slot remains after dangerous cards", () => {
     // Q♠ fills slot 1, A♥ fills slot 2. 1 slot remains.
     // ♦7 is the only diamond → void fires, ♦7 fills slot 3.
@@ -915,7 +915,7 @@ describe("selectCardsToPass — #1636 void creation (Hard)", () => {
   });
 });
 
-describe("selectCardsToPass — #1636 void creation (Medium)", () => {
+describe("selectCardsToPass — #1636 void creation (Schemer)", () => {
   it("voids a 1-card suit when 1 slot remains after Q♠ and 1 danger heart", () => {
     // Q♠ → slot 1, A♥ → slot 2. 1 slot remains.
     // ♦7 is the only diamond → Schemer voids it (1 ≤ maxSuitSize 2).
@@ -1042,7 +1042,7 @@ describe("selectCardsToPass — #1636 void creation (Medium)", () => {
 // Daring AI — moon-viable passing (#1637)
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — #1637 moon-viable passing (Hard)", () => {
+describe("selectCardsToPass — #1637 moon-viable passing (Daring)", () => {
   it("keeps Q♠ and all hearts when dealt 5+ hearts + Q♠", () => {
     // 5 hearts + Q♠ → moon-viable. Daring passes LOWEST non-hearts (3♠, 5♠, 7♣) to
     // keep Aces and Kings for trick control during the moon attempt (#1647).
@@ -1887,7 +1887,7 @@ describe("chooseLeadHard — Q♠ last-resort fallback (#1594) + shortest-suit l
 // selectCardsToPass — #1595 pass direction awareness
 // ---------------------------------------------------------------------------
 
-describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
+describe("selectCardsToPass — #1595 direction awareness (Schemer)", () => {
   it("passes Q♠ going right even when protected by A♠+K♠", () => {
     // Schemer normally keeps Q♠ when holding both A♠ and K♠.
     // Going right relaxes protection — Q♠ should be passed.
@@ -1958,9 +1958,9 @@ describe("selectCardsToPass — #1595 direction awareness (Medium)", () => {
   });
 });
 
-describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
+describe("selectCardsToPass — #1595 direction awareness (Daring)", () => {
   it("passes Q♠ regardless of direction (left and right both always pass Q♠)", () => {
-    // Daring is more aggressive than Medium — direction does not protect Q♠.
+    // Daring is more aggressive than Schemer — direction does not protect Q♠.
     const hand = [
       c("spades", 12),
       c("spades", 1),
@@ -2012,7 +2012,7 @@ describe("selectCardsToPass — #1595 direction awareness (Hard)", () => {
   });
 });
 
-describe("selectCardsToPass — #1595 across direction (Medium)", () => {
+describe("selectCardsToPass — #1595 across direction (Schemer)", () => {
   it("passes Q♠ going across even when holding A♠+K♠", () => {
     // "across" is treated the same as "right" — Q♠ protection threshold is relaxed.
     const hand = [
@@ -2112,7 +2112,7 @@ describe("selectCardToPlay — Daring difficulty, adversarial void discard", () 
   });
 });
 
-describe("selectCardsToPass — #1638 adversarial targeting (Hard)", () => {
+describe("selectCardsToPass — #1638 adversarial targeting (Daring)", () => {
   it("passes Q♠ to seat 0 even in moon-viable mode (left pass from seat 3)", () => {
     // Seat 3 passes left → recipient is seat 0. Hand is moon-viable (5+ hearts + Q♠).
     // Without targeting, moonViable keeps Q♠; with targeting, Q♠ is passed to seat 0.

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -50,7 +50,7 @@ function h4(
 function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
   return {
     _v: 3,
-    aiDifficulty: "medium",
+    aiDifficulty: "schemer",
     phase: "playing",
     handNumber: 1,
     passDirection: "left",

--- a/frontend/src/game/hearts/__tests__/storage.test.ts
+++ b/frontend/src/game/hearts/__tests__/storage.test.ts
@@ -80,21 +80,28 @@ describe("hearts storage", () => {
     expect(await loadGame()).toBeNull();
   });
 
-  it("loadGame migrates v2 save by defaulting aiDifficulty to medium (#1168)", async () => {
+  it("loadGame migrates v2 save by defaulting aiDifficulty to schemer (#1168, #1653)", async () => {
     const v2Save = { ...dealGame(), _v: 2 } as unknown as Record<string, unknown>;
     delete v2Save["aiDifficulty"];
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(v2Save));
     const loaded = await loadGame();
     expect(loaded).not.toBeNull();
     expect(loaded?._v).toBe(3);
-    expect(loaded?.aiDifficulty).toBe("medium");
+    expect(loaded?.aiDifficulty).toBe("schemer");
   });
 
-  it("loadGame round-trips aiDifficulty: hard", async () => {
-    const state: HeartsState = { ...dealGame(), aiDifficulty: "hard" };
+  it("loadGame migrates old difficulty values to persona names (#1653)", async () => {
+    const oldState = { ...dealGame(), aiDifficulty: "hard" };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(oldState));
+    const loaded = await loadGame();
+    expect(loaded?.aiDifficulty).toBe("daring");
+  });
+
+  it("loadGame round-trips aiDifficulty: daring", async () => {
+    const state: HeartsState = { ...dealGame(), aiDifficulty: "daring" };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(state));
     const loaded = await loadGame();
-    expect(loaded?.aiDifficulty).toBe("hard");
+    expect(loaded?.aiDifficulty).toBe("daring");
   });
 
   it("loadGame rejects handScores with out-of-range values (#1540)", async () => {

--- a/frontend/src/game/hearts/__tests__/storage.test.ts
+++ b/frontend/src/game/hearts/__tests__/storage.test.ts
@@ -90,11 +90,15 @@ describe("hearts storage", () => {
     expect(loaded?.aiDifficulty).toBe("schemer");
   });
 
-  it("loadGame migrates old difficulty values to persona names (#1653)", async () => {
-    const oldState = { ...dealGame(), aiDifficulty: "hard" };
+  it.each([
+    ["easy", "cautious"],
+    ["medium", "schemer"],
+    ["hard", "daring"],
+  ])("loadGame migrates old '%s' to '%s' (#1653)", async (oldValue, newValue) => {
+    const oldState = { ...dealGame(), aiDifficulty: oldValue };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(oldState));
     const loaded = await loadGame();
-    expect(loaded?.aiDifficulty).toBe("daring");
+    expect(loaded?.aiDifficulty).toBe(newValue);
   });
 
   it("loadGame round-trips aiDifficulty: daring", async () => {

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -2,12 +2,12 @@
  * Hearts AI (#606, #1168).
  *
  * Pure TypeScript rule-based strategy for the 3 computer opponents.
- * Supports Easy / Medium / Hard difficulty via the `difficulty` parameter.
+ * Supports Cautious / Schemer / Daring personas via the `difficulty` parameter.
  * No randomness beyond deterministic tie-breaking. No React/AsyncStorage.
  */
 
 import { getValidPlays } from "./engine";
-import type { AiDifficulty, Card, HeartsState, PassDirection, TrickCard } from "./types";
+import type { AiPersona, Card, HeartsState, PassDirection, TrickCard } from "./types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -393,18 +393,18 @@ function selectCardsToPassHard(
 
 /**
  * Select exactly 3 cards to pass.
- * `difficulty` defaults to "medium" (current behaviour) so existing callers are unchanged.
+ * `difficulty` defaults to "schemer" (current behaviour) so existing callers are unchanged.
  * `playerIndex` defaults to 0 (human seat) — seat 0 never passes so the default never
- * triggers adversarial targeting; pass the actual AI seat index (1–3) for Hard targeting.
+ * triggers adversarial targeting; pass the actual AI seat index (1–3) for Daring targeting.
  */
 export function selectCardsToPass(
   hand: Card[],
   direction: PassDirection,
-  difficulty: AiDifficulty = "medium",
+  difficulty: AiPersona = "schemer",
   playerIndex = 0
 ): Card[] {
-  if (difficulty === "easy") return selectCardsToPassEasy(hand);
-  if (difficulty === "hard") return selectCardsToPassHard(hand, direction, playerIndex);
+  if (difficulty === "cautious") return selectCardsToPassEasy(hand);
+  if (difficulty === "daring") return selectCardsToPassHard(hand, direction, playerIndex);
   return selectCardsToPassMedium(hand, direction);
 }
 
@@ -751,17 +751,17 @@ function selectCardToPlayHard(
 
 /**
  * Choose a card to play.
- * `difficulty` defaults to "medium" (current behaviour) so existing callers are unchanged.
+ * `difficulty` defaults to "schemer" (current behaviour) so existing callers are unchanged.
  */
 export function selectCardToPlay(
   hand: Card[],
   trick: TrickCard[],
   state: HeartsState,
   playerIndex: number,
-  difficulty: AiDifficulty = "medium"
+  difficulty: AiPersona = "schemer"
 ): Card {
-  if (difficulty === "easy") return selectCardToPlayEasy(hand, trick, state, playerIndex);
-  if (difficulty === "hard") return selectCardToPlayHard(hand, trick, state, playerIndex);
+  if (difficulty === "cautious") return selectCardToPlayEasy(hand, trick, state, playerIndex);
+  if (difficulty === "daring") return selectCardToPlayHard(hand, trick, state, playerIndex);
   return selectCardToPlayMedium(hand, trick, state, playerIndex);
 }
 

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -6,7 +6,7 @@
  * on each transition — state is immutable.
  */
 
-import type { AiDifficulty, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
+import type { AiPersona, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
 import { RANKS, SUITS } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ export function getPassDirection(handNumber: number): PassDirection {
 }
 
 /** Initial game state for a fresh game (hand 1). */
-export function dealGame(difficulty: AiDifficulty = "medium"): HeartsState {
+export function dealGame(difficulty: AiPersona = "schemer"): HeartsState {
   const hands = dealHands();
   const passDirection = getPassDirection(1);
   const leaderIndex = passDirection === "none" ? find2ClubsHolder(hands) : 0;

--- a/frontend/src/game/hearts/storage.ts
+++ b/frontend/src/game/hearts/storage.ts
@@ -1,9 +1,14 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import type { AiDifficulty, HeartsState } from "./types";
+import type { AiPersona, HeartsState } from "./types";
 
 const GAME_KEY = "hearts_game";
-const AI_DIFFICULTY_VALUES: readonly string[] = ["easy", "medium", "hard"];
+const AI_PERSONA_VALUES: readonly string[] = ["cautious", "schemer", "daring"];
+const LEGACY_PERSONA_MAP: Record<string, string> = {
+  easy: "cautious",
+  medium: "schemer",
+  hard: "daring",
+};
 
 export async function saveGame(state: HeartsState): Promise<void> {
   try {
@@ -23,16 +28,22 @@ export async function loadGame(): Promise<HeartsState | null> {
     // v2 → v3 migration: add aiDifficulty default
     if (rawV === 2) {
       parsed["_v"] = 3;
-      parsed["aiDifficulty"] = "medium";
+      parsed["aiDifficulty"] = "schemer";
     } else if (rawV !== 3) {
       await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
       return null;
     }
 
+    // Migrate pre-#1653 persona values ("easy"→"cautious", etc.)
+    const storedPersona = parsed["aiDifficulty"];
+    if (typeof storedPersona === "string" && storedPersona in LEGACY_PERSONA_MAP) {
+      parsed["aiDifficulty"] = LEGACY_PERSONA_MAP[storedPersona];
+    }
+
     const p = parsed as Partial<HeartsState>;
     if (
       p._v !== 3 ||
-      !AI_DIFFICULTY_VALUES.includes(p.aiDifficulty as string) ||
+      !AI_PERSONA_VALUES.includes(p.aiDifficulty as string) ||
       !Array.isArray(p.playerHands) ||
       p.playerHands.length !== 4 ||
       !Array.isArray(p.cumulativeScores) ||
@@ -65,7 +76,7 @@ export async function loadGame(): Promise<HeartsState | null> {
       await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
       return null;
     }
-    return { ...p, aiDifficulty: p.aiDifficulty as AiDifficulty } as HeartsState;
+    return { ...p, aiDifficulty: p.aiDifficulty as AiPersona } as HeartsState;
   } catch (e) {
     Sentry.captureMessage("hearts.storage: corrupt game payload, discarding", {
       level: "warning",

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -9,7 +9,6 @@ export type AiPersona = "cautious" | "schemer" | "daring";
 /** @deprecated Use AiPersona */
 export type AiDifficulty = AiPersona;
 export const AI_PERSONAS: readonly AiPersona[] = ["cautious", "schemer", "daring"];
-export const AI_DIFFICULTIES = AI_PERSONAS;
 
 /** UI events emitted by the engine and consumed by the animation layer. */
 export type GameEvent =

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -5,8 +5,11 @@
  * engine, AI, UI components, and persistence layer alike.
  */
 
-export type AiDifficulty = "easy" | "medium" | "hard";
-export const AI_DIFFICULTIES: readonly AiDifficulty[] = ["easy", "medium", "hard"];
+export type AiPersona = "cautious" | "schemer" | "daring";
+/** @deprecated Use AiPersona */
+export type AiDifficulty = AiPersona;
+export const AI_PERSONAS: readonly AiPersona[] = ["cautious", "schemer", "daring"];
+export const AI_DIFFICULTIES = AI_PERSONAS;
 
 /** UI events emitted by the engine and consumed by the animation layer. */
 export type GameEvent =
@@ -47,7 +50,8 @@ export type HeartsPhase =
  * Players: index 0 = human, 1 = left AI, 2 = top AI, 3 = right AI.
  * `_v` is a schema version so persisted saves can be migrated or rejected.
  * v2 adds `scoreHistory` so per-round deltas survive screen unmount (#745).
- * v3 adds `aiDifficulty` for the Easy/Medium/Hard AI difficulty selector (#1168).
+ * v3 adds `aiDifficulty` for the AI persona selector (#1168). Values renamed to
+ * "cautious"/"schemer"/"daring" (#1653); old "easy"/"medium"/"hard" are migrated on load.
  */
 export interface HeartsState {
   readonly _v: 3;

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -75,9 +75,12 @@
   "events.moonShot": "{{name}} shot the moon!",
   "events.queenOfSpades": "{{name}} takes the Queen of Spades!",
 
-  "difficulty.groupLabel": "AI Difficulty",
-  "difficulty.easy": "Easy",
-  "difficulty.medium": "Medium",
-  "difficulty.hard": "Hard",
+  "difficulty.groupLabel": "Opponent Style",
+  "difficulty.cautious": "Cautious",
+  "difficulty.cautious.desc": "Plays conservatively, avoids taking points",
+  "difficulty.schemer": "Schemer",
+  "difficulty.schemer.desc": "Creates suit voids, deflects the Queen of Spades",
+  "difficulty.daring": "Daring",
+  "difficulty.daring.desc": "Swings for moon shots, targets you with the Queen",
   "game.startGame": "Start Game"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -59,9 +59,12 @@
   "events.moonShot": "{{name}} לקח את הכל!",
   "events.queenOfSpades": "{{name}} לקח את מלכת הספייד!",
 
-  "difficulty.groupLabel": "רמת קושי",
-  "difficulty.easy": "קל",
-  "difficulty.medium": "בינוני",
-  "difficulty.hard": "קשה",
+  "difficulty.groupLabel": "סגנון יריב",
+  "difficulty.cautious": "זהיר",
+  "difficulty.cautious.desc": "משחק בזהירות, נמנע מלקחת נקודות",
+  "difficulty.schemer": "מתכנן",
+  "difficulty.schemer.desc": "יוצר חסרים, מסיט את מלכת הספייד",
+  "difficulty.daring": "נועז",
+  "difficulty.daring.desc": "מנסה לירות ירח, מכוון אליך עם המלכה",
   "game.startGame": "התחל משחק"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -59,9 +59,12 @@
   "events.moonShot": "{{name}}が月を射抜いた！",
   "events.queenOfSpades": "{{name}}がスペードのQを取った！",
 
-  "difficulty.groupLabel": "難易度",
-  "difficulty.easy": "かんたん",
-  "difficulty.medium": "ふつう",
-  "difficulty.hard": "むずかしい",
+  "difficulty.groupLabel": "対戦相手のスタイル",
+  "difficulty.cautious": "慎重",
+  "difficulty.cautious.desc": "保守的にプレイし、点数を取らないようにする",
+  "difficulty.schemer": "策士",
+  "difficulty.schemer.desc": "スートの欠如を作り、スペードのクイーンをかわす",
+  "difficulty.daring": "大胆",
+  "difficulty.daring.desc": "月を狙い、あなたをクイーンで標的にする",
   "game.startGame": "ゲームスタート"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -43,7 +43,7 @@ import { OfflineBanner } from "../components/shared/OfflineBanner";
 import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
 import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnimation";
 import { HeartsQueenOfSpadesAnimation } from "../components/hearts/HeartsQueenOfSpadesAnimation";
-import type { AiDifficulty, Card, HeartsState, TrickCard } from "../game/hearts/types";
+import type { AiPersona, Card, HeartsState, TrickCard } from "../game/hearts/types";
 
 const HUMAN = 0;
 const MAX_NAME_LENGTH = 32;
@@ -72,7 +72,7 @@ export default function HeartsScreen() {
   const { isOnline, isInitialized } = useNetwork();
 
   const [gameState, setGameState] = useState<HeartsState | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<AiDifficulty>("medium");
+  const [selectedDifficulty, setSelectedDifficulty] = useState<AiPersona>("schemer");
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
   const [showHeartsBroken, setShowHeartsBroken] = useState(false);
   const [showMoonShot, setShowMoonShot] = useState(false);
@@ -398,7 +398,7 @@ export default function HeartsScreen() {
     }
   }
 
-  function handleStartGame(difficulty: AiDifficulty) {
+  function handleStartGame(difficulty: AiPersona) {
     setLastTrick(null);
     setShowMoonShot(false);
     setShowHeartsBroken(false);
@@ -463,7 +463,7 @@ export default function HeartsScreen() {
       >
         <View style={styles.preGameContainer}>
           <Text style={[styles.preGameTitle, { color: colors.text }]}>
-            {t("difficulty.groupLabel", { defaultValue: "AI Difficulty" })}
+            {t("difficulty.groupLabel", { defaultValue: "Opponent Style" })}
           </Text>
           <HeartsAiDifficultySelector value={selectedDifficulty} onChange={setSelectedDifficulty} />
           <Pressable

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -23,7 +23,7 @@ import {
   selectCardsToPass,
 } from "../frontend/src/game/hearts/ai";
 import type {
-  AiDifficulty,
+  AiPersona,
   Card,
   HeartsState,
 } from "../frontend/src/game/hearts/types";
@@ -32,7 +32,7 @@ import type {
 // Simulation
 // ---------------------------------------------------------------------------
 
-type Difficulties = [AiDifficulty, AiDifficulty, AiDifficulty, AiDifficulty];
+type Difficulties = [AiPersona, AiPersona, AiPersona, AiPersona];
 
 interface GameResult {
   win: number;
@@ -282,7 +282,7 @@ function sigLabel(z: number): string {
 // CLI dispatch
 // ---------------------------------------------------------------------------
 
-const VALID_DIFFICULTIES = new Set<AiDifficulty>(["easy", "medium", "hard"]);
+const VALID_DIFFICULTIES = new Set<AiPersona>(["cautious", "schemer", "daring"]);
 
 function parseCount(args: string[], flag: string): number | null {
   const idx = args.indexOf(flag);
@@ -297,7 +297,7 @@ function parseDifficulties(args: string[]): Difficulties | null {
   const parts = (args[idx + 1] ?? "").split(",");
   if (parts.length !== 4) return null;
   for (const p of parts) {
-    if (!VALID_DIFFICULTIES.has(p as AiDifficulty)) return null;
+    if (!VALID_DIFFICULTIES.has(p as AiPersona)) return null;
   }
   return parts as unknown as Difficulties;
 }
@@ -314,16 +314,16 @@ if (count !== null) {
   const difficultiesArg = parseDifficulties(process.argv);
   if (process.argv.includes("--difficulties") && difficultiesArg === null) {
     process.stderr.write(
-      "Error: --difficulties must be 4 comma-separated values of easy/medium/hard\n" +
-        "  Example: --difficulties easy,medium,hard,medium\n",
+      "Error: --difficulties must be 4 comma-separated values of cautious/schemer/daring\n" +
+        "  Example: --difficulties cautious,schemer,daring,schemer\n",
     );
     process.exit(1);
   }
   const logDifficulties: Difficulties = difficultiesArg ?? [
-    "medium",
-    "medium",
-    "medium",
-    "medium",
+    "schemer",
+    "schemer",
+    "schemer",
+    "schemer",
   ];
   for (let i = 0; i < count; i++) {
     const log = simulateGameLogged(logDifficulties, i);
@@ -353,36 +353,36 @@ const GAMES_PER_BATCH = 3000;
 
 const batches: Array<{ label: string; difficulties: Difficulties }> = [
   {
-    label: "Easy vs Easy vs Easy (baseline)",
-    difficulties: ["easy", "easy", "easy", "easy"],
+    label: "Cautious vs Cautious vs Cautious (baseline)",
+    difficulties: ["cautious", "cautious", "cautious", "cautious"],
   },
   {
-    label: "Easy vs Medium vs Medium vs Medium",
-    difficulties: ["easy", "medium", "medium", "medium"],
+    label: "Cautious vs Schemer vs Schemer vs Schemer",
+    difficulties: ["cautious", "schemer", "schemer", "schemer"],
   },
   {
-    label: "Easy vs Hard vs Hard vs Hard",
-    difficulties: ["easy", "hard", "hard", "hard"],
+    label: "Cautious vs Daring vs Daring vs Daring",
+    difficulties: ["cautious", "daring", "daring", "daring"],
   },
   {
-    label: "Medium vs Hard vs Hard vs Hard",
-    difficulties: ["medium", "hard", "hard", "hard"],
+    label: "Schemer vs Daring vs Daring vs Daring",
+    difficulties: ["schemer", "daring", "daring", "daring"],
   },
   {
-    // Hard vs Medium, with 2 Easy neutrals to reduce field noise.
-    // If Hard beats Medium, player 0 (Hard) should win > player 1 (Medium).
-    label: "Hard vs Medium + 2 Easy neutrals (player 0 = Hard)",
-    difficulties: ["hard", "medium", "easy", "easy"],
+    // Daring vs Schemer, with 2 Cautious neutrals to reduce field noise.
+    // If Daring beats Schemer, player 0 (Daring) should win > player 1 (Schemer).
+    label: "Daring vs Schemer + 2 Cautious neutrals (player 0 = Daring)",
+    difficulties: ["daring", "schemer", "cautious", "cautious"],
   },
   {
-    // Mirror of the above — player 0 is now Medium.
-    // Comparing batch 5 win rate vs batch 6 win rate isolates Hard vs Medium.
-    label: "Medium vs Hard + 2 Easy neutrals (player 0 = Medium)",
-    difficulties: ["medium", "hard", "easy", "easy"],
+    // Mirror of the above — player 0 is now Schemer.
+    // Comparing batch 5 win rate vs batch 6 win rate isolates Daring vs Schemer.
+    label: "Schemer vs Daring + 2 Cautious neutrals (player 0 = Schemer)",
+    difficulties: ["schemer", "daring", "cautious", "cautious"],
   },
 ];
 
-console.log("Hearts AI Difficulty Simulation Results");
+console.log("Hearts AI Persona Simulation Results");
 console.log("=======================================\n");
 
 const batchWinRates: number[] = [];
@@ -457,38 +457,38 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
 // ---------------------------------------------------------------------------
 
 const [
-  easyWr,
-  easyVsMedWr,
-  easyVsHardWr,
-  medVs3HardWr,
-  hardVsMedNeutralWr,
-  medVsHardNeutralWr,
+  cautiousWr,
+  cautiousVsSchemerWr,
+  cautiousVsDaringWr,
+  schemerVs3DaringWr,
+  daringVsSchemerNeutralWr,
+  schemerVsDaringNeutralWr,
 ] = batchWinRates as [number, number, number, number, number, number];
 
-const zEM = zTest(easyWr, easyVsMedWr, GAMES_PER_BATCH);
-const zEH = zTest(easyWr, easyVsHardWr, GAMES_PER_BATCH);
-const zMHFull = zTest(easyVsMedWr, easyVsHardWr, GAMES_PER_BATCH);
-// Direct Hard vs Medium comparison: Hard (batch 5) vs Medium (batch 6) — same game, seat swapped.
-const zHvM_direct = zTest(
-  hardVsMedNeutralWr,
-  medVsHardNeutralWr,
+const zCS = zTest(cautiousWr, cautiousVsSchemerWr, GAMES_PER_BATCH);
+const zCD = zTest(cautiousWr, cautiousVsDaringWr, GAMES_PER_BATCH);
+const zSDFull = zTest(cautiousVsSchemerWr, cautiousVsDaringWr, GAMES_PER_BATCH);
+// Direct Daring vs Schemer comparison: Daring (batch 5) vs Schemer (batch 6) — same game, seat swapped.
+const zDvS_direct = zTest(
+  daringVsSchemerNeutralWr,
+  schemerVsDaringNeutralWr,
   GAMES_PER_BATCH,
 );
 const check = (cond: boolean) => (cond ? "✓" : "✗");
 
 console.log("Interpretation:");
 console.log(
-  `  ${check(easyWr > 0.2 && easyWr < 0.3)} Easy baseline win rate near 25% (got ${(easyWr * 100).toFixed(1)}%)`,
+  `  ${check(cautiousWr > 0.2 && cautiousWr < 0.3)} Cautious baseline win rate near 25% (got ${(cautiousWr * 100).toFixed(1)}%)`,
 );
 console.log(
-  `  ${check(easyVsMedWr < easyWr)} Easy vs Medium: win rate drops (${sigLabel(zEM)})`,
+  `  ${check(cautiousVsSchemerWr < cautiousWr)} Cautious vs Schemer: win rate drops (${sigLabel(zCS)})`,
 );
 console.log(
-  `  ${check(easyVsHardWr < easyVsMedWr)} Easy vs Hard: win rate drops further (${sigLabel(zEH)})`,
+  `  ${check(cautiousVsDaringWr < cautiousVsSchemerWr)} Cautious vs Daring: win rate drops further (${sigLabel(zCD)})`,
 );
 console.log(
-  `  ${check(medVs3HardWr < 0.25)} Medium vs 3 Hard: Medium below 25% (got ${(medVs3HardWr * 100).toFixed(1)}%, ${sigLabel(zMHFull)} vs Easy batches)`,
+  `  ${check(schemerVs3DaringWr < 0.25)} Schemer vs 3 Daring: Schemer below 25% (got ${(schemerVs3DaringWr * 100).toFixed(1)}%, ${sigLabel(zSDFull)} vs Cautious batches)`,
 );
 console.log(
-  `  ${check(hardVsMedNeutralWr > medVsHardNeutralWr)} Hard vs Medium (neutral field): Hard ${(hardVsMedNeutralWr * 100).toFixed(1)}% vs Medium ${(medVsHardNeutralWr * 100).toFixed(1)}% (${sigLabel(zHvM_direct)})`,
+  `  ${check(daringVsSchemerNeutralWr > schemerVsDaringNeutralWr)} Daring vs Schemer (neutral field): Daring ${(daringVsSchemerNeutralWr * 100).toFixed(1)}% vs Schemer ${(schemerVsDaringNeutralWr * 100).toFixed(1)}% (${sigLabel(zDvS_direct)})`,
 );


### PR DESCRIPTION
## Summary

- Replaces `Easy / Medium / Hard` with `Cautious / Schemer / Daring` across all surfaces (UI, AI logic, storage, simulator, tests)
- Adds a one-line play-style description to each option in the picker (e.g. _"Swings for moon shots, targets you with the Queen"_)
- Existing saved games (`"easy"` / `"medium"` / `"hard"` values) are migrated transparently on load — no schema version bump needed
- No AI logic changes; pure naming and framing update per issue spec

## Test plan

- [x] All 243 Hearts unit tests pass (`npx jest --testPathPattern="hearts"`)
- [x] No new TypeScript errors in Hearts files
- [x] Storage migration test covers old → new value mapping
- [x] E2E tests updated to assert `Cautious / Schemer / Daring` radio buttons and `Opponent Style` group label

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)