### PR TITLE
fix(assets): remove duplicate Mahjong tile asset load on web

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -9,11 +9,10 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Asset } from "expo-asset";
 import { useTranslation } from "react-i18next";
 import { getMatchingFreeTileIds, hasFreePairs, isFreeTile } from "../../game/mahjong/engine";
 import type { MahjongState, SlotTile } from "../../game/mahjong/types";
-import { TILE_REQUIRES } from "./tileAssets";
+import { loadTileAssets } from "./tileAssetLoader";
 import {
   MAHJONG_BOARD_BG,
   MAHJONG_GLOW_SHADOW,
@@ -308,37 +307,33 @@ export default function GameCanvas({
     return () => mql.removeEventListener("change", handler);
   }, [dpr]);
 
-  // Load all 42 SVG tile images once on mount.
+  // Load all 42 SVG tile images once on mount, reusing assets already
+  // downloaded by the screen-level loadTileAssets() singleton.
   useEffect(() => {
     const images: (HTMLImageElement | null)[] = Array(42).fill(null);
     tileImagesRef.current = images;
     let cancelled = false;
 
-    (async () => {
-      await Promise.all(
-        (TILE_REQUIRES as number[]).map(async (src, i) => {
-          try {
-            const asset = Asset.fromModule(src);
-            await asset.downloadAsync();
-            const uri = asset.localUri ?? asset.uri;
-            if (!uri || cancelled) return;
-            await new Promise<void>((resolve) => {
-              const img = new window.Image();
-              img.crossOrigin = "anonymous";
-              img.src = uri;
-              img.onload = () => {
-                if (!cancelled) images[i] = img;
-                resolve();
-              };
-              img.onerror = () => resolve();
-            });
-          } catch {
-            // SVG failed to load — suit-color fallback stays
-          }
+    loadTileAssets().then((uris) => {
+      if (cancelled) return;
+      Promise.all(
+        uris.map((uri, i) => {
+          if (!uri) return Promise.resolve();
+          return new Promise<void>((resolve) => {
+            const img = new window.Image();
+            img.crossOrigin = "anonymous";
+            img.src = uri;
+            img.onload = () => {
+              if (!cancelled) images[i] = img;
+              resolve();
+            };
+            img.onerror = () => resolve();
+          });
         })
-      );
-      if (!cancelled && images.some((img) => img !== null)) setImagesVersion((v) => v + 1);
-    })();
+      ).then(() => {
+        if (!cancelled && images.some((img) => img !== null)) setImagesVersion((v) => v + 1);
+      });
+    });
 
     return () => {
       cancelled = true;

--- a/frontend/src/components/mahjong/tileAssetLoader.ts
+++ b/frontend/src/components/mahjong/tileAssetLoader.ts
@@ -1,0 +1,4 @@
+// Native stub — tile SVGs are rendered via Skia on native and do not use this loader.
+export function loadTileAssets(): Promise<readonly (string | null)[]> {
+  return Promise.resolve([]);
+}

--- a/frontend/src/components/mahjong/tileAssetLoader.web.ts
+++ b/frontend/src/components/mahjong/tileAssetLoader.web.ts
@@ -1,0 +1,27 @@
+import { Asset } from "expo-asset";
+import { TILE_REQUIRES } from "./tileAssets";
+
+// Module-level singleton: first caller triggers the download; every subsequent
+// caller (including concurrent ones) awaits the same in-flight promise.
+let _promise: Promise<readonly (string | null)[]> | null = null;
+
+export function loadTileAssets(): Promise<readonly (string | null)[]> {
+  if (!_promise) {
+    _promise = (async () => {
+      const uris: (string | null)[] = Array(TILE_REQUIRES.length).fill(null);
+      await Promise.all(
+        (TILE_REQUIRES as number[]).map(async (src, i) => {
+          try {
+            const asset = Asset.fromModule(src);
+            await asset.downloadAsync();
+            uris[i] = asset.localUri ?? asset.uri ?? null;
+          } catch {
+            // keep null — suit-color fallback remains in canvas renderer
+          }
+        })
+      );
+      return uris as readonly (string | null)[];
+    })();
+  }
+  return _promise;
+}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -29,7 +29,6 @@ import {
   View,
   ViewStyle,
 } from "react-native";
-import { Asset } from "expo-asset";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -48,6 +47,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import type { HomeStackParamList } from "../../App";
 import { TILE_REQUIRES } from "../components/mahjong/tileAssets";
+import { loadTileAssets } from "../components/mahjong/tileAssetLoader";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";
@@ -447,24 +447,14 @@ export default function MahjongScreen() {
 
   // Load SVG asset URIs for the flying-pair tile overlay (web only — native SVG
   // display requires Skia and can't run inside Animated.View).
+  // Reuses the singleton promise from loadTileAssets() so no duplicate
+  // network requests are made when GameCanvas also calls it on mount.
   useEffect(() => {
     if (Platform.OS !== "web") return;
     let cancelled = false;
-    const uris: (string | null)[] = Array(TILE_REQUIRES.length).fill(null);
-    (async () => {
-      await Promise.all(
-        (TILE_REQUIRES as readonly number[]).map(async (src, i) => {
-          try {
-            const asset = Asset.fromModule(src);
-            await asset.downloadAsync();
-            uris[i] = asset.uri ?? null;
-          } catch {
-            /* keep null */
-          }
-        })
-      );
+    loadTileAssets().then((uris) => {
       if (!cancelled) setTileUris([...uris]);
-    })();
+    });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
## Summary

Closes #1629

- Both `GameCanvas.web.tsx` and `MahjongScreen.tsx` independently called `Asset.fromModule().downloadAsync()` over all 42 SVG tiles on mount, causing 84 network requests instead of 42.
- Introduce `tileAssetLoader.web.ts` with a module-level singleton promise so the first caller downloads all tiles and every subsequent caller (including concurrent ones) awaits the same in-flight result.
- A native stub (`tileAssetLoader.ts`) is provided for Metro platform resolution — the native code path is unchanged.

## Changes

- **`frontend/src/components/mahjong/tileAssetLoader.web.ts`** (new) — singleton `loadTileAssets()` that downloads once and caches the promise
- **`frontend/src/components/mahjong/tileAssetLoader.ts`** (new) — native stub returning `Promise.resolve([])`
- **`frontend/src/components/mahjong/GameCanvas.web.tsx`** — calls `loadTileAssets()` to get pre-downloaded URIs, then creates `HTMLImageElement` objects; drops direct `expo-asset` usage
- **`frontend/src/screens/MahjongScreen.tsx`** — calls `loadTileAssets()` for `FlyingPair` overlay URIs; drops direct `expo-asset` usage

## Test plan

- [ ] Open Mahjong on web and check the browser Network tab — 42 SVG requests, not 84
- [ ] Tiles render correctly on the board
- [ ] Matched-pair FlyingPair animation shows correct tile art
- [ ] No regressions on native (native path is separate, stub is a no-op)

https://claude.ai/code/session_01HozzRZh7KuwPVWuZR4Bz1W

---
_Generated by [Claude Code](https://claude.ai/code/session_01HozzRZh7KuwPVWuZR4Bz1W)_