### PR TITLE
fix(mahjong): post-merge cleanup — dead import + unchained Promise.all

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -316,7 +316,7 @@ export default function GameCanvas({
 
     loadTileAssets().then((uris) => {
       if (cancelled) return;
-      Promise.all(
+      return Promise.all(
         uris.map((uri, i) => {
           if (!uri) return Promise.resolve();
           return new Promise<void>((resolve) => {

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -46,7 +46,6 @@ import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import type { HomeStackParamList } from "../../App";
-import { TILE_REQUIRES } from "../components/mahjong/tileAssets";
 import { loadTileAssets } from "../components/mahjong/tileAssetLoader";
 import { useTheme } from "../theme/ThemeContext";
 import { typography } from "../theme/typography";
@@ -325,7 +324,7 @@ export default function MahjongScreen() {
 
   // Tile image URIs for the flying-pair overlay (web: loaded via expo-asset; native: stays null[]).
   const [tileUris, setTileUris] = useState<(string | null)[]>(
-    Array(TILE_REQUIRES.length).fill(null)
+    Array(42).fill(null)
   );
 
   // Animation state

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -323,9 +323,7 @@ export default function MahjongScreen() {
   );
 
   // Tile image URIs for the flying-pair overlay (web: loaded via expo-asset; native: stays null[]).
-  const [tileUris, setTileUris] = useState<(string | null)[]>(
-    Array(42).fill(null)
-  );
+  const [tileUris, setTileUris] = useState<(string | null)[]>(Array(42).fill(null));
 
   // Animation state
   const [flyingPairs, setFlyingPairs] = useState<FlyingPairData[]>([]);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes unused `TILE_REQUIRES` import from `MahjongScreen.tsx`; replaces `Array(TILE_REQUIRES.length).fill(null)` with `Array(42).fill(null)` to match the hardcoded count already used in `GameCanvas.web.tsx`
- Adds `return` before the inner `Promise.all` in `GameCanvas.web.tsx` so rejections propagate through the `.then()` chain instead of floating silently

## Test plan

- [ ] Web tile rendering shows no regressions — tiles load and flying-pair overlay works on match
- [ ] No TypeScript/lint errors (`tsc --noEmit`, ESLint)
- [ ] No console errors related to unhandled promise rejections on tile asset load

Closes #1724
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgcFEFp3Rkf5qCm9aG5vms)_