### PR TITLE
feat(yacht): show AI dice, holds, roll counter, and opponent scorecard during VS turns

### DIFF
--- a/e2e/tests/yacht-ai-turn.spec.ts
+++ b/e2e/tests/yacht-ai-turn.spec.ts
@@ -88,4 +88,44 @@ test.describe("Yacht — AI turn flow (#1602)", () => {
     // Both players have now scored round 1 → should be Round 2
     await expect(page.getByText("Round 2 / 13")).toBeVisible({ timeout: 5000 });
   });
+
+  test("opponent scorecard label is visible in VS mode", async ({ page }) => {
+    // On Desktop Chrome (1280px wide) both scorecards render side-by-side.
+    // The "Opp." label above the AI scorecard should be visible immediately.
+    await expect(page.getByText("Opp.", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("You", { exact: true }).first()).toBeVisible();
+  });
+
+  test("shows AI roll counter during computer turn", async ({ page }) => {
+    await page.getByRole("button", { name: /Roll dice/i }).click();
+
+    const chanceBtn = page.getByRole("button", {
+      name: /Chance: potential score/i,
+    });
+    await expect(chanceBtn).toBeVisible();
+    await chanceBtn.click();
+
+    // AI starts its turn — roll counter should appear after first roll (~700 ms)
+    await expect(page.getByText(/Roll [123] \/ 3/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("AI dice are visible during computer turn", async ({ page }) => {
+    await page.getByRole("button", { name: /Roll dice/i }).click();
+
+    const chanceBtn = page.getByRole("button", {
+      name: /Chance: potential score/i,
+    });
+    await expect(chanceBtn).toBeVisible();
+    await chanceBtn.click();
+
+    // Computer's Turn banner must appear
+    await expect(page.getByText(/Computer'?s Turn/i)).toBeVisible();
+
+    // After the first AI roll, at least one die should show a numeric value.
+    // Die accessibility labels contain "Die N: showing V" — wait for any die label
+    // that includes "showing" to appear (confirming dice values are rendered).
+    await expect(
+      page.getByRole("button", { name: /Die [1-5]: showing [1-6]/i }).first(),
+    ).toBeVisible({ timeout: 5000 });
+  });
 });

--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -85,7 +85,7 @@ export default function DiceRow({
             value={val}
             held={held[i] ?? false}
             onPress={() => onToggleHold(i)}
-            disabled={(!locked && rollsUsed === 0) || gameOver}
+            disabled={locked || rollsUsed === 0 || gameOver}
             rolling={rollingIndices?.includes(i) ?? false}
             reduceMotion={reduceMotion}
           />

--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -29,6 +29,8 @@ interface DiceRowProps {
   onToggleHold: (index: number) => void;
   /** Indices of dice that are currently animating a roll. */
   rollingIndices?: readonly number[];
+  /** When true, disables the roll button but keeps dice at full opacity (used to show opponent dice). */
+  locked?: boolean;
 }
 
 export default function DiceRow({
@@ -39,6 +41,7 @@ export default function DiceRow({
   onRoll,
   onToggleHold,
   rollingIndices,
+  locked = false,
 }: DiceRowProps) {
   const { t } = useTranslation("yacht");
   const { colors } = useTheme();
@@ -60,7 +63,7 @@ export default function DiceRow({
     }
   }
 
-  const canRoll = rollsUsed < 3 && !gameOver;
+  const canRoll = rollsUsed < 3 && !gameOver && !locked;
   const rollsLeft = 3 - rollsUsed;
 
   // Web gradient for roll button; native falls back to flat accentBright
@@ -82,7 +85,7 @@ export default function DiceRow({
             value={val}
             held={held[i] ?? false}
             onPress={() => onToggleHold(i)}
-            disabled={rollsUsed === 0 || gameOver}
+            disabled={(!locked && rollsUsed === 0) || gameOver}
             rolling={rollingIndices?.includes(i) ?? false}
             reduceMotion={reduceMotion}
           />

--- a/frontend/src/i18n/locales/ar/yacht.json
+++ b/frontend/src/i18n/locales/ar/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "فزت!",
   "gameOver.computerWins": "فاز الكمبيوتر!",
   "gameOver.tie": "تعادل!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "رمية {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/ar/yacht.json
+++ b/frontend/src/i18n/locales/ar/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "فاز الكمبيوتر!",
   "gameOver.tie": "تعادل!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "رمية {{count}} / 3"
+  "vsMode.rollCounter": "رمية {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/de/yacht.json
+++ b/frontend/src/i18n/locales/de/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "Computer gewinnt!",
   "gameOver.tie": "Unentschieden!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Wurf {{count}} / 3"
+  "vsMode.rollCounter": "Wurf {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/de/yacht.json
+++ b/frontend/src/i18n/locales/de/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "Du gewinnst!",
   "gameOver.computerWins": "Computer gewinnt!",
   "gameOver.tie": "Unentschieden!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Wurf {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/en/yacht.json
+++ b/frontend/src/i18n/locales/en/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "Computer Wins!",
   "gameOver.tie": "It's a Tie!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Roll {{count}} / 3"
+  "vsMode.rollCounter": "Roll {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/en/yacht.json
+++ b/frontend/src/i18n/locales/en/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "You Win!",
   "gameOver.computerWins": "Computer Wins!",
   "gameOver.tie": "It's a Tie!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Roll {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/es/yacht.json
+++ b/frontend/src/i18n/locales/es/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "¡Gana la computadora!",
   "gameOver.tie": "¡Empate!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Tiro {{count}} / 3"
+  "vsMode.rollCounter": "Tiro {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/es/yacht.json
+++ b/frontend/src/i18n/locales/es/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "¡Ganaste!",
   "gameOver.computerWins": "¡Gana la computadora!",
   "gameOver.tie": "¡Empate!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Tiro {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/fr-CA/yacht.json
+++ b/frontend/src/i18n/locales/fr-CA/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "Vous gagnez !",
   "gameOver.computerWins": "L'ordinateur gagne !",
   "gameOver.tie": "Égalité !",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Lancé {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/fr-CA/yacht.json
+++ b/frontend/src/i18n/locales/fr-CA/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "L'ordinateur gagne !",
   "gameOver.tie": "Égalité !",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Lancé {{count}} / 3"
+  "vsMode.rollCounter": "Lancé {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/he/yacht.json
+++ b/frontend/src/i18n/locales/he/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "המחשב ניצח!",
   "gameOver.tie": "תיקו!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "הטלה {{count}} / 3"
+  "vsMode.rollCounter": "הטלה {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/he/yacht.json
+++ b/frontend/src/i18n/locales/he/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "ניצחת!",
   "gameOver.computerWins": "המחשב ניצח!",
   "gameOver.tie": "תיקו!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "הטלה {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/hi/yacht.json
+++ b/frontend/src/i18n/locales/hi/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "कंप्यूटर जीता!",
   "gameOver.tie": "बराबरी!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "रोल {{count}} / 3"
+  "vsMode.rollCounter": "रोल {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/hi/yacht.json
+++ b/frontend/src/i18n/locales/hi/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "आप जीते!",
   "gameOver.computerWins": "कंप्यूटर जीता!",
   "gameOver.tie": "बराबरी!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "रोल {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/ja/yacht.json
+++ b/frontend/src/i18n/locales/ja/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "コンピュータの勝ち！",
   "gameOver.tie": "引き分け！",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "ロール {{count}} / 3"
+  "vsMode.rollCounter": "ロール {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/ja/yacht.json
+++ b/frontend/src/i18n/locales/ja/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "あなたの勝ち！",
   "gameOver.computerWins": "コンピュータの勝ち！",
   "gameOver.tie": "引き分け！",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "ロール {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/ko/yacht.json
+++ b/frontend/src/i18n/locales/ko/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "당신이 이겼습니다!",
   "gameOver.computerWins": "컴퓨터가 이겼습니다!",
   "gameOver.tie": "무승부!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "던지기 {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/ko/yacht.json
+++ b/frontend/src/i18n/locales/ko/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "컴퓨터가 이겼습니다!",
   "gameOver.tie": "무승부!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "던지기 {{count}} / 3"
+  "vsMode.rollCounter": "던지기 {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/nl/yacht.json
+++ b/frontend/src/i18n/locales/nl/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "Jij wint!",
   "gameOver.computerWins": "Computer wint!",
   "gameOver.tie": "Gelijkspel!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Gooi {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/nl/yacht.json
+++ b/frontend/src/i18n/locales/nl/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "Computer wint!",
   "gameOver.tie": "Gelijkspel!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Gooi {{count}} / 3"
+  "vsMode.rollCounter": "Gooi {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/pt/yacht.json
+++ b/frontend/src/i18n/locales/pt/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "O computador venceu!",
   "gameOver.tie": "Empate!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Lance {{count}} / 3"
+  "vsMode.rollCounter": "Lance {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/pt/yacht.json
+++ b/frontend/src/i18n/locales/pt/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "Você venceu!",
   "gameOver.computerWins": "O computador venceu!",
   "gameOver.tie": "Empate!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Lance {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/ru/yacht.json
+++ b/frontend/src/i18n/locales/ru/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "Компьютер выиграл!",
   "gameOver.tie": "Ничья!",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "Бросок {{count}} / 3"
+  "vsMode.rollCounter": "Бросок {{n}} / 3"
 }

--- a/frontend/src/i18n/locales/ru/yacht.json
+++ b/frontend/src/i18n/locales/ru/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "Вы выиграли!",
   "gameOver.computerWins": "Компьютер выиграл!",
   "gameOver.tie": "Ничья!",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "Бросок {{count}} / 3"
 }

--- a/frontend/src/i18n/locales/zh/yacht.json
+++ b/frontend/src/i18n/locales/zh/yacht.json
@@ -71,5 +71,6 @@
   "gameOver.youWin": "你赢了！",
   "gameOver.computerWins": "电脑赢了！",
   "gameOver.tie": "平局！",
-  "vsMode.vs": "vs"
+  "vsMode.vs": "vs",
+  "vsMode.rollCounter": "第{{count}}掷 / 3"
 }

--- a/frontend/src/i18n/locales/zh/yacht.json
+++ b/frontend/src/i18n/locales/zh/yacht.json
@@ -72,5 +72,5 @@
   "gameOver.computerWins": "电脑赢了！",
   "gameOver.tie": "平局！",
   "vsMode.vs": "vs",
-  "vsMode.rollCounter": "第{{count}}掷 / 3"
+  "vsMode.rollCounter": "第{{n}}掷 / 3"
 }

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { Modal, ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
+import { Modal, ScrollView, View, Text, StyleSheet, Pressable, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -54,6 +54,8 @@ export default function GameScreen({ navigation, route }: Props) {
   const { t } = useTranslation(["yacht", "common"]);
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const { width: screenWidth } = useWindowDimensions();
+  const isVsWide = screenWidth >= 700;
   const [gameState, setGameState] = useState<GameState>(route.params.initialState);
   const [possibleScores, setPossibleScores] = useState<Record<string, number>>({});
   const [gameKey, setGameKey] = useState(0);
@@ -78,6 +80,8 @@ export default function GameScreen({ navigation, route }: Props) {
   );
   const [aiGameState, setAiGameState] = useState<GameState | null>(route.params.aiState ?? null);
   const [isAiTurn, setIsAiTurn] = useState(false);
+  const [aiRollingIndices, setAiRollingIndices] = useState<readonly number[]>([]);
+  const [vsScorecardTab, setVsScorecardTab] = useState<"player" | "opponent">("player");
 
   // Keep refs in sync for use inside async AI turn loop and callbacks.
   const gameStateRef = useRef(gameState);
@@ -94,6 +98,12 @@ export default function GameScreen({ navigation, route }: Props) {
   useEffect(() => {
     aiGameStateRef.current = aiGameState;
   }, [aiGameState]);
+
+  // Auto-switch VS scorecard tab to show the active player's scorecard.
+  useEffect(() => {
+    if (!aiDifficulty) return;
+    setVsScorecardTab(isAiTurn ? "opponent" : "player");
+  }, [isAiTurn, aiDifficulty]);
 
   // Game event instrumentation (#368 / #549).
   const {
@@ -185,17 +195,23 @@ export default function GameScreen({ navigation, route }: Props) {
       let s = aiGameStateRef.current!;
 
       // Initial roll (all dice free)
+      setAiRollingIndices([0, 1, 2, 3, 4]);
       await delay(700);
       if (cancelled) return;
       s = engineRoll(s, [false, false, false, false, false]);
       setAiGameState(s);
+      setAiRollingIndices([]);
 
       // Up to two re-rolls using hold strategy
       while (s.rolls_used < 3) {
+        const holds = holdStrategy(s, diff);
+        const rolledIdxs = holds.reduce<number[]>((acc, h, i) => { if (!h) acc.push(i); return acc; }, []);
+        setAiRollingIndices(rolledIdxs);
         await delay(650);
         if (cancelled) return;
-        s = engineRoll(s, holdStrategy(s, diff));
+        s = engineRoll(s, holds);
         setAiGameState(s);
+        setAiRollingIndices([]);
       }
 
       // Score using opponent's current total for strategic decisions
@@ -402,18 +418,24 @@ export default function GameScreen({ navigation, route }: Props) {
           >
             {isAiTurn ? t("vsMode.computerTurn") : t("vsMode.yourTurn")}
           </Text>
+          {isAiTurn && aiGameState && aiGameState.rolls_used > 0 && (
+            <Text style={[styles.rollCounterText, { color: colors.textMuted }]}>
+              {t("vsMode.rollCounter", { count: aiGameState.rolls_used })}
+            </Text>
+          )}
         </View>
       )}
 
-      {/* Dice */}
+      {/* Dice — show AI dice during AI turn */}
       <DiceRow
-        dice={gameState.dice}
-        held={gameState.held}
-        rollsUsed={gameState.rolls_used}
-        gameOver={gameState.game_over || isAiTurn}
+        dice={isAiTurn && aiGameState ? aiGameState.dice : gameState.dice}
+        held={isAiTurn && aiGameState ? aiGameState.held : gameState.held}
+        rollsUsed={isAiTurn && aiGameState ? aiGameState.rolls_used : gameState.rolls_used}
+        gameOver={gameState.game_over}
         onRoll={handleRoll}
         onToggleHold={handleToggleHold}
-        rollingIndices={rollingIndices}
+        rollingIndices={isAiTurn ? aiRollingIndices : rollingIndices}
+        locked={isAiTurn}
       />
 
       {/* VS mode score comparison */}
@@ -437,23 +459,129 @@ export default function GameScreen({ navigation, route }: Props) {
         </View>
       )}
 
-      {/* Scorecard */}
-      <View style={styles.scorecardContainer}>
-        <Scorecard
-          key={gameKey}
-          scores={gameState.scores}
-          possibleScores={possibleScores}
-          rollsUsed={gameState.rolls_used}
-          gameOver={gameState.game_over}
-          upperSubtotal={gameState.upper_subtotal}
-          upperBonus={gameState.upper_bonus}
-          yachtBonusCount={gameState.yacht_bonus_count}
-          yachtBonusTotal={gameState.yacht_bonus_total}
-          totalScore={gameState.total_score}
-          onScore={handleScore}
-          locked={isAiTurn}
-        />
-      </View>
+      {/* Scorecard — VS mode shows both scorecards; solo shows just the player's */}
+      {aiDifficulty && difficultyChosen && aiGameState ? (
+        <View style={styles.vsScorecardWrapper}>
+          {!isVsWide && (
+            <View style={[styles.vsTabRow, { borderBottomColor: colors.border }]}>
+              {(["player", "opponent"] as const).map((tab) => {
+                const isActive = vsScorecardTab === tab;
+                const tabColor = tab === "player" ? colors.accent : colors.secondary;
+                return (
+                  <Pressable
+                    key={tab}
+                    style={[
+                      styles.vsTabButton,
+                      { borderBottomColor: isActive ? tabColor : "transparent" },
+                    ]}
+                    onPress={() => setVsScorecardTab(tab)}
+                    accessibilityRole="tab"
+                    accessibilityState={{ selected: isActive }}
+                    accessibilityLabel={tab === "player" ? t("score.you") : t("score.opponent")}
+                  >
+                    <Text style={[styles.vsTabText, { color: isActive ? tabColor : colors.textMuted }]}>
+                      {tab === "player" ? t("score.you") : t("score.opponent")}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+          {isVsWide ? (
+            <View style={styles.vsWideRow}>
+              <View style={styles.vsWideCol}>
+                <Text style={[styles.vsScorecardLabel, { color: colors.accent }]}>
+                  {t("score.you")}
+                </Text>
+                <Scorecard
+                  key={gameKey}
+                  scores={gameState.scores}
+                  possibleScores={possibleScores}
+                  rollsUsed={gameState.rolls_used}
+                  gameOver={gameState.game_over}
+                  upperSubtotal={gameState.upper_subtotal}
+                  upperBonus={gameState.upper_bonus}
+                  yachtBonusCount={gameState.yacht_bonus_count}
+                  yachtBonusTotal={gameState.yacht_bonus_total}
+                  totalScore={gameState.total_score}
+                  onScore={handleScore}
+                  locked={isAiTurn}
+                />
+              </View>
+              <View style={styles.vsWideCol}>
+                <Text style={[styles.vsScorecardLabel, { color: colors.secondary }]}>
+                  {t("score.opponent")}
+                </Text>
+                <Scorecard
+                  key={`ai-${gameKey}`}
+                  scores={aiGameState.scores}
+                  possibleScores={{}}
+                  rollsUsed={aiGameState.rolls_used}
+                  gameOver={aiGameState.game_over}
+                  upperSubtotal={aiGameState.upper_subtotal}
+                  upperBonus={aiGameState.upper_bonus}
+                  yachtBonusCount={aiGameState.yacht_bonus_count}
+                  yachtBonusTotal={aiGameState.yacht_bonus_total}
+                  totalScore={aiGameState.total_score}
+                  onScore={() => {}}
+                  locked
+                />
+              </View>
+            </View>
+          ) : (
+            <View style={styles.scorecardContainer}>
+              {vsScorecardTab === "player" ? (
+                <Scorecard
+                  key={gameKey}
+                  scores={gameState.scores}
+                  possibleScores={possibleScores}
+                  rollsUsed={gameState.rolls_used}
+                  gameOver={gameState.game_over}
+                  upperSubtotal={gameState.upper_subtotal}
+                  upperBonus={gameState.upper_bonus}
+                  yachtBonusCount={gameState.yacht_bonus_count}
+                  yachtBonusTotal={gameState.yacht_bonus_total}
+                  totalScore={gameState.total_score}
+                  onScore={handleScore}
+                  locked={isAiTurn}
+                />
+              ) : (
+                <Scorecard
+                  key={`ai-${gameKey}`}
+                  scores={aiGameState.scores}
+                  possibleScores={{}}
+                  rollsUsed={aiGameState.rolls_used}
+                  gameOver={aiGameState.game_over}
+                  upperSubtotal={aiGameState.upper_subtotal}
+                  upperBonus={aiGameState.upper_bonus}
+                  yachtBonusCount={aiGameState.yacht_bonus_count}
+                  yachtBonusTotal={aiGameState.yacht_bonus_total}
+                  totalScore={aiGameState.total_score}
+                  onScore={() => {}}
+                  locked
+                />
+              )}
+            </View>
+          )}
+        </View>
+      ) : (
+        <View style={styles.scorecardContainer}>
+          <Scorecard
+            key={gameKey}
+            scores={gameState.scores}
+            possibleScores={possibleScores}
+            rollsUsed={gameState.rolls_used}
+            gameOver={gameState.game_over}
+            upperSubtotal={gameState.upper_subtotal}
+            upperBonus={gameState.upper_bonus}
+            yachtBonusCount={gameState.yacht_bonus_count}
+            yachtBonusTotal={gameState.yacht_bonus_total}
+            totalScore={gameState.total_score}
+            onScore={handleScore}
+            locked={isAiTurn}
+          />
+        </View>
+      )}
 
       <YachtCelebrationAnimation
         visible={showYachtCelebration}
@@ -699,6 +827,53 @@ const styles = StyleSheet.create({
     minHeight: 0,
     marginHorizontal: 12,
     marginBottom: 12,
+  },
+  rollCounterText: {
+    fontSize: 11,
+    letterSpacing: 0.5,
+    marginTop: 2,
+  },
+  vsScorecardWrapper: {
+    flex: 1,
+    minHeight: 0,
+    marginHorizontal: 12,
+    marginBottom: 12,
+  },
+  vsTabRow: {
+    flexDirection: "row",
+    borderBottomWidth: 1,
+    marginBottom: 8,
+  },
+  vsTabButton: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 36,
+    borderBottomWidth: 2,
+    paddingBottom: 6,
+  },
+  vsTabText: {
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+  },
+  vsWideRow: {
+    flex: 1,
+    flexDirection: "row",
+    gap: 8,
+  },
+  vsWideCol: {
+    flex: 1,
+    minWidth: 0,
+  },
+  vsScorecardLabel: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    textAlign: "center",
+    marginBottom: 4,
   },
   // VS mode styles
   turnBanner: {

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { Modal, ScrollView, View, Text, StyleSheet, Pressable, useWindowDimensions } from "react-native";
+import {
+  Modal,
+  ScrollView,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  useWindowDimensions,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -45,6 +53,8 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const VS_WIDE_BREAKPOINT = 700;
+
 type Props = {
   navigation: NativeStackNavigationProp<HomeStackParamList, "Game">;
   route: RouteProp<HomeStackParamList, "Game">;
@@ -55,7 +65,7 @@ export default function GameScreen({ navigation, route }: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const { width: screenWidth } = useWindowDimensions();
-  const isVsWide = screenWidth >= 700;
+  const isVsWide = screenWidth >= VS_WIDE_BREAKPOINT;
   const [gameState, setGameState] = useState<GameState>(route.params.initialState);
   const [possibleScores, setPossibleScores] = useState<Record<string, number>>({});
   const [gameKey, setGameKey] = useState(0);
@@ -205,7 +215,10 @@ export default function GameScreen({ navigation, route }: Props) {
       // Up to two re-rolls using hold strategy
       while (s.rolls_used < 3) {
         const holds = holdStrategy(s, diff);
-        const rolledIdxs = holds.reduce<number[]>((acc, h, i) => { if (!h) acc.push(i); return acc; }, []);
+        const rolledIdxs = holds.reduce<number[]>((acc, h, i) => {
+          if (!h) acc.push(i);
+          return acc;
+        }, []);
         setAiRollingIndices(rolledIdxs);
         await delay(650);
         if (cancelled) return;
@@ -362,6 +375,26 @@ export default function GameScreen({ navigation, route }: Props) {
   // Modal visible only when both players have finished in VS mode.
   const gameReallyOver = gameState.game_over && (!aiDifficulty || aiGameState?.game_over === true);
 
+  function renderScorecard(which: "player" | "opponent") {
+    const s = which === "player" ? gameState : aiGameState!;
+    return (
+      <Scorecard
+        key={which === "player" ? gameKey : `ai-${gameKey}`}
+        scores={s.scores}
+        possibleScores={which === "player" ? possibleScores : {}}
+        rollsUsed={s.rolls_used}
+        gameOver={s.game_over}
+        upperSubtotal={s.upper_subtotal}
+        upperBonus={s.upper_bonus}
+        yachtBonusCount={s.yacht_bonus_count}
+        yachtBonusTotal={s.yacht_bonus_total}
+        totalScore={s.total_score}
+        onScore={which === "player" ? handleScore : () => {}}
+        locked={which === "opponent" || isAiTurn}
+      />
+    );
+  }
+
   const roundPill = (
     <View
       style={[styles.roundPill, { backgroundColor: colors.surfaceAlt, borderColor: colors.accent }]}
@@ -420,7 +453,7 @@ export default function GameScreen({ navigation, route }: Props) {
           </Text>
           {isAiTurn && aiGameState && aiGameState.rolls_used > 0 && (
             <Text style={[styles.rollCounterText, { color: colors.textMuted }]}>
-              {t("vsMode.rollCounter", { count: aiGameState.rolls_used })}
+              {t("vsMode.rollCounter", { n: aiGameState.rolls_used })}
             </Text>
           )}
         </View>
@@ -479,7 +512,9 @@ export default function GameScreen({ navigation, route }: Props) {
                     accessibilityState={{ selected: isActive }}
                     accessibilityLabel={tab === "player" ? t("score.you") : t("score.opponent")}
                   >
-                    <Text style={[styles.vsTabText, { color: isActive ? tabColor : colors.textMuted }]}>
+                    <Text
+                      style={[styles.vsTabText, { color: isActive ? tabColor : colors.textMuted }]}
+                    >
                       {tab === "player" ? t("score.you") : t("score.opponent")}
                     </Text>
                   </Pressable>
@@ -493,94 +528,21 @@ export default function GameScreen({ navigation, route }: Props) {
                 <Text style={[styles.vsScorecardLabel, { color: colors.accent }]}>
                   {t("score.you")}
                 </Text>
-                <Scorecard
-                  key={gameKey}
-                  scores={gameState.scores}
-                  possibleScores={possibleScores}
-                  rollsUsed={gameState.rolls_used}
-                  gameOver={gameState.game_over}
-                  upperSubtotal={gameState.upper_subtotal}
-                  upperBonus={gameState.upper_bonus}
-                  yachtBonusCount={gameState.yacht_bonus_count}
-                  yachtBonusTotal={gameState.yacht_bonus_total}
-                  totalScore={gameState.total_score}
-                  onScore={handleScore}
-                  locked={isAiTurn}
-                />
+                {renderScorecard("player")}
               </View>
               <View style={styles.vsWideCol}>
                 <Text style={[styles.vsScorecardLabel, { color: colors.secondary }]}>
                   {t("score.opponent")}
                 </Text>
-                <Scorecard
-                  key={`ai-${gameKey}`}
-                  scores={aiGameState.scores}
-                  possibleScores={{}}
-                  rollsUsed={aiGameState.rolls_used}
-                  gameOver={aiGameState.game_over}
-                  upperSubtotal={aiGameState.upper_subtotal}
-                  upperBonus={aiGameState.upper_bonus}
-                  yachtBonusCount={aiGameState.yacht_bonus_count}
-                  yachtBonusTotal={aiGameState.yacht_bonus_total}
-                  totalScore={aiGameState.total_score}
-                  onScore={() => {}}
-                  locked
-                />
+                {renderScorecard("opponent")}
               </View>
             </View>
           ) : (
-            <View style={styles.scorecardContainer}>
-              {vsScorecardTab === "player" ? (
-                <Scorecard
-                  key={gameKey}
-                  scores={gameState.scores}
-                  possibleScores={possibleScores}
-                  rollsUsed={gameState.rolls_used}
-                  gameOver={gameState.game_over}
-                  upperSubtotal={gameState.upper_subtotal}
-                  upperBonus={gameState.upper_bonus}
-                  yachtBonusCount={gameState.yacht_bonus_count}
-                  yachtBonusTotal={gameState.yacht_bonus_total}
-                  totalScore={gameState.total_score}
-                  onScore={handleScore}
-                  locked={isAiTurn}
-                />
-              ) : (
-                <Scorecard
-                  key={`ai-${gameKey}`}
-                  scores={aiGameState.scores}
-                  possibleScores={{}}
-                  rollsUsed={aiGameState.rolls_used}
-                  gameOver={aiGameState.game_over}
-                  upperSubtotal={aiGameState.upper_subtotal}
-                  upperBonus={aiGameState.upper_bonus}
-                  yachtBonusCount={aiGameState.yacht_bonus_count}
-                  yachtBonusTotal={aiGameState.yacht_bonus_total}
-                  totalScore={aiGameState.total_score}
-                  onScore={() => {}}
-                  locked
-                />
-              )}
-            </View>
+            <View style={styles.scorecardContainer}>{renderScorecard(vsScorecardTab)}</View>
           )}
         </View>
       ) : (
-        <View style={styles.scorecardContainer}>
-          <Scorecard
-            key={gameKey}
-            scores={gameState.scores}
-            possibleScores={possibleScores}
-            rollsUsed={gameState.rolls_used}
-            gameOver={gameState.game_over}
-            upperSubtotal={gameState.upper_subtotal}
-            upperBonus={gameState.upper_bonus}
-            yachtBonusCount={gameState.yacht_bonus_count}
-            yachtBonusTotal={gameState.yacht_bonus_total}
-            totalScore={gameState.total_score}
-            onScore={handleScore}
-            locked={isAiTurn}
-          />
-        </View>
+        <View style={styles.scorecardContainer}>{renderScorecard("player")}</View>
       )}
 
       <YachtCelebrationAnimation


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **AI dice tray**: During the computer's turn, the dice tray switches to show the AI's current dice values with hold indicators and roll animations, replacing the player's (now irrelevant) dice display.
- **Roll counter**: The "Computer's Turn" banner now shows `Roll 1 / 3`, `Roll 2 / 3`, `Roll 3 / 3` as the AI progresses through its turn.
- **Opponent scorecard**: Both player and AI scorecards are always visible in VS mode — side-by-side on wide screens (≥700px) with "You" / "Opp." labels, or via switchable tabs on narrow screens. The active tab auto-switches to the opponent's scorecard when the AI turn begins and back to the player's when it ends.
- **No solo-mode regression**: The scorecard change is gated on `aiDifficulty && aiGameState`, so solo mode is unaffected.

Closes #1658

## Changes

| File | What changed |
|---|---|
| `DiceRow.tsx` | Added `locked` prop — disables roll button but keeps dice at full opacity (vs. the 40% opacity of `gameOver`) |
| `GameScreen.tsx` | Switches DiceRow to AI state when `isAiTurn`; adds roll counter to turn banner; renders dual-scorecard VS layout; tracks `aiRollingIndices` for die animations |
| `locales/*/yacht.json` (×13) | Added `vsMode.rollCounter` translation key |
| `yacht-ai-turn.spec.ts` | Extended with 3 new assertions: opponent scorecard label, roll counter text, AI dice values visible |

## Test plan

- [ ] Start a VS game (any difficulty) — "You" and "Opp." labels appear above both scorecards immediately
- [ ] Roll and score a category — "Computer's Turn" banner appears, AI dice replace player dice in the tray, roll counter increments (Roll 1 → 2 → 3)
- [ ] Held dice show the HELD badge while the AI holds them between re-rolls
- [ ] After AI scores, opponent scorecard fills in the scored category; tab/focus returns to player
- [ ] Solo mode: single scorecard, no VS tabs, behavior identical to before
- [ ] Existing E2E suite (`yacht-ai-turn.spec.ts`) passes including new assertions

https://claude.ai/code/session_01BNCq9NMabcDMNkeTYTk4RG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNCq9NMabcDMNkeTYTk4RG)_