### PR TITLE
fix(mahjong): remove rubber-band bounce on zoom limit

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "1.0.8",
       "dependencies": {
-        "@dimforge/rapier2d-compat": "^0.19.3",
         "@expo-google-fonts/manrope": "^0.4.2",
         "@expo-google-fonts/space-grotesk": "^0.4.1",
         "@expo/vector-icons": "^15.1.1",
@@ -1488,12 +1487,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@dimforge/rapier2d-compat": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@dimforge/rapier2d-compat/-/rapier2d-compat-0.19.3.tgz",
-      "integrity": "sha512-5HZUgiSpu9Uba3He+4SCPVte3h2vgxcodkxWThRjd3X/zgq/Z4OyRUKpNEOsOR6AC+OfulPkkZ5asZGzRMpcwA==",
-      "license": "Apache-2.0"
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",

--- a/frontend/src/game/mahjong/__tests__/zoom.test.ts
+++ b/frontend/src/game/mahjong/__tests__/zoom.test.ts
@@ -4,8 +4,6 @@ import {
   computeZoomBounds,
   MIN_READABLE_TILE_PX,
   MIN_ZOOM_HEADROOM,
-  rubberClamp,
-  RUBBER_FACTOR,
 } from "../zoom";
 
 describe("computeZoomBounds", () => {
@@ -101,36 +99,6 @@ describe("computePanBounds", () => {
     //   should equal viewportWidth / 2
     const boardRightEdge = (boardWidth * scale) / 2 - maxTranslateX;
     expect(boardRightEdge).toBeCloseTo(viewportWidth / 2, 5);
-  });
-});
-
-describe("rubberClamp", () => {
-  it("passes through values within [min, max]", () => {
-    expect(rubberClamp(1.0, 0.5, 2.0)).toBe(1.0);
-  });
-
-  it("at-min boundary returns min exactly", () => {
-    expect(rubberClamp(0.5, 0.5, 2.0)).toBe(0.5);
-  });
-
-  it("at-max boundary returns max exactly", () => {
-    expect(rubberClamp(2.0, 0.5, 2.0)).toBe(2.0);
-  });
-
-  it("allows overshoot below min with RUBBER_FACTOR resistance", () => {
-    // min + (value - min) * RUBBER_FACTOR = 0.5 + (0.2 - 0.5) * 0.3 = 0.41
-    const result = rubberClamp(0.2, 0.5, 2.0);
-    expect(result).toBeCloseTo(0.5 + (0.2 - 0.5) * RUBBER_FACTOR, 10);
-    expect(result).toBeLessThan(0.5);
-    expect(result).toBeGreaterThan(0.2);
-  });
-
-  it("allows overshoot above max with RUBBER_FACTOR resistance", () => {
-    // max + (value - max) * RUBBER_FACTOR = 2.0 + (3.0 - 2.0) * 0.3 = 2.3
-    const result = rubberClamp(3.0, 0.5, 2.0);
-    expect(result).toBeCloseTo(2.0 + (3.0 - 2.0) * RUBBER_FACTOR, 10);
-    expect(result).toBeGreaterThan(2.0);
-    expect(result).toBeLessThan(3.0);
   });
 });
 

--- a/frontend/src/game/mahjong/zoom.ts
+++ b/frontend/src/game/mahjong/zoom.ts
@@ -49,4 +49,3 @@ export function clamp(value: number, min: number, max: number): number {
   "worklet";
   return Math.min(Math.max(value, min), max);
 }
-

--- a/frontend/src/game/mahjong/zoom.ts
+++ b/frontend/src/game/mahjong/zoom.ts
@@ -6,9 +6,6 @@ export const MIN_READABLE_TILE_PX = 48;
 // even on large screens where tiles already exceed MIN_READABLE_TILE_PX.
 export const MIN_ZOOM_HEADROOM = 1.5;
 
-// Resistance factor for rubber-band overshoot past zoom limits (0 = rigid, 1 = no resistance).
-export const RUBBER_FACTOR = 0.3;
-
 /**
  * Compute the [minZoom, maxZoom] bounds for the board gesture layer.
  *
@@ -53,9 +50,3 @@ export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-export function rubberClamp(value: number, min: number, max: number): number {
-  "worklet";
-  if (value < min) return min + (value - min) * RUBBER_FACTOR;
-  if (value > max) return max + (value - max) * RUBBER_FACTOR;
-  return value;
-}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -79,7 +79,7 @@ import { useMahjongAudio } from "../game/mahjong/useMahjongAudio";
 import { scoreQueue } from "../game/_shared/scoreQueue";
 import { useGameSync } from "../game/_shared/useGameSync";
 import { useNetwork } from "../game/_shared/NetworkContext";
-import { clamp, computeZoomBounds, rubberClamp } from "../game/mahjong/zoom";
+import { clamp, computeZoomBounds } from "../game/mahjong/zoom";
 
 const MAX_NAME_LENGTH = 32;
 
@@ -357,15 +357,10 @@ export default function MahjongScreen() {
 
   const pinchGesture = Gesture.Pinch()
     .onUpdate((e) => {
-      // Allow rubber-band overshoot past limits; onEnd springs back.
-      zoomScale.value = rubberClamp(baseScale.value * e.scale, minZoom.value, maxZoom.value);
+      zoomScale.value = clamp(baseScale.value * e.scale, minZoom.value, maxZoom.value);
     })
     .onEnd(() => {
-      const target = clamp(zoomScale.value, minZoom.value, maxZoom.value);
-      baseScale.value = target;
-      if (Math.abs(zoomScale.value - target) > 1e-6) {
-        zoomScale.value = withSpring(target, { damping: 20, stiffness: 300 });
-      }
+      baseScale.value = zoomScale.value;
     });
 
   const panGesture = Gesture.Pan()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces `rubberClamp` with hard `clamp` in the pinch `onUpdate` handler so `zoomScale` never exceeds `[minZoom, maxZoom]` during the gesture
- Removes the `withSpring` snap-back in `onEnd` — no overshoot means no correction needed
- Deletes the now-unused `rubberClamp` function, `RUBBER_FACTOR` constant, and their unit tests

Closes #1683

## Test plan

- [ ] Pinch to zoom in past max — zoom stops immediately at ceiling, no bounce
- [ ] Pinch to zoom out past min — zoom stops immediately at floor, no bounce
- [ ] Normal zoom within bounds still feels smooth
- [ ] All 15 `zoom.test.ts` unit tests pass
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ecjjXJPFuGJf1unc116Uj)_