### PR TITLE
feat(maestro): game smoke flows — all 10 games + offline

### DIFF
--- a/e2e/maestro/README.md
+++ b/e2e/maestro/README.md
@@ -87,6 +87,23 @@ To navigate to a game, use `navigate-to.yaml`:
 
 > **Note:** most slugs match the kebab-case convention (`yacht`, `solitaire`, etc.). The one exception is `daily_word` (underscore), which matches the typed `GameType` literal used across the codebase.
 
+## Pre-game selectors
+
+Several games show a selector before the game starts. Each smoke flow handles this automatically:
+
+| Game | Selector | How the flow handles it |
+|---|---|---|
+| Yacht | Mode picker (Solo / VS Computer) | taps `yacht-mode-solo` |
+| Hearts | Difficulty picker | taps `hearts-start-game` |
+| Sort | Level select | taps `sort-level-1` |
+| Mahjong | Layout select | taps `mahjong-layout-turtle` |
+| Sudoku | Difficulty / variant | taps `sudoku-pregame-start` |
+| StarSwarm | Difficulty picker | taps `starswarm-start-game` |
+
+## Offline flow
+
+`offline/smoke.yaml` uses `toggleAirplaneMode` (Android only). On iOS, put the device in Airplane Mode before running the flow. The flow navigates to Solitaire — a client-side game — taps the stock pile, and asserts the game responds without a network connection.
+
 ## Scope
 
 Each game flow is a **smoke test only**: launch → navigate → one interaction → assert screen is stable. Detailed logic (scoring, edge cases, persistence) is covered by Playwright.

--- a/e2e/maestro/flows/blackjack/smoke.yaml
+++ b/e2e/maestro/flows/blackjack/smoke.yaml
@@ -1,0 +1,21 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "blackjack"
+      screenLabel: "Blackjack"
+- assertVisible:
+    id: "blackjack-chip-1"
+    timeout: 8000
+- tapOn:
+    id: "blackjack-chip-1"
+- assertVisible:
+    id: "blackjack-deal-button"
+- tapOn:
+    id: "blackjack-deal-button"
+- assertVisible:
+    id: "blackjack-table-area"
+    timeout: 10000
+- takeScreenshot: blackjack-smoke

--- a/e2e/maestro/flows/cascade/smoke.yaml
+++ b/e2e/maestro/flows/cascade/smoke.yaml
@@ -1,0 +1,14 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "cascade"
+      screenLabel: "Cascade"
+- assertVisible:
+    id: "cascade-game-area"
+    timeout: 8000
+- tapOn:
+    id: "cascade-game-area"
+- takeScreenshot: cascade-smoke

--- a/e2e/maestro/flows/daily-word/smoke.yaml
+++ b/e2e/maestro/flows/daily-word/smoke.yaml
@@ -11,7 +11,9 @@ appId: com.buffingchi.games
     timeout: 8000
 - tapOn:
     id: "daily-word-key-a"
+# Assert the first tile is still rendered (not that "A" appears somewhere on screen,
+# which was trivially true before the tap due to the keyboard key).
 - assertVisible:
-    text: "A"
+    id: "tile-0-0"
     timeout: 3000
 - takeScreenshot: daily-word-smoke

--- a/e2e/maestro/flows/daily-word/smoke.yaml
+++ b/e2e/maestro/flows/daily-word/smoke.yaml
@@ -1,0 +1,17 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "daily_word"
+      screenLabel: "Daily Word"
+- assertVisible:
+    id: "tile-0-0"
+    timeout: 8000
+- tapOn:
+    id: "daily-word-key-a"
+- assertVisible:
+    text: "A"
+    timeout: 3000
+- takeScreenshot: daily-word-smoke

--- a/e2e/maestro/flows/freecell/smoke.yaml
+++ b/e2e/maestro/flows/freecell/smoke.yaml
@@ -9,6 +9,7 @@ appId: com.buffingchi.games
 - assertVisible:
     id: "freecell-board"
     timeout: 8000
+# Tap Hint — a real interactive button — proving native touch reaches the game.
 - tapOn:
-    id: "freecell-board"
+    id: "freecell-hint-button"
 - takeScreenshot: freecell-smoke

--- a/e2e/maestro/flows/freecell/smoke.yaml
+++ b/e2e/maestro/flows/freecell/smoke.yaml
@@ -1,0 +1,14 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "freecell"
+      screenLabel: "FreeCell"
+- assertVisible:
+    id: "freecell-board"
+    timeout: 8000
+- tapOn:
+    id: "freecell-board"
+- takeScreenshot: freecell-smoke

--- a/e2e/maestro/flows/hearts/smoke.yaml
+++ b/e2e/maestro/flows/hearts/smoke.yaml
@@ -6,10 +6,11 @@ appId: com.buffingchi.games
     env:
       gameSlug: "hearts"
       screenLabel: "Hearts"
-# Difficulty picker shows on fresh start — confirm to begin.
+# Difficulty picker only shows when no game is saved; skip if one is in progress.
 - tapOn:
     id: "hearts-start-game"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "hearts-player-hand-area"
     timeout: 10000

--- a/e2e/maestro/flows/hearts/smoke.yaml
+++ b/e2e/maestro/flows/hearts/smoke.yaml
@@ -1,0 +1,18 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "hearts"
+      screenLabel: "Hearts"
+# Difficulty picker shows on fresh start — confirm to begin.
+- tapOn:
+    id: "hearts-start-game"
+    timeout: 8000
+- assertVisible:
+    id: "hearts-player-hand-area"
+    timeout: 10000
+- tapOn:
+    id: "hearts-player-hand-area"
+- takeScreenshot: hearts-smoke

--- a/e2e/maestro/flows/mahjong/smoke.yaml
+++ b/e2e/maestro/flows/mahjong/smoke.yaml
@@ -1,0 +1,18 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "mahjong"
+      screenLabel: "Mahjong Solitaire"
+# Layout select shows on fresh start — tap Turtle (always unlocked).
+- tapOn:
+    id: "mahjong-layout-turtle"
+    timeout: 8000
+- assertVisible:
+    id: "mahjong-board-viewport"
+    timeout: 15000
+- tapOn:
+    id: "mahjong-hint-button"
+- takeScreenshot: mahjong-smoke

--- a/e2e/maestro/flows/mahjong/smoke.yaml
+++ b/e2e/maestro/flows/mahjong/smoke.yaml
@@ -6,10 +6,11 @@ appId: com.buffingchi.games
     env:
       gameSlug: "mahjong"
       screenLabel: "Mahjong Solitaire"
-# Layout select shows on fresh start — tap Turtle (always unlocked).
+# Layout select only shows when no saved game is in progress; skip if resuming.
 - tapOn:
     id: "mahjong-layout-turtle"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "mahjong-board-viewport"
     timeout: 15000

--- a/e2e/maestro/flows/offline/smoke.yaml
+++ b/e2e/maestro/flows/offline/smoke.yaml
@@ -3,8 +3,8 @@ appId: com.buffingchi.games
 # Offline smoke — proves client-side game logic runs without network.
 # toggleAirplaneMode is Android-only. iOS: run with device in Airplane Mode manually,
 # or use a network-conditioner profile before launching the test.
-- runFlow: ../_shared/launch.yaml
 - toggleAirplaneMode
+- runFlow: ../_shared/launch.yaml
 - runFlow:
     file: ../_shared/navigate-to.yaml
     env:

--- a/e2e/maestro/flows/offline/smoke.yaml
+++ b/e2e/maestro/flows/offline/smoke.yaml
@@ -1,0 +1,19 @@
+appId: com.buffingchi.games
+---
+# Offline smoke — proves client-side game logic runs without network.
+# toggleAirplaneMode is Android-only. iOS: run with device in Airplane Mode manually,
+# or use a network-conditioner profile before launching the test.
+- runFlow: ../_shared/launch.yaml
+- toggleAirplaneMode
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "solitaire"
+      screenLabel: "Solitaire"
+- assertVisible:
+    id: "solitaire-stock-pile"
+    timeout: 8000
+- tapOn:
+    id: "solitaire-stock-pile"
+- takeScreenshot: offline-solitaire-no-network
+- toggleAirplaneMode

--- a/e2e/maestro/flows/solitaire/smoke.yaml
+++ b/e2e/maestro/flows/solitaire/smoke.yaml
@@ -1,0 +1,14 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "solitaire"
+      screenLabel: "Solitaire"
+- assertVisible:
+    id: "solitaire-stock-pile"
+    timeout: 8000
+- tapOn:
+    id: "solitaire-stock-pile"
+- takeScreenshot: solitaire-smoke

--- a/e2e/maestro/flows/sort/smoke.yaml
+++ b/e2e/maestro/flows/sort/smoke.yaml
@@ -1,0 +1,18 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "sort"
+      screenLabel: "Sort Puzzle"
+# Level select shows first — tap level 1 (always unlocked).
+- tapOn:
+    id: "sort-level-1"
+    timeout: 8000
+- assertVisible:
+    id: "sort-board"
+    timeout: 8000
+- tapOn:
+    id: "sort-board"
+- takeScreenshot: sort-smoke

--- a/e2e/maestro/flows/sort/smoke.yaml
+++ b/e2e/maestro/flows/sort/smoke.yaml
@@ -6,10 +6,11 @@ appId: com.buffingchi.games
     env:
       gameSlug: "sort"
       screenLabel: "Sort Puzzle"
-# Level select shows first — tap level 1 (always unlocked).
+# Level select only shows when no saved game is in progress; skip if resuming.
 - tapOn:
     id: "sort-level-1"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "sort-board"
     timeout: 8000

--- a/e2e/maestro/flows/starswarm/smoke.yaml
+++ b/e2e/maestro/flows/starswarm/smoke.yaml
@@ -6,10 +6,11 @@ appId: com.buffingchi.games
     env:
       gameSlug: "starswarm"
       screenLabel: "Star Swarm"
-# Difficulty picker shows before every new game — confirm default selection.
+# Difficulty picker only shows when no saved session exists; skip if restoring a pause.
 - tapOn:
     id: "starswarm-start-game"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "starswarm-canvas-outer"
     timeout: 8000

--- a/e2e/maestro/flows/starswarm/smoke.yaml
+++ b/e2e/maestro/flows/starswarm/smoke.yaml
@@ -1,0 +1,18 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "starswarm"
+      screenLabel: "Star Swarm"
+# Difficulty picker shows before every new game — confirm default selection.
+- tapOn:
+    id: "starswarm-start-game"
+    timeout: 8000
+- assertVisible:
+    id: "starswarm-canvas-outer"
+    timeout: 8000
+- tapOn:
+    id: "starswarm-canvas-outer"
+- takeScreenshot: starswarm-smoke

--- a/e2e/maestro/flows/sudoku/smoke.yaml
+++ b/e2e/maestro/flows/sudoku/smoke.yaml
@@ -1,0 +1,18 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "sudoku"
+      screenLabel: "Sudoku"
+# PreGame difficulty picker shows on fresh start — tap Start.
+- tapOn:
+    id: "sudoku-pregame-start"
+    timeout: 8000
+- assertVisible:
+    id: "sudoku-digit-1"
+    timeout: 8000
+- tapOn:
+    id: "sudoku-digit-1"
+- takeScreenshot: sudoku-smoke

--- a/e2e/maestro/flows/sudoku/smoke.yaml
+++ b/e2e/maestro/flows/sudoku/smoke.yaml
@@ -6,10 +6,11 @@ appId: com.buffingchi.games
     env:
       gameSlug: "sudoku"
       screenLabel: "Sudoku"
-# PreGame difficulty picker shows on fresh start — tap Start.
+# PreGame only shows when no puzzle is in progress; skip if resuming a saved puzzle.
 - tapOn:
     id: "sudoku-pregame-start"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "sudoku-digit-1"
     timeout: 8000

--- a/e2e/maestro/flows/twenty48/smoke.yaml
+++ b/e2e/maestro/flows/twenty48/smoke.yaml
@@ -1,0 +1,16 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "twenty48"
+      screenLabel: "2048"
+- assertVisible:
+    id: "twenty48-board"
+    timeout: 8000
+- swipe:
+    direction: RIGHT
+    from:
+      id: "twenty48-board"
+- takeScreenshot: twenty48-smoke

--- a/e2e/maestro/flows/yacht/smoke.yaml
+++ b/e2e/maestro/flows/yacht/smoke.yaml
@@ -6,16 +6,18 @@ appId: com.buffingchi.games
     env:
       gameSlug: "yacht"
       screenLabel: "Yacht"
-# Difficulty picker shows for every fresh game — always tap Solo.
+# Mode picker only shows for fresh games; skip if a saved game is already in play.
 - tapOn:
     id: "yacht-mode-solo"
-    timeout: 8000
+    optional: true
+    timeout: 3000
 - assertVisible:
     id: "yacht-roll-button"
     timeout: 8000
 - tapOn:
     id: "yacht-roll-button"
+# "Tap dice to hold" only appears after the first roll — proves the roll fired.
 - assertVisible:
-    id: "yacht-die-0"
+    text: "Tap dice to hold"
     timeout: 5000
 - takeScreenshot: yacht-smoke

--- a/e2e/maestro/flows/yacht/smoke.yaml
+++ b/e2e/maestro/flows/yacht/smoke.yaml
@@ -1,0 +1,21 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "yacht"
+      screenLabel: "Yacht"
+# Difficulty picker shows for every fresh game — always tap Solo.
+- tapOn:
+    id: "yacht-mode-solo"
+    timeout: 8000
+- assertVisible:
+    id: "yacht-roll-button"
+    timeout: 8000
+- tapOn:
+    id: "yacht-roll-button"
+- assertVisible:
+    id: "yacht-die-0"
+    timeout: 5000
+- takeScreenshot: yacht-smoke

--- a/frontend/src/components/blackjack/BettingPanel.tsx
+++ b/frontend/src/components/blackjack/BettingPanel.tsx
@@ -104,6 +104,7 @@ export default function BettingPanel({
         </Pressable>
 
         <Pressable
+          testID="blackjack-deal-button"
           style={[styles.dealBtn, { backgroundColor: canDeal ? resolvedAccent : colors.border }]}
           onPress={() => onDeal(bet)}
           disabled={!canDeal}

--- a/frontend/src/components/blackjack/ChipButton.tsx
+++ b/frontend/src/components/blackjack/ChipButton.tsx
@@ -24,6 +24,7 @@ export default function ChipButton({
 
   return (
     <Pressable
+      testID={`blackjack-chip-${amount}`}
       style={[styles.chip, { backgroundColor: chipColor, opacity: disabled ? 0.35 : 1 }]}
       onPress={onPress}
       disabled={disabled}

--- a/frontend/src/components/sudoku/NumberPad.tsx
+++ b/frontend/src/components/sudoku/NumberPad.tsx
@@ -56,6 +56,7 @@ export default function NumberPad({
           return (
             <Pressable
               key={d}
+              testID={`sudoku-digit-${d}`}
               onPress={() => onDigit(d)}
               disabled={disabled}
               accessibilityRole="button"

--- a/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
+++ b/frontend/src/components/sudoku/__tests__/__snapshots__/components.test.tsx.snap
@@ -281,6 +281,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-1"
     >
       <Text
         style={
@@ -366,6 +367,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-2"
     >
       <Text
         style={
@@ -451,6 +453,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-3"
     >
       <Text
         style={
@@ -536,6 +539,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-4"
     >
       <Text
         style={
@@ -621,6 +625,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-5"
     >
       <Text
         style={
@@ -706,6 +711,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-6"
     >
       <Text
         style={
@@ -791,6 +797,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-7"
     >
       <Text
         style={
@@ -876,6 +883,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-8"
     >
       <Text
         style={
@@ -961,6 +969,7 @@ exports[`NumberPad matches snapshot — notes mode active 1`] = `
           },
         ]
       }
+      testID="sudoku-digit-9"
     >
       <Text
         style={

--- a/frontend/src/game/mahjong/LayoutSelectScreen.tsx
+++ b/frontend/src/game/mahjong/LayoutSelectScreen.tsx
@@ -63,6 +63,7 @@ export default function LayoutSelectScreen({
               return (
                 <Pressable
                   key={layout.id}
+                  testID={`mahjong-layout-${layout.id}`}
                   style={[
                     styles.card,
                     {

--- a/frontend/src/game/sort/components/LevelSelectScreen.tsx
+++ b/frontend/src/game/sort/components/LevelSelectScreen.tsx
@@ -58,6 +58,7 @@ export default function LevelSelectScreen({ levels, progress, onSelectLevel, onC
               return (
                 <Pressable
                   key={level.id}
+                  testID={`sort-level-${level.id}`}
                   style={[
                     styles.card,
                     {

--- a/frontend/src/screens/BlackjackTableScreen.tsx
+++ b/frontend/src/screens/BlackjackTableScreen.tsx
@@ -245,7 +245,7 @@ export default function BlackjackTableScreen({ navigation }: Props) {
 
       {/* Table */}
       {state && (
-        <View style={styles.tableArea}>
+        <View testID="blackjack-table-area" style={styles.tableArea}>
           <BlackjackTable
             playerHand={state.player_hand}
             dealerHand={state.dealer_hand}

--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -307,6 +307,7 @@ function WordKeyboard({
     return (
       <Pressable
         key={`${key}-${idx}`}
+        testID={`daily-word-key-${key.toLowerCase()}`}
         onPress={() => onKey(key)}
         style={[keyStyles.key, isAction && keyStyles.actionKey, { backgroundColor: bg }]}
         accessibilityRole="button"

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -194,6 +194,7 @@ export default function FreeCellScreen() {
       rightSlot={
         <View style={styles.headerBtnRow}>
           <Pressable
+            testID="freecell-hint-button"
             onPress={handleHint}
             disabled={hintDisabled}
             style={[
@@ -241,7 +242,11 @@ export default function FreeCellScreen() {
               </Text>
             </View>
 
-            <View testID="freecell-board" style={styles.boardWrap} accessibilityLabel={t("freecell:a11y.boardRegion")}>
+            <View
+              testID="freecell-board"
+              style={styles.boardWrap}
+              accessibilityLabel={t("freecell:a11y.boardRegion")}
+            >
               <FreeCellBoard state={state} onMove={handleMove} />
             </View>
 

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -241,7 +241,7 @@ export default function FreeCellScreen() {
               </Text>
             </View>
 
-            <View style={styles.boardWrap} accessibilityLabel={t("freecell:a11y.boardRegion")}>
+            <View testID="freecell-board" style={styles.boardWrap} accessibilityLabel={t("freecell:a11y.boardRegion")}>
               <FreeCellBoard state={state} onMove={handleMove} />
             </View>
 

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -542,6 +542,7 @@ export default function GameScreen({ navigation, route }: Props) {
               </Text>
 
               <Pressable
+                testID="yacht-mode-solo"
                 style={[styles.modeBtn, { borderColor: colors.border }]}
                 onPress={handleChooseSolo}
                 accessibilityRole="button"

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -469,6 +469,7 @@ export default function HeartsScreen() {
           </Text>
           <HeartsAiDifficultySelector value={selectedDifficulty} onChange={setSelectedDifficulty} />
           <Pressable
+            testID="hearts-start-game"
             style={[styles.btn, { backgroundColor: colors.accent }]}
             onPress={() => handleStartGame(selectedDifficulty)}
             accessibilityRole="button"
@@ -537,7 +538,7 @@ export default function HeartsScreen() {
         </View>
 
         {/* Human hand */}
-        <View style={styles.bottomArea}>
+        <View testID="hearts-player-hand-area" style={styles.bottomArea}>
           <Text style={[styles.humanLabel, { color: colors.textMuted }]}>
             {playerLabels[0] ?? ""}
           </Text>

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -959,6 +959,7 @@ export default function MahjongScreen() {
 
           {/* Viewport container — clips the board during zoom/pan */}
           <View
+            testID="mahjong-board-viewport"
             style={{
               width: camera.viewportWidth,
               height: camera.viewportHeight,

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -704,6 +704,7 @@ export default function SortScreen() {
 
       {/* Board */}
       <View
+        testID="sort-board"
         style={styles.boardContainer}
         onLayout={(e: LayoutChangeEvent) => setBoardHeight(e.nativeEvent.layout.height)}
       >

--- a/frontend/src/screens/StarSwarmScreen.tsx
+++ b/frontend/src/screens/StarSwarmScreen.tsx
@@ -258,7 +258,7 @@ export default function StarSwarmScreen() {
         paddingRight: Math.max(insets.right, 0),
       }}
     >
-      <View style={styles.canvasOuter} onLayout={onLayout}>
+      <View testID="starswarm-canvas-outer" style={styles.canvasOuter} onLayout={onLayout}>
         {scale > 0 && (
           <View style={{ width: displayW, height: displayH }}>
             <GameCanvas
@@ -355,6 +355,7 @@ export default function StarSwarmScreen() {
                   ))}
                 </ScrollView>
                 <Pressable
+                  testID="starswarm-start-game"
                   style={[styles.devActionBtn, dynamicStyles.devPrimary, styles.pickerStartBtn]}
                   onPress={handleConfirmDifficulty}
                 >

--- a/frontend/src/screens/SudokuScreen.tsx
+++ b/frontend/src/screens/SudokuScreen.tsx
@@ -624,6 +624,7 @@ function PreGame({
           <DifficultySelector value={difficulty} onChange={onChange} />
         </View>
         <Pressable
+          testID="sudoku-pregame-start"
           onPress={onStart}
           style={[styles.preGameStart, gradient]}
           accessibilityRole="button"

--- a/frontend/src/screens/Twenty48Screen.tsx
+++ b/frontend/src/screens/Twenty48Screen.tsx
@@ -413,7 +413,7 @@ export default function Twenty48Screen({ navigation }: Props) {
 
       {/* Board */}
       <GestureDetector gesture={swipeGesture}>
-        <View style={styles.boardContainer}>
+        <View testID="twenty48-board" style={styles.boardContainer}>
           {/* Ambient glow blobs — decorative, placed behind the grid */}
           <View
             style={[styles.glowTopLeft, { backgroundColor: colors.accent }, glowBlur]}


### PR DESCRIPTION
## Summary

- Adds `smoke.yaml` Maestro flows for all 10 games: Blackjack, Yacht, Cascade, FreeCell, Hearts, Solitaire, 2048, Sudoku, Daily Word, Sort Puzzle, Mahjong Solitaire, StarSwarm
- Adds `offline/smoke.yaml` — navigates to Solitaire with airplane mode enabled (Android), proving client-side game logic runs without network (something Playwright fundamentally cannot test)
- Adds the minimum `testID` props to 15 source files needed to make flows reliable, following the `game-element[-qualifier]` naming convention

Each flow: launch → navigate → handle any pre-game selector → one native interaction → screenshot.

## Pre-game selectors handled

| Game | Selector | Flow action |
|---|---|---|
| Yacht | Mode picker (Solo / VS Computer) | taps `yacht-mode-solo` |
| Hearts | Difficulty picker | taps `hearts-start-game` |
| Sort | Level select | taps `sort-level-1` |
| Mahjong | Layout select | taps `mahjong-layout-turtle` |
| Sudoku | Difficulty / variant | taps `sudoku-pregame-start` |
| StarSwarm | Difficulty picker | taps `starswarm-start-game` |

## testIDs added

| testID | Component | Purpose |
|---|---|---|
| `blackjack-chip-{n}` | ChipButton | tap a chip to place a bet |
| `blackjack-deal-button` | BettingPanel | tap Deal |
| `blackjack-table-area` | BlackjackTableScreen | assert table screen loaded |
| `yacht-mode-solo` | GameScreen | dismiss mode picker |
| `twenty48-board` | Twenty48Screen | swipe target |
| `sort-board` | SortScreen | board tap target |
| `sort-level-{id}` | LevelSelectScreen | select level 1 |
| `starswarm-canvas-outer` | StarSwarmScreen | canvas tap target |
| `starswarm-start-game` | StarSwarmScreen | confirm difficulty |
| `freecell-board` | FreeCellScreen | board tap target |
| `hearts-player-hand-area` | HeartsScreen | hand area tap target |
| `hearts-start-game` | HeartsScreen | start game from difficulty picker |
| `sudoku-digit-{n}` | NumberPad | tap digit 1 |
| `sudoku-pregame-start` | SudokuScreen | start game from pre-game |
| `daily-word-key-{letter}` | DailyWordScreen | tap keyboard keys |
| `mahjong-board-viewport` | MahjongScreen | assert board loaded |
| `mahjong-layout-{id}` | LayoutSelectScreen | select Turtle layout |

## Test plan

- [ ] Run `maestro test e2e/maestro/flows/blackjack/smoke.yaml` on Android emulator
- [ ] Run `maestro test e2e/maestro/flows/yacht/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/cascade/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/freecell/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/hearts/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/solitaire/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/twenty48/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/sudoku/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/daily-word/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/sort/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/mahjong/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/starswarm/smoke.yaml`
- [ ] Run `maestro test e2e/maestro/flows/offline/smoke.yaml` (Android only)
- [ ] ESLint passes on all modified source files ✅

Closes #1675, #1676, #1677, #1678, #1679, #1680, #1681
Part of #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)