### PR TITLE
feat(cascade): S7 UC3 — per-tier density, restitution, and bounce threshold

### DIFF
--- a/e2e/tests/cascade-uc3-bounce.spec.ts
+++ b/e2e/tests/cascade-uc3-bounce.spec.ts
@@ -98,27 +98,50 @@ test.describe("Cascade UC3 — heterogeneous bounce, per-tier density", () => {
     expect(yDelta).toBeLessThan(5);
   });
 
-  test("tier-0 density is less than tier-10 density (lighter small fruits)", async ({
+  test("tier-0 bounces more times than tier-10 before settling", async ({
     page,
   }) => {
-    // Verify via physics: a tier-0 body dropped into an otherwise empty bin reaches
-    // the floor later than a tier-10 body dropped from the same height (same terminal
-    // velocity from MAX_FRUIT_SPEED_PX_S, so the density difference manifests in how
-    // quickly the body reaches terminal velocity). The test is more conceptual — we
-    // simply assert the fruits exist and have moved under gravity.
+    // Drop tier-0 and tier-10 side by side, both from the same height.
+    // Sample y-positions at two windows (1200–1500 ms and 1500–1800 ms after drop).
+    // tier-0 (restitution=0.5) is still bouncing in both windows → two large deltas.
+    // tier-10 (restitution=0.05) settles before 1200 ms → near-zero deltas in both.
     await spawnTierAt(page, 0, 100);
     await spawnTierAt(page, 10, 300);
 
-    await fastForward(page, 800);
+    await fastForward(page, 1200);
+    const snap1 = await getState(page);
 
-    const state = await getState(page);
-    const tier0 = state.fruits.find((f) => f.tier === 0);
-    const tier10 = state.fruits.find((f) => f.tier === 10);
-    expect(tier0).toBeDefined();
-    expect(tier10).toBeDefined();
+    await fastForward(page, 300);
+    const snap2 = await getState(page);
 
-    // Both fruits have fallen under gravity
-    if (tier0) expect(tier0.y).toBeGreaterThan(50);
-    if (tier10) expect(tier10.y).toBeGreaterThan(50);
+    await fastForward(page, 300);
+    const snap3 = await getState(page);
+
+    const tier0a = snap1.fruits.find((f) => f.tier === 0);
+    const tier0b = snap2.fruits.find((f) => f.tier === 0);
+    const tier0c = snap3.fruits.find((f) => f.tier === 0);
+    const tier10a = snap1.fruits.find((f) => f.tier === 10);
+    const tier10b = snap2.fruits.find((f) => f.tier === 10);
+    const tier10c = snap3.fruits.find((f) => f.tier === 10);
+
+    expect(tier0a).toBeDefined();
+    expect(tier0b).toBeDefined();
+    expect(tier0c).toBeDefined();
+    expect(tier10a).toBeDefined();
+    expect(tier10b).toBeDefined();
+    expect(tier10c).toBeDefined();
+    if (!tier0a || !tier0b || !tier0c || !tier10a || !tier10b || !tier10c)
+      return;
+
+    const tier0Delta1 = Math.abs(tier0b.y - tier0a.y);
+    const tier0Delta2 = Math.abs(tier0c.y - tier0b.y);
+    const tier10Delta1 = Math.abs(tier10b.y - tier10a.y);
+    const tier10Delta2 = Math.abs(tier10c.y - tier10b.y);
+
+    // tier-0 must still be moving visibly in at least one window (bouncing)
+    expect(Math.max(tier0Delta1, tier0Delta2)).toBeGreaterThan(5);
+    // tier-10 must be settled in both windows
+    expect(tier10Delta1).toBeLessThan(5);
+    expect(tier10Delta2).toBeLessThan(5);
   });
 });

--- a/e2e/tests/cascade-uc3-bounce.spec.ts
+++ b/e2e/tests/cascade-uc3-bounce.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * cascade-uc3-bounce.spec.ts
+ *
+ * UC3 acceptance: per-tier density and restitution produce heterogeneous
+ * bounce behaviour. Tier-0 (smallest, highest restitution) bounces visibly;
+ * tier-10 (largest, lowest restitution) settles within a frame or two.
+ *
+ * Approach: drop each fruit, let it reach the floor, then sample y-position
+ * twice 300 ms apart. A still-bouncing body has a large y-delta; a settled
+ * body has a near-zero y-delta.
+ *
+ * Requires a test build: EXPO_PUBLIC_TEST_HOOKS=1 npx expo export --platform web
+ */
+import { test, expect } from "./fixtures";
+import {
+  gotoCascade,
+  getState,
+  fastForward,
+  mockLeaderboard,
+  spawnTierAt,
+} from "./helpers/cascade";
+
+const WORLD_W = 400;
+const WALL_THICKNESS = 16;
+
+// Tier radii — must match RADII in fruitSets.ts
+const TIER_0_RADIUS = 18;
+const TIER_10_RADIUS = 168;
+
+// Rest y for each tier when sitting on the floor
+const TIER_0_REST_Y = 700 - WALL_THICKNESS - TIER_0_RADIUS; // 666
+const TIER_10_REST_Y = 700 - WALL_THICKNESS - TIER_10_RADIUS; // 516
+
+test.describe("Cascade UC3 — heterogeneous bounce, per-tier density", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboard(page);
+    await gotoCascade(page);
+  });
+
+  test("tier-0 (smallest, restitution=0.5) bounces visibly after floor contact", async ({
+    page,
+  }) => {
+    // Drop tier-0 at centre — small fruit, no risk of merge with anything
+    await spawnTierAt(page, 0, WORLD_W / 2);
+
+    // Let it fall and hit the floor (floor contact ~930 ms from y≈50)
+    await fastForward(page, 1200);
+
+    const before = await getState(page);
+    const f1 = before.fruits.find((f) => f.tier === 0);
+    expect(f1).toBeDefined();
+    if (!f1) return;
+
+    // Fruit must be near the floor at this point
+    expect(f1.y).toBeGreaterThan(TIER_0_REST_Y - 120);
+
+    // Advance 300 ms — a bouncing body with restitution=0.5 will be many pixels
+    // above its previous y (it bounced upward after the floor contact)
+    await fastForward(page, 300);
+
+    const after = await getState(page);
+    const f2 = after.fruits.find((f) => f.tier === 0);
+    expect(f2).toBeDefined();
+    if (!f2) return;
+
+    // The fruit was bouncing — its y changed by more than 5 px between snapshots
+    const yDelta = Math.abs(f2.y - f1.y);
+    expect(yDelta).toBeGreaterThan(5);
+  });
+
+  test("tier-10 (largest, restitution=0.05) settles quickly — y barely changes after landing", async ({
+    page,
+  }) => {
+    // Tier-10 radius=168 fits the bin: centre at x=200, walls at 16 and 384
+    await spawnTierAt(page, 10, WORLD_W / 2);
+
+    // Let it fall and hit the floor (floor contact ~900 ms from y≈50, for tier-10 rest_y=516)
+    await fastForward(page, 1200);
+
+    const mid = await getState(page);
+    const f1 = mid.fruits.find((f) => f.tier === 10);
+    expect(f1).toBeDefined();
+    if (!f1) return;
+
+    // Fruit must be near the floor
+    expect(f1.y).toBeGreaterThan(TIER_10_REST_Y - 120);
+
+    // Advance 300 ms — with restitution=0.05 the bounce is < 1 px; body should be settled
+    await fastForward(page, 300);
+
+    const after = await getState(page);
+    const f2 = after.fruits.find((f) => f.tier === 10);
+    expect(f2).toBeDefined();
+    if (!f2) return;
+
+    // Settled: y delta over 300 ms must be less than 5 px
+    const yDelta = Math.abs(f2.y - f1.y);
+    expect(yDelta).toBeLessThan(5);
+  });
+
+  test("tier-0 density is less than tier-10 density (lighter small fruits)", async ({
+    page,
+  }) => {
+    // Verify via physics: a tier-0 body dropped into an otherwise empty bin reaches
+    // the floor later than a tier-10 body dropped from the same height (same terminal
+    // velocity from MAX_FRUIT_SPEED_PX_S, so the density difference manifests in how
+    // quickly the body reaches terminal velocity). The test is more conceptual — we
+    // simply assert the fruits exist and have moved under gravity.
+    await spawnTierAt(page, 0, 100);
+    await spawnTierAt(page, 10, 300);
+
+    await fastForward(page, 800);
+
+    const state = await getState(page);
+    const tier0 = state.fruits.find((f) => f.tier === 0);
+    const tier10 = state.fruits.find((f) => f.tier === 10);
+    expect(tier0).toBeDefined();
+    expect(tier10).toBeDefined();
+
+    // Both fruits have fallen under gravity
+    if (tier0) expect(tier0.y).toBeGreaterThan(50);
+    if (tier10) expect(tier10.y).toBeGreaterThan(50);
+  });
+});

--- a/frontend/src/game/cascade/__tests__/engine.unified.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.unified.test.ts
@@ -22,6 +22,7 @@ import {
   FRUIT_ANGULAR_DAMPING,
   FRUIT_FRICTION_AIR,
   FRUIT_DENSITY_BY_TIER,
+  FRUIT_RESTITUTION_BY_TIER,
 } from "../engine.shared";
 import { FRUIT_SETS, FruitSet, FruitDefinition } from "../../../theme/fruitSets";
 
@@ -1210,13 +1211,29 @@ describe("UC2 — warm-spawn merge", () => {
 });
 
 // ---------------------------------------------------------------------------
-// UC3: per-tier density (S7 / #1612)
+// UC3: per-tier density and restitution (S7 / #1612)
 // ---------------------------------------------------------------------------
 
-describe("UC3 — per-tier density", () => {
+describe("UC3 — per-tier density and restitution", () => {
+  // --- static array invariants ---
+
   it("FRUIT_DENSITY_BY_TIER has exactly 11 entries", () => {
     expect(FRUIT_DENSITY_BY_TIER).toHaveLength(11);
   });
+
+  it("FRUIT_RESTITUTION_BY_TIER has exactly 11 entries", () => {
+    expect(FRUIT_RESTITUTION_BY_TIER).toHaveLength(11);
+  });
+
+  it("tier-0 density is less than tier-10 density (small = lighter)", () => {
+    expect(FRUIT_DENSITY_BY_TIER[0]).toBeLessThan(FRUIT_DENSITY_BY_TIER[10]);
+  });
+
+  it("tier-0 restitution is greater than tier-10 restitution (small = bouncier)", () => {
+    expect(FRUIT_RESTITUTION_BY_TIER[0]).toBeGreaterThan(FRUIT_RESTITUTION_BY_TIER[10]);
+  });
+
+  // --- spawned body properties ---
 
   it("spawnAt tier-0 body has density === FRUIT_DENSITY_BY_TIER[0]", async () => {
     const createSpy = jest.spyOn(Matter.Engine, "create");
@@ -1248,7 +1265,33 @@ describe("UC3 — per-tier density", () => {
     handle.cleanup();
   });
 
-  it("tier-0 density is less than tier-10 density (small = lighter)", () => {
-    expect(FRUIT_DENSITY_BY_TIER[0]).toBeLessThan(FRUIT_DENSITY_BY_TIER[10]);
+  it("spawnAt tier-0 body has restitution === FRUIT_RESTITUTION_BY_TIER[0]", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    handle.drop(fruit(0), "fruits", W / 2, 30);
+    handle.step(1 / 60);
+
+    const bodies = Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.restitution).toBeCloseTo(FRUIT_RESTITUTION_BY_TIER[0], 6);
+
+    handle.cleanup();
+  });
+
+  it("spawnAt tier-10 body has restitution === FRUIT_RESTITUTION_BY_TIER[10]", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    handle.drop(fruit(10), "fruits", W / 2, 100);
+    handle.step(1 / 60);
+
+    const bodies = Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.restitution).toBeCloseTo(FRUIT_RESTITUTION_BY_TIER[10], 6);
+
+    handle.cleanup();
   });
 });

--- a/frontend/src/game/cascade/__tests__/engine.unified.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.unified.test.ts
@@ -21,6 +21,7 @@ import {
   GAME_OVER_MERGE_COOLDOWN_TICKS,
   FRUIT_ANGULAR_DAMPING,
   FRUIT_FRICTION_AIR,
+  FRUIT_DENSITY_BY_TIER,
 } from "../engine.shared";
 import { FRUIT_SETS, FruitSet, FruitDefinition } from "../../../theme/fruitSets";
 
@@ -1205,5 +1206,49 @@ describe("UC2 — warm-spawn merge", () => {
     expect(elapsed).toBeLessThan(16);
 
     handle.cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UC3: per-tier density (S7 / #1612)
+// ---------------------------------------------------------------------------
+
+describe("UC3 — per-tier density", () => {
+  it("FRUIT_DENSITY_BY_TIER has exactly 11 entries", () => {
+    expect(FRUIT_DENSITY_BY_TIER).toHaveLength(11);
+  });
+
+  it("spawnAt tier-0 body has density === FRUIT_DENSITY_BY_TIER[0]", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    handle.drop(fruit(0), "fruits", W / 2, 30);
+    handle.step(1 / 60);
+
+    const bodies = Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.density).toBeCloseTo(FRUIT_DENSITY_BY_TIER[0], 6);
+
+    handle.cleanup();
+  });
+
+  it("spawnAt tier-10 body has density === FRUIT_DENSITY_BY_TIER[10]", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    handle.drop(fruit(10), "fruits", W / 2, 100);
+    handle.step(1 / 60);
+
+    const bodies = Matter.Composite.allBodies(engineInstance.world).filter((b) => !b.isStatic);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.density).toBeCloseTo(FRUIT_DENSITY_BY_TIER[10], 6);
+
+    handle.cleanup();
+  });
+
+  it("tier-0 density is less than tier-10 density (small = lighter)", () => {
+    expect(FRUIT_DENSITY_BY_TIER[0]).toBeLessThan(FRUIT_DENSITY_BY_TIER[10]);
   });
 });

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -45,35 +45,53 @@ export const POP_IMPULSE_SCALE = 2.0;
 // Density (matter-js pixel-area units): heavier for larger fruit so large tiers sink into piles.
 // Tuple type ensures noUncheckedIndexedAccess won't widen to `number | undefined` for FruitTier indices.
 export const FRUIT_DENSITY_BY_TIER: readonly [
-  number, number, number, number, number,
-  number, number, number, number, number, number
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
 ] = [
   0.0005, // tier-0  (r=18)
   0.0006, // tier-1  (r=23)
   0.0007, // tier-2  (r=28)
   0.0008, // tier-3  (r=35)
   0.0009, // tier-4  (r=44)
-  0.0010, // tier-5  (r=55)
+  0.001, // tier-5  (r=55)
   0.0012, // tier-6  (r=69)
   0.0014, // tier-7  (r=86)
   0.0016, // tier-8  (r=107)
   0.0018, // tier-9  (r=134)
-  0.0020, // tier-10 (r=168)
+  0.002, // tier-10 (r=168)
 ];
 // Restitution: smaller fruit bounce more; larger fruit thud and settle.
 export const FRUIT_RESTITUTION_BY_TIER: readonly [
-  number, number, number, number, number,
-  number, number, number, number, number, number
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
 ] = [
-  0.50, // tier-0
+  0.5, // tier-0
   0.42, // tier-1
   0.35, // tier-2
   0.29, // tier-3
   0.24, // tier-4
-  0.20, // tier-5
+  0.2, // tier-5
   0.16, // tier-6
   0.13, // tier-7
-  0.10, // tier-8
+  0.1, // tier-8
   0.07, // tier-9
   0.05, // tier-10
 ];

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -30,8 +30,6 @@ export const GAME_OVER_CONSECUTIVE_TICKS = 180;
 export const GAME_OVER_MERGE_COOLDOWN_TICKS = 90;
 
 // --- Physics tuning constants ---
-/** Low restitution = THUD feel (original Suika); fruits barely bounce. */
-export const FRUIT_RESTITUTION = 0.1;
 /** Low friction = fruits slide and settle naturally (spec: 0.05–0.1). */
 export const FRUIT_FRICTION = 0.08;
 /** Angular damping kills residual spin so fruits stop rotating after landing (UC1). */
@@ -42,7 +40,45 @@ export const FRUIT_FRICTION_AIR = 0.01;
 export const WALL_FRICTION = 0.2;
 /** Radial pop impulse applied to neighbors on merge: magnitude = nextTierRadius × this. Tunable. */
 export const POP_IMPULSE_SCALE = 2.0;
-export const FRUIT_DENSITY = 1.0;
+
+// --- Per-tier physics (UC3) ---
+// Density (matter-js pixel-area units): heavier for larger fruit so large tiers sink into piles.
+// Tuple type ensures noUncheckedIndexedAccess won't widen to `number | undefined` for FruitTier indices.
+export const FRUIT_DENSITY_BY_TIER: readonly [
+  number, number, number, number, number,
+  number, number, number, number, number, number
+] = [
+  0.0005, // tier-0  (r=18)
+  0.0006, // tier-1  (r=23)
+  0.0007, // tier-2  (r=28)
+  0.0008, // tier-3  (r=35)
+  0.0009, // tier-4  (r=44)
+  0.0010, // tier-5  (r=55)
+  0.0012, // tier-6  (r=69)
+  0.0014, // tier-7  (r=86)
+  0.0016, // tier-8  (r=107)
+  0.0018, // tier-9  (r=134)
+  0.0020, // tier-10 (r=168)
+];
+// Restitution: smaller fruit bounce more; larger fruit thud and settle.
+export const FRUIT_RESTITUTION_BY_TIER: readonly [
+  number, number, number, number, number,
+  number, number, number, number, number, number
+] = [
+  0.50, // tier-0
+  0.42, // tier-1
+  0.35, // tier-2
+  0.29, // tier-3
+  0.24, // tier-4
+  0.20, // tier-5
+  0.16, // tier-6
+  0.13, // tier-7
+  0.10, // tier-8
+  0.07, // tier-9
+  0.05, // tier-10
+];
+/** Approach velocity (px/tick) below which restitution is suppressed — Matter.Resolver._restingThresh. */
+export const RESTITUTION_THRESHOLD = 0.5;
 
 // --- Matter.js gravity ---
 // Equivalent to ~1800 px/s² at 60 Hz (matches Rapier GRAVITY_Y=18 × SCALE=0.01 × 1/SCALE).

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -96,6 +96,9 @@ export async function createEngine(
   // Higher counts resolve penetration in 15-deep stacks cleanly.
   engine.positionIterations = MATTER_POSITION_ITERATIONS;
   engine.velocityIterations = MATTER_VELOCITY_ITERATIONS;
+  // _restingThresh is a global singleton on Matter.Resolver (not per-engine).
+  // Setting it here is intentionally process-wide — every createEngine call writes
+  // the same constant, so there is no cross-instance divergence risk.
   (Matter.Resolver as unknown as Record<string, number>)._restingThresh = RESTITUTION_THRESHOLD;
 
   const world = engine.world;

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -12,13 +12,14 @@ export {
   GAME_OVER_GRACE_MS,
   GAME_OVER_CONSECUTIVE_TICKS,
   GAME_OVER_MERGE_COOLDOWN_TICKS,
-  FRUIT_RESTITUTION,
+  FRUIT_DENSITY_BY_TIER,
+  FRUIT_RESTITUTION_BY_TIER,
   FRUIT_FRICTION,
   FRUIT_ANGULAR_DAMPING,
   FRUIT_FRICTION_AIR,
   WALL_FRICTION,
   POP_IMPULSE_SCALE,
-  FRUIT_DENSITY,
+  RESTITUTION_THRESHOLD,
   MATTER_GRAVITY_Y,
   FIXED_STEP_MS,
   MATTER_POSITION_ITERATIONS,
@@ -47,12 +48,14 @@ import {
   GAME_OVER_GRACE_MS,
   GAME_OVER_CONSECUTIVE_TICKS,
   GAME_OVER_MERGE_COOLDOWN_TICKS,
-  FRUIT_RESTITUTION,
+  FRUIT_DENSITY_BY_TIER,
+  FRUIT_RESTITUTION_BY_TIER,
   FRUIT_FRICTION,
   FRUIT_ANGULAR_DAMPING,
   FRUIT_FRICTION_AIR,
   WALL_FRICTION,
   POP_IMPULSE_SCALE,
+  RESTITUTION_THRESHOLD,
   MATTER_GRAVITY_Y,
   FIXED_STEP_MS,
   MATTER_POSITION_ITERATIONS,
@@ -93,6 +96,7 @@ export async function createEngine(
   // Higher counts resolve penetration in 15-deep stacks cleanly.
   engine.positionIterations = MATTER_POSITION_ITERATIONS;
   engine.velocityIterations = MATTER_VELOCITY_ITERATIONS;
+  (Matter.Resolver as unknown as Record<string, number>)._restingThresh = RESTITUTION_THRESHOLD;
 
   const world = engine.world;
 
@@ -166,10 +170,10 @@ export async function createEngine(
 
     let body: Matter.Body;
     const bodyOpts = {
-      restitution: FRUIT_RESTITUTION,
+      restitution: FRUIT_RESTITUTION_BY_TIER[def.tier],
       friction: FRUIT_FRICTION,
       frictionAir: FRUIT_FRICTION_AIR,
-      density: 0.001, // matter.js density is per-pixel-area; tuned for natural feel
+      density: FRUIT_DENSITY_BY_TIER[def.tier],
       sleepThreshold: MATTER_SLEEP_THRESHOLD,
       collisionFilter: {
         category: COLLISION_GROUP_DYNAMIC,


### PR DESCRIPTION
## Summary

- Adds `FRUIT_DENSITY_BY_TIER` (11 values, 0.0005→0.0020) and `FRUIT_RESTITUTION_BY_TIER` (11 values, 0.50→0.05) to `engine.shared.ts`
- `spawnAt` in `engine.ts` now uses per-tier density and restitution instead of the previous hardcoded `density: 0.001` and uniform `FRUIT_RESTITUTION`
- `RESTITUTION_THRESHOLD = 0.5` wired to `Matter.Resolver._restingThresh` (verified 0.20.x API: `_restingThresh` on `Matter.Resolver`, not directly on the Engine object)
- Removed dead constants `FRUIT_DENSITY` and `FRUIT_RESTITUTION` from re-exports (nothing outside the engine referenced them)

## Physics notes

- `Matter.Resolver._restingThresh` (default 2) controls the approach-velocity floor below which restitution is suppressed. Setting it to 0.5 lets small-fruit bouncing register for gentle contacts, while tier-10's restitution of 0.05 keeps its bounce < 1 px regardless.
- Tuple type annotations on both arrays prevent `noUncheckedIndexedAccess` from widening to `number | undefined` for `FruitTier` (0–10) indices.

## Test plan

- [ ] Unit: `FRUIT_DENSITY_BY_TIER` has 11 entries; `spawnAt(tier: 0/10)` body density matches array value
- [ ] E2E: `cascade-uc3-bounce.spec.ts` — tier-0 y-delta > 5 px between snapshots 300 ms apart (bouncing); tier-10 y-delta < 5 px (settled)
- [ ] Regression: all 6 existing `cascade-*.spec.ts` E2E files pass with per-tier physics

Closes #1612

🤖 Generated with [Claude Code](https://claude.com/claude-code)