### PR TITLE
fix(e2e): wait for AnimationOverlay opacity:1 before axe scan on overlays

### DIFF
--- a/e2e/tests/twenty48-a11y.spec.ts
+++ b/e2e/tests/twenty48-a11y.spec.ts
@@ -253,10 +253,13 @@ test.describe("2048 — axe-core scans", () => {
     await injectGameState(page, wonState());
     await page.getByRole("button", { name: "Play 2048" }).click();
     await page.getByText("You Win!").waitFor();
-    // AnimationOverlay fades in over 300 ms. Wait for opacity:1 before running
-    // axe — mid-animation opacity composites effective fg/bg colors against the
-    // page behind the overlay, deflating contrast ratios (#1743).
-    await expect(page.getByTestId("animation-overlay")).toHaveCSS("opacity", "1");
+    // AnimationOverlay fades in over 300 ms. Two overlays share the testID
+    // (win + game-over), so filter to the one containing this overlay's text.
+    // Mid-animation opacity composites effective fg/bg against the page,
+    // deflating contrast ratios — wait for 1 before running axe (#1743).
+    await expect(
+      page.getByTestId("animation-overlay").filter({ has: page.getByText("You Win!") }),
+    ).toHaveCSS("opacity", "1");
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
@@ -268,10 +271,13 @@ test.describe("2048 — axe-core scans", () => {
     await injectGameState(page, gameOverState());
     await page.getByRole("button", { name: "Play 2048" }).click();
     await page.getByText("Game Over").waitFor();
-    // AnimationOverlay fades in over 300 ms. Wait for opacity:1 before running
-    // axe — mid-animation opacity composites effective fg/bg colors against the
-    // page behind the overlay, deflating contrast ratios (#1743).
-    await expect(page.getByTestId("animation-overlay")).toHaveCSS("opacity", "1");
+    // AnimationOverlay fades in over 300 ms. Two overlays share the testID
+    // (win + game-over), so filter to the one containing this overlay's text.
+    // Mid-animation opacity composites effective fg/bg against the page,
+    // deflating contrast ratios — wait for 1 before running axe (#1743).
+    await expect(
+      page.getByTestId("animation-overlay").filter({ has: page.getByText("Game Over") }),
+    ).toHaveCSS("opacity", "1");
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/e2e/tests/twenty48-a11y.spec.ts
+++ b/e2e/tests/twenty48-a11y.spec.ts
@@ -253,6 +253,10 @@ test.describe("2048 — axe-core scans", () => {
     await injectGameState(page, wonState());
     await page.getByRole("button", { name: "Play 2048" }).click();
     await page.getByText("You Win!").waitFor();
+    // AnimationOverlay fades in over 300 ms. Wait for opacity:1 before running
+    // axe — mid-animation opacity composites effective fg/bg colors against the
+    // page behind the overlay, deflating contrast ratios (#1743).
+    await expect(page.getByTestId("animation-overlay")).toHaveCSS("opacity", "1");
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
@@ -264,6 +268,10 @@ test.describe("2048 — axe-core scans", () => {
     await injectGameState(page, gameOverState());
     await page.getByRole("button", { name: "Play 2048" }).click();
     await page.getByText("Game Over").waitFor();
+    // AnimationOverlay fades in over 300 ms. Wait for opacity:1 before running
+    // axe — mid-animation opacity composites effective fg/bg colors against the
+    // page behind the overlay, deflating contrast ratios (#1743).
+    await expect(page.getByTestId("animation-overlay")).toHaveCSS("opacity", "1");
 
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])

--- a/frontend/src/components/twenty48/GameOverlay.tsx
+++ b/frontend/src/components/twenty48/GameOverlay.tsx
@@ -60,6 +60,8 @@ export default function GameOverlay({
             borderTopColor: accentColor,
           },
         ]}
+        accessibilityRole="dialog"
+        accessibilityViewIsModal
       >
         <Text
           style={[styles.title, { color: colors.text, fontFamily: typography.heading }]}


### PR DESCRIPTION
## Root cause

`AnimationOverlay` fades in over 300 ms (`opacity: 0 → 1` via Reanimated). The axe tests only waited for overlay text to appear in the DOM (`getByText("Game Over").waitFor()`), which resolves at mount while the `Animated.View` is still mid-animation.

Axe's contrast algorithm traverses CSS stacking contexts and composites parent `opacity` into effective fg/bg values. At `opacity ≈ 0.71`:

| Token | Theoretical | Axe-computed at ~0.71 | Threshold |
|---|---|---|---|
| `textMuted` (#a0a0ac) fg | 5.83:1 on surfaceHigh | 3.5:1 (#75757f on #212128) | 4.5:1 ❌ |
| `secondary` (#d674ff) fg | 5.66:1 on surfaceHigh | 2.84:1 (#9a57b8 on #352a3f) | 3:1 ❌ |

The win overlay didn't fail consistently because `colors.accent` (`#8ff5ff`, high-luminance cyan) retains sufficient contrast even at partial opacity. `colors.secondary` (purple) doesn't.

Working derivation: `#a0a0ac * 0.706 + #0e0e13 * 0.294 = #75757f` — exactly the axe-reported value.

## Fix

**Test:** add `await expect(page.getByTestId("animation-overlay")).toHaveCSS("opacity", "1")` before each `axe.analyze()` call on overlay states. Applied to both the game-over and win overlay tests (preventive on win).

**Component:** add `accessibilityRole="dialog"` + `accessibilityViewIsModal` to `GameOverlay`'s card `View` — correct modal a11y semantics that hide background content from screen readers when the overlay is shown.

## Test plan

- [ ] `no axe violations on game-over overlay` — passes consistently (no longer races the animation)
- [ ] `no axe violations on win overlay` — still passes
- [ ] All other `twenty48-a11y` tests — unaffected
- [ ] `AnimationOverlay` behaviour unchanged — `opacity:1` assertion times out only if Reanimated stops working, which would be a real failure

Closes #1743

🤖 Generated with [Claude Code](https://claude.ai/claude-code)