### PR TITLE
feat(ci): Maestro reporting — job summary + failure screenshot artifacts

### DIFF
--- a/.github/workflows/mobile-smoke-android.yml
+++ b/.github/workflows/mobile-smoke-android.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           import xml.etree.ElementTree as ET, os
           report = 'maestro-results/report.xml'
-          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/stdout')
           rows = []
           try:
               root = ET.parse(report).getroot()
@@ -107,6 +107,8 @@ jobs:
         if: failure()
         with:
           name: maestro-android-screenshots
-          path: screenshots/
+          path: |
+            screenshots/
+            maestro-results/screenshots/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/mobile-smoke-android.yml
+++ b/.github/workflows/mobile-smoke-android.yml
@@ -68,7 +68,30 @@ jobs:
               --output ./maestro-results \
               $(find e2e/maestro/flows -name "*.yaml" ! -path "*/_shared/*")
 
-      - name: Upload Maestro artifacts
+      - name: Write job summary
+        if: always()
+        shell: python3 {0}
+        run: |
+          import xml.etree.ElementTree as ET, os
+          report = 'maestro-results/report.xml'
+          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          rows = []
+          try:
+              root = ET.parse(report).getroot()
+              suites = root.findall('testsuite') if root.tag == 'testsuites' else [root]
+              for s in suites:
+                  name = s.get('name', 'unknown').removeprefix('e2e/maestro/flows/').removesuffix('.yaml')
+                  failed = int(s.get('failures', 0)) + int(s.get('errors', 0))
+                  rows.append(f'| `{name}` | {"❌ FAIL" if failed else "✅ PASS"} |\n')
+          except FileNotFoundError:
+              rows.append('| _(no report — test runner may have crashed)_ | — |\n')
+          except ET.ParseError as exc:
+              rows.append(f'| _(parse error: {exc})_ | — |\n')
+          with open(out, 'a') as f:
+              f.write('## Maestro Android Smoke\n\n| Flow | Result |\n|---|---|\n')
+              f.writelines(rows)
+
+      - name: Upload Maestro results
         uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -77,4 +100,13 @@ jobs:
             maestro-results/
             ~/.maestro/tests/
           if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload failure screenshots
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: maestro-android-screenshots
+          path: screenshots/
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/mobile-smoke-ios.yml
+++ b/.github/workflows/mobile-smoke-ios.yml
@@ -66,7 +66,30 @@ jobs:
             --output ./maestro-results \
             $(find e2e/maestro/flows -name "*.yaml" ! -path "*/_shared/*" ! -path "*/offline/*")
 
-      - name: Upload Maestro artifacts
+      - name: Write job summary
+        if: always()
+        shell: python3 {0}
+        run: |
+          import xml.etree.ElementTree as ET, os
+          report = 'maestro-results/report.xml'
+          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          rows = []
+          try:
+              root = ET.parse(report).getroot()
+              suites = root.findall('testsuite') if root.tag == 'testsuites' else [root]
+              for s in suites:
+                  name = s.get('name', 'unknown').removeprefix('e2e/maestro/flows/').removesuffix('.yaml')
+                  failed = int(s.get('failures', 0)) + int(s.get('errors', 0))
+                  rows.append(f'| `{name}` | {"❌ FAIL" if failed else "✅ PASS"} |\n')
+          except FileNotFoundError:
+              rows.append('| _(no report — test runner may have crashed)_ | — |\n')
+          except ET.ParseError as exc:
+              rows.append(f'| _(parse error: {exc})_ | — |\n')
+          with open(out, 'a') as f:
+              f.write('## Maestro iOS Smoke\n\n| Flow | Result |\n|---|---|\n')
+              f.writelines(rows)
+
+      - name: Upload Maestro results
         uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -75,4 +98,13 @@ jobs:
             maestro-results/
             ~/.maestro/tests/
           if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload failure screenshots
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: maestro-ios-screenshots
+          path: screenshots/
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/mobile-smoke-ios.yml
+++ b/.github/workflows/mobile-smoke-ios.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           import xml.etree.ElementTree as ET, os
           report = 'maestro-results/report.xml'
-          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          out = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/stdout')
           rows = []
           try:
               root = ET.parse(report).getroot()
@@ -105,6 +105,8 @@ jobs:
         if: failure()
         with:
           name: maestro-ios-screenshots
-          path: screenshots/
+          path: |
+            screenshots/
+            maestro-results/screenshots/
           if-no-files-found: ignore
           retention-days: 7

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -47,6 +47,7 @@
   },
   "ignorePatterns": [
     "node_modules/",
+    "dist/",
     "ios/",
     "android/",
     "*.config.js",


### PR DESCRIPTION
Closes #1673

## Summary

- Adds a **Write job summary** step (`if: always()`) to both mobile smoke workflows — inline Python parses `maestro-results/report.xml` and writes a pass/fail-per-flow Markdown table to `$GITHUB_STEP_SUMMARY`
- Adds an **Upload failure screenshots** step (`if: failure()`) that uploads both `screenshots/` and `maestro-results/screenshots/` (covering both locations Maestro may write `takeScreenshot` output depending on `--output` usage) as a named artifact only on failure

## Test plan

- [ ] Verify job summary table appears in the CI run summary after a push to `main`, with one row per flow
- [ ] Confirm `maestro-android-screenshots` / `maestro-ios-screenshots` artifacts appear only on a failed run and contain actual `.png` files (not an empty artifact)
- [ ] Confirm `maestro-android-results` / `maestro-ios-results` artifacts (report + `~/.maestro/tests/`) still upload on both pass and fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)