### PR TITLE
fix(ios/ci): disable react-native-audio-api FFmpeg download in Xcode Cloud

### DIFF
--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -16,6 +16,8 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
+# react-native-audio-api: disable FFmpeg xcframework download (app.json disableFFmpeg:true)
+ENV['DISABLE_AUDIOAPI_FFMPEG'] ||= '1'
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 
 prepare_react_native_project!

--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -55,6 +55,11 @@ cd "$CI_PRIMARY_REPOSITORY_PATH/frontend/ios"
 rm -rf Pods Podfile.lock
 which pod || brew install cocoapods
 
+# Disable FFmpeg download in react-native-audio-api (app.json disableFFmpeg:true).
+# Without this, pod install tries to fetch large FFmpeg xcframeworks from GitHub
+# which times out on Xcode Cloud runners (issue #1813).
+export DISABLE_AUDIOAPI_FFMPEG=1
+
 # Retry pod install up to 3 times — Xcode Cloud runners occasionally
 # time out reaching cdn.cocoapods.org on the first attempt.
 for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary

- Adds `ENV['DISABLE_AUDIOAPI_FFMPEG'] ||= '1'` to `ios/Podfile` so local `pod install` respects the `disableFFmpeg:true` setting from `app.json`
- Adds `export DISABLE_AUDIOAPI_FFMPEG=1` to `ci_post_clone.sh` before the `pod install` loop as belt-and-suspenders for Xcode Cloud

## Root Cause

`react-native-audio-api@0.12.2` has a `prepare_command` that downloads prebuilt binaries from GitHub. Without `DISABLE_AUDIOAPI_FFMPEG=1`, it downloads large FFmpeg xcframeworks (`ffmpeg_ios.zip` + 3 xcframework ZIPs from `software-mansion-labs/rn-audio-libs/releases/v3.1.0`), which times out on Xcode Cloud runners.

`app.json` already sets `disableFFmpeg:true` for the expo plugin. The equivalent was applied for Android via `03780f2f` but the iOS `Podfile` was never updated via `expo prebuild --platform ios`.

Fixes #1813 (Xcode Cloud Build 71 failure).

## Test plan

- [ ] Trigger a new Xcode Cloud build and confirm `pod install` completes without FFmpeg download errors
- [ ] Verify build succeeds end-to-end (archive + export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)