### PR TITLE
fix(ios): add NSMicrophoneUsageDescription to resolve ITMS-90683

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -50,7 +50,7 @@
       ],
       "expo-localization",
       "expo-audio",
-      ["react-native-audio-api", { "disableFFmpeg": true }]
+      ["react-native-audio-api", { "disableFFmpeg": true, "iosMicrophonePermission": "Audio playback libraries used for game sound effects and background music require this permission." }]
     ]
   }
 }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -50,7 +50,13 @@
       ],
       "expo-localization",
       "expo-audio",
-      ["react-native-audio-api", { "disableFFmpeg": true, "iosMicrophonePermission": "Audio playback libraries used for game sound effects and background music require this permission." }]
+      [
+        "react-native-audio-api",
+        {
+          "disableFFmpeg": true,
+          "iosMicrophonePermission": "Audio playback libraries used for game sound effects and background music require this permission."
+        }
+      ]
     ]
   }
 }

--- a/frontend/ios/GamingApp/Info.plist
+++ b/frontend/ios/GamingApp/Info.plist
@@ -72,5 +72,7 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Audio playback libraries used for game sound effects and background music require this permission.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Adds `NSMicrophoneUsageDescription` to `frontend/ios/GamingApp/Info.plist`
- Adds `iosMicrophonePermission` to the `react-native-audio-api` plugin config in `app.json` so future `expo prebuild` runs preserve the string

## Root Cause

Build 71 was rejected by App Store Connect (ITMS-90683) for a missing microphone purpose string. `react-native-audio-api@0.12.2` links `AVFoundation` and related audio frameworks that reference microphone APIs. Apple requires `NSMicrophoneUsageDescription` whenever any linked library touches those APIs — even for BGM/SFX playback-only use cases.

Closes #1815

## Test plan

- [ ] Trigger new Xcode Cloud build — confirm archive uploads without ITMS-90683 rejection
- [ ] Verify `NSMicrophoneUsageDescription` appears in Settings → Privacy → Microphone on device if prompted

🤖 Generated with [Claude Code](https://claude.com/claude-code)