### PR TITLE
feat(cascade): S8 UC4 — cascade combo fix + game-over suppression (#1613)

### DIFF
--- a/e2e/tests/cascade-uc4-cascade.spec.ts
+++ b/e2e/tests/cascade-uc4-cascade.spec.ts
@@ -56,8 +56,6 @@ test.describe("Cascade UC4 — cascade combo and game-over suppression", () => {
     page,
   }) => {
     // Spawn several overlapping pairs that will merge in rapid succession.
-    // The merge cooldown (GAME_OVER_MERGE_COOLDOWN_TICKS) must keep gameOver
-    // suppressed throughout, leaving the game running after the cascade.
     await spawnTierAt(page, 0, WORLD_W / 4);
     await spawnTierAt(page, 0, WORLD_W / 4 + 2);
 
@@ -67,8 +65,10 @@ test.describe("Cascade UC4 — cascade combo and game-over suppression", () => {
     await spawnTierAt(page, 0, (3 * WORLD_W) / 4);
     await spawnTierAt(page, 0, (3 * WORLD_W) / 4 + 2);
 
-    // Advance far enough for merges to chain and settle, but not so far that
-    // the GAME_OVER_GRACE_MS (3 s) expires for the merged fruit.
+    // fastForward advances physics ticks but not Date.now(), so spawned fruits
+    // remain within GAME_OVER_GRACE_MS (3 s). gameOver is blocked by the grace
+    // period here, not by the merge cooldown. The merge-cooldown path is covered
+    // by "merge in last 90 ticks suppresses gameOver" in engine.unified.test.ts.
     await fastForward(page, 2000);
 
     const state = await getState(page);

--- a/e2e/tests/cascade-uc4-cascade.spec.ts
+++ b/e2e/tests/cascade-uc4-cascade.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * cascade-uc4-cascade.spec.ts
+ *
+ * UC4 acceptance: cascade combo fires only when ≥3 merges chain from a single
+ * drop, and gameOver is not emitted while a merge cooldown is active.
+ *
+ * Approach:
+ *   (a) Spawn 3 pairs of identical-tier fruits close together; fast-forward to
+ *       let them all merge; assert comboCount increments (combo event was fired).
+ *   (b) Rapidly spawn multiple merging pairs near each other; verify gameOver
+ *       stays false throughout the merge chain.
+ *
+ * Requires a test build: EXPO_PUBLIC_TEST_HOOKS=1 npx expo export --platform web
+ */
+import { test, expect } from "./fixtures";
+import {
+  gotoCascade,
+  getState,
+  fastForward,
+  mockLeaderboard,
+  spawnTierAt,
+} from "./helpers/cascade";
+
+const WORLD_W = 400;
+
+test.describe("Cascade UC4 — cascade combo and game-over suppression", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboard(page);
+    await gotoCascade(page);
+  });
+
+  test("≥3 consecutive merges from one drop increments comboCount", async ({
+    page,
+  }) => {
+    // Spawn 3 pairs of tier-0 fruits, each pair separated by 2px so they
+    // immediately overlap and merge once physics ticks forward.
+    // All 3 pairs are in a single "drop session" (no player drop between them).
+    await spawnTierAt(page, 0, 100);
+    await spawnTierAt(page, 0, 102);
+
+    await spawnTierAt(page, 0, 200);
+    await spawnTierAt(page, 0, 202);
+
+    await spawnTierAt(page, 0, 300);
+    await spawnTierAt(page, 0, 302);
+
+    // Let all 3 pairs fall, merge, and any cascade settle (4 s)
+    await fastForward(page, 4000);
+
+    const state = await getState(page);
+    // At least one cascadeCombo event must have fired
+    expect(state.comboCount).toBeGreaterThan(0);
+  });
+
+  test("gameOver is not emitted while merge chains are resolving", async ({
+    page,
+  }) => {
+    // Spawn several overlapping pairs that will merge in rapid succession.
+    // The merge cooldown (GAME_OVER_MERGE_COOLDOWN_TICKS) must keep gameOver
+    // suppressed throughout, leaving the game running after the cascade.
+    await spawnTierAt(page, 0, WORLD_W / 4);
+    await spawnTierAt(page, 0, WORLD_W / 4 + 2);
+
+    await spawnTierAt(page, 0, WORLD_W / 2);
+    await spawnTierAt(page, 0, WORLD_W / 2 + 2);
+
+    await spawnTierAt(page, 0, (3 * WORLD_W) / 4);
+    await spawnTierAt(page, 0, (3 * WORLD_W) / 4 + 2);
+
+    // Advance far enough for merges to chain and settle, but not so far that
+    // the GAME_OVER_GRACE_MS (3 s) expires for the merged fruit.
+    await fastForward(page, 2000);
+
+    const state = await getState(page);
+    expect(state.gameOver).toBe(false);
+  });
+});

--- a/e2e/tests/helpers/cascade.ts
+++ b/e2e/tests/helpers/cascade.ts
@@ -19,7 +19,14 @@ export interface CascadeState {
   dangerRatio: number;
   gameOver: boolean;
   nextFruitTier: number;
-  fruits: Array<{ id: number; tier: number; x: number; y: number; angle: number }>;
+  comboCount: number;
+  fruits: Array<{
+    id: number;
+    tier: number;
+    x: number;
+    y: number;
+    angle: number;
+  }>;
 }
 
 /** Mock leaderboard endpoint so tests don't depend on a running backend. */
@@ -70,6 +77,7 @@ export async function getState(page: Page): Promise<CascadeState> {
         dangerRatio: 0,
         gameOver: false,
         nextFruitTier: 0,
+        comboCount: 0,
         fruits: [] as CascadeState["fruits"],
       },
   );

--- a/frontend/src/components/cascade/GameCanvas.web.tsx
+++ b/frontend/src/components/cascade/GameCanvas.web.tsx
@@ -63,6 +63,12 @@ export interface GameCanvasHandle {
   isReady?: () => boolean;
   /** Seed the spawn-queue RNG. Only present when EXPO_PUBLIC_TEST_HOOKS=1. */
   setSeed?: (seed: number) => void;
+  /**
+   * Spawn a fruit without resetting the cascade combo counter. Test-only —
+   * used by __cascade_spawnTierAt so RAF-frame merges between spawns don't
+   * cause the subsequent drop() call to wipe the running combo count.
+   */
+  spawnRaw?: (def: FruitDefinition, x: number) => void;
 }
 
 interface Props {
@@ -514,6 +520,15 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         },
         setSeed(seed: number) {
           onSetSeed?.(seed);
+        },
+        spawnRaw(def: FruitDefinition, x: number) {
+          if (!engineRef.current) return;
+          const clamped = clamp(
+            x,
+            WALL_THICKNESS + def.radius,
+            width - WALL_THICKNESS - def.radius
+          );
+          engineRef.current.spawnRaw?.(def, fruitSetRef.current.id, clamped, DROP_Y);
         },
       };
     }, [initEngine, width, height, onSetSeed]);

--- a/frontend/src/game/cascade/__tests__/engine.unified.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.unified.test.ts
@@ -1306,16 +1306,10 @@ describe("UC3 — per-tier density and restitution", () => {
 // for 3 ticks, so the chain naturally has empty ticks between stages.
 
 describe("UC4 — cascade combo and game-over suppression (S8 / #1613)", () => {
-  /**
-   * Return all non-static Matter.js parent bodies in the world.
-   * `b.parent === b` filters out sub-bodies of compound (polygon) bodies.
-   */
+  // `b.parent === b` filters out sub-bodies of compound (polygon) bodies.
   const getDynamic = (eng: Matter.Engine) =>
     Matter.Composite.allBodies(eng.world).filter((b) => !b.isStatic && b.parent === b);
 
-  /**
-   * Drop a fruit and return the newly added Matter.Body by diffing body IDs.
-   */
   function dropAndTrack(
     handle: EngineHandle,
     eng: Matter.Engine,
@@ -1441,8 +1435,13 @@ describe("UC4 — cascade combo and game-over suppression (S8 / #1613)", () => {
 
   it("synthetic 5-stage chain: all 5 fruitMerge events fire and gameOver is suppressed throughout", async () => {
     const createSpy = jest.spyOn(Matter.Engine, "create");
-    const FIXED_NOW = 1_000_000;
-    const handle = await createEngine(W, H, fruitSet, () => FIXED_NOW);
+    // Bodies are created 5 s before T0 so GAME_OVER_GRACE_MS (3 s) has already
+    // expired by the time the chain runs. The merge cooldown is then the only
+    // mechanism suppressing gameOver during the chain — exactly what this test
+    // is meant to verify.
+    const T0 = 1_000_000;
+    const fakeNow = { t: T0 - 5000 };
+    const handle = await createEngine(W, H, fruitSet, () => fakeNow.t);
     const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
 
     // Pre-drop one body of each tier (0-4) to pair with each cascade-spawned body.
@@ -1452,7 +1451,10 @@ describe("UC4 — cascade combo and game-over suppression (S8 / #1613)", () => {
       stageBodies.push(dropAndTrack(handle, engineInstance, tier, 50 + tier * 50, 400));
       stageBodies.push(dropAndTrack(handle, engineInstance, tier, 60 + tier * 50, 400));
     }
-    handle.step(1e-9); // register all bodies
+    handle.step(1e-9); // register all bodies (createdAt = T0 - 5000)
+
+    // Advance clock past GAME_OVER_GRACE_MS — grace expired, cooldown is sole guard
+    fakeNow.t = T0;
 
     const allEvents: { type: string }[] = [];
     let totalTicks = 0;
@@ -1478,6 +1480,7 @@ describe("UC4 — cascade combo and game-over suppression (S8 / #1613)", () => {
 
     const merges = allEvents.filter((e) => e.type === "fruitMerge");
     expect(merges).toHaveLength(5);
+    expect(allEvents.some((e) => e.type === "cascadeCombo")).toBe(true);
     expect(allEvents.some((e) => e.type === "gameOver")).toBe(false);
 
     // Chain completes in ≤ GAME_OVER_MERGE_COOLDOWN_TICKS — no bump to 120 needed

--- a/frontend/src/game/cascade/__tests__/engine.unified.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine.unified.test.ts
@@ -1295,3 +1295,223 @@ describe("UC3 — per-tier density and restitution", () => {
     handle.cleanup();
   });
 });
+
+// ---------------------------------------------------------------------------
+// UC4 — cascade combo and game-over suppression (S8 / #1613)
+// ---------------------------------------------------------------------------
+// Uses tiny dt (1e-9 s) so physics sub-steps are skipped (remainingMs < 0.01 ms)
+// while still advancing game-tick counters. Synthetic collisionStart events
+// trigger merges programmatically so the cascade is deterministic.
+// SPAWN_GRACE_TICKS = 3: each newly spawned body is immune to dynamic collisions
+// for 3 ticks, so the chain naturally has empty ticks between stages.
+
+describe("UC4 — cascade combo and game-over suppression (S8 / #1613)", () => {
+  /**
+   * Return all non-static Matter.js parent bodies in the world.
+   * `b.parent === b` filters out sub-bodies of compound (polygon) bodies.
+   */
+  const getDynamic = (eng: Matter.Engine) =>
+    Matter.Composite.allBodies(eng.world).filter((b) => !b.isStatic && b.parent === b);
+
+  /**
+   * Drop a fruit and return the newly added Matter.Body by diffing body IDs.
+   */
+  function dropAndTrack(
+    handle: EngineHandle,
+    eng: Matter.Engine,
+    tier: number,
+    x: number,
+    y: number
+  ): Matter.Body {
+    const idsBefore = new Set(getDynamic(eng).map((b) => b.id));
+    handle.drop(fruit(tier), "fruits", x, y);
+    const newBodies = getDynamic(eng).filter((b) => !idsBefore.has(b.id));
+    if (!newBodies[0]) throw new Error(`dropAndTrack: no new body for tier=${tier}`);
+    return newBodies[0];
+  }
+
+  it("cascadeCombo fires after ≥3 merges from a single drop (no reset across empty ticks)", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    // Drop 3 pairs of tier-0 fruits far apart — they won't auto-merge under tiny dt
+    const b0a = dropAndTrack(handle, engineInstance, 0, 50, 300);
+    const b0b = dropAndTrack(handle, engineInstance, 0, 60, 300);
+    const b1a = dropAndTrack(handle, engineInstance, 0, 150, 300);
+    const b1b = dropAndTrack(handle, engineInstance, 0, 160, 300);
+    const b2a = dropAndTrack(handle, engineInstance, 0, 250, 300);
+    const b2b = dropAndTrack(handle, engineInstance, 0, 260, 300);
+    handle.step(1e-9); // register without physics
+
+    const allEvents: { type: string }[] = [];
+
+    // Trigger merge 1, then step (tiny dt — physics frozen)
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b0a, bodyB: b0b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    allEvents.push(...handle.step(1e-9).events);
+
+    // 3 grace-tick steps between stages — counter must NOT reset during these
+    for (let i = 0; i < SPAWN_GRACE_TICKS; i++) allEvents.push(...handle.step(1e-9).events);
+
+    // Trigger merge 2
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b1a, bodyB: b1b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    allEvents.push(...handle.step(1e-9).events);
+
+    for (let i = 0; i < SPAWN_GRACE_TICKS; i++) allEvents.push(...handle.step(1e-9).events);
+
+    // Trigger merge 3 — cascadeCombo must fire now (count reaches COMBO_THRESHOLD = 3)
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b2a, bodyB: b2b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    allEvents.push(...handle.step(1e-9).events);
+
+    expect(allEvents.some((e) => e.type === "cascadeCombo")).toBe(true);
+    handle.cleanup();
+  });
+
+  it("cascadeCombo does NOT fire when fewer than 3 merges happen in a drop", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    const b0a = dropAndTrack(handle, engineInstance, 0, 50, 300);
+    const b0b = dropAndTrack(handle, engineInstance, 0, 60, 300);
+    const b1a = dropAndTrack(handle, engineInstance, 0, 150, 300);
+    const b1b = dropAndTrack(handle, engineInstance, 0, 160, 300);
+    handle.step(1e-9);
+
+    const allEvents: { type: string }[] = [];
+
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b0a, bodyB: b0b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    allEvents.push(...handle.step(1e-9).events);
+
+    for (let i = 0; i < SPAWN_GRACE_TICKS; i++) allEvents.push(...handle.step(1e-9).events);
+
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b1a, bodyB: b1b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    allEvents.push(...handle.step(1e-9).events);
+
+    expect(allEvents.some((e) => e.type === "cascadeCombo")).toBe(false);
+    handle.cleanup();
+  });
+
+  it("combo counter resets when a new drop occurs — merges from a prior cascade do not carry over", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    // First drop: trigger 2 merges (below combo threshold)
+    const b0a = dropAndTrack(handle, engineInstance, 0, 50, 300);
+    const b0b = dropAndTrack(handle, engineInstance, 0, 60, 300);
+    const b1a = dropAndTrack(handle, engineInstance, 0, 150, 300);
+    const b1b = dropAndTrack(handle, engineInstance, 0, 160, 300);
+    handle.step(1e-9);
+
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b0a, bodyB: b0b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    handle.step(1e-9);
+    for (let i = 0; i < SPAWN_GRACE_TICKS; i++) handle.step(1e-9);
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b1a, bodyB: b1b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    handle.step(1e-9); // count = 2 after first drop
+
+    // New drop — resets counter to 0
+    const b2a = dropAndTrack(handle, engineInstance, 0, 250, 300);
+    const b2b = dropAndTrack(handle, engineInstance, 0, 260, 300);
+    handle.step(1e-9);
+
+    // Only 1 merge in second drop — must NOT fire combo (0+1 = 1 < 3)
+    Matter.Events.trigger(engineInstance, "collisionStart", {
+      pairs: [{ bodyA: b2a, bodyB: b2b, activeContacts: [], separation: 0, isActive: true }],
+    });
+    const { events } = handle.step(1e-9);
+    expect(events.some((e) => e.type === "cascadeCombo")).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it("synthetic 5-stage chain: all 5 fruitMerge events fire and gameOver is suppressed throughout", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const FIXED_NOW = 1_000_000;
+    const handle = await createEngine(W, H, fruitSet, () => FIXED_NOW);
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    // Pre-drop one body of each tier (0-4) to pair with each cascade-spawned body.
+    // Positions are spread widely to prevent accidental auto-merges.
+    const stageBodies: Matter.Body[] = [];
+    for (let tier = 0; tier < 5; tier++) {
+      stageBodies.push(dropAndTrack(handle, engineInstance, tier, 50 + tier * 50, 400));
+      stageBodies.push(dropAndTrack(handle, engineInstance, tier, 60 + tier * 50, 400));
+    }
+    handle.step(1e-9); // register all bodies
+
+    const allEvents: { type: string }[] = [];
+    let totalTicks = 0;
+
+    // Chain 5 stages: for each stage, trigger collision between the pre-placed pair,
+    // step to process the merge, then wait SPAWN_GRACE_TICKS for the spawned body.
+    for (let stage = 0; stage < 5; stage++) {
+      const bA = stageBodies[stage * 2]!;
+      const bB = stageBodies[stage * 2 + 1]!;
+
+      Matter.Events.trigger(engineInstance, "collisionStart", {
+        pairs: [{ bodyA: bA, bodyB: bB, activeContacts: [], separation: 0, isActive: true }],
+      });
+      allEvents.push(...handle.step(1e-9).events);
+      totalTicks++;
+
+      // Wait out grace period before triggering next stage
+      for (let g = 0; g < SPAWN_GRACE_TICKS; g++) {
+        allEvents.push(...handle.step(1e-9).events);
+        totalTicks++;
+      }
+    }
+
+    const merges = allEvents.filter((e) => e.type === "fruitMerge");
+    expect(merges).toHaveLength(5);
+    expect(allEvents.some((e) => e.type === "gameOver")).toBe(false);
+
+    // Chain completes in ≤ GAME_OVER_MERGE_COOLDOWN_TICKS — no bump to 120 needed
+    expect(totalTicks).toBeLessThanOrEqual(GAME_OVER_MERGE_COOLDOWN_TICKS);
+
+    handle.cleanup();
+  });
+
+  it("all bodies sleep within 300 ticks after a merge", async () => {
+    const createSpy = jest.spyOn(Matter.Engine, "create");
+    const handle = await buildEngine();
+    const engineInstance = createSpy.mock.results[0]?.value as Matter.Engine;
+
+    // Drop two tier-0 fruits close together so they collide and merge naturally
+    handle.drop(fruit(0), "fruits", W / 2 - 5, 30);
+    handle.drop(fruit(0), "fruits", W / 2 + 5, 30);
+
+    // Wait for the merge to fire
+    let merged = false;
+    for (let i = 0; i < 300; i++) {
+      const { events } = handle.step(1 / 60);
+      if (events.some((e) => e.type === "fruitMerge")) {
+        merged = true;
+        break;
+      }
+    }
+    expect(merged).toBe(true);
+
+    // Run 300 more real physics ticks (300/60 = 5 s) — all fruit bodies must be sleeping
+    for (let i = 0; i < 300; i++) handle.step(1 / 60);
+
+    const awakeBodies = getDynamic(engineInstance).filter((b) => !b.isSleeping);
+    expect(awakeBodies).toHaveLength(0);
+
+    handle.cleanup();
+  });
+});

--- a/frontend/src/game/cascade/engine.shared.ts
+++ b/frontend/src/game/cascade/engine.shared.ts
@@ -184,8 +184,13 @@ export interface EngineHandle {
    *   simulated time at 1/6 s to prevent a spiral-of-death after tab suspension.
    */
   step: (dt?: number) => { snapshots: BodySnapshot[]; events: GameEvent[] };
-  /** Drop a fruit at the given pixel coordinates. */
+  /** Drop a fruit at the given pixel coordinates. Resets the cascade combo counter. */
   drop: (def: FruitDefinition, fruitSetId: string, x: number, y: number) => void;
+  /**
+   * Spawn a fruit without resetting the cascade combo counter. Test-only —
+   * used by __cascade_spawnTierAt so combo state survives between spawns.
+   */
+  spawnRaw?: (def: FruitDefinition, fruitSetId: string, x: number, y: number) => void;
   cleanup: () => void;
 }
 

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -533,6 +533,10 @@ export async function createEngine(
       spawnAt(def, fruitSetId, x, y);
     },
 
+    spawnRaw(def: FruitDefinition, fruitSetId: string, x: number, y: number): void {
+      spawnAt(def, fruitSetId, x, y);
+    },
+
     cleanup(): void {
       Matter.Events.off(engine, "collisionStart");
       Matter.World.clear(world, false);

--- a/frontend/src/game/cascade/engine.ts
+++ b/frontend/src/game/cascade/engine.ts
@@ -413,6 +413,10 @@ export async function createEngine(
       });
 
       // Cascade combo and merge-cooldown tracking.
+      // comboMergeCount only resets when the player drops a new fruit (see drop()).
+      // Empty steps during grace periods must not clear the running total so that
+      // multi-stage chains (where each spawned body has a 3-tick grace period)
+      // can accumulate ≥ 3 merges and fire the cascadeCombo event.
       if (mergesThisStep > 0) {
         comboMergeCount += mergesThisStep;
         if (!comboFired && comboMergeCount >= COMBO_THRESHOLD) {
@@ -421,8 +425,6 @@ export async function createEngine(
         }
         ticksSinceLastMerge = 0;
       } else {
-        comboMergeCount = 0;
-        comboFired = false;
         ticksSinceLastMerge++;
       }
 
@@ -524,6 +526,10 @@ export async function createEngine(
     },
 
     drop(def: FruitDefinition, fruitSetId: string, x: number, y: number): void {
+      // Each player drop starts a fresh cascade window — reset so only merges
+      // caused by THIS drop accumulate toward the cascadeCombo threshold.
+      comboMergeCount = 0;
+      comboFired = false;
       spawnAt(def, fruitSetId, x, y);
     },
 

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -529,7 +529,10 @@ function CascadeGame() {
       if (gameOverRef.current) return;
       const def = activeFruitSetRef.current.fruits[tier];
       if (!def) return;
-      canvasRef.current?.drop(def, x);
+      // Use spawnRaw (not drop) so the cascade combo counter is not reset
+      // between spawns — drop() resets comboMergeCount, which would wipe
+      // any merges that fired via the RAF loop between await spawnTierAt calls.
+      canvasRef.current?.spawnRaw?.(def, x);
     };
     return () => {
       delete g.__cascade_getState;

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -178,6 +178,7 @@ function CascadeGame() {
   const completedGameIdRef = useRef<string | null>(null);
   const gameStartTimeRef = useRef<number>(Date.now());
   const mergeCountRef = useRef(0);
+  const comboCountRef = useRef(0);
 
   // Reload persistence state (#216).
   const lastSaveTimeRef = useRef<number>(0);
@@ -414,6 +415,7 @@ function CascadeGame() {
             ]);
           }
         } else if (evt.type === "cascadeCombo") {
+          comboCountRef.current += 1;
           playCascadeCombo();
           if (!reduceMotion) {
             comboOpacity.value = 0.4;
@@ -502,6 +504,7 @@ function CascadeGame() {
       score: scoreRef.current,
       gameOver: gameOverRef.current,
       nextFruitTier: queueRef.current.peek(),
+      comboCount: comboCountRef.current,
       ...canvasRef.current?.getEngineState?.(),
     });
     g.__cascade_setSeed = handleSetSeed;
@@ -548,6 +551,7 @@ function CascadeGame() {
     scoreRef.current = 0;
     gameOverRef.current = false;
     dropCountRef.current = 0;
+    comboCountRef.current = 0;
     setScore(0);
     setGameOver(false);
     setQueueVersion((v) => v + 1);


### PR DESCRIPTION
## Summary

- **Bug fix:** Cascade combo counter was resetting to 0 on any step with no merges — the `else` branch cleared it, which meant the 3-tick spawn-grace gaps between cascade stages always killed the running total before it could reach the 3-merge threshold. Fix: remove the reset from the no-merge path; reset only inside `drop()` so each player drop starts a fresh window and empty ticks during grace periods are transparent to combo tracking.
- **New E2E hook:** `comboCount` added to `CascadeState` (via `comboCountRef` in CascadeScreen + `__cascade_getState`) so E2E tests can assert the combo fired.
- **UC4 unit tests:** 5-stage synthetic chain test confirms all 5 merges fire, `gameOver` is suppressed throughout, chain completes in ≤90 ticks (cooldown constant stays at 90 — no bump needed), and all bodies sleep within 300 ticks post-merge.
- **E2E spec:** `cascade-uc4-cascade.spec.ts` covering combo fires (comboCount > 0) and gameOver stays false during active merge chains.

## Test plan

- [ ] `test-frontend` — UC4 describe block: combo fires at ≥3, not at <3, resets on drop, 5-stage chain assertions, body-sleep check
- [ ] `Playwright E2E` — `cascade-uc4-cascade.spec.ts` (2 tests) + all existing `cascade-*.spec.ts` pass
- [ ] `lint-frontend` — eslint + prettier clean
- [ ] All other required checks green

Closes #1613
Part of #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)