### PR TITLE
feat(cascade): v2 piece preview queue — pure PieceQueue with SavedState v3 (#1756)

### DIFF
--- a/frontend/src/game/cascade/__tests__/pieceQueue2.test.ts
+++ b/frontend/src/game/cascade/__tests__/pieceQueue2.test.ts
@@ -25,14 +25,12 @@ describe("createPieceQueue", () => {
   });
 
   it("respects provided history for drought/streak avoidance", () => {
-    // Fill history with 4 of tier 0 → tier 0 should be banned (anti-streak)
+    // Anti-streak is a hard ban (weight = 0), not probabilistic — all seeds must avoid tier 0
     const history = [0, 0, 0, 0];
-    let banHit = false;
     for (let seed = 1; seed <= 50; seed++) {
       const q = createPieceQueue(history, seededRng(seed));
-      if (q.current !== 0) banHit = true;
+      expect(q.current).not.toBe(0);
     }
-    expect(banHit).toBe(true);
   });
 });
 
@@ -64,6 +62,23 @@ describe("advanceQueue", () => {
     advanceQueue(queue, [queue.current], false, rng);
     expect(queue.current).toBe(before.current);
     expect(queue.next).toBe(before.next);
+  });
+
+  it("suppresses high tiers in danger state", () => {
+    const highTiers = DROPPABLE_PIECE_TIERS.filter((t) => t >= 3);
+    const safe = Array.from({ length: 200 }, (_, i) => {
+      const rng = seededRng(i + 1);
+      const q = createPieceQueue([], rng);
+      return advanceQueue(q, [q.current], false, rng).next;
+    });
+    const danger = Array.from({ length: 200 }, (_, i) => {
+      const rng = seededRng(i + 1);
+      const q = createPieceQueue([], rng);
+      return advanceQueue(q, [q.current], true, rng).next;
+    });
+    const safeHigh = safe.filter((t) => highTiers.includes(t)).length;
+    const dangerHigh = danger.filter((t) => highTiers.includes(t)).length;
+    expect(dangerHigh).toBeLessThan(safeHigh);
   });
 
   it("chains correctly over multiple advances", () => {

--- a/frontend/src/game/cascade/__tests__/pieceQueue2.test.ts
+++ b/frontend/src/game/cascade/__tests__/pieceQueue2.test.ts
@@ -1,0 +1,85 @@
+import { createPieceQueue, advanceQueue } from "../pieceQueue2";
+import { DROPPABLE_PIECE_TIERS } from "../pieceDefs";
+
+function seededRng(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (Math.imul(48271, s) + (s >>> 16)) | 0;
+    return (s >>> 0) / 0x100000000;
+  };
+}
+
+describe("createPieceQueue", () => {
+  it("current and next are valid droppable tiers", () => {
+    for (let seed = 1; seed <= 30; seed++) {
+      const q = createPieceQueue([], seededRng(seed));
+      expect(DROPPABLE_PIECE_TIERS).toContain(q.current);
+      expect(DROPPABLE_PIECE_TIERS).toContain(q.next);
+    }
+  });
+
+  it("works with no arguments", () => {
+    const q = createPieceQueue();
+    expect(DROPPABLE_PIECE_TIERS).toContain(q.current);
+    expect(DROPPABLE_PIECE_TIERS).toContain(q.next);
+  });
+
+  it("respects provided history for drought/streak avoidance", () => {
+    // Fill history with 4 of tier 0 → tier 0 should be banned (anti-streak)
+    const history = [0, 0, 0, 0];
+    let banHit = false;
+    for (let seed = 1; seed <= 50; seed++) {
+      const q = createPieceQueue(history, seededRng(seed));
+      if (q.current !== 0) banHit = true;
+    }
+    expect(banHit).toBe(true);
+  });
+});
+
+describe("advanceQueue", () => {
+  it("sets current to old next", () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const rng = seededRng(seed);
+      const queue = createPieceQueue([], rng);
+      const history = [queue.current];
+      const advanced = advanceQueue(queue, history, false, rng);
+      expect(advanced.current).toBe(queue.next);
+    }
+  });
+
+  it("next is a valid droppable tier", () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const rng = seededRng(seed);
+      const queue = createPieceQueue([], rng);
+      const history = [queue.current];
+      const advanced = advanceQueue(queue, history, false, rng);
+      expect(DROPPABLE_PIECE_TIERS).toContain(advanced.next);
+    }
+  });
+
+  it("does not mutate the input queue", () => {
+    const rng = seededRng(7);
+    const queue = createPieceQueue([], rng);
+    const before = { current: queue.current, next: queue.next };
+    advanceQueue(queue, [queue.current], false, rng);
+    expect(queue.current).toBe(before.current);
+    expect(queue.next).toBe(before.next);
+  });
+
+  it("chains correctly over multiple advances", () => {
+    const rng = seededRng(42);
+    let q = createPieceQueue([], rng);
+    const history: number[] = [q.current, q.next];
+
+    for (let i = 0; i < 20; i++) {
+      const prevNext = q.next;
+      q = advanceQueue(q, history, false, rng);
+      history.push(q.next);
+      if (history.length > 10) history.shift();
+
+      expect(q.current).toBe(prevNext);
+      expect(DROPPABLE_PIECE_TIERS).toContain(q.current);
+      expect(DROPPABLE_PIECE_TIERS).toContain(q.next);
+    }
+  });
+});

--- a/frontend/src/game/cascade/__tests__/storage2.test.ts
+++ b/frontend/src/game/cascade/__tests__/storage2.test.ts
@@ -3,13 +3,14 @@ import * as Sentry from "@sentry/react-native";
 import { saveGame, loadGame, clearGame, looksValid } from "../storage2";
 import type { SavedState } from "../storage2";
 
-const STORAGE_KEY = "cascade_game_v2";
+const STORAGE_KEY = "cascade_game_v3";
 
 const makeSavedState = (overrides: Partial<SavedState> = {}): SavedState => ({
-  version: 2,
+  version: 3,
   pieces: [{ tier: 1, x: 100, y: 200 }],
   score: 42,
   savedAt: 1700000000000,
+  queue: { current: 0, next: 1 },
   ...overrides,
 });
 
@@ -22,8 +23,8 @@ describe("cascade storage2 — looksValid", () => {
     expect(looksValid(makeSavedState({ pieces: [] }))).toBe(true);
   });
 
-  it("returns false for version !== 2", () => {
-    expect(looksValid({ ...makeSavedState(), version: 1 })).toBe(false);
+  it("returns false for version !== 3", () => {
+    expect(looksValid({ ...makeSavedState(), version: 2 })).toBe(false);
   });
 
   it("returns false when pieces is not an array", () => {
@@ -40,6 +41,19 @@ describe("cascade storage2 — looksValid", () => {
 
   it("returns false when savedAt is not a number", () => {
     expect(looksValid({ ...makeSavedState(), savedAt: null as unknown as number })).toBe(false);
+  });
+
+  it("returns false when queue is missing", () => {
+    const { queue: _q, ...noQueue } = makeSavedState();
+    expect(looksValid(noQueue)).toBe(false);
+  });
+
+  it("returns false when queue.current is not a number", () => {
+    expect(looksValid({ ...makeSavedState(), queue: { current: "0", next: 1 } })).toBe(false);
+  });
+
+  it("returns false when queue.next is not a number", () => {
+    expect(looksValid({ ...makeSavedState(), queue: { current: 0, next: null } })).toBe(false);
   });
 
   it("returns false for null", () => {
@@ -76,8 +90,8 @@ describe("cascade storage2 — save / load roundtrip", () => {
     await expect(loadGame()).resolves.toBeNull();
   });
 
-  it("version !== 2 → looksValid returns false and loadGame returns null", async () => {
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ ...makeSavedState(), version: 1 }));
+  it("version !== 3 → looksValid returns false and loadGame returns null", async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ ...makeSavedState(), version: 2 }));
     expect(await loadGame()).toBeNull();
   });
 
@@ -126,6 +140,13 @@ describe("cascade storage2 — save / load roundtrip", () => {
     await saveGame(state);
     const loaded = await loadGame();
     expect(loaded?.pieces).toEqual(state.pieces);
+  });
+
+  it("preserves queue through save/load", async () => {
+    const state = makeSavedState({ queue: { current: 2, next: 4 } });
+    await saveGame(state);
+    const loaded = await loadGame();
+    expect(loaded?.queue).toEqual({ current: 2, next: 4 });
   });
 
   it("preserves score and savedAt through save/load", async () => {

--- a/frontend/src/game/cascade/pieceQueue2.ts
+++ b/frontend/src/game/cascade/pieceQueue2.ts
@@ -1,0 +1,21 @@
+import { selectNextTier } from "./spawnSelector2";
+
+export interface PieceQueue {
+  current: number;
+  next: number;
+}
+
+export function createPieceQueue(history: number[] = [], rng?: () => number): PieceQueue {
+  const current = selectNextTier(history, false, rng);
+  const next = selectNextTier([...history, current], false, rng);
+  return { current, next };
+}
+
+export function advanceQueue(
+  queue: PieceQueue,
+  history: number[],
+  isInDanger = false,
+  rng?: () => number
+): PieceQueue {
+  return { current: queue.next, next: selectNextTier(history, isInDanger, rng) };
+}

--- a/frontend/src/game/cascade/storage2.ts
+++ b/frontend/src/game/cascade/storage2.ts
@@ -1,31 +1,41 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 
-const GAME_KEY = "cascade_game_v2";
+const GAME_KEY = "cascade_game_v3";
 
 export interface SavedState {
-  version: 2;
+  version: 3;
   pieces: Array<{ tier: number; x: number; y: number }>;
   score: number;
   savedAt: number;
+  queue: { current: number; next: number };
 }
 
 export function looksValid(data: unknown): data is SavedState {
   if (typeof data !== "object" || data === null) return false;
   const d = data as Record<string, unknown>;
-  return (
-    d.version === 2 &&
-    Array.isArray(d.pieces) &&
-    (d.pieces as unknown[]).every(
+  if (
+    d.version !== 3 ||
+    !Array.isArray(d.pieces) ||
+    !(d.pieces as unknown[]).every(
       (p) =>
         typeof p === "object" &&
         p !== null &&
         typeof (p as Record<string, unknown>).tier === "number" &&
         typeof (p as Record<string, unknown>).x === "number" &&
         typeof (p as Record<string, unknown>).y === "number"
-    ) &&
-    typeof d.score === "number" &&
-    typeof d.savedAt === "number"
+    ) ||
+    typeof d.score !== "number" ||
+    typeof d.savedAt !== "number"
+  ) {
+    return false;
+  }
+  const q = d.queue as Record<string, unknown> | undefined;
+  return (
+    typeof q === "object" &&
+    q !== null &&
+    typeof q.current === "number" &&
+    typeof q.next === "number"
   );
 }
 

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -28,7 +28,8 @@ import {
   DANGER_STACK_MARGIN,
 } from "../game/cascade/constants";
 import { PIECE_DEFS } from "../game/cascade/pieceDefs";
-import { selectNextTier, DROUGHT_WINDOW } from "../game/cascade/spawnSelector2";
+import { DROUGHT_WINDOW } from "../game/cascade/spawnSelector2";
+import { PieceQueue, createPieceQueue, advanceQueue } from "../game/cascade/pieceQueue2";
 import NextFruitPreview from "../components/cascade/NextFruitPreview";
 import ScoreDisplay from "../components/cascade/ScoreDisplay";
 import ThemeSelector from "../components/cascade/ThemeSelector";
@@ -48,20 +49,6 @@ import {
 
 const SETTLE_TICKS = 60;
 
-class ControlledSpawnSelector {
-  private readonly rng: () => number;
-  private history: number[] = [];
-  constructor(rng?: () => number) {
-    this.rng = rng ?? Math.random;
-  }
-  next(isInDanger = false): FruitTier {
-    const tier = selectNextTier(this.history, isInDanger, this.rng) as FruitTier;
-    this.history.push(tier);
-    if (this.history.length > DROUGHT_WINDOW) this.history.shift();
-    return tier;
-  }
-}
-
 function createSeededRng(seed: number): () => number {
   let s = seed | 0;
   return () => {
@@ -70,29 +57,9 @@ function createSeededRng(seed: number): () => number {
   };
 }
 
-class FruitQueue {
-  private queue: FruitTier[];
-  private readonly selector: ControlledSpawnSelector;
-  constructor(
-    selector = new ControlledSpawnSelector(),
-    initialQueue?: readonly [FruitTier, FruitTier]
-  ) {
-    this.selector = selector;
-    this.queue = initialQueue
-      ? [initialQueue[0], initialQueue[1]]
-      : [this.selector.next(), this.selector.next()];
-  }
-  peek(): FruitTier {
-    return this.queue[0] ?? 0;
-  }
-  peekNext(): FruitTier {
-    return this.queue[1] ?? 0;
-  }
-  consume(isInDanger = false): FruitTier {
-    const tier = this.queue.shift()!;
-    this.queue.push(this.selector.next(isInDanger));
-    return tier;
-  }
+function makeQueue(rng?: () => number): { queue: PieceQueue; history: number[] } {
+  const queue = createPieceQueue([], rng);
+  return { queue, history: [queue.current, queue.next] };
 }
 import { useSound } from "../game/_shared/useSound";
 import { useSoundSettings } from "../game/_shared/SoundContext";
@@ -247,7 +214,15 @@ function CascadeGame() {
   const { play: playGameOver } = useSound("cascade.gameOver");
 
   const engineRef = useRef<CascadeEngine | null>(null);
-  const queueRef = useRef(new FruitQueue());
+  // Initialized lazily below so queue and history come from the same makeQueue() call.
+  const queueRef = useRef<PieceQueue | null>(null);
+  const queueHistoryRef = useRef<number[]>([]);
+  const queueRngRef = useRef<(() => number) | undefined>(undefined);
+  if (queueRef.current === null) {
+    const init = makeQueue();
+    queueRef.current = init.queue;
+    queueHistoryRef.current = init.history;
+  }
   const droppingRef = useRef(false);
   const lastDropTimeRef = useRef<number>(Date.now());
   const dropCountRef = useRef<number>(0);
@@ -334,6 +309,9 @@ function CascadeGame() {
       engineRef.current?.restore(snapshot.pieces, snapshot.score);
       scoreRef.current = snapshot.score;
       setScore(snapshot.score);
+      queueRef.current = snapshot.queue;
+      queueHistoryRef.current = [snapshot.queue.current, snapshot.queue.next];
+      setQueueVersion((v) => v + 1);
       settlingTicksLeftRef.current = SETTLE_TICKS;
     });
     return () => {
@@ -344,10 +322,11 @@ function CascadeGame() {
 
   const buildSnapshot = useCallback((): SavedState => {
     return {
-      version: 2,
+      version: 3,
       pieces: piecesRef.current.map((p) => ({ tier: p.tier, x: p.x, y: p.y })),
       score: scoreRef.current,
       savedAt: Date.now(),
+      queue: queueRef.current ?? { current: 0, next: 0 },
     };
   }, []);
 
@@ -368,7 +347,10 @@ function CascadeGame() {
     if (prevFruitSetId.current !== activeFruitSet.id) {
       prevFruitSetId.current = activeFruitSet.id;
       endInstrumentedSession(gameOverRef.current ? "completed" : "abandoned");
-      queueRef.current = new FruitQueue();
+      queueRngRef.current = undefined;
+      const reset = makeQueue();
+      queueRef.current = reset.queue;
+      queueHistoryRef.current = reset.history;
       scoreRef.current = 0;
       gameOverRef.current = false;
       dropCountRef.current = 0;
@@ -528,7 +510,11 @@ function CascadeGame() {
       const pieces = engineRef.current?.getState().pieces ?? [];
       // isInDanger shapes the piece added to the back of the queue (2 drops ahead)
       const isInDanger = pieces.some((p) => p.y < OVERFLOW_LINE_Y + DANGER_STACK_MARGIN);
-      const tier = queueRef.current.consume(isInDanger);
+      const currentQueue = queueRef.current!;
+      const tier = currentQueue.current as FruitTier;
+      const newQueue = advanceQueue(currentQueue, queueHistoryRef.current, isInDanger, queueRngRef.current);
+      queueHistoryRef.current = [...queueHistoryRef.current, newQueue.next].slice(-DROUGHT_WINDOW);
+      queueRef.current = newQueue;
       setQueueVersion((v) => v + 1);
 
       console.log(
@@ -557,7 +543,11 @@ function CascadeGame() {
   );
 
   const handleSetSeed = useCallback((seed: number) => {
-    queueRef.current = new FruitQueue(new ControlledSpawnSelector(createSeededRng(seed)));
+    const rng = createSeededRng(seed);
+    queueRngRef.current = rng;
+    const seeded = makeQueue(rng);
+    queueRef.current = seeded.queue;
+    queueHistoryRef.current = seeded.history;
     setQueueVersion((v) => v + 1);
   }, []);
 
@@ -572,7 +562,7 @@ function CascadeGame() {
       return {
         score: scoreRef.current,
         gameOver: gameOverRef.current,
-        nextFruitTier: queueRef.current.peek(),
+        nextFruitTier: queueRef.current?.current ?? 0,
         comboCount: 0,
         fruitCount: state?.pieces.length ?? 0,
         dangerRatio: 0,
@@ -585,9 +575,12 @@ function CascadeGame() {
     g.__cascade_dropAt = (x: number) => {
       if (gameOverRef.current) return;
       const dangerPieces = engineRef.current?.getState().pieces ?? [];
-      const tier = queueRef.current.consume(
-        dangerPieces.some((p) => p.y < OVERFLOW_LINE_Y + DANGER_STACK_MARGIN)
-      );
+      const isInDanger = dangerPieces.some((p) => p.y < OVERFLOW_LINE_Y + DANGER_STACK_MARGIN);
+      const currentQueue = queueRef.current!;
+      const tier = currentQueue.current as FruitTier;
+      const newQueue = advanceQueue(currentQueue, queueHistoryRef.current, isInDanger, queueRngRef.current);
+      queueHistoryRef.current = [...queueHistoryRef.current, newQueue.next].slice(-DROUGHT_WINDOW);
+      queueRef.current = newQueue;
       setQueueVersion((v) => v + 1);
       engineRef.current?.drop(tier, x);
     };
@@ -636,7 +629,10 @@ function CascadeGame() {
 
   function handleRestart() {
     endInstrumentedSession(gameOverRef.current ? "completed" : "abandoned");
-    queueRef.current = new FruitQueue();
+    queueRngRef.current = undefined;
+    const restarted = makeQueue();
+    queueRef.current = restarted.queue;
+    queueHistoryRef.current = restarted.history;
     scoreRef.current = 0;
     gameOverRef.current = false;
     dropCountRef.current = 0;
@@ -652,9 +648,9 @@ function CascadeGame() {
     pushScoreboardSnapshot();
   }
 
-  const queue = queueRef.current;
-  const currentDef = activeFruitSet.fruits[queue.peek()];
-  const nextDef = activeFruitSet.fruits[queue.peekNext()];
+  const queue = queueRef.current!;
+  const currentDef = activeFruitSet.fruits[queue.current];
+  const nextDef = activeFruitSet.fruits[queue.next];
 
   const scale =
     containerWidth > 0 && containerHeight > 0

--- a/frontend/src/screens/CascadeScreen.tsx
+++ b/frontend/src/screens/CascadeScreen.tsx
@@ -214,11 +214,11 @@ function CascadeGame() {
   const { play: playGameOver } = useSound("cascade.gameOver");
 
   const engineRef = useRef<CascadeEngine | null>(null);
-  // Initialized lazily below so queue and history come from the same makeQueue() call.
-  const queueRef = useRef<PieceQueue | null>(null);
+  // Initialized lazily so queue and history come from the same makeQueue() call.
+  const queueRef = useRef<PieceQueue>(null as unknown as PieceQueue);
   const queueHistoryRef = useRef<number[]>([]);
   const queueRngRef = useRef<(() => number) | undefined>(undefined);
-  if (queueRef.current === null) {
+  if (queueRef.current == null) {
     const init = makeQueue();
     queueRef.current = init.queue;
     queueHistoryRef.current = init.history;
@@ -285,6 +285,20 @@ function CascadeGame() {
     [syncComplete]
   );
 
+  // Pops queue.current, advances the queue, updates history. Returns the dropped tier.
+  const consumeFromQueue = useCallback((isInDanger: boolean): FruitTier => {
+    const tier = queueRef.current.current as FruitTier;
+    const newQueue = advanceQueue(
+      queueRef.current,
+      queueHistoryRef.current,
+      isInDanger,
+      queueRngRef.current
+    );
+    queueHistoryRef.current = [...queueHistoryRef.current, newQueue.next].slice(-DROUGHT_WINDOW);
+    queueRef.current = newQueue;
+    return tier;
+  }, []); // reads/writes refs only — no reactive deps
+
   const pushScoreboardSnapshot = useCallback(() => {
     setScoreboardSnapshot({
       score: scoreRef.current,
@@ -326,7 +340,7 @@ function CascadeGame() {
       pieces: piecesRef.current.map((p) => ({ tier: p.tier, x: p.x, y: p.y })),
       score: scoreRef.current,
       savedAt: Date.now(),
-      queue: queueRef.current ?? { current: 0, next: 0 },
+      queue: queueRef.current,
     };
   }, []);
 
@@ -510,11 +524,7 @@ function CascadeGame() {
       const pieces = engineRef.current?.getState().pieces ?? [];
       // isInDanger shapes the piece added to the back of the queue (2 drops ahead)
       const isInDanger = pieces.some((p) => p.y < OVERFLOW_LINE_Y + DANGER_STACK_MARGIN);
-      const currentQueue = queueRef.current!;
-      const tier = currentQueue.current as FruitTier;
-      const newQueue = advanceQueue(currentQueue, queueHistoryRef.current, isInDanger, queueRngRef.current);
-      queueHistoryRef.current = [...queueHistoryRef.current, newQueue.next].slice(-DROUGHT_WINDOW);
-      queueRef.current = newQueue;
+      const tier = consumeFromQueue(isInDanger);
       setQueueVersion((v) => v + 1);
 
       console.log(
@@ -539,7 +549,7 @@ function CascadeGame() {
         droppingRef.current = false;
       }, 200);
     },
-    [gameOver, saveGameThrottled, syncEnqueue, syncMarkStarted]
+    [consumeFromQueue, gameOver, saveGameThrottled, syncEnqueue, syncMarkStarted]
   );
 
   const handleSetSeed = useCallback((seed: number) => {
@@ -562,7 +572,7 @@ function CascadeGame() {
       return {
         score: scoreRef.current,
         gameOver: gameOverRef.current,
-        nextFruitTier: queueRef.current?.current ?? 0,
+        nextFruitTier: queueRef.current.current,
         comboCount: 0,
         fruitCount: state?.pieces.length ?? 0,
         dangerRatio: 0,
@@ -576,11 +586,7 @@ function CascadeGame() {
       if (gameOverRef.current) return;
       const dangerPieces = engineRef.current?.getState().pieces ?? [];
       const isInDanger = dangerPieces.some((p) => p.y < OVERFLOW_LINE_Y + DANGER_STACK_MARGIN);
-      const currentQueue = queueRef.current!;
-      const tier = currentQueue.current as FruitTier;
-      const newQueue = advanceQueue(currentQueue, queueHistoryRef.current, isInDanger, queueRngRef.current);
-      queueHistoryRef.current = [...queueHistoryRef.current, newQueue.next].slice(-DROUGHT_WINDOW);
-      queueRef.current = newQueue;
+      const tier = consumeFromQueue(isInDanger);
       setQueueVersion((v) => v + 1);
       engineRef.current?.drop(tier, x);
     };
@@ -648,7 +654,7 @@ function CascadeGame() {
     pushScoreboardSnapshot();
   }
 
-  const queue = queueRef.current!;
+  const queue = queueRef.current;
   const currentDef = activeFruitSet.fruits[queue.current];
   const nextDef = activeFruitSet.fruits[queue.next];
 


### PR DESCRIPTION
Closes #1756

Part of the Cascade v2 Epic (#1746).

## Summary

- **`pieceQueue2.ts`** — new pure module: `PieceQueue` interface (`{ current, next }`) + `createPieceQueue()` and `advanceQueue()` pure functions backed by `selectNextTier()`; no side effects, rng-injectable for tests
- **`storage2.ts`** — bumped to version 3 (`cascade_game_v3` storage key); `SavedState` now includes `queue: { current: number; next: number }`; `looksValid` validates the new field
- **`CascadeScreen.tsx`** — removed `FruitQueue` / `ControlledSpawnSelector` classes; wired `queueRef` + `queueHistoryRef` with pure functions; `buildSnapshot` persists the queue; load-restore hydrates it from saved state; restart, theme-switch, and seeded-RNG paths all updated
- **Preview UI** — already wired via `NextFruitPreview` (no component changes needed; `queue.current` / `queue.next` feed it directly)

## Test plan

- [x] `pieceQueue2.test.ts` — 8 new unit tests: validity, immutability, multi-advance chaining, history influence
- [x] `storage2.test.ts` — updated for v3 schema; 4 new queue field validation tests
- [x] All 98 cascade tests pass (`npx jest --testPathPattern="cascade"`)
- [x] TypeScript: no new errors introduced (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)