### PR TITLE
fix(mahjong): correct HUD_ROW_H 36→48 to fix zoom pan cutoff on large layouts

### DIFF
--- a/frontend/src/game/mahjong/__tests__/layout.test.ts
+++ b/frontend/src/game/mahjong/__tests__/layout.test.ts
@@ -94,8 +94,9 @@ describe("calculateMahjongLayout", () => {
       safeAreaBottom,
       ...TURTLE,
     });
-    // availH = screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H (116)
-    const availH = screenHeight - safeAreaTop - safeAreaBottom - 116;
+    // availH = screenHeight - safeAreaTop - safeAreaBottom - MAHJONG_CHROME_H (128)
+    // MAHJONG_CHROME_H = APP_HEADER_H(64) + HUD_ROW_H(48) + MIN_BOTTOM_PAD(16)
+    const availH = screenHeight - safeAreaTop - safeAreaBottom - 128;
     expect(l.boardHeight).toBeLessThanOrEqual(availH + 1); // allow 1px rounding
   });
 

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -143,7 +143,7 @@ const APP_HEADER_H = 64;
 // hudRow paddingVertical:8 (×2 = 16) + button minHeight:32 = 48
 const HUD_ROW_H = 48;
 const MIN_BOTTOM_PAD = 16;
-// App header + HUD row + bottom padding = 116
+// App header + HUD row + bottom padding = 128
 const MAHJONG_CHROME_H = APP_HEADER_H + HUD_ROW_H + MIN_BOTTOM_PAD;
 // Minimum horizontal margin on each side when safe-area insets are absent
 const MIN_HORIZ_MARGIN = 8;

--- a/frontend/src/game/mahjong/layout.ts
+++ b/frontend/src/game/mahjong/layout.ts
@@ -140,7 +140,8 @@ const PAD_Y_R = 14 / 44;
 
 // Keep APP_HEADER_H in sync with AppHeader.APP_HEADER_HEIGHT
 const APP_HEADER_H = 64;
-const HUD_ROW_H = 36;
+// hudRow paddingVertical:8 (×2 = 16) + button minHeight:32 = 48
+const HUD_ROW_H = 48;
 const MIN_BOTTOM_PAD = 16;
 // App header + HUD row + bottom padding = 116
 const MAHJONG_CHROME_H = APP_HEADER_H + HUD_ROW_H + MIN_BOTTOM_PAD;


### PR DESCRIPTION
## Summary

- `HUD_ROW_H` in `layout.ts` was hardcoded as 36pt but the actual rendered HUD row is **48pt** (button `minHeight:32` + `paddingVertical:8×2 = 16pt`).
- This 12pt undercount made `camera.viewportHeight` 12pt too large, causing the viewport container to overflow its allocated screen area and making `computePanBounds` compute a `maxTranslateY` ~6pt too small.
- Combined effect: ~18pt of the bottom of large layouts (spider, four rivers, etc.) was unreachable when zoomed in.

## Why it only appeared after #1737 (pan boundary clamping)

Before clamping, users could freely over-pan past the computed limit and naturally reach all tiles. After clamping, the floor is enforced and those ~18pt at the bottom become permanently inaccessible.

## Changes

- `frontend/src/game/mahjong/layout.ts`: `HUD_ROW_H: 36 → 48`
- `frontend/src/game/mahjong/__tests__/layout.test.ts`: update hardcoded chrome-height constant in assertion comment from 116 → 128

Fixes #1767. Applies to all 25 layouts.

## Test plan

- [ ] Open Spider layout, zoom to max, pan to bottom — all tile rows visible
- [ ] Open Turtle layout, zoom to max — board still fits with margin, no regression
- [ ] Rotate device to landscape — board re-fits correctly
- [ ] Layout unit test (`layout.test.ts`) passes with updated chrome height constant

https://claude.ai/code/session_01WgnryH3XKAPYnmK347zARE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgnryH3XKAPYnmK347zARE)_