### PR TITLE
fix: move CORSMiddleware outside rate limiter so 429/413 errors carry CORS headers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -128,11 +128,11 @@ _allowed_origins: list[str] = (
 # ---------------------------------------------------------------------------
 # Middleware stack (registered last = outermost in Starlette)
 # Order outermost → innermost:
-#   1. request_logger  (logs all requests including 429s)
-#   2. SlowAPIMiddleware  (rate limiting)
-#   3. MaxBodySizeMiddleware  (reject oversized bodies early)
-#   4. CORSMiddleware
-#   5. security_headers  (@app.middleware decorator, innermost)
+#   1. request_logger  (@app.middleware, outermost — logs every request incl. 429s)
+#   2. security_headers  (@app.middleware)
+#   3. CORSMiddleware  (must wrap SlowAPI/MaxBody so 429/413 errors carry CORS headers)
+#   4. SlowAPIMiddleware  (rate limiting)
+#   5. MaxBodySizeMiddleware  (reject oversized bodies early, innermost)
 # ---------------------------------------------------------------------------
 
 DEFAULT_MAX_BODY_BYTES = 1_024  # 1 KB — legacy game payloads (~50 bytes max)
@@ -161,7 +161,13 @@ class MaxBodySizeMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-# Register in reverse of desired execution order (last registered = outermost)
+# Register in reverse of desired execution order (last registered = outermost).
+# CORSMiddleware is registered last so it wraps SlowAPI and MaxBody — this
+# ensures 429 (rate-limited) and 413 (body-too-large) responses include the
+# Access-Control-Allow-Origin header. Without it, browsers block those error
+# responses and raise TypeError: Failed to fetch (#1739).
+app.add_middleware(MaxBodySizeMiddleware)
+app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_allowed_origins,
@@ -169,8 +175,22 @@ app.add_middleware(
     expose_headers=["Retry-After"],
     allow_headers=["Content-Type", "X-Session-ID", "X-Admin-Token"],
 )
-app.add_middleware(MaxBodySizeMiddleware)
-app.add_middleware(SlowAPIMiddleware)
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next) -> Response:
+    response = await call_next(request)
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Content-Security-Policy"] = (
+        "default-src 'none'; "
+        "connect-src 'self' https://dev-games-api.buffingchi.com https://dev-games.buffingchi.com; "
+        "frame-ancestors 'none'"
+    )
+    if "server" in response.headers:
+        del response.headers["server"]
+    return response
 
 
 @app.middleware("http")
@@ -195,22 +215,6 @@ async def request_logger(request: Request, call_next) -> Response:
         record["event"] = "server_error"
 
     _audit_log.info(json.dumps(record))
-    return response
-
-
-@app.middleware("http")
-async def security_headers(request: Request, call_next) -> Response:
-    response = await call_next(request)
-    response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Content-Security-Policy"] = (
-        "default-src 'none'; "
-        "connect-src 'self' https://dev-games-api.buffingchi.com https://dev-games.buffingchi.com; "
-        "frame-ancestors 'none'"
-    )
-    if "server" in response.headers:
-        del response.headers["server"]
     return response
 
 

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -232,3 +232,33 @@ def test_cors_disallowed_origin_excluded(
     # Request still succeeds server-side, but the allow-origin header must be
     # absent so the browser enforces the block.
     assert r.headers.get("access-control-allow-origin") is None
+
+
+def test_cors_oversized_body_response_includes_allow_origin(client: TestClient) -> None:
+    """413 from MaxBodySizeMiddleware must carry CORS headers (#1739 regression)."""
+    from main import DEFAULT_MAX_BODY_BYTES
+
+    r = client.post(
+        "/entitlements",
+        content=b"x" * (DEFAULT_MAX_BODY_BYTES + 1),
+        headers={"Origin": _TEST_ORIGIN, "Content-Type": "application/json"},
+    )
+    assert r.status_code == 413
+    assert r.headers.get("access-control-allow-origin") == _TEST_ORIGIN
+
+
+def test_cors_rate_limited_response_includes_allow_origin(
+    client: TestClient, session_id: str
+) -> None:
+    """429 from the rate limiter must carry CORS headers (#1739 regression)."""
+    from limiter import limiter
+
+    limiter.reset()
+    for _ in range(30):
+        client.get("/entitlements", headers={**_headers(session_id), "Origin": _TEST_ORIGIN})
+
+    r = client.get("/entitlements", headers={**_headers(session_id), "Origin": _TEST_ORIGIN})
+    assert r.status_code == 429
+    assert r.headers.get("access-control-allow-origin") == _TEST_ORIGIN
+
+    limiter.reset()

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -197,9 +197,7 @@ def test_render_yaml_prod_does_not_set_dev_override() -> None:
 _TEST_ORIGIN = "http://localhost:8081"
 
 
-def test_cors_get_entitlements_includes_allow_origin(
-    client: TestClient, session_id: str
-) -> None:
+def test_cors_get_entitlements_includes_allow_origin(client: TestClient, session_id: str) -> None:
     r = client.get(
         "/entitlements",
         headers={**_headers(session_id), "Origin": _TEST_ORIGIN},
@@ -222,9 +220,7 @@ def test_cors_preflight_entitlements(client: TestClient) -> None:
     assert "GET" in r.headers.get("access-control-allow-methods", "")
 
 
-def test_cors_disallowed_origin_excluded(
-    client: TestClient, session_id: str
-) -> None:
+def test_cors_disallowed_origin_excluded(client: TestClient, session_id: str) -> None:
     r = client.get(
         "/entitlements",
         headers={**_headers(session_id), "Origin": "https://evil.example.com"},

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -183,3 +183,52 @@ def test_render_yaml_prod_does_not_set_dev_override() -> None:
     prod_service = next(s for s in config["services"] if s["name"] == "bc-arcade-api")
     env_keys = {e["key"] for e in prod_service.get("envVars", [])}
     assert "ENTITLEMENT_DEV_OVERRIDE" not in env_keys
+
+
+# ---------------------------------------------------------------------------
+# CORS — web platform requests must receive Access-Control-Allow-Origin (#1739)
+#
+# _allowed_origins is resolved at import time from ALLOWED_ORIGINS env var;
+# when the var is unset in tests the default is ["http://localhost:8081",
+# "http://localhost:19006"].  Tests use one of those values as the Origin so
+# they exercise real CORSMiddleware behaviour without re-importing the module.
+# ---------------------------------------------------------------------------
+
+_TEST_ORIGIN = "http://localhost:8081"
+
+
+def test_cors_get_entitlements_includes_allow_origin(
+    client: TestClient, session_id: str
+) -> None:
+    r = client.get(
+        "/entitlements",
+        headers={**_headers(session_id), "Origin": _TEST_ORIGIN},
+    )
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == _TEST_ORIGIN
+
+
+def test_cors_preflight_entitlements(client: TestClient) -> None:
+    r = client.options(
+        "/entitlements",
+        headers={
+            "Origin": _TEST_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "content-type, x-session-id",
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == _TEST_ORIGIN
+    assert "GET" in r.headers.get("access-control-allow-methods", "")
+
+
+def test_cors_disallowed_origin_excluded(
+    client: TestClient, session_id: str
+) -> None:
+    r = client.get(
+        "/entitlements",
+        headers={**_headers(session_id), "Origin": "https://evil.example.com"},
+    )
+    # Request still succeeds server-side, but the allow-origin header must be
+    # absent so the browser enforces the block.
+    assert r.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `CORSMiddleware` was registered innermost (first `add_middleware` call), placing it *inside* `SlowAPIMiddleware` and `MaxBodySizeMiddleware`. Early error responses (429 rate-limit, 413 body-too-large) bypassed CORS entirely — no `Access-Control-Allow-Origin` header — so browsers raised `TypeError: Failed to fetch`, silently leaving web users without a refreshed entitlement token (342 Sentry events, 15 users, #1739).
- Reordered `add_middleware` calls so `CORSMiddleware` is registered last (outermost of those three), ensuring all responses pass through CORS.
- Fixed `@app.middleware` definition order (`security_headers` → `request_logger`) so `request_logger` is genuinely the outermost middleware as the existing comment always intended.
- Added 3 CORS tests: allowed-origin GET, OPTIONS preflight, disallowed-origin exclusion.

## Test plan

- [ ] All 569 existing tests pass (verified locally)
- [ ] `test_cors_get_entitlements_includes_allow_origin` — GET with valid `Origin` returns `Access-Control-Allow-Origin`
- [ ] `test_cors_preflight_entitlements` — OPTIONS preflight returns CORS headers with `GET` in allowed methods
- [ ] `test_cors_disallowed_origin_excluded` — unlisted origin receives no `Access-Control-Allow-Origin` header
- [ ] Deploy to dev and confirm no new `API entitlements network failure` Sentry warnings on web platform

Closes #1739

https://claude.ai/code/session_01NNPZ3K24ZoWpP1wmkZmLi9
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNPZ3K24ZoWpP1wmkZmLi9)_