### PR TITLE
test(cascade): v2 TDD — engine2.test.ts before implementation (#1749)

### DIFF
--- a/frontend/src/game/cascade/__tests__/engine2.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine2.test.ts
@@ -1,5 +1,5 @@
-import { CascadeEngine, type EngineEvent, type StepResult } from '../engine2';
-import { PIECE_DEFS, MAX_TIER } from '../pieceDefs';
+import { CascadeEngine, type EngineEvent, type StepResult } from "../engine2";
+import { PIECE_DEFS, MAX_TIER } from "../pieceDefs";
 import {
   WORLD_WIDTH,
   WORLD_HEIGHT,
@@ -7,7 +7,7 @@ import {
   FLOOR_THICKNESS,
   OVERFLOW_LINE_Y,
   OVERFLOW_TICKS_THRESHOLD,
-} from '../constants';
+} from "../constants";
 
 function runSteps(engine: CascadeEngine, count: number): StepResult[] {
   const results: StepResult[] = [];
@@ -21,37 +21,37 @@ function allEvents(results: StepResult[]): EngineEvent[] {
   return results.flatMap((r) => r.events);
 }
 
-describe('CascadeEngine — construction', () => {
-  it('constructs without throwing', () => {
+describe("CascadeEngine — construction", () => {
+  it("constructs without throwing", () => {
     expect(() => new CascadeEngine({})).not.toThrow();
   });
 
-  it('getState() returns initial empty state', () => {
+  it("getState() returns initial empty state", () => {
     const engine = new CascadeEngine({});
     expect(engine.getState()).toEqual({ pieces: [], score: 0, gameOver: false });
   });
 });
 
-describe('CascadeEngine — drop', () => {
-  it('adds a piece to the world', () => {
+describe("CascadeEngine — drop", () => {
+  it("adds a piece to the world", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     expect(engine.getState().pieces).toHaveLength(1);
   });
 
-  it('dropped piece has the correct tier', () => {
+  it("dropped piece has the correct tier", () => {
     const engine = new CascadeEngine({});
     engine.drop(2, 200);
     expect(engine.getState().pieces[0]!.tier).toBe(2);
   });
 
-  it('dropped piece x position matches the specified x (within tolerance)', () => {
+  it("dropped piece x position matches the specified x (within tolerance)", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 150);
     expect(engine.getState().pieces[0]!.x).toBeCloseTo(150, 0);
   });
 
-  it('dropping the same tier twice gives 2 pieces', () => {
+  it("dropping the same tier twice gives 2 pieces", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 100);
     engine.drop(0, 300);
@@ -59,8 +59,8 @@ describe('CascadeEngine — drop', () => {
   });
 });
 
-describe('CascadeEngine — physics / falling', () => {
-  it('after N steps, a dropped piece y position is greater than its starting y', () => {
+describe("CascadeEngine — physics / falling", () => {
+  it("after N steps, a dropped piece y position is greater than its starting y", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     const initialY = engine.getState().pieces[0]!.y;
@@ -68,7 +68,7 @@ describe('CascadeEngine — physics / falling', () => {
     expect(engine.getState().pieces[0]!.y).toBeGreaterThan(initialY);
   });
 
-  it('after enough steps, a dropped piece reaches near the floor', () => {
+  it("after enough steps, a dropped piece reaches near the floor", () => {
     const engine = new CascadeEngine({});
     const tier = 0;
     const radius = (PIECE_DEFS[tier]!.shape as { radius: number }).radius;
@@ -78,40 +78,40 @@ describe('CascadeEngine — physics / falling', () => {
     expect(engine.getState().pieces[0]!.y).toBeGreaterThan(floorY - radius * 2);
   });
 
-  it('a piece dropped near the left wall stays inside the left wall boundary', () => {
+  it("a piece dropped near the left wall stays inside the left wall boundary", () => {
     const engine = new CascadeEngine({});
-    engine.drop(0, WALL_THICKNESS + 1);
+    const tier = 0;
+    const radius = (PIECE_DEFS[tier]!.shape as { radius: number }).radius;
+    engine.drop(tier, WALL_THICKNESS + 1);
     runSteps(engine, 300);
-    expect(engine.getState().pieces[0]!.x).toBeGreaterThanOrEqual(WALL_THICKNESS);
+    // centroid must clear the wall by at least the piece radius
+    expect(engine.getState().pieces[0]!.x).toBeGreaterThanOrEqual(WALL_THICKNESS + radius);
   });
 
-  it('a piece dropped near the right wall stays inside the right wall boundary', () => {
+  it("a piece dropped near the right wall stays inside the right wall boundary", () => {
     const engine = new CascadeEngine({});
-    engine.drop(0, WORLD_WIDTH - WALL_THICKNESS - 1);
+    const tier = 0;
+    const radius = (PIECE_DEFS[tier]!.shape as { radius: number }).radius;
+    engine.drop(tier, WORLD_WIDTH - WALL_THICKNESS - 1);
     runSteps(engine, 300);
-    expect(engine.getState().pieces[0]!.x).toBeLessThanOrEqual(WORLD_WIDTH - WALL_THICKNESS);
+    // centroid must clear the wall by at least the piece radius
+    expect(engine.getState().pieces[0]!.x).toBeLessThanOrEqual(
+      WORLD_WIDTH - WALL_THICKNESS - radius
+    );
   });
 });
 
-describe('CascadeEngine — merge', () => {
-  it('two tier-0 pieces dropped at the same x → merge event fires', () => {
+describe("CascadeEngine — merge", () => {
+  it("merge event fires with correct shape: { type, tierA, tierB, result }", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     engine.drop(0, 200);
     const results = runSteps(engine, 600);
-    expect(allEvents(results).some((e) => e.type === 'merge')).toBe(true);
+    const mergeEvent = allEvents(results).find((e) => e.type === "merge");
+    expect(mergeEvent).toMatchObject({ type: "merge", tierA: 0, tierB: 0, result: 1 });
   });
 
-  it('merge event shape: { type, tierA, tierB, result }', () => {
-    const engine = new CascadeEngine({});
-    engine.drop(0, 200);
-    engine.drop(0, 200);
-    const results = runSteps(engine, 600);
-    const mergeEvent = allEvents(results).find((e) => e.type === 'merge');
-    expect(mergeEvent).toMatchObject({ type: 'merge', tierA: 0, tierB: 0, result: 1 });
-  });
-
-  it('after merge, getState().pieces has 1 piece (not 2)', () => {
+  it("after merge, getState().pieces has 1 piece (not 2)", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     engine.drop(0, 200);
@@ -119,7 +119,7 @@ describe('CascadeEngine — merge', () => {
     expect(engine.getState().pieces).toHaveLength(1);
   });
 
-  it('remaining piece after merge has tier 1', () => {
+  it("remaining piece after merge has tier 1", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     engine.drop(0, 200);
@@ -127,7 +127,7 @@ describe('CascadeEngine — merge', () => {
     expect(engine.getState().pieces[0]!.tier).toBe(1);
   });
 
-  it('score increases by PIECE_DEFS[1].scoreValue after a tier-0 + tier-0 merge', () => {
+  it("score increases by PIECE_DEFS[1].scoreValue after a tier-0 + tier-0 merge", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
     engine.drop(0, 200);
@@ -135,7 +135,7 @@ describe('CascadeEngine — merge', () => {
     expect(engine.getState().score).toBe(PIECE_DEFS[1]!.scoreValue);
   });
 
-  it('merging the highest tier does not crash — result is capped or handled gracefully', () => {
+  it("merging the highest tier does not crash — result is capped or handled gracefully", () => {
     const engine = new CascadeEngine({});
     engine.drop(MAX_TIER, 200);
     engine.drop(MAX_TIER, 200);
@@ -143,12 +143,13 @@ describe('CascadeEngine — merge', () => {
   });
 });
 
-describe('CascadeEngine — game over', () => {
-  // Fill the world by repeatedly dropping large pieces and letting them stack
+describe("CascadeEngine — game over", () => {
+  // Alternate between two adjacent tiers so pieces do not merge with each other,
+  // guaranteeing vertical stacking rather than merges that reduce piece count.
   function overflowWorld(engine: CascadeEngine): StepResult[] {
     const all: StepResult[] = [];
     for (let i = 0; i < 25; i++) {
-      engine.drop(MAX_TIER, WORLD_WIDTH / 2);
+      engine.drop(i % 2 === 0 ? MAX_TIER - 2 : MAX_TIER - 1, WORLD_WIDTH / 2);
       all.push(...runSteps(engine, 8));
     }
     all.push(...runSteps(engine, OVERFLOW_TICKS_THRESHOLD + 60));
@@ -158,16 +159,16 @@ describe('CascadeEngine — game over', () => {
   it(`stacking pieces above OVERFLOW_LINE_Y (y=${OVERFLOW_LINE_Y}) for ${OVERFLOW_TICKS_THRESHOLD} ticks → gameOver event fires`, () => {
     const engine = new CascadeEngine({});
     const results = overflowWorld(engine);
-    expect(allEvents(results).some((e) => e.type === 'gameOver')).toBe(true);
+    expect(allEvents(results).some((e) => e.type === "gameOver")).toBe(true);
   });
 
-  it('after gameOver event, getState().gameOver is true', () => {
+  it("after gameOver event, getState().gameOver is true", () => {
     const engine = new CascadeEngine({});
     overflowWorld(engine);
     expect(engine.getState().gameOver).toBe(true);
   });
 
-  it('drop() after game-over is a no-op — no new piece added', () => {
+  it("drop() after game-over is a no-op — no new piece added", () => {
     const engine = new CascadeEngine({});
     overflowWorld(engine);
     const countBefore = engine.getState().pieces.length;
@@ -176,8 +177,8 @@ describe('CascadeEngine — game over', () => {
   });
 });
 
-describe('CascadeEngine — guard rails (no silent removal)', () => {
-  it('pieces count never decreases outside of a confirmed merge', () => {
+describe("CascadeEngine — guard rails (no silent removal)", () => {
+  it("pieces count never decreases outside of a confirmed merge", () => {
     const engine = new CascadeEngine({});
     // Use different tiers so they do not merge with each other
     engine.drop(0, 100);
@@ -185,24 +186,16 @@ describe('CascadeEngine — guard rails (no silent removal)', () => {
     let mergeCount = 0;
     for (let i = 0; i < 300; i++) {
       const result = engine.step(16.67);
-      mergeCount += result.events.filter((e) => e.type === 'merge').length;
+      mergeCount += result.events.filter((e) => e.type === "merge").length;
       expect(engine.getState().pieces.length).toBeGreaterThanOrEqual(2 - mergeCount);
     }
   });
 
-  it('if a piece leaves world bounds, guardRailFired event is emitted and piece is kept', () => {
-    // Normal play should not trigger this, but the engine must not silently delete pieces.
-    // We verify the invariant: pieces are preserved across a run.
+  it("piece is not silently removed during normal play", () => {
     const engine = new CascadeEngine({});
     engine.drop(0, 200);
-    const results = runSteps(engine, 300);
-    // If a guard rail fired, the piece must still be present (moved inside, not deleted)
-    const guardFired = allEvents(results).some((e) => e.type === 'guardRailFired');
-    if (guardFired) {
-      expect(engine.getState().pieces.length).toBeGreaterThanOrEqual(1);
-    } else {
-      // No guard rail needed in normal play — piece is still present
-      expect(engine.getState().pieces.length).toBe(1);
-    }
+    runSteps(engine, 300);
+    // The piece must still be present — guard rail moves OOB pieces back inside, never deletes them
+    expect(engine.getState().pieces).toHaveLength(1);
   });
 });

--- a/frontend/src/game/cascade/__tests__/engine2.test.ts
+++ b/frontend/src/game/cascade/__tests__/engine2.test.ts
@@ -1,0 +1,208 @@
+import { CascadeEngine, type EngineEvent, type StepResult } from '../engine2';
+import { PIECE_DEFS, MAX_TIER } from '../pieceDefs';
+import {
+  WORLD_WIDTH,
+  WORLD_HEIGHT,
+  WALL_THICKNESS,
+  FLOOR_THICKNESS,
+  OVERFLOW_LINE_Y,
+  OVERFLOW_TICKS_THRESHOLD,
+} from '../constants';
+
+function runSteps(engine: CascadeEngine, count: number): StepResult[] {
+  const results: StepResult[] = [];
+  for (let i = 0; i < count; i++) {
+    results.push(engine.step(16.67));
+  }
+  return results;
+}
+
+function allEvents(results: StepResult[]): EngineEvent[] {
+  return results.flatMap((r) => r.events);
+}
+
+describe('CascadeEngine — construction', () => {
+  it('constructs without throwing', () => {
+    expect(() => new CascadeEngine({})).not.toThrow();
+  });
+
+  it('getState() returns initial empty state', () => {
+    const engine = new CascadeEngine({});
+    expect(engine.getState()).toEqual({ pieces: [], score: 0, gameOver: false });
+  });
+});
+
+describe('CascadeEngine — drop', () => {
+  it('adds a piece to the world', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    expect(engine.getState().pieces).toHaveLength(1);
+  });
+
+  it('dropped piece has the correct tier', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(2, 200);
+    expect(engine.getState().pieces[0]!.tier).toBe(2);
+  });
+
+  it('dropped piece x position matches the specified x (within tolerance)', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 150);
+    expect(engine.getState().pieces[0]!.x).toBeCloseTo(150, 0);
+  });
+
+  it('dropping the same tier twice gives 2 pieces', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 100);
+    engine.drop(0, 300);
+    expect(engine.getState().pieces).toHaveLength(2);
+  });
+});
+
+describe('CascadeEngine — physics / falling', () => {
+  it('after N steps, a dropped piece y position is greater than its starting y', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    const initialY = engine.getState().pieces[0]!.y;
+    runSteps(engine, 30);
+    expect(engine.getState().pieces[0]!.y).toBeGreaterThan(initialY);
+  });
+
+  it('after enough steps, a dropped piece reaches near the floor', () => {
+    const engine = new CascadeEngine({});
+    const tier = 0;
+    const radius = (PIECE_DEFS[tier]!.shape as { radius: number }).radius;
+    engine.drop(tier, 200);
+    runSteps(engine, 300);
+    const floorY = WORLD_HEIGHT - FLOOR_THICKNESS;
+    expect(engine.getState().pieces[0]!.y).toBeGreaterThan(floorY - radius * 2);
+  });
+
+  it('a piece dropped near the left wall stays inside the left wall boundary', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, WALL_THICKNESS + 1);
+    runSteps(engine, 300);
+    expect(engine.getState().pieces[0]!.x).toBeGreaterThanOrEqual(WALL_THICKNESS);
+  });
+
+  it('a piece dropped near the right wall stays inside the right wall boundary', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, WORLD_WIDTH - WALL_THICKNESS - 1);
+    runSteps(engine, 300);
+    expect(engine.getState().pieces[0]!.x).toBeLessThanOrEqual(WORLD_WIDTH - WALL_THICKNESS);
+  });
+});
+
+describe('CascadeEngine — merge', () => {
+  it('two tier-0 pieces dropped at the same x → merge event fires', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    engine.drop(0, 200);
+    const results = runSteps(engine, 600);
+    expect(allEvents(results).some((e) => e.type === 'merge')).toBe(true);
+  });
+
+  it('merge event shape: { type, tierA, tierB, result }', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    engine.drop(0, 200);
+    const results = runSteps(engine, 600);
+    const mergeEvent = allEvents(results).find((e) => e.type === 'merge');
+    expect(mergeEvent).toMatchObject({ type: 'merge', tierA: 0, tierB: 0, result: 1 });
+  });
+
+  it('after merge, getState().pieces has 1 piece (not 2)', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    engine.drop(0, 200);
+    runSteps(engine, 600);
+    expect(engine.getState().pieces).toHaveLength(1);
+  });
+
+  it('remaining piece after merge has tier 1', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    engine.drop(0, 200);
+    runSteps(engine, 600);
+    expect(engine.getState().pieces[0]!.tier).toBe(1);
+  });
+
+  it('score increases by PIECE_DEFS[1].scoreValue after a tier-0 + tier-0 merge', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    engine.drop(0, 200);
+    runSteps(engine, 600);
+    expect(engine.getState().score).toBe(PIECE_DEFS[1]!.scoreValue);
+  });
+
+  it('merging the highest tier does not crash — result is capped or handled gracefully', () => {
+    const engine = new CascadeEngine({});
+    engine.drop(MAX_TIER, 200);
+    engine.drop(MAX_TIER, 200);
+    expect(() => runSteps(engine, 600)).not.toThrow();
+  });
+});
+
+describe('CascadeEngine — game over', () => {
+  // Fill the world by repeatedly dropping large pieces and letting them stack
+  function overflowWorld(engine: CascadeEngine): StepResult[] {
+    const all: StepResult[] = [];
+    for (let i = 0; i < 25; i++) {
+      engine.drop(MAX_TIER, WORLD_WIDTH / 2);
+      all.push(...runSteps(engine, 8));
+    }
+    all.push(...runSteps(engine, OVERFLOW_TICKS_THRESHOLD + 60));
+    return all;
+  }
+
+  it(`stacking pieces above OVERFLOW_LINE_Y (y=${OVERFLOW_LINE_Y}) for ${OVERFLOW_TICKS_THRESHOLD} ticks → gameOver event fires`, () => {
+    const engine = new CascadeEngine({});
+    const results = overflowWorld(engine);
+    expect(allEvents(results).some((e) => e.type === 'gameOver')).toBe(true);
+  });
+
+  it('after gameOver event, getState().gameOver is true', () => {
+    const engine = new CascadeEngine({});
+    overflowWorld(engine);
+    expect(engine.getState().gameOver).toBe(true);
+  });
+
+  it('drop() after game-over is a no-op — no new piece added', () => {
+    const engine = new CascadeEngine({});
+    overflowWorld(engine);
+    const countBefore = engine.getState().pieces.length;
+    engine.drop(0, 200);
+    expect(engine.getState().pieces).toHaveLength(countBefore);
+  });
+});
+
+describe('CascadeEngine — guard rails (no silent removal)', () => {
+  it('pieces count never decreases outside of a confirmed merge', () => {
+    const engine = new CascadeEngine({});
+    // Use different tiers so they do not merge with each other
+    engine.drop(0, 100);
+    engine.drop(1, 300);
+    let mergeCount = 0;
+    for (let i = 0; i < 300; i++) {
+      const result = engine.step(16.67);
+      mergeCount += result.events.filter((e) => e.type === 'merge').length;
+      expect(engine.getState().pieces.length).toBeGreaterThanOrEqual(2 - mergeCount);
+    }
+  });
+
+  it('if a piece leaves world bounds, guardRailFired event is emitted and piece is kept', () => {
+    // Normal play should not trigger this, but the engine must not silently delete pieces.
+    // We verify the invariant: pieces are preserved across a run.
+    const engine = new CascadeEngine({});
+    engine.drop(0, 200);
+    const results = runSteps(engine, 300);
+    // If a guard rail fired, the piece must still be present (moved inside, not deleted)
+    const guardFired = allEvents(results).some((e) => e.type === 'guardRailFired');
+    if (guardFired) {
+      expect(engine.getState().pieces.length).toBeGreaterThanOrEqual(1);
+    } else {
+      // No guard rail needed in normal play — piece is still present
+      expect(engine.getState().pieces.length).toBe(1);
+    }
+  });
+});

--- a/frontend/src/game/cascade/engine2.ts
+++ b/frontend/src/game/cascade/engine2.ts
@@ -18,9 +18,9 @@ export interface GameState {
 }
 
 export type EngineEvent =
-  | { type: 'merge'; tierA: number; tierB: number; result: number }
-  | { type: 'gameOver' }
-  | { type: 'guardRailFired' };
+  | { type: "merge"; tierA: number; tierB: number; result: number }
+  | { type: "gameOver" }
+  | { type: "guardRailFired" };
 
 export interface StepResult {
   events: EngineEvent[];
@@ -28,18 +28,18 @@ export interface StepResult {
 
 export class CascadeEngine {
   constructor(_config: EngineConfig = {}) {
-    throw new Error('CascadeEngine: not yet implemented — see #1750');
+    throw new Error("CascadeEngine: not yet implemented — see #1750");
   }
 
   getState(): GameState {
-    throw new Error('not implemented');
+    throw new Error("not implemented");
   }
 
   drop(_tier: number, _x: number): void {
-    throw new Error('not implemented');
+    throw new Error("not implemented");
   }
 
   step(_dtMs: number): StepResult {
-    throw new Error('not implemented');
+    throw new Error("not implemented");
   }
 }

--- a/frontend/src/game/cascade/engine2.ts
+++ b/frontend/src/game/cascade/engine2.ts
@@ -1,0 +1,45 @@
+// Stub — types only. Implementation lands in #1750.
+
+export interface EngineConfig {
+  worldWidth?: number;
+  worldHeight?: number;
+}
+
+export interface PieceState {
+  tier: number;
+  x: number;
+  y: number;
+}
+
+export interface GameState {
+  pieces: PieceState[];
+  score: number;
+  gameOver: boolean;
+}
+
+export type EngineEvent =
+  | { type: 'merge'; tierA: number; tierB: number; result: number }
+  | { type: 'gameOver' }
+  | { type: 'guardRailFired' };
+
+export interface StepResult {
+  events: EngineEvent[];
+}
+
+export class CascadeEngine {
+  constructor(_config: EngineConfig = {}) {
+    throw new Error('CascadeEngine: not yet implemented — see #1750');
+  }
+
+  getState(): GameState {
+    throw new Error('not implemented');
+  }
+
+  drop(_tier: number, _x: number): void {
+    throw new Error('not implemented');
+  }
+
+  step(_dtMs: number): StepResult {
+    throw new Error('not implemented');
+  }
+}


### PR DESCRIPTION
## Summary

- Writes `frontend/src/game/cascade/__tests__/engine2.test.ts` with 21 tests covering all cases from #1749 (construction, drop, physics/falling, merge, game-over, guard rails)
- Adds `engine2.ts` stub (types only, constructor throws) so the test file compiles cleanly with no TypeScript errors
- All 21 tests are **red** — implementation lands in #1750

## Test plan

- [ ] `npx jest src/game/cascade/__tests__/engine2.test.ts --no-coverage` → 21 failed, 0 passed (expected)
- [ ] `npx tsc --noEmit --project tsconfig.json` → no errors touching engine2 files

Closes #1749

🤖 Generated with [Claude Code](https://claude.com/claude-code)