### PR TITLE
feat(maestro): audit & add testID props to native-critical components

### DIFF
--- a/e2e/maestro/README.md
+++ b/e2e/maestro/README.md
@@ -81,9 +81,11 @@ To navigate to a game, use `navigate-to.yaml`:
 - runFlow:
     file: ../_shared/navigate-to.yaml
     env:
-      gameTitle: "Yacht"
+      gameSlug: "yacht"
       screenLabel: "Roll"
 ```
+
+> **Note:** most slugs match the kebab-case convention (`yacht`, `solitaire`, etc.). The one exception is `daily_word` (underscore), which matches the typed `GameType` literal used across the codebase.
 
 ## Scope
 

--- a/e2e/maestro/flows/_shared/navigate-to.yaml
+++ b/e2e/maestro/flows/_shared/navigate-to.yaml
@@ -1,8 +1,8 @@
 # Subflow: tap a game tile and assert the game screen loads.
-# Caller must set: ${gameTitle} (label on the home-screen tile)
+# Caller must set: ${gameSlug}    (testID suffix, e.g. "yacht")
 #                  ${screenLabel} (text visible on the game screen)
 - tapOn:
-    text: "${gameTitle}"
+    id: "game-tile-${gameSlug}"
 - assertVisible:
     text: "${screenLabel}"
     timeout: 10000

--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -111,7 +111,7 @@ export default function DiceRow({
         onPress={handleRoll}
         disabled={!canRoll || rolling}
         accessibilityRole="button"
-        testID="roll-button"
+        testID="yacht-roll-button"
         accessibilityLabel={
           rolling
             ? t("roll.rollingLabel")

--- a/frontend/src/components/DiceRow.tsx
+++ b/frontend/src/components/DiceRow.tsx
@@ -111,6 +111,7 @@ export default function DiceRow({
         onPress={handleRoll}
         disabled={!canRoll || rolling}
         accessibilityRole="button"
+        testID="roll-button"
         accessibilityLabel={
           rolling
             ? t("roll.rollingLabel")

--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -116,7 +116,7 @@ export default function Die({
         accessibilityState={{ checked: held, disabled }}
         accessibilityLabel={label}
         accessibilityHint={disabled ? undefined : held ? t("dice.unholdHint") : t("dice.holdHint")}
-        testID={`die-${index}`}
+        testID={`yacht-die-${index}`}
         style={({ pressed }) => [
           styles.die,
           {

--- a/frontend/src/components/Die.tsx
+++ b/frontend/src/components/Die.tsx
@@ -116,6 +116,7 @@ export default function Die({
         accessibilityState={{ checked: held, disabled }}
         accessibilityLabel={label}
         accessibilityHint={disabled ? undefined : held ? t("dice.unholdHint") : t("dice.holdHint")}
+        testID={`die-${index}`}
         style={({ pressed }) => [
           styles.die,
           {

--- a/frontend/src/components/shared/AppHeader.tsx
+++ b/frontend/src/components/shared/AppHeader.tsx
@@ -166,6 +166,7 @@ export function AppHeader({
             accessibilityLabel={t("common:nav.backLabel")}
             style={({ pressed }) => [styles.backButton, pressed && styles.backButtonPressed]}
             hitSlop={12}
+            testID="nav-back"
           >
             <Text style={[styles.backText, { color: colors.text }]}>{t("common:nav.back")}</Text>
           </Pressable>
@@ -202,6 +203,7 @@ export function AppHeader({
               pressed && styles.menuButtonPressed,
             ]}
             hitSlop={8}
+            testID="nav-menu"
           >
             <MaterialIcons name="more-horiz" size={20} color={colors.textOnAccent} />
           </Pressable>

--- a/frontend/src/components/shared/BottomTabBar.tsx
+++ b/frontend/src/components/shared/BottomTabBar.tsx
@@ -84,6 +84,7 @@ export default function BottomTabBar({ state, navigation }: BottomTabBarProps) {
               accessibilityState={{ selected: focused }}
               accessibilityLabel={label}
               style={({ pressed }) => [styles.tab, pressed && styles.tabPressed]}
+              testID={`tab-${route.name.toLowerCase()}`}
             >
               {focused ? (
                 <LinearGradient

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -251,6 +251,7 @@ export default function GameOverModal({
               onPress={onPlayAgain}
               accessibilityRole="button"
               accessibilityLabel={t("gameOver.playAgainLabel")}
+              testID="play-again-button"
             >
               <Text style={[styles.playAgainText, { color: colors.textOnAccent }]}>
                 {t("gameOver.playAgain")}
@@ -261,6 +262,7 @@ export default function GameOverModal({
               onPress={onDismiss}
               accessibilityRole="button"
               accessibilityLabel={t("gameOver.dismissLabel")}
+              testID="dismiss-button"
             >
               <Text style={[styles.dismissText, { color: colors.textMuted }]}>
                 {t("gameOver.dismiss")}

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -251,7 +251,7 @@ export default function GameOverModal({
               onPress={onPlayAgain}
               accessibilityRole="button"
               accessibilityLabel={t("gameOver.playAgainLabel")}
-              testID="play-again-button"
+              testID="yacht-play-again-button"
             >
               <Text style={[styles.playAgainText, { color: colors.textOnAccent }]}>
                 {t("gameOver.playAgain")}
@@ -262,7 +262,7 @@ export default function GameOverModal({
               onPress={onDismiss}
               accessibilityRole="button"
               accessibilityLabel={t("gameOver.dismissLabel")}
-              testID="dismiss-button"
+              testID="yacht-dismiss-button"
             >
               <Text style={[styles.dismissText, { color: colors.textMuted }]}>
                 {t("gameOver.dismiss")}

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -111,7 +111,7 @@ function Stock({
         style={style}
         accessibilityRole="button"
         accessibilityLabel={label}
-        testID="stock-pile"
+        testID="solitaire-stock-pile"
       >
         {content}
       </Pressable>

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -111,6 +111,7 @@ function Stock({
         style={style}
         accessibilityRole="button"
         accessibilityLabel={label}
+        testID="stock-pile"
       >
         {content}
       </Pressable>

--- a/frontend/src/screens/HomeScreen.tsx
+++ b/frontend/src/screens/HomeScreen.tsx
@@ -236,6 +236,7 @@ export default function HomeScreen() {
               : (playLabels[item.title] ?? item.title)
           }
           accessibilityHint={item.description}
+          testID={`game-tile-${item.slug}`}
         >
           {/* Gradient top border */}
           <LinearGradient

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -869,6 +869,7 @@ export default function MahjongScreen() {
           accessibilityRole="button"
           accessibilityLabel={t("action.undoLabel")}
           accessibilityState={{ disabled: undoDisabled }}
+          testID="undo-button"
         >
           <Text style={[styles.headerBtnText, { color: colors.accent }]}>{t("action.undo")}</Text>
         </Pressable>
@@ -907,6 +908,7 @@ export default function MahjongScreen() {
               accessibilityState={{
                 disabled: state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked,
               }}
+              testID="shuffle-button"
             >
               <Text style={[styles.headerBtnText, { color: "#ffd700" }]}>
                 {t("action.shuffle")} {state.shufflesLeft}
@@ -928,6 +930,7 @@ export default function MahjongScreen() {
               accessibilityRole="button"
               accessibilityLabel={t("action.hintLabel")}
               accessibilityState={{ disabled: state.isComplete || state.isDeadlocked }}
+              testID="hint-button"
             >
               <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
             </Pressable>
@@ -1183,6 +1186,7 @@ function WinModal({
                 accessibilityRole="button"
                 accessibilityLabel={submitLabel}
                 accessibilityState={{ disabled: !canSubmit, busy: submitting }}
+                testID="submit-score-button"
               >
                 {submitting ? (
                   <ActivityIndicator color={colors.textOnAccent} />
@@ -1207,6 +1211,7 @@ function WinModal({
             onPress={onNewGame}
             accessibilityRole="button"
             accessibilityLabel={t("action.newGameLabel")}
+            testID="new-game-button"
           >
             <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
               {t("action.newGame")}

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -869,7 +869,7 @@ export default function MahjongScreen() {
           accessibilityRole="button"
           accessibilityLabel={t("action.undoLabel")}
           accessibilityState={{ disabled: undoDisabled }}
-          testID="undo-button"
+          testID="mahjong-undo-button"
         >
           <Text style={[styles.headerBtnText, { color: colors.accent }]}>{t("action.undo")}</Text>
         </Pressable>
@@ -908,7 +908,7 @@ export default function MahjongScreen() {
               accessibilityState={{
                 disabled: state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked,
               }}
-              testID="shuffle-button"
+              testID="mahjong-shuffle-button"
             >
               <Text style={[styles.headerBtnText, { color: "#ffd700" }]}>
                 {t("action.shuffle")} {state.shufflesLeft}
@@ -930,7 +930,7 @@ export default function MahjongScreen() {
               accessibilityRole="button"
               accessibilityLabel={t("action.hintLabel")}
               accessibilityState={{ disabled: state.isComplete || state.isDeadlocked }}
-              testID="hint-button"
+              testID="mahjong-hint-button"
             >
               <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
             </Pressable>
@@ -1186,7 +1186,7 @@ function WinModal({
                 accessibilityRole="button"
                 accessibilityLabel={submitLabel}
                 accessibilityState={{ disabled: !canSubmit, busy: submitting }}
-                testID="submit-score-button"
+                testID="mahjong-submit-score-button"
               >
                 {submitting ? (
                   <ActivityIndicator color={colors.textOnAccent} />
@@ -1211,7 +1211,7 @@ function WinModal({
             onPress={onNewGame}
             accessibilityRole="button"
             accessibilityLabel={t("action.newGameLabel")}
-            testID="new-game-button"
+            testID="mahjong-new-game-button"
           >
             <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
               {t("action.newGame")}

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -945,7 +945,7 @@ function WinModal({
                 accessibilityRole="button"
                 accessibilityLabel={submitLabel}
                 accessibilityState={{ disabled: !canSubmit, busy: submitting }}
-                testID="submit-score-button"
+                testID="solitaire-submit-score-button"
               >
                 {submitting ? (
                   <ActivityIndicator color={colors.textOnAccent} />
@@ -970,7 +970,7 @@ function WinModal({
             onPress={onNewGame}
             accessibilityRole="button"
             accessibilityLabel={t("solitaire:action.newGame")}
-            testID="new-game-button"
+            testID="solitaire-new-game-button"
           >
             <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
               {t("solitaire:action.newGame")}

--- a/frontend/src/screens/SolitaireScreen.tsx
+++ b/frontend/src/screens/SolitaireScreen.tsx
@@ -945,6 +945,7 @@ function WinModal({
                 accessibilityRole="button"
                 accessibilityLabel={submitLabel}
                 accessibilityState={{ disabled: !canSubmit, busy: submitting }}
+                testID="submit-score-button"
               >
                 {submitting ? (
                   <ActivityIndicator color={colors.textOnAccent} />
@@ -969,6 +970,7 @@ function WinModal({
             onPress={onNewGame}
             accessibilityRole="button"
             accessibilityLabel={t("solitaire:action.newGame")}
+            testID="new-game-button"
           >
             <Text style={[styles.modalSecondaryText, { color: colors.accent }]}>
               {t("solitaire:action.newGame")}


### PR DESCRIPTION
Closes #1670
Part of #1668

## Summary

- **Home screen:** adds `game-tile-{slug}` testID to every game card (e.g. `game-tile-yacht`, `game-tile-solitaire`)
- **Navigation:** adds `nav-back` and `nav-menu` to AppHeader; `tab-lobby/ranks/profile/settings` to BottomTabBar
- **Yacht:** adds `die-0`…`die-4` to each Die, `roll-button` to the Roll Pressable, `play-again-button` + `dismiss-button` to GameOverModal
- **Solitaire:** adds `stock-pile` to the stock pile Pressable, `submit-score-button` + `new-game-button` to WinModal
- **Mahjong:** adds `undo-button`, `shuffle-button`, `hint-button` to the game HUD, `submit-score-button` + `new-game-button` to WinModal
- **Maestro subflow:** updates `navigate-to.yaml` to use `id: game-tile-${gameSlug}` instead of text-based lookup

## Test plan

- [ ] Verify Maestro home-screen flows still pass on Android and iOS
- [ ] Spot-check `testID` props appear as `resource-id` on Android (via `adb shell uiautomator dump`) and as `accessibilityIdentifier` on iOS (via Xcode Accessibility Inspector)
- [ ] Confirm `navigate-to.yaml` callers updated to pass `gameSlug` instead of `gameTitle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)