### PR TITLE
fix(drag): iOS/Android drag reliability — null rnMeasure fallback + stale drop-zone bounds

### DIFF
--- a/e2e/maestro/flows/freecell/drag.yaml
+++ b/e2e/maestro/flows/freecell/drag.yaml
@@ -9,6 +9,10 @@ appId: com.buffingchi.games
 - assertVisible:
     id: "freecell-board"
     timeout: 8000
+# Confirm the drag source exists before swiping.
+- assertVisible:
+    id: "freecell-col-0-top"
+    timeout: 3000
 # Drag the top card of column 0 to freecell slot 0.
 # At game start all 4 freecell slots are always empty and every column has cards,
 # so this move is always valid — a reliable probe of the drag gesture path.
@@ -18,4 +22,8 @@ appId: com.buffingchi.games
     to:
       id: "freecell-slot-0"
     duration: 600
+# Confirm the board is still functional (no crash) and the drag target is visible.
+- assertVisible:
+    id: "freecell-slot-0"
+    timeout: 2000
 - takeScreenshot: freecell-drag

--- a/e2e/maestro/flows/freecell/drag.yaml
+++ b/e2e/maestro/flows/freecell/drag.yaml
@@ -1,0 +1,21 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "freecell"
+      screenLabel: "FreeCell"
+- assertVisible:
+    id: "freecell-board"
+    timeout: 8000
+# Drag the top card of column 0 to freecell slot 0.
+# At game start all 4 freecell slots are always empty and every column has cards,
+# so this move is always valid — a reliable probe of the drag gesture path.
+- swipe:
+    from:
+      id: "freecell-col-0-top"
+    to:
+      id: "freecell-slot-0"
+    duration: 600
+- takeScreenshot: freecell-drag

--- a/e2e/maestro/flows/solitaire/drag.yaml
+++ b/e2e/maestro/flows/solitaire/drag.yaml
@@ -1,0 +1,27 @@
+appId: com.buffingchi.games
+---
+- runFlow: ../_shared/launch.yaml
+- runFlow:
+    file: ../_shared/navigate-to.yaml
+    env:
+      gameSlug: "solitaire"
+      screenLabel: "Solitaire"
+- assertVisible:
+    id: "solitaire-stock-pile"
+    timeout: 8000
+# Draw one card from stock so the waste pile is non-empty.
+- tapOn:
+    id: "solitaire-stock-pile"
+- assertVisible:
+    id: "solitaire-waste-top"
+    timeout: 3000
+# Drag the waste top card toward tableau column 0.
+# The move may or may not be valid (deal is random); either outcome — card placed
+# or snap-back — exercises the full drag gesture path and drop-zone hit-test.
+- swipe:
+    from:
+      id: "solitaire-waste-top"
+    to:
+      id: "solitaire-tableau-0"
+    duration: 600
+- takeScreenshot: solitaire-drag

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,15 @@
       "global": {
         "lines": 80,
         "statements": 80
+      },
+      "./src/game/solitaire/engine.ts": {
+        "lines": 80
+      },
+      "./src/game/freecell/engine.ts": {
+        "lines": 80
+      },
+      "./src/game/hearts/engine.ts": {
+        "lines": 80
       }
     },
     "moduleNameMapper": {

--- a/frontend/src/components/freecell/FreeCellSlot.tsx
+++ b/frontend/src/components/freecell/FreeCellSlot.tsx
@@ -89,6 +89,7 @@ export default function FreeCellSlot({
       return (
         <DropTarget
           id={dropId!}
+          testID={dropId}
           onDrop={onDrop!}
           highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 6 }}
           dimStyle={{ opacity: 0.4 }}
@@ -134,6 +135,7 @@ export default function FreeCellSlot({
     return (
       <DropTarget
         id={dropId!}
+        testID={dropId}
         onDrop={onDrop!}
         highlightStyle={{ borderColor: colors.accent, borderWidth: 2, borderRadius: 6 }}
         dimStyle={{ opacity: 0.4 }}

--- a/frontend/src/components/freecell/TableauColumn.tsx
+++ b/frontend/src/components/freecell/TableauColumn.tsx
@@ -119,6 +119,7 @@ export default function TableauColumn({
     return (
       <DraggableCard
         key={cardIndex}
+        testID={isTop ? `freecell-col-${colIndex}-top` : undefined}
         style={[styles.cardSlot, { top: offsets[cardIndex] ?? 0 }]}
         onTap={handlePress}
         dragCards={dragCards}

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -149,11 +149,21 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
         zone,
       }));
 
-      results.forEach((entry, i) => {
-        zones[i]!.measureFresh((bounds) => {
+      // Safety net: if any measureInWindow callback never fires (e.g. view unmounted
+      // mid-drag on Android) the card must not stay frozen on screen indefinitely.
+      const timeout = setTimeout(() => {
+        if (remaining > 0) snapBackAndClear();
+      }, 300);
+
+      results.forEach((entry) => {
+        entry.zone.measureFresh((bounds) => {
+          // No-op if the timeout already fired and snapped back.
+          if (remaining <= 0) return;
           entry.bounds = bounds;
           remaining--;
           if (remaining > 0) return;
+
+          clearTimeout(timeout);
 
           // All measurements received — run hit-test.
           // Guard against a second drag starting before this callback fires.

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -33,6 +33,7 @@ export type DropHandler = (source: DragSource, cards: DragCard[]) => boolean;
 
 interface DropZoneEntry {
   getMeasurement: () => { x: number; y: number; width: number; height: number } | null;
+  refreshMeasurement: () => void;
   onDrop: DropHandler;
 }
 
@@ -113,6 +114,11 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
       setDragState(state);
       if (getLegalDropIds) {
         setLegalTargetIds(new Set(getLegalDropIds(source, cards)));
+      }
+      // Refresh all drop-zone bounds so hit-tests use current window coordinates,
+      // not potentially-stale onLayout measurements.
+      for (const [, zone] of dropZonesRef.current) {
+        zone.refreshMeasurement();
       }
     },
     [getLegalDropIds]

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -31,9 +31,11 @@ export interface DragState {
 /** Return true if the drop was accepted, false to trigger snap-back. */
 export type DropHandler = (source: DragSource, cards: DragCard[]) => boolean;
 
+type Bounds = { x: number; y: number; width: number; height: number };
+
 interface DropZoneEntry {
-  getMeasurement: () => { x: number; y: number; width: number; height: number } | null;
-  refreshMeasurement: () => void;
+  /** Measure the zone's window bounds right now, calling cb when ready. */
+  measureFresh: (cb: (bounds: Bounds | null) => void) => void;
   onDrop: DropHandler;
 }
 
@@ -115,11 +117,6 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
       if (getLegalDropIds) {
         setLegalTargetIds(new Set(getLegalDropIds(source, cards)));
       }
-      // Refresh all drop-zone bounds so hit-tests use current window coordinates,
-      // not potentially-stale onLayout measurements.
-      for (const [, zone] of dropZonesRef.current) {
-        zone.refreshMeasurement();
-      }
     },
     [getLegalDropIds]
   );
@@ -137,23 +134,49 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
       const state = dragStateRef.current;
       if (!state) return;
 
-      for (const [, zone] of dropZonesRef.current) {
-        const bounds = zone.getMeasurement();
-        if (!bounds) continue;
-        if (
-          absoluteX >= bounds.x &&
-          absoluteX <= bounds.x + bounds.width &&
-          absoluteY >= bounds.y &&
-          absoluteY <= bounds.y + bounds.height
-        ) {
-          const accepted = zone.onDrop(state.source, state.cards);
-          if (accepted) {
-            clearDrag();
-            return;
-          }
-        }
+      // Take a snapshot of zones at this moment (Map entry order = registration order).
+      const zones = Array.from(dropZonesRef.current.values());
+      if (zones.length === 0) {
+        snapBackAndClear();
+        return;
       }
-      snapBackAndClear();
+
+      // Measure every zone fresh via measureInWindow so we always use current
+      // window coordinates — cached onLayout values can be stale or zero on iOS.
+      let remaining = zones.length;
+      const results: { bounds: Bounds | null; zone: DropZoneEntry }[] = zones.map((zone) => ({
+        bounds: null,
+        zone,
+      }));
+
+      results.forEach((entry, i) => {
+        zones[i]!.measureFresh((bounds) => {
+          entry.bounds = bounds;
+          remaining--;
+          if (remaining > 0) return;
+
+          // All measurements received — run hit-test.
+          // Guard against a second drag starting before this callback fires.
+          if (dragStateRef.current !== state) return;
+
+          for (const { bounds: b, zone } of results) {
+            if (!b) continue;
+            if (
+              absoluteX >= b.x &&
+              absoluteX <= b.x + b.width &&
+              absoluteY >= b.y &&
+              absoluteY <= b.y + b.height
+            ) {
+              const accepted = zone.onDrop(state.source, state.cards);
+              if (accepted) {
+                clearDrag();
+                return;
+              }
+            }
+          }
+          snapBackAndClear();
+        });
+      });
     },
     [clearDrag, snapBackAndClear]
   );

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -70,7 +70,7 @@ export function DraggableCard({
     .activeOffsetX([-12, 12])
     .activeOffsetY([-12, 12])
     .enabled(draggable)
-    .onStart(() => {
+    .onStart((e) => {
       "worklet";
       panActivated.value = true;
       const cardMeasured = rnMeasure(viewRef);
@@ -80,8 +80,12 @@ export function DraggableCard({
         containerOffsetX.value = containerMeasured.pageX;
         containerOffsetY.value = containerMeasured.pageY;
       }
-      const localX = (cardMeasured?.pageX ?? 0) - containerOffsetX.value;
-      const localY = (cardMeasured?.pageY ?? 0) - containerOffsetY.value;
+      // rnMeasure can return null on iOS/Android before the first native layout pass.
+      // RNGH guarantee: e.absoluteX - e.x = absolute window X of the gesture view's origin.
+      const pageX = cardMeasured?.pageX ?? (e.absoluteX - e.x);
+      const pageY = cardMeasured?.pageY ?? (e.absoluteY - e.y);
+      const localX = pageX - containerOffsetX.value;
+      const localY = pageY - containerOffsetY.value;
       originX.value = localX;
       originY.value = localY;
       cardX.value = localX;

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -82,8 +82,9 @@ export function DraggableCard({
       }
       // rnMeasure can return null on iOS/Android before the first native layout pass.
       // RNGH guarantee: e.absoluteX - e.x = absolute window X of the gesture view's origin.
-      const pageX = cardMeasured?.pageX ?? (e.absoluteX - e.x);
-      const pageY = cardMeasured?.pageY ?? (e.absoluteY - e.y);
+      // Assumes GestureDetector + innerEl share the same origin as viewRef (no intervening padding).
+      const pageX = cardMeasured?.pageX ?? e.absoluteX - e.x;
+      const pageY = cardMeasured?.pageY ?? e.absoluteY - e.y;
       const localX = pageX - containerOffsetX.value;
       const localY = pageY - containerOffsetY.value;
       originX.value = localX;

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { View } from "react-native";
 import type { ViewStyle } from "react-native";
 import { useTheme } from "../../../theme/ThemeContext";
@@ -28,7 +28,6 @@ export function DropTarget({
   testID,
 }: DropTargetProps) {
   const viewRef = useRef<View>(null);
-  const boundsRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const { colors } = useTheme();
 
   // Keep the latest onDrop in a ref so re-renders don't force re-registration.
@@ -39,27 +38,23 @@ export function DropTarget({
 
   const { dragState, legalTargetIds, registerDropZone, unregisterDropZone } = useDragContext();
 
-  const getMeasurement = useCallback(() => boundsRef.current, []);
-
-  const onLayout = useCallback(() => {
-    // measureInWindow is more reliable than measure on iOS for absolute window coordinates.
-    viewRef.current?.measureInWindow((x, y, w, h) => {
-      boundsRef.current = { x, y, width: w, height: h };
-    });
-  }, []);
-
   useEffect(() => {
     registerDropZone(id, {
-      getMeasurement,
-      refreshMeasurement: () => {
-        viewRef.current?.measureInWindow((x, y, w, h) => {
-          boundsRef.current = { x, y, width: w, height: h };
+      // Always measure fresh via measureInWindow so the hit-test uses current
+      // window coordinates — cached onLayout values can be stale or zero on iOS.
+      measureFresh: (cb) => {
+        if (!viewRef.current) {
+          cb(null);
+          return;
+        }
+        viewRef.current.measureInWindow((x, y, w, h) => {
+          cb({ x, y, width: w, height: h });
         });
       },
       onDrop: (source, cards) => onDropRef.current(source, cards),
     });
     return () => unregisterDropZone(id);
-  }, [id, getMeasurement, registerDropZone, unregisterDropZone]);
+  }, [id, registerDropZone, unregisterDropZone]);
 
   const isDragActive = dragState !== null;
   const isLegal = legalTargetIds.has(id);
@@ -75,7 +70,6 @@ export function DropTarget({
         isDragActive && isLegal && highlightStyle,
         isDragActive && !isLegal && dimStyle,
       ]}
-      onLayout={onLayout}
     >
       {children}
     </View>

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -51,6 +51,11 @@ export function DropTarget({
   useEffect(() => {
     registerDropZone(id, {
       getMeasurement,
+      refreshMeasurement: () => {
+        viewRef.current?.measureInWindow((x, y, w, h) => {
+          boundsRef.current = { x, y, width: w, height: h };
+        });
+      },
       onDrop: (source, cards) => onDropRef.current(source, cards),
     });
     return () => unregisterDropZone(id);

--- a/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
@@ -37,7 +37,9 @@ function DropZoneRegistrar({
   onMeasureFresh,
 }: {
   id: string;
-  onMeasureFresh?: (cb: (bounds: { x: number; y: number; width: number; height: number } | null) => void) => void;
+  onMeasureFresh?: (
+    cb: (bounds: { x: number; y: number; width: number; height: number } | null) => void
+  ) => void;
 }) {
   const { registerDropZone, unregisterDropZone } = useDragContext();
   React.useEffect(() => {
@@ -100,5 +102,76 @@ describe("DragContext", () => {
 
     expect(measure1).toHaveBeenCalledTimes(1);
     expect(measure2).toHaveBeenCalledTimes(1);
+  });
+
+  it("endDrag snaps back immediately when no drop zones are registered", () => {
+    const withSpring = jest.spyOn(Reanimated, "withSpring");
+
+    function StartEndTrigger() {
+      const { startDrag, endDrag } = useDragContext();
+      return (
+        <>
+          <Text accessibilityLabel="start2" onPress={() => startDrag(dragSource, dragCards)}>
+            start
+          </Text>
+          <Text accessibilityLabel="end2" onPress={() => endDrag(0, 0)}>
+            end
+          </Text>
+        </>
+      );
+    }
+
+    const { getByLabelText } = render(wrap(<StartEndTrigger />));
+    fireEvent.press(getByLabelText("start2"));
+    fireEvent.press(getByLabelText("end2"));
+
+    expect(withSpring).toHaveBeenCalled();
+    withSpring.mockRestore();
+  });
+
+  it("endDrag calls onDrop and clears drag when finger lands inside a zone", () => {
+    const onDrop = jest.fn().mockReturnValue(true);
+    const measureFresh = jest.fn(
+      (cb: (b: { x: number; y: number; width: number; height: number }) => void) =>
+        cb({ x: 0, y: 0, width: 1000, height: 1000 })
+    );
+
+    function HitZoneRegistrar() {
+      const { registerDropZone, unregisterDropZone } = useDragContext();
+      React.useEffect(() => {
+        registerDropZone("zone-hit", { measureFresh, onDrop });
+        return () => unregisterDropZone("zone-hit");
+      }, [registerDropZone, unregisterDropZone]);
+      return null;
+    }
+
+    function StartEndTrigger() {
+      const { startDrag, endDrag } = useDragContext();
+      return (
+        <>
+          <Text accessibilityLabel="start3" onPress={() => startDrag(dragSource, dragCards)}>
+            start
+          </Text>
+          <Text accessibilityLabel="end3" onPress={() => endDrag(500, 500)}>
+            end
+          </Text>
+        </>
+      );
+    }
+
+    const { getByLabelText } = render(
+      <DragProvider>
+        <ThemeProvider>
+          <HitZoneRegistrar />
+          <StartEndTrigger />
+        </ThemeProvider>
+      </DragProvider>
+    );
+
+    fireEvent.press(getByLabelText("start3"));
+    fireEvent.press(getByLabelText("end3"));
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(onDrop).toHaveBeenCalledWith(dragSource, dragCards);
   });
 });

--- a/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
@@ -32,6 +32,34 @@ function SnapBackTrigger() {
   );
 }
 
+function DropZoneRegistrar({
+  id,
+  onRefresh,
+}: {
+  id: string;
+  onRefresh: () => void;
+}) {
+  const { registerDropZone, unregisterDropZone } = useDragContext();
+  React.useEffect(() => {
+    registerDropZone(id, {
+      getMeasurement: () => null,
+      refreshMeasurement: onRefresh,
+      onDrop: () => false,
+    });
+    return () => unregisterDropZone(id);
+  }, [id, onRefresh, registerDropZone, unregisterDropZone]);
+  return null;
+}
+
+function StartDragTrigger() {
+  const { startDrag } = useDragContext();
+  return (
+    <Text accessibilityLabel="start" onPress={() => startDrag(dragSource, dragCards)}>
+      start
+    </Text>
+  );
+}
+
 describe("DragContext", () => {
   it("snapBackAndClear calls withSpring for the animation", () => {
     const withSpring = jest.spyOn(Reanimated, "withSpring");
@@ -42,5 +70,25 @@ describe("DragContext", () => {
 
     expect(withSpring).toHaveBeenCalled();
     withSpring.mockRestore();
+  });
+
+  it("startDrag calls refreshMeasurement on every registered drop zone", () => {
+    const refresh1 = jest.fn();
+    const refresh2 = jest.fn();
+
+    const { getByLabelText } = render(
+      <DragProvider>
+        <ThemeProvider>
+          <DropZoneRegistrar id="zone-a" onRefresh={refresh1} />
+          <DropZoneRegistrar id="zone-b" onRefresh={refresh2} />
+          <StartDragTrigger />
+        </ThemeProvider>
+      </DragProvider>
+    );
+
+    fireEvent.press(getByLabelText("start"));
+
+    expect(refresh1).toHaveBeenCalledTimes(1);
+    expect(refresh2).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
@@ -34,20 +34,19 @@ function SnapBackTrigger() {
 
 function DropZoneRegistrar({
   id,
-  onRefresh,
+  onMeasureFresh,
 }: {
   id: string;
-  onRefresh: () => void;
+  onMeasureFresh?: (cb: (bounds: { x: number; y: number; width: number; height: number } | null) => void) => void;
 }) {
   const { registerDropZone, unregisterDropZone } = useDragContext();
   React.useEffect(() => {
     registerDropZone(id, {
-      getMeasurement: () => null,
-      refreshMeasurement: onRefresh,
+      measureFresh: onMeasureFresh ?? ((cb) => cb(null)),
       onDrop: () => false,
     });
     return () => unregisterDropZone(id);
-  }, [id, onRefresh, registerDropZone, unregisterDropZone]);
+  }, [id, onMeasureFresh, registerDropZone, unregisterDropZone]);
   return null;
 }
 
@@ -72,23 +71,34 @@ describe("DragContext", () => {
     withSpring.mockRestore();
   });
 
-  it("startDrag calls refreshMeasurement on every registered drop zone", () => {
-    const refresh1 = jest.fn();
-    const refresh2 = jest.fn();
+  it("endDrag calls measureFresh on every registered drop zone", () => {
+    const measure1 = jest.fn((cb: (b: null) => void) => cb(null));
+    const measure2 = jest.fn((cb: (b: null) => void) => cb(null));
+
+    function EndDragTrigger() {
+      const { endDrag } = useDragContext();
+      return (
+        <Text accessibilityLabel="end" onPress={() => endDrag(999, 999)}>
+          end
+        </Text>
+      );
+    }
 
     const { getByLabelText } = render(
       <DragProvider>
         <ThemeProvider>
-          <DropZoneRegistrar id="zone-a" onRefresh={refresh1} />
-          <DropZoneRegistrar id="zone-b" onRefresh={refresh2} />
+          <DropZoneRegistrar id="zone-a" onMeasureFresh={measure1} />
+          <DropZoneRegistrar id="zone-b" onMeasureFresh={measure2} />
           <StartDragTrigger />
+          <EndDragTrigger />
         </ThemeProvider>
       </DragProvider>
     );
 
     fireEvent.press(getByLabelText("start"));
+    fireEvent.press(getByLabelText("end"));
 
-    expect(refresh1).toHaveBeenCalledTimes(1);
-    expect(refresh2).toHaveBeenCalledTimes(1);
+    expect(measure1).toHaveBeenCalledTimes(1);
+    expect(measure2).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DraggableCard.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { render, fireEvent } from "@testing-library/react-native";
+import * as Reanimated from "react-native-reanimated";
 
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import { DragProvider, useDragContext } from "../DragContext";
@@ -122,6 +123,26 @@ describe("DraggableCard", () => {
     expect(getByTestId("card")).toHaveStyle({ opacity: 1 });
     fireEvent.press(getByLabelText("trigger"));
     expect(getByTestId("card")).toHaveStyle({ opacity: 0.6 });
+  });
+
+  it("renders without crash when rnMeasure is mocked to return null", () => {
+    // Pan gesture worklets run natively and can't be simulated in Jest, but we can
+    // verify the component mounts and tap-fallback still works when rnMeasure returns null.
+    const measureSpy = jest.spyOn(Reanimated, "measure").mockReturnValue(null);
+    const onTap = jest.fn();
+
+    const { getByRole } = render(
+      wrap(
+        <DraggableCard onTap={onTap} dragCards={dragCards} dragSource={dragSource}>
+          <Text accessibilityRole="button">A♠</Text>
+        </DraggableCard>
+      )
+    );
+
+    expect(() => fireEvent.press(getByRole("button"))).not.toThrow();
+    expect(onTap).toHaveBeenCalledTimes(1);
+
+    measureSpy.mockRestore();
   });
 
   it("accepts hitSlop prop without throwing", () => {

--- a/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
@@ -72,21 +72,32 @@ describe("DropTarget", () => {
     expect(merged.backgroundColor).toMatch(/33$/);
   });
 
-  it("does not throw when startDrag triggers refreshMeasurement on the registered zone", () => {
-    // refreshMeasurement calls viewRef.current?.measureInWindow — in the test
-    // environment the ref is null so the optional-chain is a no-op. Verify no crash.
+  it("calls measureFresh without throwing when endDrag fires", () => {
+    // measureFresh calls viewRef.current.measureInWindow — in the test
+    // environment the ref is null so the cb is called with null. Verify no crash.
+    function EndDragTrigger() {
+      const { endDrag } = useDragContext();
+      return (
+        <Text accessibilityLabel="end-drag" onPress={() => endDrag(999, 999)}>
+          end
+        </Text>
+      );
+    }
+
     const { getByLabelText } = render(
       wrap(
         <>
           <StartDragTrigger source={dragSource} cards={dragCards} />
-          <DropTarget id="pile-refresh" onDrop={() => false} testID="target">
+          <EndDragTrigger />
+          <DropTarget id="pile-fresh" onDrop={() => false} testID="target">
             <Text>Content</Text>
           </DropTarget>
         </>
       )
     );
 
-    expect(() => fireEvent.press(getByLabelText("start-drag"))).not.toThrow();
+    fireEvent.press(getByLabelText("start-drag"));
+    expect(() => fireEvent.press(getByLabelText("end-drag"))).not.toThrow();
   });
 
   it("applies dimStyle when drag is active and this target is not legal", () => {

--- a/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
@@ -30,6 +30,15 @@ function DragTrigger({ source, cards }: { source: DragSource; cards: DragCard[] 
   );
 }
 
+function StartDragTrigger({ source, cards }: { source: DragSource; cards: DragCard[] }) {
+  const { startDrag } = useDragContext();
+  return (
+    <Text accessibilityLabel="start-drag" onPress={() => startDrag(source, cards)}>
+      start
+    </Text>
+  );
+}
+
 describe("DropTarget", () => {
   it("renders children without highlight when no drag is active", () => {
     const { getByTestId } = render(
@@ -61,6 +70,23 @@ describe("DropTarget", () => {
     const merged = Object.assign({}, ...flatStyle.filter(Boolean));
     expect(merged.backgroundColor).toBeDefined();
     expect(merged.backgroundColor).toMatch(/33$/);
+  });
+
+  it("does not throw when startDrag triggers refreshMeasurement on the registered zone", () => {
+    // refreshMeasurement calls viewRef.current?.measureInWindow — in the test
+    // environment the ref is null so the optional-chain is a no-op. Verify no crash.
+    const { getByLabelText } = render(
+      wrap(
+        <>
+          <StartDragTrigger source={dragSource} cards={dragCards} />
+          <DropTarget id="pile-refresh" onDrop={() => false} testID="target">
+            <Text>Content</Text>
+          </DropTarget>
+        </>
+      )
+    );
+
+    expect(() => fireEvent.press(getByLabelText("start-drag"))).not.toThrow();
   });
 
   it("applies dimStyle when drag is active and this target is not legal", () => {

--- a/frontend/src/game/freecell/__tests__/engine.test.ts
+++ b/frontend/src/game/freecell/__tests__/engine.test.ts
@@ -760,6 +760,16 @@ describe("getHintMoves", () => {
     // The reversible swap from col 0 must not appear
     expect(hints.every((m) => m.type !== "tableau-to-tableau" || m.fromCol !== 0)).toBe(true);
   });
+
+  it("includes freecell-to-tableau move when freecell card can reach tableau", () => {
+    // 7♠ (black, rank 7) in freecell 0 can move onto 8♥ (red, rank 8) in col 0
+    const state = mkState({
+      tableau: [[c("hearts", 8)], [], [], [], [], [], [], []],
+      freeCells: [c("spades", 7), null, null, null],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.some((m) => m.type === "freecell-to-tableau")).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/hearts/__tests__/engine.test.ts
+++ b/frontend/src/game/hearts/__tests__/engine.test.ts
@@ -16,6 +16,7 @@
 import {
   applyHandScoring,
   commitPass,
+  createSeededRng,
   dealGame,
   dealNextHand,
   detectMoon,
@@ -75,6 +76,37 @@ function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
 
 afterEach(() => {
   setRng(Math.random);
+});
+
+// ---------------------------------------------------------------------------
+// createSeededRng
+// ---------------------------------------------------------------------------
+
+describe("createSeededRng", () => {
+  it("returns values in [0, 1)", () => {
+    const rng = createSeededRng(42);
+    for (let i = 0; i < 10; i++) {
+      const v = rng();
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it("produces a deterministic sequence for the same seed", () => {
+    const r1 = createSeededRng(12345);
+    const r2 = createSeededRng(12345);
+    expect(r1()).toBe(r2());
+    expect(r1()).toBe(r2());
+    expect(r1()).toBe(r2());
+  });
+
+  it("produces different sequences for different seeds", () => {
+    const r1 = createSeededRng(1);
+    const r2 = createSeededRng(2);
+    const seq1 = [r1(), r1(), r1()];
+    const seq2 = [r2(), r2(), r2()];
+    expect(seq1).not.toEqual(seq2);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/solitaire/components/StockWastePile.tsx
+++ b/frontend/src/game/solitaire/components/StockWastePile.tsx
@@ -173,6 +173,7 @@ function Waste({
   if (drawMode !== 3) {
     return (
       <DraggableCard
+        testID="solitaire-waste-top"
         onTap={onPress}
         dragCards={topDragCards}
         dragSource={{ game: "solitaire", type: "waste" }}
@@ -209,6 +210,7 @@ function Waste({
               style={[styles.wasteFanCard, { left: i * wasteFanOffset }]}
             >
               <DraggableCard
+                testID="solitaire-waste-top"
                 onTap={onPress}
                 dragCards={topDragCards}
                 dragSource={{ game: "solitaire", type: "waste" }}

--- a/frontend/src/game/solitaire/components/TableauPile.tsx
+++ b/frontend/src/game/solitaire/components/TableauPile.tsx
@@ -83,6 +83,7 @@ export default function TableauPile({
       return (
         <DropTarget
           id={dropId!}
+          testID={dropId}
           onDrop={onDrop!}
           highlightStyle={highlightStyle}
           dimStyle={dimStyle}
@@ -169,6 +170,7 @@ export default function TableauPile({
     return (
       <DropTarget
         id={dropId!}
+        testID={dropId}
         onDrop={onDrop!}
         style={containerStyle}
         highlightStyle={highlightStyle}


### PR DESCRIPTION
## Summary

Fixes two silent failure modes in the shared drag infrastructure that caused cards to fail to drag or land in the wrong place on iOS and Android in both FreeCell and Klondike Solitaire.

- **`rnMeasure` null fallback** — `pan.onStart` silently used `?? 0` when `rnMeasure` returned null on first-render native layout, placing the DragOverlay at the wrong coordinate. Now uses `e.absoluteX - e.x` / `e.absoluteY - e.y` as the RNGH-guaranteed fallback for the gesture view's window origin. (Closes #1833)
- **Fresh drop-zone measurement** — `DropTarget` previously cached `measureInWindow` results at `onLayout` time; stale or zero bounds caused all drops to miss on iOS. Now `endDrag` calls `measureFresh` (a live `measureInWindow`) on every registered zone and waits for all callbacks before running the hit-test, guaranteeing current window coordinates at drop time. A 300ms timeout ensures the card can never get stuck if a callback fails to fire. (Closes #1834)
- **testIDs + Maestro drag flows** — Adds `testID` props to `FreeCellSlot`, `TableauColumn`, `StockWastePile`, and `TableauPile` DropTargets/DraggableCards; adds `freecell/drag.yaml` and `solitaire/drag.yaml` Maestro smoke flows for both platforms. (Closes #1836)

## Files changed

| Area | Files |
|---|---|
| Shared drag infra | `DraggableCard.tsx`, `DragContext.tsx`, `DropTarget.tsx` |
| FreeCell components | `FreeCellSlot.tsx`, `TableauColumn.tsx` |
| Solitaire components | `StockWastePile.tsx`, `TableauPile.tsx` |
| Tests | `DraggableCard.test.tsx`, `DragContext.test.tsx`, `DropTarget.test.tsx` |
| Maestro | `e2e/maestro/flows/freecell/drag.yaml`, `e2e/maestro/flows/solitaire/drag.yaml` |

## Test plan

- [ ] All 18 drag unit tests pass (`npx jest src/game/_shared/drag`)
- [ ] Maestro FreeCell drag flow: drag col-0 top card → freecell slot 0 (always valid at game start)
- [ ] Maestro Solitaire drag flow: draw from stock, drag waste top → tableau col 0
- [ ] Manual: drag a card in FreeCell on iOS and Android — confirm it starts and lands correctly
- [ ] Manual: drag a card in Solitaire on iOS and Android — confirm same

Closes #1833, #1834, #1836. Part of epic #1837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)