### PR TITLE
docs: overhaul — per-game references, accessibility, architecture corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Stack
 
-- **Backend:** Python 3.13, FastAPI, uvicorn (in-memory, no DB)
+- **Backend:** Python 3.13, FastAPI, uvicorn, PostgreSQL (Alembic migrations)
 - **Frontend:** Expo TypeScript, runs in browser via Expo Web
 - **Setup & runbook:** [`README.md`](README.md)
 - **Docs:** testing, iOS/Android CI, Render, branding — see [`docs/`](docs/)
@@ -32,8 +32,9 @@ Deployment (Render): [`docs/RENDER.md`](docs/RENDER.md). Design system is **BC A
 
 ## Key Conventions
 
-- All rule enforcement is server-side in `backend/<game>/module.py`. Frontend is display only.
-- Frontend replaces state wholesale from each API response.
+- Game logic lives in `frontend/src/game/<name>/engine.ts` (client-side, offline-capable). See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+- Scoring is server-side; outcomes are queued locally when offline and flushed by `SyncWorker`.
+- Premium access is gated by an RS256 entitlement JWT from `GET /entitlements` (24-hr TTL, 7-day offline grace). See [`docs/ARCHITECTURE.md §10`](docs/ARCHITECTURE.md).
 - Yacht scoring keys: `ones` `twos` `threes` `fours` `fives` `sixes` `three_of_a_kind` `four_of_a_kind` `full_house` `small_straight` `large_straight` `yacht` `chance`.
 - `EXPO_PUBLIC_API_URL` env var overrides `BASE_URL` in `frontend/src/api/client.ts`.
 
@@ -41,8 +42,8 @@ Deployment (Render): [`docs/RENDER.md`](docs/RENDER.md). Design system is **BC A
 
 Project subagents in `.claude/agents/`, invoked via the `Agent` tool. Prefer these over general-purpose:
 
-| Agent | `subagent_type` | When to use |
-|---|---|---|
-| lint-review | `lint-review` | Auto-fix lint issues after a lint-gate hook failure |
-| plan-issues | `plan-issues` | Break a feature/bug/initiative into scoped GitHub issues — investigates code, drafts for confirmation, then `gh issue create` |
-| policy-compliance | `policy-compliance` | Check and fix policy violations after a policy-gate hook failure |
+| Agent             | `subagent_type`     | When to use                                                                                                                   |
+| ----------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| lint-review       | `lint-review`       | Auto-fix lint issues after a lint-gate hook failure                                                                           |
+| plan-issues       | `plan-issues`       | Break a feature/bug/initiative into scoped GitHub issues — investigates code, drafts for confirmation, then `gh issue create` |
+| policy-compliance | `policy-compliance` | Check and fix policy violations after a policy-gate hook failure                                                              |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,6 +96,15 @@ _Not every check applies to every project — mobile-only repos skip frontend np
 - Certificate pinning evaluated on each release for sensitive endpoints
 - Privacy manifest reviewed before each App Store / Google Play submission
 
+### Entitlement Tokens (Premium Access)
+
+- Premium game access is gated by a short-lived RS256-signed JWT issued from `GET /entitlements`
+- The private signing key is loaded exclusively from the `ENTITLEMENT_PRIVATE_KEY` environment variable — never hard-coded or committed
+- Token payload (`entitled_games[]`, `sub`, `iat`, `exp`) is server-generated; no client-supplied claim is trusted
+- Every premium API route uses the `require_entitlement(game_slug)` FastAPI dependency, which validates the token signature and expiry and returns `403` on failure
+- Offline grace period (7 days) is enforced client-side only and does not bypass server-side entitlement checks on score submission
+- `ENTITLEMENT_DEV_OVERRIDE=true` bypasses checks for local development — must never be set in production environments
+
 ### Secrets Management
 
 - All secrets stored in environment variables or GitHub Actions secrets — never in source

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,129 @@
+# BC Arcade — Accessibility
+
+BC Arcade targets **WCAG 2.1 Level AA** across web, iOS, and Android. This document defines the standards and per-surface checklist every game and screen must satisfy.
+
+---
+
+## 1. Color Contrast
+
+| Context                            | Minimum ratio | Notes                                 |
+| ---------------------------------- | ------------- | ------------------------------------- |
+| Body text (< 18pt / < 14pt bold)   | 4.5 : 1       | Against the surface it sits on        |
+| Large text (≥ 18pt or ≥ 14pt bold) | 3 : 1         |                                       |
+| UI components & interactive states | 3 : 1         | Borders, icons, focus rings           |
+| Disabled / decorative              | Exempt        | Must not convey essential information |
+
+Both dark and light themes must pass independently. Use the design tokens from [`docs/BRANDING.md`](BRANDING.md) — they are calibrated for AA compliance. Never add one-off hex values without running them through a contrast checker.
+
+**Tooling:** [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/), Figma Contrast plugin, axe DevTools browser extension.
+
+---
+
+## 2. Touch Targets
+
+- Minimum **44 × 44 pt** on iOS and Android (Apple HIG / Material guidance).
+- No interactive game control — card, tile, button, die — may be smaller than this.
+- If a visual element is naturally smaller (e.g. a small card), expand the hit area with padding or a transparent overlay rather than enlarging the visual.
+- On web, minimum **24 × 24 CSS px** for pointer targets (WCAG 2.5.8 AA).
+
+---
+
+## 3. Motion & Animation
+
+BC Arcade uses React Native Reanimated and Matter.js physics. Both must respect the OS-level "Reduce Motion" preference.
+
+- All animations must check `useReduceMotion()` from Reanimated and skip or simplify motion when it returns `true`.
+- Physics simulations (Cascade) must resolve immediately to final state when reduce motion is active — no dropping, bouncing, or sliding.
+- Do not auto-play looping animations that cannot be paused.
+- Avoid content that flashes more than 3 times per second (seizure risk).
+
+This requirement is already enforced at Layer 4 of the gameplay architecture — see [`docs/GAMEPLAY_STANDARDS.md §5`](GAMEPLAY_STANDARDS.md).
+
+---
+
+## 4. Screen Readers
+
+### React Native components
+
+- Every interactive element must have `accessibilityLabel` (a short, meaningful description) and `accessibilityRole` (e.g. `"button"`, `"text"`, `"image"`).
+- Decorative images must use `accessible={false}` so screen readers skip them.
+- Score updates and turn changes must use `accessibilityLiveRegion="polite"` so VoiceOver / TalkBack announces them without interrupting the user.
+- Group related elements with `accessibilityViewIsModal` or `accessible={true}` + `accessibilityLabel` on the container where appropriate.
+
+### Canvas-based games (Cascade, Starswarm, Mahjong on native)
+
+Canvas (`@shopify/react-native-skia`) renders outside the native accessibility tree. These games must provide an accessible text layer alongside or beneath the canvas:
+
+- Current score displayed in a native `Text` element (not only on canvas).
+- Game-over / win / loss state announced via a live region or modal.
+- Canvas itself marked `accessible={false}` to prevent double-announcement.
+
+---
+
+## 5. Keyboard & Focus (Web)
+
+- All game controls must be reachable and operable via **Tab** (focus) and **Enter / Space** (activate).
+- Focus order must follow visual reading order — no invisible focus traps.
+- Focus ring must be visible and meet the 3 : 1 contrast ratio against the adjacent background.
+- Do not suppress the default browser focus outline without replacing it with a custom one that meets contrast requirements.
+- Canvas games (web) must provide keyboard alternatives for every primary action (e.g. arrow keys or dedicated key bindings), documented in the game's `docs/games/<name>.md`.
+
+---
+
+## 6. Text & Readability
+
+- Never convey information through color alone — always pair with a label, icon, or pattern.
+- Minimum body font size: **14 sp** (Android), **14 pt** (iOS), **14 px** (web).
+- Do not override system text-size settings — use scalable units (`sp` / dynamic type / `rem`), not fixed `px`.
+- Line length for any prose UI (rules screen, onboarding) should not exceed 75 characters.
+
+---
+
+## 7. Testing Checklist
+
+Run this before shipping any new game or screen.
+
+### Automated
+
+- [ ] **axe-core (web):** `npx axe <url>` or axe DevTools browser extension — zero critical / serious violations
+- [ ] **Color contrast:** run design tokens through a contrast checker for both dark and light themes
+
+### Manual — iOS
+
+- [ ] **VoiceOver:** enable in Settings → Accessibility → VoiceOver. Navigate the game with swipe + double-tap only. Every interactive element must be reachable and announced correctly.
+- [ ] **Reduce Motion:** enable in Settings → Accessibility → Motion → Reduce Motion. Confirm all animations simplify or are skipped.
+- [ ] **Dynamic Type:** set text size to the largest accessibility size. Confirm no text is clipped or overlaps.
+
+### Manual — Android
+
+- [ ] **TalkBack:** enable in Settings → Accessibility → TalkBack. Same navigation test as VoiceOver.
+- [ ] **Reduce Animations:** enable in Developer Options → Animator duration scale → Off. Confirm physics and transitions resolve correctly.
+- [ ] **Font size:** maximum system font size. Confirm no layout breaks.
+
+### Manual — Web
+
+- [ ] **Keyboard-only:** unplug mouse and navigate the full game flow with Tab / Shift+Tab / Enter / Space / arrow keys.
+- [ ] **NVDA or JAWS (Windows) or VoiceOver (macOS):** spot-check interactive elements and live regions.
+
+---
+
+## 8. Per-Game Notes
+
+| Game        | Canvas?            | Known accessibility work                                              |
+| ----------- | ------------------ | --------------------------------------------------------------------- |
+| Yacht       | No                 | Dice faces need `accessibilityLabel` (e.g. "Die showing 4")           |
+| Hearts      | No                 | Card labels must include suit + rank (e.g. "Queen of Spades")         |
+| Blackjack   | No                 | Card labels must include suit + rank; chip count must use live region |
+| Solitaire   | No                 | Pile positions and card labels required                               |
+| Sudoku      | No                 | Cell coordinates + value in labels (e.g. "Row 3, Column 5, empty")    |
+| Cascade     | Yes (Skia)         | Score + game state must have native text overlay; keyboard alt TBD    |
+| 2048        | No                 | Grid cell values must be announced on merge                           |
+| FreeCell    | No                 | Same card label convention as Solitaire                               |
+| Mahjong     | Yes (Skia, native) | Same overlay requirement as Cascade                                   |
+| Bottle Sort | No                 | Bottle contents must be labeled by color sequence                     |
+| Daily Word  | No                 | Letter input cells need row/column position labels                    |
+| Starswarm   | Yes (Skia)         | Score + state overlay required; no keyboard equivalent yet            |
+
+---
+
+_See [`docs/BRANDING.md`](BRANDING.md) for color token values and contrast baselines. See [`docs/GAMEPLAY_STANDARDS.md §5`](GAMEPLAY_STANDARDS.md) for the animation layer contract._

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -74,19 +74,19 @@ What we log:
 
 **Memory cap: 2 MB total queue size.** When the queue exceeds this, eviction
 kicks in (see §5). If 2 MB turns out to be too small in practice, that is a
-signal to revisit *how* we queue — not a signal to bump the cap.
+signal to revisit _how_ we queue — not a signal to bump the cap.
 
 ## 5. Eviction policy
 
 When the queue is over budget, evict oldest entries from the lowest non-empty
 tier first.
 
-| Tier | Contents | Eviction order |
-|------|----------|----------------|
-| **P0** (most precious) | High-priority bug reports / crashes | last to evict |
-| **P1** | Game outcomes (final score, completion, duration) | evicted after P2 / P3 |
-| **P2** | Low-priority bug reports / user feedback | evicted after P3 |
-| **P3** | Normal gameplay event logs | first to evict |
+| Tier                   | Contents                                          | Eviction order        |
+| ---------------------- | ------------------------------------------------- | --------------------- |
+| **P0** (most precious) | High-priority bug reports / crashes               | last to evict         |
+| **P1**                 | Game outcomes (final score, completion, duration) | evicted after P2 / P3 |
+| **P2**                 | Low-priority bug reports / user feedback          | evicted after P3      |
+| **P3**                 | Normal gameplay event logs                        | first to evict        |
 
 Bug priority is **assigned automatically by the client**, not by the user:
 
@@ -108,7 +108,7 @@ Even though the server is not a referee, it remains the security boundary:
 - Auth and authorization on anything user-scoped.
 
 This layer is anti-OWASP, not anti-cheat. The fact that we trust the client
-about *game rules* does not mean we trust it about *the request*.
+about _game rules_ does not mean we trust it about _the request_.
 
 ## 7. Multi-player
 
@@ -152,3 +152,55 @@ tracked in:
 
 Both issues note that "first step is further research" — the snapshots in those
 issues are not authoritative.
+
+## 10. Premium entitlements
+
+BC Arcade has a server-authoritative premium access layer that is independent of
+game rule enforcement. Entitlements control _which games a session may open_, not
+how those games behave once open.
+
+### 10.1 How it works
+
+1. The client calls `GET /entitlements` on startup (and on foreground-resume if
+   the cached token is within 1 hour of expiry).
+2. The server returns an **RS256-signed JWT** containing:
+   - `sub`: session_id
+   - `entitled_games`: array of game slugs the session may access
+   - `iat` / `exp`: issued-at and expiry (24-hour TTL)
+3. The token is cached in AsyncStorage by `EntitlementContext.tsx`.
+4. Before navigating to any premium game, the context checks `entitled_games`.
+   If the game is absent, the UI shows an upgrade prompt instead.
+
+### 10.2 Offline grace period
+
+Tokens remain valid for **7 days past expiry** when the device is offline. If
+a token is missing or expired beyond the grace period, the app shows a
+"Reconnect to restore premium access" message. Free games are always accessible
+regardless of token state.
+
+### 10.3 Route protection
+
+Every premium API endpoint uses the `require_entitlement(game_slug)` FastAPI
+dependency. A missing or invalid token returns `403 not_entitled`. This prevents
+score submission from a session that has lost its entitlement between sessions.
+
+### 10.4 Dev override
+
+Set `ENTITLEMENT_DEV_OVERRIDE=true` in the backend environment to skip all
+entitlement checks and grant access to every game. Never set this in production.
+
+### 10.5 Key files
+
+| Layer                            | File                                                      |
+| -------------------------------- | --------------------------------------------------------- |
+| Backend — JWT issuance           | `backend/entitlements/service.py`                         |
+| Backend — Route guard            | `backend/entitlements/dependencies.py`                    |
+| Frontend — Token cache & context | `frontend/src/entitlements/EntitlementContext.tsx`        |
+| DB — entitlement rows            | `backend/alembic/versions/0014_game_types_premium_cat.py` |
+
+### 10.6 Adding a premium game
+
+1. Add `is_premium=true` in the Alembic migration that inserts the game row.
+2. Add the game slug to `PREMIUM_GAMES` in `EntitlementContext.tsx`.
+3. Add `require_entitlement("<slug>")` to every route in `backend/<game>/router.py`.
+4. Document the tier in `docs/games/<game>.md`.

--- a/docs/GAME-CONTRACT.md
+++ b/docs/GAME-CONTRACT.md
@@ -15,7 +15,7 @@ This document is the single reference for adding a new game to BC Arcade. It cov
    - [Metadata models](#14-metadata-models)
    - [stats_shape()](#15-stats_shape)
    - [players\[\]](#16-players)
-2. [Frontend contract](#2-frontend-contract) *(pending Epic #522)*
+2. [Frontend contract](#2-frontend-contract) _(pending Epic #522)_
 3. [New-game checklist](#3-new-game-checklist)
 
 ---
@@ -129,12 +129,20 @@ Each game's `games.metadata` JSONB column is validated on write by a Pydantic mo
 
 All metadata models use `extra="forbid"` to prevent arbitrary data from being silently stored.
 
-| Game | Model | Fields |
-|---|---|---|
-| Blackjack | `BlackjackMetadata` | *(none — state is in-memory)* |
-| Cascade | `CascadeMetadata` | `player_name: str = ""` (max 64 chars) |
-| Daily Word | `DailyWordMetadata` | `puzzle_id: str`, `language: Literal["en","hi"] = "en"` |
-| Pachisi | `PachisiMetadata` | *(none — state is in-memory)* |
+| Game        | Model               | Fields                                                                                                                                                             |
+| ----------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Blackjack   | `BlackjackMetadata` | `best_run_chips: int \| None`, `total_runs: int \| None`, `runs_completed: int \| None`, `current_table: Literal["beginner","intermediate","high_roller"] \| None` |
+| Cascade     | `CascadeMetadata`   | `player_name: str = ""` (max 64 chars)                                                                                                                             |
+| Daily Word  | `DailyWordMetadata` | `puzzle_id: str` (required), `language: Literal["en","hi"] = "en"`                                                                                                 |
+| FreeCell    | —                   | No metadata model; uses standalone leaderboard router                                                                                                              |
+| Hearts      | `HeartsMetadata`    | `player_name: str = ""` (max 64 chars)                                                                                                                             |
+| Mahjong     | `MahjongMetadata`   | `player_name: str = ""` (max 64 chars)                                                                                                                             |
+| Solitaire   | `SolitaireMetadata` | `player_name: str = ""` (max 64 chars)                                                                                                                             |
+| Bottle Sort | `SortMetadata`      | `player_name: str = ""` (max 32 chars)                                                                                                                             |
+| Starswarm   | —                   | No backend module; router-only                                                                                                                                     |
+| Sudoku      | `SudokuMetadata`    | `player_name: str = ""` (max 64 chars), `difficulty: Literal["easy","medium","hard"]` (required), `variant: Literal["classic","mini"] = "classic"`                 |
+| Twenty48    | —                   | Frontend-only; no backend module                                                                                                                                   |
+| Yacht       | `YachtMetadata`     | `difficulty: Literal["easy","medium","hard"] = "easy"`                                                                                                             |
 
 **Adding a metadata model:**
 
@@ -154,13 +162,13 @@ Unregistered game types (e.g. seeded in the DB before their module is implemente
 
 **`raw_stats` keys passed to every `stats_shape` call:**
 
-| Key | Type | Description |
-|---|---|---|
-| `played` | `int` | completed game count |
-| `best` | `int \| None` | highest `final_score` |
-| `avg` | `float \| None` | mean `final_score` |
-| `last_played_at` | `datetime \| None` | most recent `completed_at` |
-| `latest_score` | `int \| None` | `final_score` of the most recently completed game |
+| Key              | Type               | Description                                       |
+| ---------------- | ------------------ | ------------------------------------------------- |
+| `played`         | `int`              | completed game count                              |
+| `best`           | `int \| None`      | highest `final_score`                             |
+| `avg`            | `float \| None`    | mean `final_score`                                |
+| `last_played_at` | `datetime \| None` | most recent `completed_at`                        |
+| `latest_score`   | `int \| None`      | `final_score` of the most recently completed game |
 
 **Return value:** a dict whose keys are a subset of `GameTypeStats` fields (`played`, `best`, `avg`, `last_played_at`, `best_chips`, `current_chips`). Omitted keys default to `None` in the response.
 
@@ -208,7 +216,7 @@ When a client omits `players` from `POST /games`, the router auto-fills `[{"play
 
 > **Pending Epic #522.** The shared frontend abstractions (`GameSession<TState, TAction>`, `GameShell`, `useGameSync`, ESLint import zone rules) do not yet exist. This section will be completed when Epic #522 is merged.
 
-### 2.1 Shared types *(TBD)*
+### 2.1 Shared types _(TBD)_
 
 Location: TBD (likely `frontend/src/game/_shared/types.ts`)
 
@@ -216,15 +224,15 @@ Location: TBD (likely `frontend/src/game/_shared/types.ts`)
 - `Player` — maps to backend `PlayerRef`
 - Per-game types extend the shared base
 
-### 2.2 GameShell *(TBD)*
+### 2.2 GameShell _(TBD)_
 
 A shared screen wrapper component that owns: header, loading/error states, and any chrome common to all games. Individual game screens own only game-specific UI.
 
-### 2.3 useGameSync *(TBD)*
+### 2.3 useGameSync _(TBD)_
 
 A hook that manages the game session lifecycle — creating, polling, and completing a game via the `/games` API. Screens call the hook; they do not call the API directly.
 
-### 2.4 ESLint import zones *(TBD)*
+### 2.4 ESLint import zones _(TBD)_
 
 Cross-game import paths (e.g. a Blackjack screen importing from `../cascade/`) will be forbidden via `no-restricted-imports` or an import-zone plugin rule. The exact configuration will be documented here when implemented.
 
@@ -248,8 +256,9 @@ Use this checklist when adding a new game. Each item links to the file to create
 - [ ] **`backend/games/registry.py`** — add the module singleton to `_REGISTRY`
 - [ ] **`backend/scripts/gen_vocab_ts.py`** — regenerate `frontend/src/api/vocab.ts`
   - CI: `tests/test_vocab.py` (TS contract drift check)
+- [ ] **Premium tier** _(if applicable)_ — set `is_premium=true` in the Alembic migration; add `require_entitlement("<slug>")` to every route in `backend/<game>/router.py`; add the slug to `PREMIUM_GAMES` in `frontend/src/entitlements/EntitlementContext.tsx`. See [`docs/ARCHITECTURE.md §10`](ARCHITECTURE.md#10-premium-entitlements).
 
-### Frontend *(pending Epic #522)*
+### Frontend _(pending Epic #522)_
 
 - [ ] **`frontend/src/api/vocab.ts`** — committed generated file includes the new `GameType` value
 - [ ] **`frontend/src/game/mygame/types.ts`** — per-game state and action types extending `GameSession<TState, TAction>`
@@ -274,4 +283,4 @@ Before merging a new game, verify all four items below. The `android-bundle-chec
 
 ---
 
-*For questions about the overall architecture, see [`docs/TESTING.md`](TESTING.md) (test patterns) and [`docs/BRANDING.md`](BRANDING.md) (design system). For deployment, see [`docs/RENDER.md`](RENDER.md).*
+_For questions about the overall architecture, see [`docs/TESTING.md`](TESTING.md) (test patterns) and [`docs/BRANDING.md`](BRANDING.md) (design system). For deployment, see [`docs/RENDER.md`](RENDER.md)._

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,4 +1,4 @@
-# BC Games — Product Principles
+# BC Arcade — Product Principles
 
 ## North Star
 
@@ -19,49 +19,55 @@ A calm, no-BS arcade of simple games designed for short moments — not long ses
 - Behavior manipulation (dark patterns)
 - Forced ads to continue playing
 - Complex user profiles
-- Multiplayer
-- Subscriptions
 - Cross-game social leaderboards
 - Advanced analytics beyond error reporting
 
-## Game Roster Strategy
+## Game Roster
 
-- Use the app yourself daily. Notice which game you open most and which feels frictionless.
-- Add one game at a time.
+All games are in active development. Nothing is released yet.
 
-## V1 Game Classification
+| Game        | Category | Notes                                   |
+| ----------- | -------- | --------------------------------------- |
+| Yacht       | Dice     | Yahtzee variant, 3 AI difficulty levels |
+| Hearts      | Card     | Trick-taking, avoid hearts + queen      |
+| Blackjack   | Card     | 3 table tiers, chip progression         |
+| Solitaire   | Card     | Klondike, draw-3 mode, undo             |
+| Sudoku      | Puzzle   | 3000 puzzles, 3 difficulty tiers        |
+| Cascade     | Arcade   | Physics fruit-drop, Matter.js + Skia    |
+| 2048        | Puzzle   | Tile-merge puzzle, frontend-only engine |
+| FreeCell    | Card     | Leaderboard by move count               |
+| Mahjong     | Puzzle   | Tile-matching, deadlock detection       |
+| Bottle Sort | Puzzle   | Level-based pour puzzle                 |
+| Daily Word  | Word     | Daily puzzle, en/hi language support    |
+| Starswarm   | Arcade   | In early development                    |
 
-| Game      | Status        | Notes                     |
-| --------- | ------------- | ------------------------- |
-| Yacht     | Public        | Core game                 |
-| Blackjack | Public        | Core game                 |
-| 2048      | Public        | Core game                 |
-| Ludo      | Beta (hidden) | Needs AI/animation polish |
-| Cascade   | Beta (hidden) | Has collision/drop bugs   |
+For individual game rules, scoring, and engine details see [`docs/games/`](games/).
+
+## Monetization
+
+BC Arcade launches with a premium tier — some games require purchase to access (exact free/premium split TBD). Premium access is controlled by a server-issued entitlement JWT; see [`docs/ARCHITECTURE.md §10`](ARCHITECTURE.md) for the technical model.
+
+**Golden rules:**
+
+- Never remove free functionality. Only add paid enhancements.
+- Never block gameplay mid-session due to an entitlement change.
+- Free games must always be playable with zero friction — no login, no payment prompt.
 
 ## Identity Tiers
 
-| Tier | Description                 | Status                 |
-| ---- | --------------------------- | ---------------------- |
-| 0    | Anonymous (UUID session)    | Done — ships with V1   |
-| 1    | Optional name input         | Post-launch            |
-| 2    | Google/Apple SSO (optional) | Post-launch — see #144 |
+| Tier | Description                 | Status             |
+| ---- | --------------------------- | ------------------ |
+| 0    | Anonymous (UUID session)    | Implemented        |
+| 1    | Optional name input         | Planned            |
+| 2    | Google/Apple SSO (optional) | Planned — see #144 |
 
 Login is always optional. Never block gameplay behind it. Prompt only after the user has played:
 
 - "Save your progress?" triggers optional login
-- "Try new games early?" triggers optional login
-
-## Monetization (NOT in V1)
-
-- **Phase 1 (launch):** Completely free, no ads, no payments
-- **Phase 2 (after usage data):** Light ads between sessions only + $2.99 Remove Ads IAP
-- **Optional:** $4.99 Premium (themes, etc.)
-- **Golden rule:** Never remove free functionality. Only add paid enhancements.
+- "Want to try new games early?" triggers optional login
 
 ## Beta Testing
 
 - Use feature flags (#142) to gate beta games, not TestFlight
 - TestFlight reserved for unstable features or major changes
 - Initial beta testers: project owner + family
-- Messaging: "Want to try new games early?"

--- a/docs/games/blackjack.md
+++ b/docs/games/blackjack.md
@@ -1,0 +1,74 @@
+# Blackjack
+
+**Category:** Card
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Standard casino Blackjack. The player competes against the dealer (AI). The goal is to get a hand value as close to 21 as possible without going over ("busting"), and closer than the dealer.
+
+### Card Values
+
+- Number cards (2–10): face value
+- Jack, Queen, King: 10
+- Ace: 1 or 11 (whichever is more favorable)
+
+### Actions
+
+| Action      | When available                                                        |
+| ----------- | --------------------------------------------------------------------- |
+| Hit         | Take another card                                                     |
+| Stand       | End your turn                                                         |
+| Double Down | Double the bet, take exactly one more card                            |
+| Split       | When dealt two cards of the same rank — split into two separate hands |
+
+### Outcomes
+
+- **Blackjack** (Ace + 10-value on first two cards): pays 3:2
+- **Win**: player total > dealer total, or dealer busts: pays 1:1
+- **Push**: equal totals — bet returned
+- **Loss**: player total < dealer total, or player busts
+
+### Table Tiers
+
+Blackjack uses a chip-based progression system across three tables:
+
+| Table        | Starting chips | Run goal | Min bet | Max bet |
+| ------------ | -------------- | -------- | ------- | ------- |
+| Beginner     | 100            | 250      | 5       | 25      |
+| Intermediate | 250            | 750      | 10      | 50      |
+| High Roller  | 500            | 1500     | 25      | 200     |
+
+Reaching the run goal on one table unlocks the next. Tables also unlock cosmetics (table themes, card backs, chip styles) for milestone achievements — e.g. winning back from ≤25% chip stack.
+
+## Scoring (Persistence)
+
+`final_score` = chip total at end of session. The backend tracks `best_run_chips` (highest run-end chip total) and `current_chips` (most recent session's ending total) via the `BlackjackMetadata` fields.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/blackjack/engine.ts`
+- Supporting files:
+  - `frontend/src/game/blackjack/tables.ts` — table tier config
+  - `frontend/src/game/blackjack/unlocks.ts` — cosmetic unlock logic
+- Key exports: hand evaluation, dealer AI logic, bet validation, split/double-down rules
+
+## Backend
+
+- Module: `backend/blackjack/module.py`
+- Endpoints: `backend/blackjack/router.py`
+- Metadata model: `BlackjackMetadata`
+  - `best_run_chips: int | None`
+  - `total_runs: int | None`
+  - `runs_completed: int | None`
+  - `current_table: Literal["beginner","intermediate","high_roller"] | None`
+- Scoring: `final_score` = chip count at session end; `stats_shape` maps `best → best_chips`, `latest_score → current_chips`
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check. If premium: requires a valid entitlement JWT; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- Tracked in issue #893 (two rule engines — migration to single TS engine in progress)

--- a/docs/games/cascade.md
+++ b/docs/games/cascade.md
@@ -1,0 +1,57 @@
+# Cascade
+
+**Category:** Arcade
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Cascade is a physics-based fruit-drop game. Fruits fall from the top of the screen into a bin. When two fruits of the same type collide they merge into a larger fruit, scoring points. The goal is to score as high as possible before the bin overflows.
+
+### Fruit Progression
+
+Fruits evolve through a fixed sequence — the smallest type merges into the next size up, and so on. The highest-tier fruit is the "cascade" (jackpot merge). The exact sequence and point values are defined in `frontend/src/game/cascade/fruitSets.ts`.
+
+### Gameplay
+
+- A queued fruit is shown at the top; the player taps or swipes to aim, then releases to drop
+- Fruits can roll and stack after landing — physics are fully simulated
+- Merges can chain: a merge may cause the new (larger) fruit to immediately contact another of the same type, triggering another merge
+- Game over when any fruit comes to rest above the bin's top edge
+
+## Scoring (Persistence)
+
+`final_score` = cumulative point total at game over. Each merge type has a fixed point value; larger merges score more. Leaderboard ranks by `final_score`.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/cascade/engine.ts` (game rules, merge detection)
+- Physics: **Matter.js** (rigid-body simulation), rendered via **@shopify/react-native-skia**
+- Theming: `frontend/src/game/cascade/fruitSets.ts`, `frontend/src/game/cascade/fruitVertices.ts`, `frontend/src/game/cascade/useFruitImages.ts`
+- Theming pipeline: [`docs/CASCADE-THEMING.md`](../CASCADE-THEMING.md)
+
+## Backend
+
+- Module: `backend/cascade/module.py`
+- Endpoints: `backend/cascade/router.py`
+- Metadata model: `CascadeMetadata` — `player_name: str = ""` (max 64 chars)
+- Scoring: `final_score` = total points at game over
+
+## Accessibility
+
+Cascade uses a Skia canvas for rendering. The native accessibility tree does not include canvas content. Requirements:
+
+- Current score must be displayed in a native `Text` element outside the canvas
+- Game-over state must be announced via an accessible modal or live region
+- Canvas element marked `accessible={false}`
+
+See [`docs/ACCESSIBILITY.md §4`](../ACCESSIBILITY.md#4-screen-readers) for the full canvas accessibility contract.
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- Angular damping and air friction tuning in progress (branch `feat/1610-cascade-uc1-angular-damping`)
+- Theming pipeline documented in [`docs/CASCADE-THEMING.md`](../CASCADE-THEMING.md)

--- a/docs/games/daily_word.md
+++ b/docs/games/daily_word.md
@@ -1,0 +1,60 @@
+# Daily Word
+
+**Category:** Word
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Daily Word is a once-per-day word-guessing puzzle (Wordle-style). The player has 6 attempts to guess a hidden word. After each guess, tiles reveal how close the guess was to the answer.
+
+### Tile Colors
+
+| Color  | Meaning                          |
+| ------ | -------------------------------- |
+| Green  | Correct letter, correct position |
+| Yellow | Correct letter, wrong position   |
+| Gray   | Letter not in the word           |
+
+### Rules
+
+- Guesses must be valid words (validated against a word list)
+- One puzzle per day per language — everyone plays the same word
+- After 6 incorrect guesses the answer is revealed
+- Progress is saved — leaving mid-game and returning continues where you left off
+- Results can be shared (emoji grid format)
+
+### Languages
+
+| Code | Language |
+| ---- | -------- |
+| `en` | English  |
+| `hi` | Hindi    |
+
+## Scoring (Persistence)
+
+`final_score` = number of guesses used (1–6), or 0 for a failed puzzle. Lower is better. The puzzle is identified by `puzzle_id` in the metadata.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/daily_word/engine.ts`
+- Key exports: guess validation, tile color computation, win/loss detection
+- Puzzle generation: `backend/daily_word/puzzle.py` generates daily puzzles server-side
+
+## Backend
+
+- Module: `backend/daily_word/module.py`
+- Endpoints: `backend/daily_word/router.py`
+- Puzzle generation: `backend/daily_word/puzzle.py`
+- Metadata model: `DailyWordMetadata`
+  - `puzzle_id: str` (required — identifies the day's puzzle)
+  - `language: Literal["en","hi"] = "en"`
+- Scoring: `final_score` = guess count at completion
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check — daily puzzle is always accessible.
+
+## Known Issues / Limitations
+
+- None tracked at this time

--- a/docs/games/freecell.md
+++ b/docs/games/freecell.md
@@ -1,0 +1,55 @@
+# FreeCell
+
+**Category:** Card
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+FreeCell is a solitaire variant where nearly every deal is winnable with correct play. The full 52-card deck is dealt face-up into 8 tableau columns at the start — there is no hidden information.
+
+### Layout
+
+- **Tableau** (8 columns): all cards dealt face-up at start; move cards to build in descending rank, alternating colors
+- **Free cells** (4): temporary holding spots for individual cards; each can hold one card at a time
+- **Foundations** (4, one per suit): built up from Ace to King
+
+### Rules
+
+- Move a single card (or a sequence, if enough free cells + empty columns exist) from one tableau column to another
+- A card may be placed on the tableau if it is one rank lower and opposite color from the top card
+- Free cells can hold any single card temporarily
+- Empty tableau columns act as extended free cells (can hold any card or sequence)
+- Win by moving all 52 cards to the foundations
+
+### Supermove
+
+The maximum number of cards moveable as a sequence is `(free cells + 1) × 2^(empty columns)`.
+
+### Double-Tap
+
+Double-tapping a card (within a 300 ms window) triggers auto-move to foundation if a valid foundation move exists.
+
+## Scoring (Persistence)
+
+`final_score` = number of moves to complete. **Lower is better.** Leaderboard ranks by fewest moves (ascending).
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/freecell/engine.ts`
+- Key exports: `validateMove`, `applyMove`, `autoMoveCandidates`, supermove calculation
+
+## Backend
+
+- No `module.py` — FreeCell uses a standalone leaderboard router
+- Endpoints: `backend/freecell/router.py`
+- No metadata model
+- Scoring: move count submitted at game completion
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check.
+
+## Known Issues / Limitations
+
+- Tracked in issue #893 (in-memory leaderboard migration)

--- a/docs/games/hearts.md
+++ b/docs/games/hearts.md
@@ -1,0 +1,51 @@
+# Hearts
+
+**Category:** Card
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Hearts is a 4-player trick-taking card game where the goal is to end with the **lowest** score. Each round, players pass 3 cards to an opponent (direction rotates each round), then take turns playing one card per trick. The player who played the highest card of the led suit wins the trick and leads the next one.
+
+Hearts (♥) may not be led until the suit has been "broken" (played as a discard on another suit). The Queen of Spades (♠Q) may be led at any time.
+
+BC Arcade's Hearts is 1v3 against AI opponents.
+
+### Penalty Points
+
+- Each heart taken: **1 point**
+- Queen of Spades: **13 points**
+- Total per round: up to **26 points**
+
+### Shooting the Moon
+
+If one player takes **all 13 hearts and the Queen of Spades** in a single round, that player scores 0 and every other player scores 26.
+
+### Winning
+
+Play continues until at least one player reaches 100 points. The player with the **lowest score** at that point wins.
+
+## Scoring (Persistence)
+
+`final_score` = the player's total penalty points at game end. Lower is better. Leaderboard ranks by lowest `final_score`.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/hearts/engine.ts`
+- Key exports: card passing logic, trick resolution, moon-shot detection, AI decision-making
+
+## Backend
+
+- Module: `backend/hearts/module.py`
+- Endpoints: `backend/hearts/router.py`
+- Metadata model: `HeartsMetadata` — `player_name: str = ""` (max 64 chars)
+- Scoring: `final_score` = total penalty points (lower = better)
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT. Offline play continues within the 7-day grace period; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- None tracked at this time

--- a/docs/games/mahjong.md
+++ b/docs/games/mahjong.md
@@ -1,0 +1,57 @@
+# Mahjong
+
+**Category:** Puzzle
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Mahjong Solitaire (Shanghai-style). Remove all tiles from the board by matching identical pairs. A tile is selectable only if it has no tile on top of it and is free on at least one side (left or right).
+
+### Layout
+
+The default layout is the Turtle / Tortoise stack: a multi-layer pyramid of 144 tiles arranged in a traditional pattern. Additional layouts may be added over time.
+
+### Rules
+
+- Select two matching free tiles to remove them
+- Tiles are "free" if they have no tiles above them and at least one horizontal side is open
+- Joker / flower tiles match any tile of the same category (if present)
+- The game is won when all tiles are removed
+- The game is lost if no matching free pairs remain (deadlock)
+
+### Shuffle
+
+If a deadlock is detected, a shuffle option is offered. Shuffles may be limited — see implementation for count.
+
+## Scoring (Persistence)
+
+`final_score` = derived from number of moves, shuffles used, and completion time. A completed board is `COMPLETED`; a deadlocked/abandoned game is `ABANDONED`.
+
+This game is **offline-capable** — the engine runs client-side and the board state persists to AsyncStorage. Scores are submitted to the server when online.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/mahjong/engine.ts`
+- Key exports: tile matching, free-tile detection, deadlock detection, shuffle
+- Rendering: `@shopify/react-native-skia` on native; Canvas2D on web
+
+## Backend
+
+- Module: `backend/mahjong/module.py`
+- Endpoints: `backend/mahjong/router.py`
+- Metadata model: `MahjongMetadata` — `player_name: str = ""` (max 64 chars)
+- Scoring: `final_score` = score at game end
+
+## Accessibility
+
+Mahjong uses a Skia canvas on native. The canvas must be complemented by native accessible elements for score and game state. See [`docs/ACCESSIBILITY.md §4`](../ACCESSIBILITY.md#4-screen-readers).
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check.
+
+## Known Issues / Limitations
+
+- Responsive board layout extraction pending (Epic #1331 — `calculateMahjongLayout()` to be extracted)
+- Engine shipping tracked in issue #870

--- a/docs/games/solitaire.md
+++ b/docs/games/solitaire.md
@@ -1,0 +1,48 @@
+# Solitaire
+
+**Category:** Card
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Klondike Solitaire. The objective is to move all 52 cards onto the 4 foundation piles, sorted by suit from Ace to King.
+
+### Layout
+
+- **Stock** (draw pile): undealt cards; tap to draw
+- **Waste**: face-up cards drawn from stock
+- **Tableau** (7 columns): alternating-color sequences in descending rank; only face-up cards can be moved; can place any card or sequence on an empty column (Kings only to open column)
+- **Foundations** (4 piles, one per suit): built up from Ace to King
+
+### Draw Mode
+
+BC Arcade uses **draw-3** by default: tapping the stock deals 3 cards to the waste. Only the top waste card is playable. Cycling through the stock after it's exhausted applies a **recycle penalty** to the score.
+
+### Undo
+
+Unlimited undos are available. Each undo step is tracked and does not affect the win/loss outcome, but the score formula may factor move count.
+
+## Scoring (Persistence)
+
+`final_score` = points accumulated during the game (formula: time bonus, moves, cards moved to foundation). A completed game (all cards on foundations) is an `COMPLETED` outcome; abandoning mid-game is `ABANDONED`.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/solitaire/engine.ts`
+- Key exports: `validateMove(state, move) → boolean`, `applyMove(state, move) → GameState`, auto-complete detection, recycle penalty logic
+
+## Backend
+
+- Module: `backend/solitaire/module.py`
+- Endpoints: `backend/solitaire/router.py`
+- Metadata model: `SolitaireMetadata` — `player_name: str = ""` (max 64 chars)
+- Scoring: `final_score` = points at game end
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check.
+
+## Known Issues / Limitations
+
+- None tracked at this time

--- a/docs/games/sort.md
+++ b/docs/games/sort.md
@@ -1,0 +1,48 @@
+# Bottle Sort
+
+**Category:** Puzzle
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Bottle Sort (also called Color Sort) is a logic puzzle. A set of bottles contains colored liquid layers. Pour liquid from one bottle into another to sort each bottle so it contains only one color.
+
+### Rules
+
+- Each bottle holds up to 4 layers of liquid
+- You can only pour the top layer of one bottle into another if:
+  - The destination bottle's top color matches the source's top color (or the destination is empty)
+  - The destination bottle has enough empty space to receive the pour
+- A pour transfers all contiguous matching-color layers from the source at once
+- The puzzle is solved when every bottle is either empty or contains a single uniform color
+
+### Level Progression
+
+Levels increase in difficulty (more bottles, more colors). Level data is defined in `backend/sort/levels.json`. Completing a level unlocks the next.
+
+## Scoring (Persistence)
+
+`final_score` = level number reached. Progress is tracked per-session. A completed level advances the counter; an abandoned session retains progress from the last completed level.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/sort/engine.ts`
+- Key exports: `validatePour(state, from, to) → boolean`, `applyPour(state, from, to) → GameState`, win detection
+- Level data: loaded from backend or bundled locally — check implementation
+
+## Backend
+
+- Module: `backend/sort/module.py`
+- Endpoints: `backend/sort/router.py`
+- Level data: `backend/sort/levels.json`
+- Metadata model: `SortMetadata` — `player_name: str = ""` (max 32 chars)
+- Scoring: `final_score` = highest level completed
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- None tracked at this time

--- a/docs/games/starswarm.md
+++ b/docs/games/starswarm.md
@@ -1,0 +1,44 @@
+# Starswarm
+
+**Category:** Arcade
+**Tier:** TBD
+**Status:** In Development (early)
+
+## How to Play
+
+Starswarm is an arcade shooter. Details of the core loop, controls, and level structure are still being defined. This document will be updated as the game design solidifies.
+
+What is known:
+
+- The game is rendered via `@shopify/react-native-skia` (canvas-based)
+- It is a score-attack game — the goal is to survive as long as possible and score as many points as possible
+- No local save state is persisted to AsyncStorage (intentional — the game has no resume state)
+
+## Scoring (Persistence)
+
+`final_score` = points at game over. Leaderboard tracks top scores.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/starswarm/` — check this directory for current engine structure
+- Rendering: `@shopify/react-native-skia`
+
+## Backend
+
+- No `module.py` — Starswarm has a router-only backend
+- Endpoints: `backend/starswarm/router.py`
+- No metadata model
+- Scoring: score submitted via the router at game over
+
+## Accessibility
+
+Starswarm uses a Skia canvas for all rendering. Accessible text overlays for score and game state are required. See [`docs/ACCESSIBILITY.md §4`](../ACCESSIBILITY.md#4-screen-readers).
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- In early development — game design is not finalized
+- No `module.py`; tracked in issue #893 (in-memory leaderboard migration)

--- a/docs/games/sudoku.md
+++ b/docs/games/sudoku.md
@@ -1,0 +1,56 @@
+# Sudoku
+
+**Category:** Puzzle
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Classic 9×9 Sudoku. Fill every cell so that each row, column, and 3×3 box contains the digits 1–9 exactly once. Pre-filled "clue" cells are fixed; the player fills the remaining empty cells.
+
+A **mini** (6×6) variant is also available for shorter sessions, using digits 1–6 and 2×3 boxes.
+
+### Difficulty Tiers
+
+| Difficulty | Clue count (classic) | Strategy required       |
+| ---------- | -------------------- | ----------------------- |
+| Easy       | High                 | Single-candidate only   |
+| Medium     | Moderate             | Some elimination chains |
+| Hard       | Low                  | Advanced logic required |
+
+All 3000 puzzles in the bank have been validated: every puzzle is solvable, has exactly one solution, and has a clue count within its tier's target range.
+
+### Interaction
+
+- Tap an empty cell to select it
+- Tap a digit button to fill the selected cell
+- Toggle notes mode to pencil in candidate digits
+- Tap a filled cell + tap same digit to erase
+
+## Scoring (Persistence)
+
+`final_score` = derived from completion time and difficulty. A completed puzzle is `COMPLETED`; an abandoned one is `ABANDONED`. Leaderboard ranks by score per difficulty.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/sudoku/engine.ts`
+- Key exports: validation (row/col/box uniqueness), candidate computation, completion check
+- Puzzle data: 3000 pre-generated puzzles in `frontend/src/game/sudoku/puzzles/` (or served from backend — check implementation)
+
+## Backend
+
+- Module: `backend/sudoku/module.py`
+- Endpoints: `backend/sudoku/router.py`
+- Metadata model: `SudokuMetadata`
+  - `player_name: str = ""` (max 64 chars)
+  - `difficulty: Literal["easy","medium","hard"]` (required)
+  - `variant: Literal["classic","mini"] = "classic"`
+- Scoring: `final_score` = time/difficulty score at completion
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- None tracked at this time

--- a/docs/games/twenty48.md
+++ b/docs/games/twenty48.md
@@ -1,0 +1,43 @@
+# 2048
+
+**Category:** Puzzle
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Classic 2048. Slide all tiles on a 4×4 grid in one of four directions (up, down, left, right). When two tiles with the same number collide, they merge into one tile with their combined value. The goal is to create a tile with the value **2048** (or beyond).
+
+### Rules
+
+- Every swipe slides **all** tiles as far as possible in the chosen direction
+- After each swipe, a new tile (value 2 or 4) spawns in a random empty cell
+- Two tiles can only merge once per swipe (a merged tile cannot merge again in the same move)
+- The game ends when the grid is full and no legal moves remain
+
+### Scoring
+
+Each merge scores points equal to the value of the new (merged) tile. A 2+2 merge scores 4; a 1024+1024 merge scores 2048.
+
+## Scoring (Persistence)
+
+`final_score` = cumulative merge score at game over. This game is **frontend-only** — there is no backend module. Score submission and leaderboard behavior: see implementation in `frontend/src/game/twenty48/`.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/twenty48/engine.ts`
+- Key exports: `applySwipe(state, direction) → GameState`, tile spawn logic, merge scoring, game-over detection
+- Storage: `frontend/src/game/twenty48/storage.ts`
+- Types: `frontend/src/game/twenty48/types.ts`
+
+## Backend
+
+No backend module. Twenty48 is a fully client-side game. Score persistence, if implemented, routes through the shared `SyncWorker` pipeline.
+
+## Entitlement
+
+Tier TBD. If free: no entitlement check — game is always accessible.
+
+## Known Issues / Limitations
+
+- No backend module; leaderboard not yet implemented

--- a/docs/games/yacht.md
+++ b/docs/games/yacht.md
@@ -1,0 +1,62 @@
+# Yacht
+
+**Category:** Dice
+**Tier:** TBD
+**Status:** In Development
+
+## How to Play
+
+Yacht is a Yahtzee-style dice game. Each turn the player rolls 5 dice and may re-roll any subset up to two more times. After the third roll the player must assign the result to one of 13 scoring categories. Each category can only be scored once per game. The game ends when all 13 categories are filled.
+
+BC Arcade's Yacht mode is 1v1 against an AI opponent. Both players alternate turns under the same rules.
+
+### Scoring Categories
+
+| Category        | How to score                | Points          |
+| --------------- | --------------------------- | --------------- |
+| Ones – Sixes    | Sum of matching face values | Variable        |
+| Three of a Kind | At least 3 dice the same    | Sum of all dice |
+| Four of a Kind  | At least 4 dice the same    | Sum of all dice |
+| Full House      | 3 of one + 2 of another     | 25              |
+| Small Straight  | 4 sequential faces          | 30              |
+| Large Straight  | 5 sequential faces          | 40              |
+| Yacht           | All 5 dice the same         | 50              |
+| Chance          | Any combination             | Sum of all dice |
+
+Upper section bonus: if the sum of Ones–Sixes ≥ 63, add 35 bonus points.
+Maximum possible score: ~400 points (with bonus).
+
+## AI Difficulty
+
+Three levels available, set at game start via `YachtMetadata.difficulty`:
+
+| Level    | Behavior                                 |
+| -------- | ---------------------------------------- |
+| `easy`   | Makes frequent suboptimal holds          |
+| `medium` | Balanced strategy                        |
+| `hard`   | Near-optimal hold and category selection |
+
+## Scoring (Persistence)
+
+`final_score` = the player's total at game end (0–400+). The AI score is not persisted — only the human player's score is submitted. Leaderboard ranks by `final_score` per difficulty level.
+
+## Client-Side Engine
+
+- Location: `frontend/src/game/yacht/engine.ts`
+- Key exports: dice roll logic, hold validation, category scoring, AI strategy per difficulty level
+
+## Backend
+
+- Module: `backend/yacht/module.py`
+- Endpoints: `backend/yacht/router.py`
+- Metadata model: `YachtMetadata` — `difficulty: Literal["easy","medium","hard"] = "easy"`
+- Scoring: `final_score` = player's total points
+
+## Entitlement
+
+Tier TBD. If premium: requires a valid entitlement JWT. Offline play continues within the 7-day grace period; see [`docs/ARCHITECTURE.md §10`](../ARCHITECTURE.md#10-premium-entitlements).
+
+## Known Issues / Limitations
+
+- Tracked in issue #893 (server-authoritative SP migration)
+- AI difficulty tuning is ongoing


### PR DESCRIPTION
Closes #1685

## Summary

- **Fix stale architecture claims** — CLAUDE.md no longer says "all rule enforcement is server-side"; PRODUCT.md game roster now shows all 12 games with correct status; monetization corrected to V1 (premium launches from day one)
- **Document the entitlement system** — ARCHITECTURE.md §10 + SECURITY.md now cover the RS256 JWT flow, 24-hr TTL, 7-day offline grace, route protection, and dev override
- **Per-game reference docs** — `docs/games/` with one file per game (rules, scoring, engine location, backend module, metadata fields, known issues)
- **Accessibility guide** — new `docs/ACCESSIBILITY.md` targeting WCAG 2.1 AA (contrast, touch targets, reduce-motion, screen readers, keyboard, canvas overlay requirements)
- **Metadata table** — GAME-CONTRACT.md §1.4 now covers all 12 games; new-game checklist includes entitlement step

## Test plan

- [ ] `wc -l CLAUDE.md` → 49 (≤50)
- [ ] `grep "server-side\|display only\|replaces state wholesale" CLAUDE.md` → no matches (only correct "Scoring is server-side" line)
- [ ] `ls docs/games/ | wc -l` → 12
- [ ] `grep "Multiplayer\|Subscriptions" docs/PRODUCT.md` → 0 matches
- [ ] Prettier ran clean — no reformatting needed after `npx prettier --check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)