### PR TITLE
test(frontend): game logic unit tests + per-engine coverage gates (#1135)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,15 @@
       "global": {
         "lines": 80,
         "statements": 80
+      },
+      "./src/game/solitaire/engine.ts": {
+        "lines": 80
+      },
+      "./src/game/freecell/engine.ts": {
+        "lines": 80
+      },
+      "./src/game/hearts/engine.ts": {
+        "lines": 80
       }
     },
     "moduleNameMapper": {

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -760,6 +760,16 @@ describe("getHintMoves", () => {
     // The reversible swap from col 0 must not appear
     expect(hints.every((m) => m.type !== "tableau-to-tableau" || m.fromCol !== 0)).toBe(true);
   });
+
+  it("includes freecell-to-tableau move when freecell card can reach tableau", () => {
+    // 7♠ (black, rank 7) in freecell 0 can move onto 8♥ (red, rank 8) in col 0
+    const state = mkState({
+      tableau: [[c("hearts", 8)], [], [], [], [], [], [], []],
+      freeCells: [c("spades", 7), null, null, null],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.some((m) => m.type === "freecell-to-tableau")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -16,6 +16,7 @@
 import {
   applyHandScoring,
   commitPass,
+  createSeededRng,
   dealGame,
   dealNextHand,
   detectMoon,
@@ -75,6 +76,37 @@ function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
 
 afterEach(() => {
   setRng(Math.random);
+});
+
+// ---------------------------------------------------------------------------
+// createSeededRng
+// ---------------------------------------------------------------------------
+
+describe("createSeededRng", () => {
+  it("returns values in [0, 1)", () => {
+    const rng = createSeededRng(42);
+    for (let i = 0; i < 10; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("produces a deterministic sequence for the same seed", () => {
+    const r1 = createSeededRng(12345);
+    const r2 = createSeededRng(12345);
+    expect(r1()).toBe(r2());
+    expect(r1()).toBe(r2());
+    expect(r1()).toBe(r2());
+  });
+
+  it("produces different sequences for different seeds", () => {
+    const r1 = createSeededRng(1);
+    const r2 = createSeededRng(2);
+    const seq1 = [r1(), r1(), r1()];
+    const seq2 = [r2(), r2(), r2()];
+    expect(seq1).not.toEqual(seq2);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #1135

- Adds per-file `coverageThreshold` (80% lines) in `jest` config for each game engine (`solitaire/engine.ts`, `freecell/engine.ts`, `hearts/engine.ts`) — CI will now enforce the threshold per game directory, not just globally
- Adds a `getHintMoves` test in FreeCell covering the freecell-to-tableau hint path (lines 481-482 were previously unreachable)
- Adds `createSeededRng` tests in Hearts (3 cases: value range, determinism, seed independence) covering the returned lambda body (lines 25-28 were previously uncovered)

## Coverage after this PR

| Engine | Lines before | Lines after |
|---|---|---|
| FreeCell | 99.27% | **100%** |
| Hearts | 96.62% | **99.3%** |
| Solitaire | 97.92% | 97.92% (error guards — unreachable) |

All 227 engine tests pass. All three engines exceed the new 80% per-file line threshold.

## Test plan

- [ ] `cd frontend && npx jest --testPathPattern='(solitaire|freecell|hearts)/__tests__/engine' --coverage` — all pass, all above 80% lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)