### PR TITLE
feat(hearts): facedown hands for N/E/W + discard pile clarity

### DIFF
--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -53,9 +53,12 @@ const SELF_CARD_W = 28;
 const SELF_CARD_H = 40;
 const SELF_OFFSET = 18;
 
-// Append alpha ~0.4 (hex 66) to a 6-digit hex color.
+// Append alpha to a 6-digit hex color.
 function alpha40(hex: string): string {
-  return hex.length === 7 ? `${hex}66` : hex;
+  return hex.length === 7 ? `${hex}66` : hex; // ~40% opacity
+}
+function alpha13(hex: string): string {
+  return hex.length === 7 ? `${hex}22` : hex; // ~13% opacity
 }
 
 interface OpponentProps {
@@ -96,7 +99,9 @@ export function OpponentCapturedPile({ cards, seatLabel }: OpponentProps) {
         ))}
       </View>
       {points > 0 && (
-        <Text style={[styles.oppBadge, { color: colors.error, backgroundColor: `${colors.error}22` }]}>
+        <Text
+          style={[styles.oppBadge, { color: colors.error, backgroundColor: alpha13(colors.error) }]}
+        >
           {`${scoredCount} · +${points}`}
         </Text>
       )}
@@ -135,7 +140,7 @@ export function SelfCapturedPile({ cards }: SelfProps) {
                   styles.selfCard,
                   {
                     left: i * SELF_OFFSET,
-                    backgroundColor: colors.surface,
+                    backgroundColor: "#fff",
                     borderColor: colors.border,
                   },
                 ]}

--- a/frontend/src/components/hearts/CapturedPile.tsx
+++ b/frontend/src/components/hearts/CapturedPile.tsx
@@ -47,7 +47,7 @@ function scoringCards(cards: readonly Card[]): Card[] {
 const OPP_CARD_W = 24;
 const OPP_CARD_H = 28;
 const OPP_OFFSET = 8;
-const OPP_MAX_VISIBLE = 4;
+const OPP_MAX_VISIBLE = 5;
 
 const SELF_CARD_W = 28;
 const SELF_CARD_H = 40;
@@ -95,6 +95,11 @@ export function OpponentCapturedPile({ cards, seatLabel }: OpponentProps) {
           />
         ))}
       </View>
+      {points > 0 && (
+        <Text style={[styles.oppBadge, { color: colors.error, backgroundColor: `${colors.error}22` }]}>
+          {`${scoredCount} · +${points}`}
+        </Text>
+      )}
     </View>
   );
 }
@@ -138,7 +143,7 @@ export function SelfCapturedPile({ cards }: SelfProps) {
                 <Text
                   style={[
                     styles.selfRank,
-                    { color: isRedSuit(card.suit) ? colors.error : colors.text },
+                    { color: isRedSuit(card.suit) ? colors.error : "#0e0e13" },
                   ]}
                 >
                   {rankText(card.rank)}
@@ -146,7 +151,7 @@ export function SelfCapturedPile({ cards }: SelfProps) {
                 <Text
                   style={[
                     styles.selfSuit,
-                    { color: isRedSuit(card.suit) ? colors.error : colors.text },
+                    { color: isRedSuit(card.suit) ? colors.error : "#0e0e13" },
                   ]}
                 >
                   {SUIT_SYMBOL[card.suit]}
@@ -165,6 +170,14 @@ const styles = StyleSheet.create({
   oppContainer: {
     alignItems: "center",
     gap: 4,
+  },
+  oppBadge: {
+    fontSize: 10,
+    fontWeight: "700",
+    letterSpacing: 0.3,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 999,
   },
   oppFan: {
     position: "relative",

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -78,6 +78,14 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
   );
 }
 
+const cardShadow = {
+  shadowColor: "#000",
+  shadowOffset: { width: 0, height: 1 },
+  shadowOpacity: 0.3,
+  shadowRadius: 3,
+  elevation: 2,
+} as const;
+
 const styles = StyleSheet.create({
   container: {
     alignItems: "center",
@@ -94,11 +102,7 @@ const styles = StyleSheet.create({
     height: H_H,
     borderRadius: 4,
     borderWidth: 1,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.3,
-    shadowRadius: 3,
-    elevation: 2,
+    ...cardShadow,
   },
   vertCard: {
     position: "absolute",
@@ -107,10 +111,6 @@ const styles = StyleSheet.create({
     height: V_H,
     borderRadius: 4,
     borderWidth: 1,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.3,
-    shadowRadius: 3,
-    elevation: 2,
+    ...cardShadow,
   },
 });

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -22,12 +22,20 @@ const V_W = 32;
 const V_H = 22;
 const V_OFFSET = 5;
 
+const cardShadow = {
+  shadowColor: "#000",
+  shadowOffset: { width: 0, height: 1 },
+  shadowOpacity: 0.3,
+  shadowRadius: 3,
+  elevation: 2,
+} as const;
+
 export default function OpponentHand({ cardCount, label, layout = "horizontal" }: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
 
   const count = Math.min(cardCount, 13);
-
+  const faceDownLabel = t("card.faceDown");
   const gradientColors = [colors.accent, colors.secondary] as [string, string];
 
   if (layout === "vertical") {
@@ -41,13 +49,19 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
         <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
         <View style={{ position: "relative", width: V_W, height: stackH }}>
           {Array.from({ length: count }).map((_, i) => (
-            <LinearGradient
+            <View
               key={i}
-              colors={gradientColors}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
+              accessible
+              accessibilityLabel={faceDownLabel}
               style={[styles.vertCard, { top: i * V_OFFSET, borderColor: colors.border }]}
-            />
+            >
+              <LinearGradient
+                colors={gradientColors}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={StyleSheet.absoluteFillObject}
+              />
+            </View>
           ))}
         </View>
       </View>
@@ -65,26 +79,24 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
       <View style={{ position: "relative", width: fanW, height: H_H }}>
         {Array.from({ length: count }).map((_, i) => (
-          <LinearGradient
+          <View
             key={i}
-            colors={gradientColors}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
+            accessible
+            accessibilityLabel={faceDownLabel}
             style={[styles.horizCard, { left: i * H_OFFSET, borderColor: colors.border }]}
-          />
+          >
+            <LinearGradient
+              colors={gradientColors}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={StyleSheet.absoluteFillObject}
+            />
+          </View>
         ))}
       </View>
     </View>
   );
 }
-
-const cardShadow = {
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 1 },
-  shadowOpacity: 0.3,
-  shadowRadius: 3,
-  elevation: 2,
-} as const;
 
 const styles = StyleSheet.create({
   container: {
@@ -102,6 +114,7 @@ const styles = StyleSheet.create({
     height: H_H,
     borderRadius: 4,
     borderWidth: 1,
+    overflow: "hidden",
     ...cardShadow,
   },
   vertCard: {
@@ -111,6 +124,7 @@ const styles = StyleSheet.create({
     height: V_H,
     borderRadius: 4,
     borderWidth: 1,
+    overflow: "hidden",
     ...cardShadow,
   },
 });

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -53,6 +53,7 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
               key={i}
               accessible
               accessibilityLabel={faceDownLabel}
+              accessibilityRole="image"
               style={[styles.vertCard, { top: i * V_OFFSET, borderColor: colors.border }]}
             >
               <LinearGradient
@@ -83,6 +84,7 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
             key={i}
             accessible
             accessibilityLabel={faceDownLabel}
+            accessibilityRole="image"
             style={[styles.horizCard, { left: i * H_OFFSET, borderColor: colors.border }]}
           >
             <LinearGradient

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -1,21 +1,61 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
-import PlayingCard from "./PlayingCard";
-import type { Card, Rank, Suit } from "../../game/hearts/types";
 
 interface Props {
   cardCount: number;
   label: string;
+  /** "horizontal" = North (portrait cards fanning left-to-right).
+   *  "vertical"   = East/West (landscape cards stacked top-to-bottom). */
+  layout?: "horizontal" | "vertical";
 }
 
-const PLACEHOLDER_CARD: Card = { suit: "spades" as Suit, rank: 2 as Rank };
+// Horizontal fan constants (North)
+const H_W = 24;
+const H_H = 34;
+const H_OFFSET = 8;
 
-export default function OpponentHand({ cardCount, label }: Props) {
+// Vertical stack constants (East / West) — wider-than-tall to read as sideways
+const V_W = 32;
+const V_H = 22;
+const V_OFFSET = 5;
+
+export default function OpponentHand({ cardCount, label, layout = "horizontal" }: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
 
+  const count = Math.min(cardCount, 13);
+
+  const gradientColors = [colors.accent, colors.secondary] as [string, string];
+
+  if (layout === "vertical") {
+    const stackH = count > 0 ? (count - 1) * V_OFFSET + V_H : 0;
+    return (
+      <View
+        style={styles.container}
+        accessibilityLabel={t("hand.opponent", { label, count: cardCount })}
+        accessibilityRole="none"
+      >
+        <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
+        <View style={{ position: "relative", width: V_W, height: stackH }}>
+          {Array.from({ length: count }).map((_, i) => (
+            <LinearGradient
+              key={i}
+              colors={gradientColors}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 1 }}
+              style={[styles.vertCard, { top: i * V_OFFSET, borderColor: colors.border }]}
+            />
+          ))}
+        </View>
+      </View>
+    );
+  }
+
+  // Horizontal fan (North)
+  const fanW = count > 0 ? (count - 1) * H_OFFSET + H_W : 0;
   return (
     <View
       style={styles.container}
@@ -23,9 +63,15 @@ export default function OpponentHand({ cardCount, label }: Props) {
       accessibilityRole="none"
     >
       <Text style={[styles.label, { color: colors.textMuted }]}>{label}</Text>
-      <View style={styles.cards}>
-        {Array.from({ length: cardCount }).map((_, i) => (
-          <PlayingCard key={i} card={PLACEHOLDER_CARD} faceDown />
+      <View style={{ position: "relative", width: fanW, height: H_H }}>
+        {Array.from({ length: count }).map((_, i) => (
+          <LinearGradient
+            key={i}
+            colors={gradientColors}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[styles.horizCard, { left: i * H_OFFSET, borderColor: colors.border }]}
+          />
         ))}
       </View>
     </View>
@@ -41,7 +87,30 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: "600",
   },
-  cards: {
-    flexDirection: "row",
+  horizCard: {
+    position: "absolute",
+    top: 0,
+    width: H_W,
+    height: H_H,
+    borderRadius: 4,
+    borderWidth: 1,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+    elevation: 2,
+  },
+  vertCard: {
+    position: "absolute",
+    left: 0,
+    width: V_W,
+    height: V_H,
+    borderRadius: 4,
+    borderWidth: 1,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.3,
+    shadowRadius: 3,
+    elevation: 2,
   },
 });

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -5,7 +5,6 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { HomeStackParamList } from "../types/navigation";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../theme/ThemeContext";
-import type { Colors } from "../theme/ThemeContext";
 import { GameShell } from "../components/shared/GameShell";
 import { OpponentCapturedPile, SelfCapturedPile } from "../components/hearts/CapturedPile";
 import OpponentHand from "../components/hearts/OpponentHand";
@@ -57,15 +56,6 @@ function delay(ms: number): Promise<void> {
 type LastTrick = { readonly trick: readonly TrickCard[]; readonly winnerIndex: number } | null;
 type SubmitState = "idle" | "submitting" | "done" | "error";
 
-// Side-seat label for narrow slots (West/East). Just the player name; the
-// captured pile beneath provides the only seat-level visual weight.
-function SideSeatLabel({ label, colors }: { label: string; colors: Colors }) {
-  return <Text style={[sideSeatStyles.label, { color: colors.textMuted }]}>{label}</Text>;
-}
-
-const sideSeatStyles = StyleSheet.create({
-  label: { fontSize: 11, fontWeight: "600" },
-});
 
 export default function HeartsScreen() {
   const { t } = useTranslation("hearts");
@@ -509,7 +499,11 @@ export default function HeartsScreen() {
         {/* Middle: Left AI | TrickArea | Right AI */}
         <View style={styles.middleRow}>
           <View style={styles.sideColumn}>
-            <SideSeatLabel label={playerLabels[1] ?? ""} colors={colors} />
+            <OpponentHand
+              cardCount={gameState.playerHands[1]?.length ?? 0}
+              label={playerLabels[1] ?? ""}
+              layout="vertical"
+            />
             <OpponentCapturedPile
               cards={gameState.wonCards[1] ?? []}
               seatLabel={playerLabels[1] ?? ""}
@@ -529,7 +523,11 @@ export default function HeartsScreen() {
             />
           </View>
           <View style={styles.sideColumn}>
-            <SideSeatLabel label={playerLabels[3] ?? ""} colors={colors} />
+            <OpponentHand
+              cardCount={gameState.playerHands[3]?.length ?? 0}
+              label={playerLabels[3] ?? ""}
+              layout="vertical"
+            />
             <OpponentCapturedPile
               cards={gameState.wonCards[3] ?? []}
               seatLabel={playerLabels[3] ?? ""}

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -56,7 +56,6 @@ function delay(ms: number): Promise<void> {
 type LastTrick = { readonly trick: readonly TrickCard[]; readonly winnerIndex: number } | null;
 type SubmitState = "idle" | "submitting" | "done" | "error";
 
-
 export default function HeartsScreen() {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();


### PR DESCRIPTION
Closes #1838

## Summary
- **`OpponentHand`**: Replaced flat `flexDirection: row` (would render 13×52px = 676px wide) with overlapping absolute-positioned gradient card backs. Adds a `layout` prop:
  - `layout="horizontal"` (North, default) — portrait card backs `24×34`, fanning at 8 px horizontal offset.
  - `layout="vertical"` (East/West) — landscape card backs `32×22`, stacking at 5 px vertical offset to evoke a hand held sideways.
- **`HeartsScreen`**: Seats 1 (West) and 3 (East) now render `<OpponentHand layout="vertical" />` above their captured pile. Removed the plain `SideSeatLabel` helper (name is now provided by `OpponentHand`).
- **`CapturedPile`**: Fixed washed-out `♠/♣` symbols — hardcoded black-suit text to `#0e0e13` (near-black on white card) instead of the light theme token. Added a `count · +pts` red pill below the opponent gradient fan so penalty accumulation is visible at a glance. Raised `OPP_MAX_VISIBLE` 4→5.

## Test plan
- [ ] Start a Hearts game — North/West/East all show facedown card fans.
- [ ] West and East fans are landscape (wider than tall), stacked vertically.
- [ ] North fan is portrait, horizontal.
- [ ] Captured pile badge (`2 · +2`) appears once penalty cards are taken.
- [ ] In your own "TAKEN" row, clubs/spades symbols are near-black (not grey).
- [ ] Card counts decrease as tricks are played.

🤖 Generated with [Claude Code](https://claude.com/claude-code)