### PR TITLE
fix: catch async AbortError from play/pause race in useSound

### DIFF
--- a/frontend/src/game/_shared/useSound.ts
+++ b/frontend/src/game/_shared/useSound.ts
@@ -40,7 +40,8 @@ export function useSound(key: SoundKey, volume = 1.0): { play: () => void } {
     if (!player) return;
     try {
       player.seekTo(0);
-      player.play();
+      // On web play() returns a Promise; catch AbortError from unmount-triggered pause races.
+      Promise.resolve(player.play()).catch(() => {});
     } catch {
       // expo-audio may throw on web if audio context is suspended; fail silently.
     }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `player.play()` on web returns a `Promise` (the browser's `HTMLMediaElement.play()`), but the return value was discarded, leaving any rejection unhandled.
- When a component unmounts before the promise resolves, `player.remove()` internally calls `pause()`, causing the in-flight promise to reject with `AbortError`.
- Fix wraps the call in `Promise.resolve(...).catch(() => {})` so the rejection is silently swallowed on web; on native where `play()` returns `void` this is a no-op.

Closes #1740

## Test plan

- [ ] Navigate Mahjong Solitaire → Layout Inspector (and back) while a sound effect is playing — no `AbortError` unhandled rejection in the console.
- [ ] Audio still plays correctly when the screen stays mounted (tile select, match, shuffle, win, deadlock sounds all fire as expected).
- [ ] No new Sentry events of type `AbortError: The play() request was interrupted`.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfxgaJEVrjhkA2JLSPaapV)_