### PR TITLE
fix(starswarm): block game during difficulty picker + add 3-2-1 wave countdown

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -89,6 +89,7 @@ interface Props {
 interface RenderState {
   game: StarSwarmState;
   sf: StarfieldState;
+  countdownDigit: number | null;
 }
 
 const GameCanvas = forwardRef<GameCanvasHandle, Props>(
@@ -138,6 +139,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     devOptionsRef.current = devOptions;
     const difficultyRef = useRef<DifficultyTier>(difficultyProp);
     difficultyRef.current = difficultyProp;
+    // ms remaining in pre-wave countdown; null = no countdown active.
+    // Restored sessions skip the countdown; new games and each new wave get 3 s.
+    const countdownMsRef = useRef<number | null>(initialState ? null : 3000);
     const lastFrameTimeRef = useRef(0);
     const prevScoreRef = useRef(0);
     const prevLivesRef = useRef(gameRef.current.player.lives);
@@ -197,6 +201,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     const [renderState, setRenderState] = useState<RenderState>({
       game: gameRef.current,
       sf: sfRef.current,
+      countdownDigit: initialState ? null : 3,
     });
 
     useImperativeHandle(
@@ -232,6 +237,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         opts?.difficulty ?? difficultyRef.current
       );
       sfRef.current = initStarfield(width, height);
+      countdownMsRef.current = 3000;
       lastFrameTimeRef.current = 0;
       inputRef.current.playerX = width / 2;
       inputRef.current.fire = true;
@@ -240,7 +246,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       prevPhaseRef.current = gameRef.current.phase;
       prevBonusLivesRef.current = gameRef.current.bonusLivesAwarded;
       bonusFlashEndRef.current = 0;
-      setRenderState({ game: gameRef.current, sf: sfRef.current });
+      setRenderState({ game: gameRef.current, sf: sfRef.current, countdownDigit: 3 });
     }, [resetTick, width, height]);
 
     // RAF game loop — drives both engine tick and Skia re-renders
@@ -261,84 +267,102 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
 
         const prev = gameRef.current;
         if (prev.phase !== "GameOver" && !isPausedRef.current) {
-          try {
-            const prevCooldown = prev.player.shootCooldown;
-            // #1039: apply pauseStraggler from devOptions each tick
-            const pauseStraggler = devOptionsRef.current?.pauseStraggler ?? false;
-            const playerFireDisabled = devOptionsRef.current?.playerFireDisabled ?? false;
-            const enemyFireDisabled = devOptionsRef.current?.enemyFireDisabled ?? false;
-            let tickInput =
-              prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
-            if (tickInput.playerFireDisabled !== playerFireDisabled)
-              tickInput = { ...tickInput, playerFireDisabled };
-            if (tickInput.enemyFireDisabled !== enemyFireDisabled)
-              tickInput = { ...tickInput, enemyFireDisabled };
-            const next = tick(tickInput, dtMs, {
-              playerX: inputRef.current.playerX,
-              fire: inputRef.current.fire,
-            });
+          if (countdownMsRef.current !== null) {
+            // Pre-wave countdown: freeze engine, tick the timer only
+            countdownMsRef.current = Math.max(0, countdownMsRef.current - dtMs);
+            if (countdownMsRef.current === 0) countdownMsRef.current = null;
+          } else {
+            try {
+              const prevCooldown = prev.player.shootCooldown;
+              // #1039: apply pauseStraggler from devOptions each tick
+              const pauseStraggler = devOptionsRef.current?.pauseStraggler ?? false;
+              const playerFireDisabled = devOptionsRef.current?.playerFireDisabled ?? false;
+              const enemyFireDisabled = devOptionsRef.current?.enemyFireDisabled ?? false;
+              let tickInput =
+                prev.pauseStraggler !== pauseStraggler ? { ...prev, pauseStraggler } : prev;
+              if (tickInput.playerFireDisabled !== playerFireDisabled)
+                tickInput = { ...tickInput, playerFireDisabled };
+              if (tickInput.enemyFireDisabled !== enemyFireDisabled)
+                tickInput = { ...tickInput, enemyFireDisabled };
+              const next = tick(tickInput, dtMs, {
+                playerX: inputRef.current.playerX,
+                fire: inputRef.current.fire,
+              });
 
-            // Dev: when infinite lives is on, intercept any lives decrement and
-            // restore lives + phase so the game never transitions to GameOver.
-            let applied = next;
-            if (infiniteLivesRef.current && next.player.lives < prevLivesRef.current) {
-              applied = {
-                ...next,
-                phase: next.phase === "GameOver" ? prevPhaseRef.current : next.phase,
-                player: { ...next.player, lives: prevLivesRef.current, invincibleTimer: 2000 },
-              };
-            }
+              // Dev: when infinite lives is on, intercept any lives decrement and
+              // restore lives + phase so the game never transitions to GameOver.
+              let applied = next;
+              if (infiniteLivesRef.current && next.player.lives < prevLivesRef.current) {
+                applied = {
+                  ...next,
+                  phase: next.phase === "GameOver" ? prevPhaseRef.current : next.phase,
+                  player: { ...next.player, lives: prevLivesRef.current, invincibleTimer: 2000 },
+                };
+              }
 
-            gameRef.current = applied;
-            if (applied.score !== prevScoreRef.current) {
-              prevScoreRef.current = applied.score;
-              onScoreChangeRef.current?.(applied.score);
+              gameRef.current = applied;
+              if (applied.score !== prevScoreRef.current) {
+                prevScoreRef.current = applied.score;
+                onScoreChangeRef.current?.(applied.score);
+              }
+              if (
+                applied.player.shootCooldown > prevCooldown &&
+                applied.activePowerUp?.type === "lightning"
+              ) {
+                onLaserFireRef.current?.();
+              }
+              if (applied.explosions.length > prev.explosions.length) {
+                onExplosionRef.current?.();
+              }
+              if (applied.player.lives < prevLivesRef.current) {
+                if (applied.phase !== "GameOver") onPlayerHitRef.current?.();
+              }
+              prevLivesRef.current = applied.player.lives;
+              if (applied.bonusLivesAwarded > prevBonusLivesRef.current) {
+                onBonusLifeRef.current?.();
+                bonusFlashEndRef.current = Date.now() + 1500;
+              }
+              prevBonusLivesRef.current = applied.bonusLivesAwarded;
+              const nowType = applied.activePowerUp?.type ?? null;
+              if (prevActivePowerUpRef.current === null && nowType !== null) {
+                onPowerUpCollectRef.current?.(nowType);
+              }
+              prevActivePowerUpRef.current = nowType;
+              if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
+                onWaveClearRef.current?.();
+                if (applied.challengingPerfect) onChallengingPerfectRef.current?.();
+              }
+              if (
+                applied.phase === "ChallengingStage" &&
+                prevPhaseRef.current !== "ChallengingStage"
+              ) {
+                onChallengingStageRef.current?.();
+              }
+              // Start countdown when WaveClear ends and the next wave begins
+              if (
+                prevPhaseRef.current === "WaveClear" &&
+                applied.phase !== "WaveClear" &&
+                applied.phase !== "GameOver"
+              ) {
+                countdownMsRef.current = 3000;
+              }
+              prevPhaseRef.current = applied.phase;
+              if (applied.phase === "GameOver") {
+                onGameOverRef.current?.(applied.score, applied.wave);
+              }
+            } catch (e) {
+              Sentry.captureException(e, { tags: { subsystem: "starswarm.loop" } });
             }
-            if (
-              applied.player.shootCooldown > prevCooldown &&
-              applied.activePowerUp?.type === "lightning"
-            ) {
-              onLaserFireRef.current?.();
-            }
-            if (applied.explosions.length > prev.explosions.length) {
-              onExplosionRef.current?.();
-            }
-            if (applied.player.lives < prevLivesRef.current) {
-              if (applied.phase !== "GameOver") onPlayerHitRef.current?.();
-            }
-            prevLivesRef.current = applied.player.lives;
-            if (applied.bonusLivesAwarded > prevBonusLivesRef.current) {
-              onBonusLifeRef.current?.();
-              bonusFlashEndRef.current = Date.now() + 1500;
-            }
-            prevBonusLivesRef.current = applied.bonusLivesAwarded;
-            const nowType = applied.activePowerUp?.type ?? null;
-            if (prevActivePowerUpRef.current === null && nowType !== null) {
-              onPowerUpCollectRef.current?.(nowType);
-            }
-            prevActivePowerUpRef.current = nowType;
-            if (applied.phase === "WaveClear" && prevPhaseRef.current !== "WaveClear") {
-              onWaveClearRef.current?.();
-              if (applied.challengingPerfect) onChallengingPerfectRef.current?.();
-            }
-            if (
-              applied.phase === "ChallengingStage" &&
-              prevPhaseRef.current !== "ChallengingStage"
-            ) {
-              onChallengingStageRef.current?.();
-            }
-            prevPhaseRef.current = applied.phase;
-            if (applied.phase === "GameOver") {
-              onGameOverRef.current?.(applied.score, applied.wave);
-            }
-          } catch (e) {
-            Sentry.captureException(e, { tags: { subsystem: "starswarm.loop" } });
           }
         }
         // Starfield scrolls continuously
         sfRef.current = tickStarfield(sfRef.current, dtMs);
 
-        setRenderState({ game: gameRef.current, sf: sfRef.current });
+        const countdownDigit =
+          countdownMsRef.current !== null
+            ? Math.max(1, Math.ceil(countdownMsRef.current / 1000))
+            : null;
+        setRenderState({ game: gameRef.current, sf: sfRef.current, countdownDigit });
         id = requestAnimationFrame(loop);
       }
 
@@ -346,7 +370,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       return () => cancelAnimationFrame(id);
     }, []); // intentionally empty — loop lives for component lifetime
 
-    const { game: state, sf } = renderState;
+    const { game: state, sf, countdownDigit } = renderState;
     const { player } = state;
     const displayW = Math.round(width * scale);
     const displayH = Math.round(height * scale);
@@ -707,7 +731,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             </View>
           )}
 
-          {state.phase === "WaveClear" && (
+          {countdownDigit !== null && (
+            <View style={styles.phaseOverlay} pointerEvents="none">
+              <Text style={styles.countdownText}>{countdownDigit}</Text>
+            </View>
+          )}
+
+          {state.phase === "WaveClear" && countdownDigit === null && (
             <View style={styles.phaseOverlay}>
               <Text style={styles.overlayTitle}>{t("phase.waveClear")}</Text>
               {state.challengingPerfect && (
@@ -716,7 +746,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             </View>
           )}
 
-          {state.phase === "ChallengingStage" && (
+          {state.phase === "ChallengingStage" && countdownDigit === null && (
             <View style={styles.phaseOverlay}>
               <Text style={[styles.overlayTitle, styles.challengingTitle]}>
                 {t("phase.challengingStage")}
@@ -820,6 +850,14 @@ const styles = StyleSheet.create({
     textShadowColor: "#ff8800",
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 8,
+  },
+  countdownText: {
+    color: "#00ffcc",
+    fontSize: 96,
+    fontWeight: "bold",
+    textShadowColor: "#00ffcc",
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 24,
   },
   gameOverOverlay: {
     backgroundColor: "rgba(0,0,0,0.65)",

--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -141,7 +141,9 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
     difficultyRef.current = difficultyProp;
     // ms remaining in pre-wave countdown; null = no countdown active.
     // Restored sessions skip the countdown; new games and each new wave get 3 s.
+    // countdownDigit in renderState must be initialized consistently with this value.
     const countdownMsRef = useRef<number | null>(initialState ? null : 3000);
+    const pendingChallengingStageRef = useRef(false);
     const lastFrameTimeRef = useRef(0);
     const prevScoreRef = useRef(0);
     const prevLivesRef = useRef(gameRef.current.player.lives);
@@ -246,6 +248,7 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
       prevPhaseRef.current = gameRef.current.phase;
       prevBonusLivesRef.current = gameRef.current.bonusLivesAwarded;
       bonusFlashEndRef.current = 0;
+      pendingChallengingStageRef.current = false;
       setRenderState({ game: gameRef.current, sf: sfRef.current, countdownDigit: 3 });
     }, [resetTick, width, height]);
 
@@ -270,7 +273,13 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
           if (countdownMsRef.current !== null) {
             // Pre-wave countdown: freeze engine, tick the timer only
             countdownMsRef.current = Math.max(0, countdownMsRef.current - dtMs);
-            if (countdownMsRef.current === 0) countdownMsRef.current = null;
+            if (countdownMsRef.current === 0) {
+              countdownMsRef.current = null;
+              if (pendingChallengingStageRef.current) {
+                pendingChallengingStageRef.current = false;
+                onChallengingStageRef.current?.();
+              }
+            }
           } else {
             try {
               const prevCooldown = prev.player.shootCooldown;
@@ -332,19 +341,24 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                 onWaveClearRef.current?.();
                 if (applied.challengingPerfect) onChallengingPerfectRef.current?.();
               }
+              // Start countdown when WaveClear ends. Evaluated before phase callbacks so
+              // onChallengingStage fires after the countdown expires, not during it.
+              // prevPhaseRef.current is updated below — after this check — so the WaveClear
+              // guard remains valid for the full duration of this tick.
+              const startingCountdown =
+                prevPhaseRef.current === "WaveClear" &&
+                applied.phase !== "WaveClear" &&
+                applied.phase !== "GameOver";
+              if (startingCountdown) countdownMsRef.current = 3000;
               if (
                 applied.phase === "ChallengingStage" &&
                 prevPhaseRef.current !== "ChallengingStage"
               ) {
-                onChallengingStageRef.current?.();
-              }
-              // Start countdown when WaveClear ends and the next wave begins
-              if (
-                prevPhaseRef.current === "WaveClear" &&
-                applied.phase !== "WaveClear" &&
-                applied.phase !== "GameOver"
-              ) {
-                countdownMsRef.current = 3000;
+                if (startingCountdown) {
+                  pendingChallengingStageRef.current = true;
+                } else {
+                  onChallengingStageRef.current?.();
+                }
               }
               prevPhaseRef.current = applied.phase;
               if (applied.phase === "GameOver") {

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -274,7 +274,7 @@ export default function StarSwarmScreen() {
               onChallengingStage={playChallengingStage}
               onChallengingPerfect={handleChallengingPerfect}
               onBonusLife={handleBonusLife}
-              isPaused={isPaused}
+              isPaused={isPaused || showDifficultyPicker}
               onPause={handlePause}
               width={CANVAS_W}
               height={CANVAS_H}


### PR DESCRIPTION
Closes #1757

## Summary

- **Bug fix:** game was ticking (enemies moving/shooting) behind the difficulty selection modal. Fixed by passing `isPaused={isPaused || showDifficultyPicker}` to `GameCanvas` in `StarSwarmScreen.tsx`.
- **Feature:** 3-2-1 countdown before every wave. On new game start and after each WaveClear→SwoopIn/ChallengingStage transition, a 3-second freeze is applied. Engine tick is skipped while the countdown runs; starfield still scrolls. A large neon digit **3 → 2 → 1** is displayed centered on screen. When it clears, SwoopIn animations begin normally.
- Restored (paused) sessions skip the countdown so resume UX is unaffected.

## Changed files

| File | Change |
|------|--------|
| `frontend/src/screens/StarSwarmScreen.tsx` | Pass `isPaused \|\| showDifficultyPicker` to GameCanvas |
| `frontend/src/components/starswarm/GameCanvas.tsx` | `countdownMsRef` + countdown RAF logic + overlay + style |

## Test plan

- [ ] Open Star Swarm — difficulty picker appears, no enemies moving behind it
- [ ] Select a difficulty and tap Start — see **3, 2, 1** countdown before swarm flies in
- [ ] Play through a wave — after WAVE CLEAR, see **3, 2, 1** before next swarm
- [ ] Play to wave 3 (Challenging Stage) — countdown appears before challenge enemies enter
- [ ] Pause mid-game and resume — no countdown on resume
- [ ] Back out during a game, re-enter (restored session) — no countdown, game resumes normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVdtf8hEYBZ3j8MPavvyrC)_