### PR TITLE
Yacht: slow down AI turn animation and add end-game scorecard

### DIFF
--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -77,7 +77,7 @@ export default function Die({
     if (reduceMotion) return;
     cancelAnimation(rotation);
     rotation.value = withSequence(
-      withTiming(360 * 2, { duration: 350 }),
+      withTiming(360 * 2, { duration: 500 }),
       withTiming(0, { duration: 0 })
     );
   }, [rolling, reduceMotion, rotation]);

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -4,13 +4,20 @@ import {
   View,
   Text,
   Pressable,
+  ScrollView,
   StyleSheet,
   Platform,
   ViewStyle,
   TextStyle,
+  useWindowDimensions,
 } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
+import {
+  UPPER_CATEGORY_KEYS,
+  LOWER_CATEGORY_KEYS,
+  CATEGORY_I18N_KEY,
+} from "../../game/yacht/categories";
 
 interface GameOverModalProps {
   visible: boolean;
@@ -18,10 +25,17 @@ interface GameOverModalProps {
   upperBonus: number;
   yachtBonusCount: number;
   yachtBonusTotal: number;
+  scores: Record<string, number | null>;
   onPlayAgain: () => void;
   onDismiss: () => void;
   vsResult?: "win" | "lose" | "tie";
   aiTotalScore?: number;
+  aiUpperBonus?: number;
+  aiScores?: Record<string, number | null>;
+}
+
+function fmtScore(val: number | null | undefined): string {
+  return val != null ? String(val) : "—";
 }
 
 export default function GameOverModal({
@@ -30,13 +44,19 @@ export default function GameOverModal({
   upperBonus,
   yachtBonusCount,
   yachtBonusTotal,
+  scores,
   onPlayAgain,
   onDismiss,
   vsResult,
   aiTotalScore,
+  aiUpperBonus,
+  aiScores,
 }: GameOverModalProps) {
   const { t } = useTranslation("yacht");
   const { colors } = useTheme();
+  const { height: screenHeight } = useWindowDimensions();
+
+  const isVs = !!aiScores;
 
   const scoreGlow: TextStyle | null =
     Platform.OS === "web"
@@ -51,6 +71,22 @@ export default function GameOverModal({
         } as ViewStyle)
       : { backgroundColor: colors.accentBright };
 
+  function renderScoreRow(cat: string) {
+    return (
+      <View key={cat} style={styles.scoreRow}>
+        <Text style={[styles.rowLabel, { color: colors.textMuted }]} numberOfLines={1}>
+          {t(CATEGORY_I18N_KEY[cat])}
+        </Text>
+        <Text style={[styles.rowVal, { color: colors.text }]}>{fmtScore(scores[cat])}</Text>
+        {isVs && (
+          <Text style={[styles.rowVal, { color: colors.textMuted }]}>
+            {fmtScore(aiScores?.[cat])}
+          </Text>
+        )}
+      </View>
+    );
+  }
+
   return (
     <Modal visible={visible} transparent animationType="fade" accessibilityViewIsModal>
       <View style={[styles.overlay, { backgroundColor: "rgba(0,0,0,0.75)" }]}>
@@ -61,104 +97,176 @@ export default function GameOverModal({
               backgroundColor: colors.surfaceHigh,
               borderColor: colors.border,
               borderTopColor: colors.accent,
+              maxHeight: screenHeight * 0.88,
             },
           ]}
         >
-          {vsResult ? (
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            bounces={false}
+          >
+            {vsResult ? (
+              <Text
+                style={[
+                  styles.title,
+                  {
+                    color:
+                      vsResult === "win"
+                        ? colors.bonus
+                        : vsResult === "lose"
+                          ? colors.textMuted
+                          : colors.text,
+                  },
+                ]}
+                accessibilityRole="header"
+              >
+                {vsResult === "win"
+                  ? t("gameOver.youWin")
+                  : vsResult === "lose"
+                    ? t("gameOver.computerWins")
+                    : t("gameOver.tie")}
+              </Text>
+            ) : (
+              <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
+                {t("gameOver.title")}
+              </Text>
+            )}
+            <Text style={[styles.scoreLabel, { color: colors.textMuted }]}>
+              {t("gameOver.finalScore")}
+            </Text>
             <Text
-              style={[
-                styles.title,
-                {
-                  color:
-                    vsResult === "win"
-                      ? colors.bonus
-                      : vsResult === "lose"
-                        ? colors.textMuted
-                        : colors.text,
-                },
-              ]}
-              accessibilityRole="header"
+              style={[styles.scoreValue, { color: colors.accent }, scoreGlow]}
+              accessibilityLabel={t("gameOver.scoreLabel", { score: totalScore })}
             >
-              {vsResult === "win"
-                ? t("gameOver.youWin")
-                : vsResult === "lose"
-                  ? t("gameOver.computerWins")
-                  : t("gameOver.tie")}
+              {totalScore}
             </Text>
-          ) : (
-            <Text style={[styles.title, { color: colors.text }]} accessibilityRole="header">
-              {t("gameOver.title")}
+            {vsResult !== undefined && aiTotalScore !== undefined && (
+              <Text style={[styles.aiScoreRow, { color: colors.textMuted }]}>
+                {t("score.opponent")}: {aiTotalScore}
+              </Text>
+            )}
+            {(upperBonus > 0 || yachtBonusTotal > 0) && (
+              <View style={styles.bonusStack}>
+                {upperBonus > 0 && (
+                  <View
+                    style={[
+                      styles.bonusPill,
+                      { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
+                    ]}
+                  >
+                    <Text style={[styles.bonusText, { color: colors.bonus }]}>
+                      {t("gameOver.upperBonus")}
+                    </Text>
+                  </View>
+                )}
+                {yachtBonusTotal > 0 && (
+                  <View
+                    style={[
+                      styles.bonusPill,
+                      { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
+                    ]}
+                  >
+                    <Text style={[styles.bonusText, { color: colors.bonus }]}>
+                      {t("gameOver.yachtBonus", {
+                        count: yachtBonusCount,
+                        total: yachtBonusTotal,
+                      })}
+                    </Text>
+                  </View>
+                )}
+              </View>
+            )}
+
+            {/* Scorecard section */}
+            <View style={[styles.scorecardDivider, { backgroundColor: colors.border }]} />
+            <Text style={[styles.scorecardHeader, { color: colors.textMuted }]}>
+              {t("gameOver.scorecard")}
             </Text>
-          )}
-          <Text style={[styles.scoreLabel, { color: colors.textMuted }]}>
-            {t("gameOver.finalScore")}
-          </Text>
-          <Text
-            style={[styles.scoreValue, { color: colors.accent }, scoreGlow]}
-            accessibilityLabel={t("gameOver.scoreLabel", { score: totalScore })}
-          >
-            {totalScore}
-          </Text>
-          {vsResult !== undefined && aiTotalScore !== undefined && (
-            <Text style={[styles.aiScoreRow, { color: colors.textMuted }]}>
-              {t("score.opponent")}: {aiTotalScore}
-            </Text>
-          )}
-          {(upperBonus > 0 || yachtBonusTotal > 0) && (
-            <View style={styles.bonusStack}>
-              {upperBonus > 0 && (
-                <View
-                  style={[
-                    styles.bonusPill,
-                    { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
-                  ]}
-                >
-                  <Text style={[styles.bonusText, { color: colors.bonus }]}>
-                    {t("gameOver.upperBonus")}
+
+            <View style={styles.scorecardContainer}>
+              {isVs && (
+                <View style={styles.scoreRow}>
+                  <Text style={[styles.rowLabel, { color: "transparent" }]}>-</Text>
+                  <Text style={[styles.colHeader, { color: colors.textMuted }]}>
+                    {t("score.you")}
+                  </Text>
+                  <Text style={[styles.colHeader, { color: colors.textMuted }]}>
+                    {t("vsMode.cpu")}
                   </Text>
                 </View>
               )}
-              {yachtBonusTotal > 0 && (
-                <View
+
+              <Text style={[styles.sectionLabel, { color: colors.textMuted }]}>
+                {t("section.upper")}
+              </Text>
+              {UPPER_CATEGORY_KEYS.map(renderScoreRow)}
+              <View style={[styles.subtotalRow, { borderTopColor: colors.border }]}>
+                <Text style={[styles.subtotalLabel, { color: colors.textMuted }]}>
+                  {t("score.bonusRow")}
+                </Text>
+                <Text
                   style={[
-                    styles.bonusPill,
-                    { backgroundColor: colors.surfaceAlt, borderColor: colors.bonus },
+                    styles.subtotalVal,
+                    { color: upperBonus > 0 ? colors.bonus : colors.textMuted },
                   ]}
                 >
-                  <Text style={[styles.bonusText, { color: colors.bonus }]}>
-                    {t("gameOver.yachtBonus", {
-                      count: yachtBonusCount,
-                      total: yachtBonusTotal,
-                    })}
+                  {upperBonus > 0 ? "+35" : "—"}
+                </Text>
+                {isVs && (
+                  <Text
+                    style={[
+                      styles.subtotalVal,
+                      { color: (aiUpperBonus ?? 0) > 0 ? colors.bonus : colors.textMuted },
+                    ]}
+                  >
+                    {(aiUpperBonus ?? 0) > 0 ? "+35" : "—"}
                   </Text>
-                </View>
-              )}
+                )}
+              </View>
+
+              <Text style={[styles.sectionLabel, { color: colors.textMuted, marginTop: 8 }]}>
+                {t("section.lower")}
+              </Text>
+              {LOWER_CATEGORY_KEYS.map(renderScoreRow)}
+
+              <View style={[styles.totalRow, { borderTopColor: colors.border }]}>
+                <Text style={[styles.totalLabel, { color: colors.text }]}>
+                  {t("section.total")}
+                </Text>
+                <Text style={[styles.totalVal, { color: colors.accent }]}>{totalScore}</Text>
+                {isVs && (
+                  <Text style={[styles.totalVal, { color: colors.text }]}>{aiTotalScore}</Text>
+                )}
+              </View>
             </View>
-          )}
-          <Pressable
-            style={({ pressed }) => [
-              styles.playAgainButton,
-              playAgainBg,
-              { transform: [{ scale: pressed ? 0.96 : 1 }] },
-            ]}
-            onPress={onPlayAgain}
-            accessibilityRole="button"
-            accessibilityLabel={t("gameOver.playAgainLabel")}
-          >
-            <Text style={[styles.playAgainText, { color: colors.textOnAccent }]}>
-              {t("gameOver.playAgain")}
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.dismissButton, { borderColor: colors.border }]}
-            onPress={onDismiss}
-            accessibilityRole="button"
-            accessibilityLabel={t("gameOver.dismissLabel")}
-          >
-            <Text style={[styles.dismissText, { color: colors.textMuted }]}>
-              {t("gameOver.dismiss")}
-            </Text>
-          </Pressable>
+
+            <Pressable
+              style={({ pressed }) => [
+                styles.playAgainButton,
+                playAgainBg,
+                { transform: [{ scale: pressed ? 0.96 : 1 }] },
+              ]}
+              onPress={onPlayAgain}
+              accessibilityRole="button"
+              accessibilityLabel={t("gameOver.playAgainLabel")}
+            >
+              <Text style={[styles.playAgainText, { color: colors.textOnAccent }]}>
+                {t("gameOver.playAgain")}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.dismissButton, { borderColor: colors.border }]}
+              onPress={onDismiss}
+              accessibilityRole="button"
+              accessibilityLabel={t("gameOver.dismissLabel")}
+            >
+              <Text style={[styles.dismissText, { color: colors.textMuted }]}>
+                {t("gameOver.dismiss")}
+              </Text>
+            </Pressable>
+          </ScrollView>
         </View>
       </View>
     </Modal>
@@ -175,10 +283,17 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     borderWidth: 1,
     borderTopWidth: 3,
-    padding: 28,
-    alignItems: "center",
     width: "86%",
     maxWidth: 340,
+    overflow: "hidden",
+  },
+  scroll: {
+    width: "100%",
+  },
+  scrollContent: {
+    alignItems: "center",
+    padding: 28,
+    paddingBottom: 20,
   },
   title: {
     fontSize: 26,
@@ -202,7 +317,7 @@ const styles = StyleSheet.create({
   },
   bonusStack: {
     gap: 6,
-    marginBottom: 18,
+    marginBottom: 4,
     alignItems: "center",
   },
   bonusPill: {
@@ -216,11 +331,102 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     letterSpacing: 0.3,
   },
+  aiScoreRow: {
+    fontSize: 13,
+    fontWeight: "600",
+    marginBottom: 8,
+    marginTop: -4,
+  },
+  scorecardDivider: {
+    height: 1,
+    alignSelf: "stretch",
+    marginVertical: 16,
+  },
+  scorecardHeader: {
+    fontSize: 10,
+    fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+    marginBottom: 8,
+    alignSelf: "flex-start",
+  },
+  scorecardContainer: {
+    alignSelf: "stretch",
+  },
+  sectionLabel: {
+    fontSize: 9,
+    fontWeight: "800",
+    letterSpacing: 1.5,
+    textTransform: "uppercase",
+    marginBottom: 2,
+    marginTop: 4,
+  },
+  scoreRow: {
+    flexDirection: "row",
+    paddingVertical: 3,
+    alignItems: "center",
+  },
+  rowLabel: {
+    flex: 3,
+    fontSize: 11,
+  },
+  rowVal: {
+    flex: 1.5,
+    fontSize: 11,
+    fontWeight: "600",
+    textAlign: "right",
+  },
+  colHeader: {
+    flex: 1.5,
+    fontSize: 9,
+    fontWeight: "800",
+    letterSpacing: 1,
+    textTransform: "uppercase",
+    textAlign: "right",
+  },
+  subtotalRow: {
+    flexDirection: "row",
+    paddingVertical: 4,
+    alignItems: "center",
+    borderTopWidth: 1,
+    marginTop: 2,
+  },
+  subtotalLabel: {
+    flex: 3,
+    fontSize: 11,
+    fontWeight: "700",
+  },
+  subtotalVal: {
+    flex: 1.5,
+    fontSize: 11,
+    fontWeight: "700",
+    textAlign: "right",
+  },
+  totalRow: {
+    flexDirection: "row",
+    paddingVertical: 5,
+    alignItems: "center",
+    borderTopWidth: 1,
+    marginTop: 4,
+  },
+  totalLabel: {
+    flex: 3,
+    fontSize: 13,
+    fontWeight: "900",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  totalVal: {
+    flex: 1.5,
+    fontSize: 13,
+    fontWeight: "900",
+    textAlign: "right",
+  },
   playAgainButton: {
     paddingHorizontal: 36,
     paddingVertical: 14,
     borderRadius: 999,
-    marginTop: 4,
+    marginTop: 16,
   },
   playAgainText: {
     fontSize: 15,
@@ -240,11 +446,5 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     letterSpacing: 0.5,
     textTransform: "uppercase",
-  },
-  aiScoreRow: {
-    fontSize: 13,
-    fontWeight: "600",
-    marginBottom: 8,
-    marginTop: -4,
   },
 });

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -80,7 +80,7 @@ export default function GameOverModal({
         <Text style={[styles.rowVal, { color: colors.text }]}>{fmtScore(scores[cat])}</Text>
         {isVs && (
           <Text style={[styles.rowVal, { color: colors.textMuted }]}>
-            {fmtScore(aiScores?.[cat])}
+            {fmtScore(aiScores[cat])}
           </Text>
         )}
       </View>
@@ -188,7 +188,7 @@ export default function GameOverModal({
             <View style={styles.scorecardContainer}>
               {isVs && (
                 <View style={styles.scoreRow}>
-                  <Text style={[styles.rowLabel, { color: "transparent" }]}>-</Text>
+                  <View style={styles.rowLabel} />
                   <Text style={[styles.colHeader, { color: colors.textMuted }]}>
                     {t("score.you")}
                   </Text>

--- a/frontend/src/i18n/locales/ar/yacht.json
+++ b/frontend/src/i18n/locales/ar/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "فزت!",
   "gameOver.computerWins": "فاز الكمبيوتر!",
   "gameOver.tie": "تعادل!",
+  "gameOver.scorecard": "بطاقة النتائج",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "رمية {{n}} / 3",
   "vsMode.category": "الفئة",

--- a/frontend/src/i18n/locales/de/yacht.json
+++ b/frontend/src/i18n/locales/de/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "Du gewinnst!",
   "gameOver.computerWins": "Computer gewinnt!",
   "gameOver.tie": "Unentschieden!",
+  "gameOver.scorecard": "Spielübersicht",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Wurf {{n}} / 3",
   "vsMode.category": "Kategorie",

--- a/frontend/src/i18n/locales/en/yacht.json
+++ b/frontend/src/i18n/locales/en/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "You Win!",
   "gameOver.computerWins": "Computer Wins!",
   "gameOver.tie": "It's a Tie!",
+  "gameOver.scorecard": "Scorecard",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Roll {{n}} / 3",
   "vsMode.category": "Category",

--- a/frontend/src/i18n/locales/es/yacht.json
+++ b/frontend/src/i18n/locales/es/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "¡Ganaste!",
   "gameOver.computerWins": "¡Gana la computadora!",
   "gameOver.tie": "¡Empate!",
+  "gameOver.scorecard": "Marcador final",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Tiro {{n}} / 3",
   "vsMode.category": "Categoría",

--- a/frontend/src/i18n/locales/fr-CA/yacht.json
+++ b/frontend/src/i18n/locales/fr-CA/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "Vous gagnez !",
   "gameOver.computerWins": "L'ordinateur gagne !",
   "gameOver.tie": "Égalité !",
+  "gameOver.scorecard": "Fiche de scores",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Lancé {{n}} / 3",
   "vsMode.category": "Catégorie",

--- a/frontend/src/i18n/locales/he/yacht.json
+++ b/frontend/src/i18n/locales/he/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "ניצחת!",
   "gameOver.computerWins": "המחשב ניצח!",
   "gameOver.tie": "תיקו!",
+  "gameOver.scorecard": "כרטיס הניקוד",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "הטלה {{n}} / 3",
   "vsMode.category": "קטגוריה",

--- a/frontend/src/i18n/locales/hi/yacht.json
+++ b/frontend/src/i18n/locales/hi/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "आप जीते!",
   "gameOver.computerWins": "कंप्यूटर जीता!",
   "gameOver.tie": "बराबरी!",
+  "gameOver.scorecard": "स्कोर कार्ड",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "रोल {{n}} / 3",
   "vsMode.category": "श्रेणी",

--- a/frontend/src/i18n/locales/ja/yacht.json
+++ b/frontend/src/i18n/locales/ja/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "あなたの勝ち！",
   "gameOver.computerWins": "コンピュータの勝ち！",
   "gameOver.tie": "引き分け！",
+  "gameOver.scorecard": "スコアカード",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "ロール {{n}} / 3",
   "vsMode.category": "カテゴリ",

--- a/frontend/src/i18n/locales/ko/yacht.json
+++ b/frontend/src/i18n/locales/ko/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "당신이 이겼습니다!",
   "gameOver.computerWins": "컴퓨터가 이겼습니다!",
   "gameOver.tie": "무승부!",
+  "gameOver.scorecard": "스코어카드",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "던지기 {{n}} / 3",
   "vsMode.category": "카테고리",

--- a/frontend/src/i18n/locales/nl/yacht.json
+++ b/frontend/src/i18n/locales/nl/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "Jij wint!",
   "gameOver.computerWins": "Computer wint!",
   "gameOver.tie": "Gelijkspel!",
+  "gameOver.scorecard": "Scorekaart",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Gooi {{n}} / 3",
   "vsMode.category": "Categorie",

--- a/frontend/src/i18n/locales/pt/yacht.json
+++ b/frontend/src/i18n/locales/pt/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "Você venceu!",
   "gameOver.computerWins": "O computador venceu!",
   "gameOver.tie": "Empate!",
+  "gameOver.scorecard": "Ficha de pontuação",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Lance {{n}} / 3",
   "vsMode.category": "Categoria",

--- a/frontend/src/i18n/locales/ru/yacht.json
+++ b/frontend/src/i18n/locales/ru/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "Вы выиграли!",
   "gameOver.computerWins": "Компьютер выиграл!",
   "gameOver.tie": "Ничья!",
+  "gameOver.scorecard": "Таблица очков",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "Бросок {{n}} / 3",
   "vsMode.category": "Категория",

--- a/frontend/src/i18n/locales/zh/yacht.json
+++ b/frontend/src/i18n/locales/zh/yacht.json
@@ -71,6 +71,7 @@
   "gameOver.youWin": "你赢了！",
   "gameOver.computerWins": "电脑赢了！",
   "gameOver.tie": "平局！",
+  "gameOver.scorecard": "计分卡",
   "vsMode.vs": "vs",
   "vsMode.rollCounter": "第{{n}}掷 / 3",
   "vsMode.category": "类别",

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -189,34 +189,38 @@ export default function GameScreen({ navigation, route }: Props) {
 
       // Initial roll (all dice free)
       setAiRollingIndices([0, 1, 2, 3, 4]);
-      await delay(700);
+      await delay(1000);
       if (cancelled) return;
       s = engineRoll(s, [false, false, false, false, false]);
       setAiGameState(s);
       setAiRollingIndices([]);
-      // Settle pause: let the player read the dice values before the next roll
-      await delay(450);
+      // Settle pause: let the player read the dice values
+      await delay(800);
       if (cancelled) return;
 
       // Up to two re-rolls using hold strategy
       while (s.rolls_used < 3) {
         const holds = holdStrategy(s, diff);
+        // Show held dice before rolling so the player can see the AI's decision
+        setAiGameState({ ...s, held: holds });
+        await delay(800);
+        if (cancelled) return;
         const rolledIdxs = holds.reduce<number[]>((acc, h, i) => {
           if (!h) acc.push(i);
           return acc;
         }, []);
         setAiRollingIndices(rolledIdxs);
-        await delay(700);
+        await delay(1000);
         if (cancelled) return;
         s = engineRoll(s, holds);
         setAiGameState(s);
         setAiRollingIndices([]);
-        await delay(450);
+        await delay(800);
         if (cancelled) return;
       }
 
       // Beat before the AI locks in its category
-      await delay(600);
+      await delay(1000);
       if (cancelled) return;
       const cat = scoreStrategy(s, diff, gameStateRef.current.total_score);
       s = engineScore(s, cat);
@@ -498,10 +502,13 @@ export default function GameScreen({ navigation, route }: Props) {
         upperBonus={gameState.upper_bonus}
         yachtBonusCount={gameState.yacht_bonus_count}
         yachtBonusTotal={gameState.yacht_bonus_total}
+        scores={gameState.scores}
         onPlayAgain={startNewGame}
         onDismiss={() => navigation.goBack()}
         vsResult={vsResult}
         aiTotalScore={aiGameState?.total_score}
+        aiUpperBonus={aiGameState?.upper_bonus}
+        aiScores={aiGameState?.scores}
       />
 
       <NewGameConfirmModal

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -140,9 +140,10 @@ describe("GameScreen", () => {
   });
 
   it("game over modal appears when game_over is true", () => {
-    const { getByText } = renderScreen({ game_over: true, total_score: 250 });
+    const { getByText, getAllByText } = renderScreen({ game_over: true, total_score: 250 });
     expect(getByText(/game over/i)).toBeTruthy();
-    expect(getByText("250")).toBeTruthy();
+    // Score appears in both the hero display and the scorecard total row
+    expect(getAllByText("250").length).toBeGreaterThan(0);
   });
 
   it("play again button starts a new game in place", async () => {


### PR DESCRIPTION
## Summary

- Closes #1818 — Slow down and clarify computer player turn animation sequence
- Closes #1819 — Show full final scorecard in end-game modal

## AI Turn Animation (#1818)

The computer's turn was too fast (~4s) and the hold-selection step was invisible. Each phase is now deliberate and readable (~8s total):

| Step | Before | After |
|------|--------|-------|
| Roll animation window | 700 ms | 1000 ms |
| Settle pause after roll | 450 ms | 800 ms |
| **Hold-selection visible pause** | — | **800 ms** |
| Decision beat before scoring | 600 ms | 1000 ms |
| Die tumble duration | 350 ms | 500 ms |

The key addition is the hold-selection pause: before each re-roll the AI's held dice light up with their "HELD" badge for 800ms, so the player can clearly see which dice the computer kept before the next roll begins.

## End-Game Scorecard (#1819)

`GameOverModal` now shows the full 13-category breakdown after every game:

- Upper section categories (Ones–Sixes) with upper bonus row (+35 or —)
- Lower section categories (Three of a Kind–Chance)
- Grand total row
- VS mode: You / CPU columns shown side by side for every row
- Modal wraps in a `ScrollView` (88% max screen height) so the Play Again / Dismiss buttons always stay reachable
- `gameOver.scorecard` translation key added to all 13 supported locales

## Test Plan

- [ ] Play a solo game to completion — end-game modal shows full scorecard with correct category values and grand total
- [ ] Play a VS game to completion — both You and CPU columns are populated correctly
- [ ] Watch a full AI turn (3 rolls) — each step is clearly visible: roll → settle → held dice light up → roll → settle → score
- [ ] Confirm AI turn takes approximately 8 seconds for a 3-roll turn
- [ ] Confirm Play Again and Dismiss buttons are accessible without scrolling on a small screen
- [ ] No regression on human player dice interaction (hold/unhold, roll button responsiveness)

https://claude.ai/code/session_01Kv3XCkAqrvEzpRKHBpTDRH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv3XCkAqrvEzpRKHBpTDRH)_