### PR TITLE
feat(hearts): add Mixed Table preset — one of each persona per AI seat (#1654)

### DIFF
--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -3,7 +3,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import type { AiPreset } from "../../game/hearts/types";
-import { AI_PRESETS } from "../../game/hearts/types";
+import { AI_PERSONAS } from "../../game/hearts/types";
 
 interface Props {
   value: AiPreset;
@@ -17,49 +17,69 @@ const PRESET_DEFAULTS: Record<AiPreset, { label: string; desc: string }> = {
   mixed: { label: "Mixed Table", desc: "One of each: Cautious left, Schemer across, Daring right" },
 };
 
+function PersonaBtn({
+  preset,
+  value,
+  onChange,
+  colors,
+  t,
+}: {
+  preset: AiPreset;
+  value: AiPreset;
+  onChange: (d: AiPreset) => void;
+  colors: ReturnType<typeof useTheme>["colors"];
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  const selected = preset === value;
+  const defaults = PRESET_DEFAULTS[preset];
+  return (
+    <Pressable
+      onPress={() => onChange(preset)}
+      accessibilityRole="radio"
+      accessibilityLabel={t(`difficulty.${preset}`, { defaultValue: defaults.label })}
+      accessibilityState={{ selected }}
+      style={[styles.btn, { backgroundColor: selected ? colors.accent : colors.surface }]}
+    >
+      <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
+        {t(`difficulty.${preset}`, { defaultValue: defaults.label })}
+      </Text>
+      <Text style={[styles.desc, { color: selected ? colors.textOnAccent : colors.textMuted }]}>
+        {t(`difficulty.${preset}.desc`, { defaultValue: defaults.desc })}
+      </Text>
+    </Pressable>
+  );
+}
+
 export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
+  const shared = { value, onChange, colors, t };
 
   return (
     <View
       accessibilityRole="radiogroup"
       accessibilityLabel={t("difficulty.groupLabel", { defaultValue: "Opponent Style" })}
-      style={[styles.row, { borderColor: colors.border }]}
+      style={[styles.container, { borderColor: colors.border }]}
     >
-      {AI_PRESETS.map((d) => {
-        const selected = d === value;
-        const defaults = PRESET_DEFAULTS[d];
-        return (
-          <Pressable
-            key={d}
-            onPress={() => onChange(d)}
-            accessibilityRole="radio"
-            accessibilityLabel={t(`difficulty.${d}`, { defaultValue: defaults.label })}
-            accessibilityState={{ selected }}
-            style={[styles.btn, { backgroundColor: selected ? colors.accent : colors.surface }]}
-          >
-            <Text style={[styles.label, { color: selected ? colors.textOnAccent : colors.text }]}>
-              {t(`difficulty.${d}`, { defaultValue: defaults.label })}
-            </Text>
-            <Text
-              style={[styles.desc, { color: selected ? colors.textOnAccent : colors.textMuted }]}
-            >
-              {t(`difficulty.${d}.desc`, { defaultValue: defaults.desc })}
-            </Text>
-          </Pressable>
-        );
-      })}
+      <View style={[styles.personaRow, { borderBottomColor: colors.border }]}>
+        {AI_PERSONAS.map((d) => (
+          <PersonaBtn key={d} preset={d} {...shared} />
+        ))}
+      </View>
+      <PersonaBtn preset="mixed" {...shared} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: "row",
+  container: {
     borderWidth: 1,
     borderRadius: 8,
     overflow: "hidden",
+  },
+  personaRow: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
   },
   btn: {
     flex: 1,

--- a/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
+++ b/frontend/src/components/hearts/HeartsAiDifficultySelector.tsx
@@ -2,18 +2,19 @@ import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
-import type { AiPersona } from "../../game/hearts/types";
-import { AI_PERSONAS } from "../../game/hearts/types";
+import type { AiPreset } from "../../game/hearts/types";
+import { AI_PRESETS } from "../../game/hearts/types";
 
 interface Props {
-  value: AiPersona;
-  onChange: (d: AiPersona) => void;
+  value: AiPreset;
+  onChange: (d: AiPreset) => void;
 }
 
-const PERSONA_DEFAULTS: Record<AiPersona, { label: string; desc: string }> = {
+const PRESET_DEFAULTS: Record<AiPreset, { label: string; desc: string }> = {
   cautious: { label: "Cautious", desc: "Plays conservatively, avoids taking points" },
   schemer: { label: "Schemer", desc: "Creates suit voids, deflects the Queen of Spades" },
   daring: { label: "Daring", desc: "Swings for moon shots, targets you with the Queen" },
+  mixed: { label: "Mixed Table", desc: "One of each: Cautious left, Schemer across, Daring right" },
 };
 
 export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
@@ -26,9 +27,9 @@ export default function HeartsAiDifficultySelector({ value, onChange }: Props) {
       accessibilityLabel={t("difficulty.groupLabel", { defaultValue: "Opponent Style" })}
       style={[styles.row, { borderColor: colors.border }]}
     >
-      {AI_PERSONAS.map((d) => {
+      {AI_PRESETS.map((d) => {
         const selected = d === value;
-        const defaults = PERSONA_DEFAULTS[d];
+        const defaults = PRESET_DEFAULTS[d];
         return (
           <Pressable
             key={d}

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -27,7 +27,8 @@ import {
   selectPassCard,
   setRng,
 } from "../engine";
-import type { Card, HeartsState, Suit, Rank } from "../types";
+import type { AiPreset, Card, HeartsState, Suit, Rank } from "../types";
+import { resolvePersona } from "../types";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1125,4 +1126,27 @@ describe("dealNextHand", () => {
     const next = dealNextHand(state);
     expect(next.scoreHistory).toEqual(history);
   });
+});
+
+// ---------------------------------------------------------------------------
+// resolvePersona (#1654) — Mixed Table seat-to-persona routing
+// ---------------------------------------------------------------------------
+
+describe("resolvePersona", () => {
+  it.each<[AiPreset, number, string]>([
+    ["mixed", 1, "cautious"],
+    ["mixed", 2, "schemer"],
+    ["mixed", 3, "daring"],
+  ])("mixed seat %i → %s", (preset, seat, expected) => {
+    expect(resolvePersona(preset, seat)).toBe(expected);
+  });
+
+  it.each<AiPreset>(["cautious", "schemer", "daring"])(
+    "non-mixed preset '%s' passes through unchanged",
+    (persona) => {
+      expect(resolvePersona(persona, 1)).toBe(persona);
+      expect(resolvePersona(persona, 2)).toBe(persona);
+      expect(resolvePersona(persona, 3)).toBe(persona);
+    }
+  );
 });

--- a/frontend/src/game/hearts/__tests__/storage.test.ts
+++ b/frontend/src/game/hearts/__tests__/storage.test.ts
@@ -108,6 +108,13 @@ describe("hearts storage", () => {
     expect(loaded?.aiDifficulty).toBe("daring");
   });
 
+  it("loadGame round-trips aiDifficulty: mixed (#1654)", async () => {
+    const state: HeartsState = { ...dealGame(), aiDifficulty: "mixed" };
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(state));
+    const loaded = await loadGame();
+    expect(loaded?.aiDifficulty).toBe("mixed");
+  });
+
   it("loadGame rejects handScores with out-of-range values (#1540)", async () => {
     const bad = { ...dealGame(), handScores: [27, 0, 0, 0] };
     (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(bad));

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -6,7 +6,7 @@
  * on each transition — state is immutable.
  */
 
-import type { AiPersona, AiPreset, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
+import type { AiPreset, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
 import { RANKS, SUITS } from "./types";
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/engine.ts
+++ b/frontend/src/game/hearts/engine.ts
@@ -6,7 +6,7 @@
  * on each transition — state is immutable.
  */
 
-import type { AiPersona, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
+import type { AiPersona, AiPreset, Card, HeartsState, PassDirection, Rank, TrickCard } from "./types";
 import { RANKS, SUITS } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -88,7 +88,7 @@ export function getPassDirection(handNumber: number): PassDirection {
 }
 
 /** Initial game state for a fresh game (hand 1). */
-export function dealGame(difficulty: AiPersona = "schemer"): HeartsState {
+export function dealGame(difficulty: AiPreset = "schemer"): HeartsState {
   const hands = dealHands();
   const passDirection = getPassDirection(1);
   const leaderIndex = passDirection === "none" ? find2ClubsHolder(hands) : 0;

--- a/frontend/src/game/hearts/storage.ts
+++ b/frontend/src/game/hearts/storage.ts
@@ -1,9 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import type { AiPersona, HeartsState } from "./types";
+import type { AiPreset, HeartsState } from "./types";
 
 const GAME_KEY = "hearts_game";
-const AI_PERSONA_VALUES: readonly string[] = ["cautious", "schemer", "daring"];
+const AI_PRESET_VALUES: readonly string[] = ["cautious", "schemer", "daring", "mixed"];
 const LEGACY_PERSONA_MAP: Record<string, string> = {
   easy: "cautious",
   medium: "schemer",
@@ -43,7 +43,7 @@ export async function loadGame(): Promise<HeartsState | null> {
     const p = parsed as Partial<HeartsState>;
     if (
       p._v !== 3 ||
-      !AI_PERSONA_VALUES.includes(p.aiDifficulty as string) ||
+      !AI_PRESET_VALUES.includes(p.aiDifficulty as string) ||
       !Array.isArray(p.playerHands) ||
       p.playerHands.length !== 4 ||
       !Array.isArray(p.cumulativeScores) ||
@@ -76,7 +76,7 @@ export async function loadGame(): Promise<HeartsState | null> {
       await AsyncStorage.removeItem(GAME_KEY).catch(() => {});
       return null;
     }
-    return { ...p, aiDifficulty: p.aiDifficulty as AiPersona } as HeartsState;
+    return { ...p, aiDifficulty: p.aiDifficulty as AiPreset } as HeartsState;
   } catch (e) {
     Sentry.captureMessage("hearts.storage: corrupt game payload, discarding", {
       level: "warning",

--- a/frontend/src/game/hearts/storage.ts
+++ b/frontend/src/game/hearts/storage.ts
@@ -1,9 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import type { AiPreset, HeartsState } from "./types";
+import { AI_PRESETS } from "./types";
 
 const GAME_KEY = "hearts_game";
-const AI_PRESET_VALUES: readonly string[] = ["cautious", "schemer", "daring", "mixed"];
 const LEGACY_PERSONA_MAP: Record<string, string> = {
   easy: "cautious",
   medium: "schemer",
@@ -43,7 +43,7 @@ export async function loadGame(): Promise<HeartsState | null> {
     const p = parsed as Partial<HeartsState>;
     if (
       p._v !== 3 ||
-      !AI_PRESET_VALUES.includes(p.aiDifficulty as string) ||
+      !(AI_PRESETS as readonly string[]).includes(p.aiDifficulty as string) ||
       !Array.isArray(p.playerHands) ||
       p.playerHands.length !== 4 ||
       !Array.isArray(p.cumulativeScores) ||

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -13,11 +13,15 @@ export const AI_PERSONAS: readonly AiPersona[] = ["cautious", "schemer", "daring
 export const AI_PRESETS: readonly AiPreset[] = ["cautious", "schemer", "daring", "mixed"];
 
 // Mixed table canonical seat assignment (seats 1–3 are AI; seat 0 is human).
-const MIXED_PERSONAS: readonly AiPersona[] = ["schemer", "cautious", "schemer", "daring"];
+const MIXED_PERSONAS: Readonly<Record<1 | 2 | 3, AiPersona>> = {
+  1: "cautious",
+  2: "schemer",
+  3: "daring",
+};
 
 export function resolvePersona(preset: AiPreset, seatIndex: number): AiPersona {
   if (preset !== "mixed") return preset;
-  return MIXED_PERSONAS[seatIndex] ?? "schemer";
+  return MIXED_PERSONAS[seatIndex as 1 | 2 | 3] ?? "schemer";
 }
 
 /** UI events emitted by the engine and consumed by the animation layer. */

--- a/frontend/src/game/hearts/types.ts
+++ b/frontend/src/game/hearts/types.ts
@@ -6,9 +6,19 @@
  */
 
 export type AiPersona = "cautious" | "schemer" | "daring";
+export type AiPreset = AiPersona | "mixed";
 /** @deprecated Use AiPersona */
 export type AiDifficulty = AiPersona;
 export const AI_PERSONAS: readonly AiPersona[] = ["cautious", "schemer", "daring"];
+export const AI_PRESETS: readonly AiPreset[] = ["cautious", "schemer", "daring", "mixed"];
+
+// Mixed table canonical seat assignment (seats 1–3 are AI; seat 0 is human).
+const MIXED_PERSONAS: readonly AiPersona[] = ["schemer", "cautious", "schemer", "daring"];
+
+export function resolvePersona(preset: AiPreset, seatIndex: number): AiPersona {
+  if (preset !== "mixed") return preset;
+  return MIXED_PERSONAS[seatIndex] ?? "schemer";
+}
 
 /** UI events emitted by the engine and consumed by the animation layer. */
 export type GameEvent =
@@ -51,10 +61,11 @@ export type HeartsPhase =
  * v2 adds `scoreHistory` so per-round deltas survive screen unmount (#745).
  * v3 adds `aiDifficulty` for the AI persona selector (#1168). Values renamed to
  * "cautious"/"schemer"/"daring" (#1653); old "easy"/"medium"/"hard" are migrated on load.
+ * "mixed" preset added (#1654): seats one of each persona per canonical order.
  */
 export interface HeartsState {
   readonly _v: 3;
-  readonly aiDifficulty: AiDifficulty;
+  readonly aiDifficulty: AiPreset;
   readonly phase: HeartsPhase;
   /** 1-based. Pass direction = getPassDirection(handNumber). */
   readonly handNumber: number;

--- a/frontend/src/i18n/locales/en/hearts.json
+++ b/frontend/src/i18n/locales/en/hearts.json
@@ -82,5 +82,7 @@
   "difficulty.schemer.desc": "Creates suit voids, deflects the Queen of Spades",
   "difficulty.daring": "Daring",
   "difficulty.daring.desc": "Swings for moon shots, targets you with the Queen",
+  "difficulty.mixed": "Mixed Table",
+  "difficulty.mixed.desc": "One of each: Cautious left, Schemer across, Daring right",
   "game.startGame": "Start Game"
 }

--- a/frontend/src/i18n/locales/he/hearts.json
+++ b/frontend/src/i18n/locales/he/hearts.json
@@ -66,5 +66,7 @@
   "difficulty.schemer.desc": "יוצר חסרים, מסיט את מלכת הספייד",
   "difficulty.daring": "נועז",
   "difficulty.daring.desc": "מנסה לירות ירח, מכוון אליך עם המלכה",
+  "difficulty.mixed": "שולחן מעורב",
+  "difficulty.mixed.desc": "אחד מכל סוג: זהיר משמאל, מתכנן ממול, נועז מימין",
   "game.startGame": "התחל משחק"
 }

--- a/frontend/src/i18n/locales/ja/hearts.json
+++ b/frontend/src/i18n/locales/ja/hearts.json
@@ -66,5 +66,7 @@
   "difficulty.schemer.desc": "スートの欠如を作り、スペードのクイーンをかわす",
   "difficulty.daring": "大胆",
   "difficulty.daring.desc": "月を狙い、あなたをクイーンで標的にする",
+  "difficulty.mixed": "ミックステーブル",
+  "difficulty.mixed.desc": "各1人ずつ：慎重が左、策士が正面、大胆が右",
   "game.startGame": "ゲームスタート"
 }

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -43,7 +43,8 @@ import { OfflineBanner } from "../components/shared/OfflineBanner";
 import { HeartsBrokenAnimation } from "../components/hearts/HeartsBrokenAnimation";
 import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnimation";
 import { HeartsQueenOfSpadesAnimation } from "../components/hearts/HeartsQueenOfSpadesAnimation";
-import type { AiPersona, Card, HeartsState, TrickCard } from "../game/hearts/types";
+import type { AiPreset, Card, HeartsState, TrickCard } from "../game/hearts/types";
+import { resolvePersona } from "../game/hearts/types";
 
 const HUMAN = 0;
 const MAX_NAME_LENGTH = 32;
@@ -72,7 +73,7 @@ export default function HeartsScreen() {
   const { isOnline, isInitialized } = useNetwork();
 
   const [gameState, setGameState] = useState<HeartsState | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<AiPersona>("schemer");
+  const [selectedDifficulty, setSelectedDifficulty] = useState<AiPreset>("schemer");
   const [lastTrick, setLastTrick] = useState<LastTrick>(null);
   const [showHeartsBroken, setShowHeartsBroken] = useState(false);
   const [showMoonShot, setShowMoonShot] = useState(false);
@@ -238,7 +239,7 @@ export default function HeartsScreen() {
             s.currentTrick as TrickCard[],
             s,
             s.currentPlayerIndex,
-            s.aiDifficulty
+            resolvePersona(s.aiDifficulty, s.currentPlayerIndex)
           );
           const completedTrick: readonly TrickCard[] | null = willComplete
             ? [...s.currentTrick, { card, playerIndex: s.currentPlayerIndex }]
@@ -360,7 +361,7 @@ export default function HeartsScreen() {
       const aiCards = selectCardsToPass(
         [...(s.playerHands[i] ?? [])],
         s.passDirection,
-        s.aiDifficulty,
+        resolvePersona(s.aiDifficulty, i),
         i
       );
       for (const c of aiCards) {
@@ -398,7 +399,7 @@ export default function HeartsScreen() {
     }
   }
 
-  function handleStartGame(difficulty: AiPersona) {
+  function handleStartGame(difficulty: AiPreset) {
     setLastTrick(null);
     setShowMoonShot(false);
     setShowHeartsBroken(false);

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -87,9 +87,9 @@ describe("HeartsScreen — pre-game persona selector (#1654)", () => {
   it("Mixed Table can be selected and reflects selected state", async () => {
     const { getAllByRole } = renderScreen();
     await waitFor(() =>
-      expect(getAllByRole("radio").some((r) => /mixed table/i.test(r.props.accessibilityLabel))).toBe(
-        true
-      )
+      expect(
+        getAllByRole("radio").some((r) => /mixed table/i.test(r.props.accessibilityLabel))
+      ).toBe(true)
     );
     const mixedBtn = getAllByRole("radio").find((r) =>
       /mixed table/i.test(r.props.accessibilityLabel)

--- a/frontend/src/screens/__tests__/HeartsScreen.test.tsx
+++ b/frontend/src/screens/__tests__/HeartsScreen.test.tsx
@@ -68,6 +68,42 @@ function renderScreen() {
   );
 }
 
+describe("HeartsScreen — pre-game persona selector (#1654)", () => {
+  beforeEach(() => {
+    (loadGame as jest.Mock).mockResolvedValue(null);
+  });
+
+  it("renders all four preset options including Mixed Table", async () => {
+    const { getAllByRole } = renderScreen();
+    await waitFor(() => {
+      const labels = getAllByRole("radio").map((r) => r.props.accessibilityLabel as string);
+      expect(labels.some((l) => /cautious/i.test(l))).toBe(true);
+      expect(labels.some((l) => /schemer/i.test(l))).toBe(true);
+      expect(labels.some((l) => /daring/i.test(l))).toBe(true);
+      expect(labels.some((l) => /mixed table/i.test(l))).toBe(true);
+    });
+  });
+
+  it("Mixed Table can be selected and reflects selected state", async () => {
+    const { getAllByRole } = renderScreen();
+    await waitFor(() =>
+      expect(getAllByRole("radio").some((r) => /mixed table/i.test(r.props.accessibilityLabel))).toBe(
+        true
+      )
+    );
+    const mixedBtn = getAllByRole("radio").find((r) =>
+      /mixed table/i.test(r.props.accessibilityLabel)
+    )!;
+    fireEvent.press(mixedBtn);
+    await waitFor(() => {
+      const updated = getAllByRole("radio").find((r) =>
+        /mixed table/i.test(r.props.accessibilityLabel)
+      )!;
+      expect(updated.props.accessibilityState.selected).toBe(true);
+    });
+  });
+});
+
 describe("HeartsScreen — passing phase (inline banner)", () => {
   beforeEach(() => {
     setRng(createSeededRng(42));


### PR DESCRIPTION
## Summary

- Adds a fourth opponent preset, **Mixed Table**, that automatically seats Cautious (left), Schemer (across), and Daring (right)
- Introduces `AiPreset = AiPersona | "mixed"` and a `resolvePersona(preset, seatIndex)` helper in `types.ts` that maps the preset to the canonical per-seat persona at each AI call site
- No new AI strategy logic — existing Cautious/Schemer/Daring functions are reused; `HeartsState.aiDifficulty` now typed as `AiPreset` and persisted/loaded cleanly
- i18n keys added for en, he, ja; component falls back to English for other locales

## Test plan

- [ ] All 275 existing Hearts unit tests pass (`npx jest --testPathPattern="hearts"`)
- [ ] New `loadGame round-trips aiDifficulty: mixed` storage test added
- [ ] Mixed Table appears in the opponent selector alongside the three individual personas
- [ ] Starting a game with Mixed Table: left AI plays Cautious, top AI plays Schemer, right AI plays Daring
- [ ] Saving and resuming a Mixed Table game restores the correct preset

Closes #1654
Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)