### PR TITLE
fix(mahjong): dynamic board dimensions per layout — fix Pyramid clipping

### DIFF
--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -4,9 +4,48 @@
  * Pure functions tested in isolation (no hooks, no React).
  */
 
-import { calculateMahjongLayout, fitToScreen, makeBoardCamera } from "../layout";
+import { calculateMahjongLayout, fitToScreen, layoutBounds, makeBoardCamera } from "../layout";
 
 const TURTLE = { boardRows: 8, boardCols: 12, boardLayers: 4 };
+
+describe("layoutBounds", () => {
+  it("returns turtle-equivalent dims for turtle coordinate range", () => {
+    // Turtle: cols 0–22 (step 2), rows 0–7, layers 0–4
+    const slots = [
+      { col: 0, row: 0, layer: 0 },
+      { col: 22, row: 7, layer: 4 },
+    ];
+    expect(layoutBounds(slots)).toEqual({ boardCols: 12, boardRows: 8, boardLayers: 4 });
+  });
+
+  it("returns correct dims for pyramid coordinate range", () => {
+    // Pyramid: cols 4–24 (step 2), rows 2–5, layers 0–4
+    const slots = [
+      { col: 4, row: 2, layer: 0 },
+      { col: 24, row: 5, layer: 4 },
+    ];
+    expect(layoutBounds(slots)).toEqual({ boardCols: 13, boardRows: 6, boardLayers: 4 });
+  });
+
+  it("returns correct dims for a tall layout like four_rivers (16 rows)", () => {
+    // Four Rivers: cols 4–24, rows 0–15, layers 0–1
+    const slots = [
+      { col: 4, row: 0, layer: 0 },
+      { col: 24, row: 15, layer: 1 },
+    ];
+    expect(layoutBounds(slots)).toEqual({ boardCols: 13, boardRows: 16, boardLayers: 1 });
+  });
+
+  it("boardLayers equals maxLayer (not maxLayer+1)", () => {
+    const slots = [{ col: 0, row: 0, layer: 3 }];
+    expect(layoutBounds(slots).boardLayers).toBe(3);
+  });
+
+  it("boardCols = maxCol/2 + 1 because tiles are 2 grid units wide", () => {
+    const slots = [{ col: 10, row: 0, layer: 0 }];
+    expect(layoutBounds(slots).boardCols).toBe(6);
+  });
+});
 
 describe("calculateMahjongLayout", () => {
   it("returns a tileWidth clamped to MAX_TILE_W (56) on a large iPad landscape screen", () => {

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -249,7 +249,17 @@ export function useMahjongCanvasLayout(slots?: readonly Slot[]): MahjongLayout {
         boardRows,
         boardLayers,
       }),
-    [width, height, insets.top, insets.bottom, insets.left, insets.right, boardCols, boardRows, boardLayers]
+    [
+      width,
+      height,
+      insets.top,
+      insets.bottom,
+      insets.left,
+      insets.right,
+      boardCols,
+      boardRows,
+      boardLayers,
+    ]
   );
 }
 

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -246,7 +246,17 @@ export function useMahjongCanvasLayout(slots?: readonly LayoutSlot[]): MahjongLa
         ...bounds,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [width, height, insets.top, insets.bottom, insets.left, insets.right, bounds.boardCols, bounds.boardRows, bounds.boardLayers]
+    [
+      width,
+      height,
+      insets.top,
+      insets.bottom,
+      insets.left,
+      insets.right,
+      bounds.boardCols,
+      bounds.boardRows,
+      bounds.boardLayers,
+    ]
   );
 }
 

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -199,14 +199,41 @@ export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout
   };
 }
 
-// Turtle layout board grid dimensions
-const TURTLE_BOARD_ROWS = 8;
-const TURTLE_BOARD_COLS = 12;
-const TURTLE_BOARD_LAYERS = 4;
+type LayoutSlot = { readonly col: number; readonly row: number; readonly layer: number };
 
-export function useMahjongCanvasLayout(): MahjongLayout {
+/**
+ * Compute the grid dimensions needed to render a layout without clipping.
+ *
+ * col values step by 2 (each tile is 2 grid units wide), so boardCols =
+ * maxCol/2 + 1 gives the number of tile-width columns required.
+ * boardLayers equals maxLayer (not +1) because the formula in
+ * calculateMahjongLayout adds boardLayers*layerDx/layerDy as the extra
+ * space needed for the highest layer's isometric offset, not as a count.
+ */
+export function layoutBounds(slots: readonly LayoutSlot[]): {
+  boardCols: number;
+  boardRows: number;
+  boardLayers: number;
+} {
+  let maxCol = 0,
+    maxRow = 0,
+    maxLayer = 0;
+  for (const s of slots) {
+    if (s.col > maxCol) maxCol = s.col;
+    if (s.row > maxRow) maxRow = s.row;
+    if (s.layer > maxLayer) maxLayer = s.layer;
+  }
+  return {
+    boardCols: maxCol / 2 + 1,
+    boardRows: maxRow + 1,
+    boardLayers: maxLayer,
+  };
+}
+
+export function useMahjongCanvasLayout(slots?: readonly LayoutSlot[]): MahjongLayout {
   const { width, height } = useWindowDimensions();
   const insets = useSafeAreaInsets();
+  const bounds = slots ? layoutBounds(slots) : { boardCols: 12, boardRows: 8, boardLayers: 4 };
   return useMemo(
     () =>
       calculateMahjongLayout({
@@ -216,16 +243,15 @@ export function useMahjongCanvasLayout(): MahjongLayout {
         safeAreaBottom: insets.bottom,
         safeAreaLeft: insets.left,
         safeAreaRight: insets.right,
-        boardRows: TURTLE_BOARD_ROWS,
-        boardCols: TURTLE_BOARD_COLS,
-        boardLayers: TURTLE_BOARD_LAYERS,
+        ...bounds,
       }),
-    [width, height, insets.top, insets.bottom, insets.left, insets.right]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [width, height, insets.top, insets.bottom, insets.left, insets.right, bounds.boardCols, bounds.boardRows, bounds.boardLayers]
   );
 }
 
-export function useMahjongCamera(): BoardCamera {
-  const layout = useMahjongCanvasLayout();
+export function useMahjongCamera(slots?: readonly LayoutSlot[]): BoardCamera {
+  const layout = useMahjongCanvasLayout(slots);
   return useMemo(
     () => makeBoardCamera(layout, layout.availWidth, layout.availHeight, 16),
     [layout]

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { Slot } from "./types";
 
 export interface MahjongLayoutInput {
   screenWidth: number;
@@ -199,7 +200,7 @@ export function calculateMahjongLayout(input: MahjongLayoutInput): MahjongLayout
   };
 }
 
-type LayoutSlot = { readonly col: number; readonly row: number; readonly layer: number };
+const TURTLE_BOUNDS = { boardCols: 12, boardRows: 8, boardLayers: 4 };
 
 /**
  * Compute the grid dimensions needed to render a layout without clipping.
@@ -210,11 +211,12 @@ type LayoutSlot = { readonly col: number; readonly row: number; readonly layer: 
  * calculateMahjongLayout adds boardLayers*layerDx/layerDy as the extra
  * space needed for the highest layer's isometric offset, not as a count.
  */
-export function layoutBounds(slots: readonly LayoutSlot[]): {
+export function layoutBounds(slots: readonly Slot[]): {
   boardCols: number;
   boardRows: number;
   boardLayers: number;
 } {
+  if (slots.length === 0) throw new Error("layoutBounds: empty slot array");
   let maxCol = 0,
     maxRow = 0,
     maxLayer = 0;
@@ -230,10 +232,10 @@ export function layoutBounds(slots: readonly LayoutSlot[]): {
   };
 }
 
-export function useMahjongCanvasLayout(slots?: readonly LayoutSlot[]): MahjongLayout {
+export function useMahjongCanvasLayout(slots?: readonly Slot[]): MahjongLayout {
   const { width, height } = useWindowDimensions();
   const insets = useSafeAreaInsets();
-  const bounds = slots ? layoutBounds(slots) : { boardCols: 12, boardRows: 8, boardLayers: 4 };
+  const { boardCols, boardRows, boardLayers } = slots ? layoutBounds(slots) : TURTLE_BOUNDS;
   return useMemo(
     () =>
       calculateMahjongLayout({
@@ -243,24 +245,15 @@ export function useMahjongCanvasLayout(slots?: readonly LayoutSlot[]): MahjongLa
         safeAreaBottom: insets.bottom,
         safeAreaLeft: insets.left,
         safeAreaRight: insets.right,
-        ...bounds,
+        boardCols,
+        boardRows,
+        boardLayers,
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      width,
-      height,
-      insets.top,
-      insets.bottom,
-      insets.left,
-      insets.right,
-      bounds.boardCols,
-      bounds.boardRows,
-      bounds.boardLayers,
-    ]
+    [width, height, insets.top, insets.bottom, insets.left, insets.right, boardCols, boardRows, boardLayers]
   );
 }
 
-export function useMahjongCamera(slots?: readonly LayoutSlot[]): BoardCamera {
+export function useMahjongCamera(slots?: readonly Slot[]): BoardCamera {
   const layout = useMahjongCanvasLayout(slots);
   return useMemo(
     () => makeBoardCamera(layout, layout.availWidth, layout.availHeight, 16),

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -294,10 +294,9 @@ export default function MahjongScreen() {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<HomeStackParamList>>();
-  const camera = useMahjongCamera();
-
   const [view, setView] = useState<"loading" | "select" | "play">("loading");
   const [state, setState] = useState<MahjongState | null>(null);
+  const camera = useMahjongCamera(getLayout(state?.currentLayoutId ?? "turtle"));
   const [loading, setLoading] = useState(true);
   const [progress, setProgress] = useState<MahjongProgress>(DEFAULT_PROGRESS);
   const [hasSavedGame, setHasSavedGame] = useState(false);


### PR DESCRIPTION
## Summary

- Board viewport was hardcoded to Turtle's grid dimensions (`boardCols: 12`, `boardRows: 8`, `boardLayers: 4`) for every layout, causing non-Turtle layouts to render with the wrong board size
- Pyramid tiles at cols 4–24 overflowed the 12-col allocation → right-edge tiles clipped or unreachable
- Four Rivers (16 rows) and Cat (13 rows) were severely undersized vertically

## Changes

- **`layout.ts`** — Added `layoutBounds(slots)` pure function that computes correct `boardCols/boardRows/boardLayers` from a layout's actual slot coordinates. `useMahjongCanvasLayout` and `useMahjongCamera` now accept an optional slot array and use live bounds instead of hardcoded Turtle values. Uses the canonical `Slot` type from `types.ts`; guards against empty input.
- **`MahjongScreen.tsx`** — `useMahjongCamera` now receives `getLayout(state?.currentLayoutId ?? "turtle")` so the viewport recalculates whenever the active layout changes
- **`layout.test.ts`** — 5 new `layoutBounds` unit tests (27 total, all passing)

## Key dimension changes per layout

| Layout | boardCols before → after | boardRows before → after |
|---|---|---|
| Turtle | 12 → 12 ✅ | 8 → 8 ✅ |
| Pyramid | 12 → **13** 🔧 | 8 → **6** 🔧 |
| Square | 12 → **10** 🔧 | 8 → 8 |
| Arena | 12 → 12 | 8 → 8 |
| Four Rivers | 12 → **13** 🔧 | 8 → **16** 🔧 |

## Test plan

- [ ] Pyramid: tiles no longer clipped on right edge; layout centered on screen
- [ ] Turtle: visually unchanged (dimensions are identical)
- [ ] Four Rivers: board tall enough to show all 16 rows without clipping
- [ ] Switching between layouts mid-session recalculates the board correctly
- [ ] All 27 layout unit tests pass

Closes #1708

https://claude.ai/code/session_01DL16uNsUyNG2otbZ2oZiN6