### PR TITLE
fix(yacht): CPU dice animation snap + joker bonus on final scorecard (#1841, #1842)

### DIFF
--- a/frontend/src/components/__tests__/GameOverModal.test.tsx
+++ b/frontend/src/components/__tests__/GameOverModal.test.tsx
@@ -1,21 +1,26 @@
-/**
- * Tests for GameOverModal — joker bonus row visibility (GH #1841).
- */
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { render, within } from "@testing-library/react-native";
 import GameOverModal from "../yacht/GameOverModal";
 import { ThemeProvider } from "../../theme/ThemeContext";
 
 const ALL_CATEGORIES = [
-  "ones", "twos", "threes", "fours", "fives", "sixes",
-  "three_of_a_kind", "four_of_a_kind", "full_house",
-  "small_straight", "large_straight", "yacht", "chance",
+  "ones",
+  "twos",
+  "threes",
+  "fours",
+  "fives",
+  "sixes",
+  "three_of_a_kind",
+  "four_of_a_kind",
+  "full_house",
+  "small_straight",
+  "large_straight",
+  "yacht",
+  "chance",
 ];
 const filledScores = Object.fromEntries(ALL_CATEGORIES.map((k) => [k, 0]));
 
-function renderModal(
-  overrides: Partial<React.ComponentProps<typeof GameOverModal>> = {}
-) {
+function renderModal(overrides: Partial<React.ComponentProps<typeof GameOverModal>> = {}) {
   const defaults: React.ComponentProps<typeof GameOverModal> = {
     visible: true,
     totalScore: 250,
@@ -33,7 +38,7 @@ function renderModal(
   );
 }
 
-describe("GameOverModal — joker bonus row (GH #1841)", () => {
+describe("GameOverModal — joker bonus row", () => {
   it("does not show joker bonus row when yachtBonusTotal is 0", () => {
     const { queryByText } = renderModal({ yachtBonusTotal: 0, yachtBonusCount: 0 });
     expect(queryByText("+100")).toBeNull();
@@ -56,14 +61,12 @@ describe("GameOverModal — joker bonus row (GH #1841)", () => {
   });
 
   it("does not show 'Yacht Bonus' scorecard row when yachtBonusTotal is 0", () => {
-    // Both the scorecard row (bonus.yachtLabel) and the bonus pill (gameOver.yachtBonus)
-    // contain the text "Yacht Bonus". Both are hidden when yachtBonusTotal === 0.
     const { queryAllByText } = renderModal({ yachtBonusTotal: 0 });
     expect(queryAllByText("Yacht Bonus")).toHaveLength(0);
   });
 });
 
-describe("GameOverModal — joker bonus row in VS mode (GH #1841)", () => {
+describe("GameOverModal — joker bonus row in VS mode", () => {
   const vsDefaults = {
     vsResult: "win" as const,
     aiTotalScore: 180,
@@ -72,16 +75,15 @@ describe("GameOverModal — joker bonus row in VS mode (GH #1841)", () => {
   };
 
   it("shows joker row with player '+100' and CPU '—' when only player has jokers", () => {
-    const { getByText, getAllByText } = renderModal({
+    const { getByTestId } = renderModal({
       ...vsDefaults,
       yachtBonusTotal: 100,
       yachtBonusCount: 1,
       aiYachtBonusTotal: 0,
     });
-    expect(getByText("+100")).toBeTruthy();
-    // "—" appears as the CPU value; it may also appear in other unfilled cells
-    const dashes = getAllByText("—");
-    expect(dashes.length).toBeGreaterThanOrEqual(1);
+    const bonusRow = getByTestId("yacht-bonus-row");
+    expect(within(bonusRow).getByText("+100")).toBeTruthy();
+    expect(within(bonusRow).getByText("—")).toBeTruthy();
   });
 
   it("shows joker row with both '+100' values when both players have jokers", () => {

--- a/frontend/src/components/__tests__/GameOverModal.test.tsx
+++ b/frontend/src/components/__tests__/GameOverModal.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for GameOverModal — joker bonus row visibility (GH #1841).
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+import GameOverModal from "../yacht/GameOverModal";
+import { ThemeProvider } from "../../theme/ThemeContext";
+
+const ALL_CATEGORIES = [
+  "ones", "twos", "threes", "fours", "fives", "sixes",
+  "three_of_a_kind", "four_of_a_kind", "full_house",
+  "small_straight", "large_straight", "yacht", "chance",
+];
+const filledScores = Object.fromEntries(ALL_CATEGORIES.map((k) => [k, 0]));
+
+function renderModal(
+  overrides: Partial<React.ComponentProps<typeof GameOverModal>> = {}
+) {
+  const defaults: React.ComponentProps<typeof GameOverModal> = {
+    visible: true,
+    totalScore: 250,
+    upperBonus: 0,
+    yachtBonusCount: 0,
+    yachtBonusTotal: 0,
+    scores: filledScores,
+    onPlayAgain: jest.fn(),
+    onDismiss: jest.fn(),
+  };
+  return render(
+    <ThemeProvider>
+      <GameOverModal {...defaults} {...overrides} />
+    </ThemeProvider>
+  );
+}
+
+describe("GameOverModal — joker bonus row (GH #1841)", () => {
+  it("does not show joker bonus row when yachtBonusTotal is 0", () => {
+    const { queryByText } = renderModal({ yachtBonusTotal: 0, yachtBonusCount: 0 });
+    expect(queryByText("+100")).toBeNull();
+    expect(queryByText("+200")).toBeNull();
+  });
+
+  it("shows joker bonus row with '+100' when yachtBonusTotal is 100", () => {
+    const { getByText } = renderModal({ yachtBonusTotal: 100, yachtBonusCount: 1 });
+    expect(getByText("+100")).toBeTruthy();
+  });
+
+  it("shows joker bonus row with '+200' when yachtBonusTotal is 200", () => {
+    const { getByText } = renderModal({ yachtBonusTotal: 200, yachtBonusCount: 2 });
+    expect(getByText("+200")).toBeTruthy();
+  });
+
+  it("shows 'Yacht Bonus' label when joker row is present", () => {
+    const { getByText } = renderModal({ yachtBonusTotal: 100, yachtBonusCount: 1 });
+    expect(getByText("Yacht Bonus")).toBeTruthy();
+  });
+
+  it("does not show 'Yacht Bonus' scorecard row when yachtBonusTotal is 0", () => {
+    // Both the scorecard row (bonus.yachtLabel) and the bonus pill (gameOver.yachtBonus)
+    // contain the text "Yacht Bonus". Both are hidden when yachtBonusTotal === 0.
+    const { queryAllByText } = renderModal({ yachtBonusTotal: 0 });
+    expect(queryAllByText("Yacht Bonus")).toHaveLength(0);
+  });
+});
+
+describe("GameOverModal — joker bonus row in VS mode (GH #1841)", () => {
+  const vsDefaults = {
+    vsResult: "win" as const,
+    aiTotalScore: 180,
+    aiUpperBonus: 0,
+    aiScores: filledScores,
+  };
+
+  it("shows joker row with player '+100' and CPU '—' when only player has jokers", () => {
+    const { getByText, getAllByText } = renderModal({
+      ...vsDefaults,
+      yachtBonusTotal: 100,
+      yachtBonusCount: 1,
+      aiYachtBonusTotal: 0,
+    });
+    expect(getByText("+100")).toBeTruthy();
+    // "—" appears as the CPU value; it may also appear in other unfilled cells
+    const dashes = getAllByText("—");
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows joker row with both '+100' values when both players have jokers", () => {
+    const { getAllByText } = renderModal({
+      ...vsDefaults,
+      yachtBonusTotal: 100,
+      yachtBonusCount: 1,
+      aiYachtBonusTotal: 100,
+    });
+    expect(getAllByText("+100")).toHaveLength(2);
+  });
+
+  it("shows joker row when only CPU has jokers (player shows '—', CPU shows '+100')", () => {
+    const { getByText } = renderModal({
+      ...vsDefaults,
+      yachtBonusTotal: 0,
+      yachtBonusCount: 0,
+      aiYachtBonusTotal: 100,
+    });
+    expect(getByText("+100")).toBeTruthy();
+  });
+
+  it("hides joker row when neither player has jokers in VS mode", () => {
+    const { queryByText } = renderModal({
+      ...vsDefaults,
+      yachtBonusTotal: 0,
+      yachtBonusCount: 0,
+      aiYachtBonusTotal: 0,
+    });
+    expect(queryByText("+100")).toBeNull();
+    expect(queryByText("Yacht Bonus")).toBeNull();
+  });
+});

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -234,7 +234,10 @@ export default function GameOverModal({
               {LOWER_CATEGORY_KEYS.map(renderScoreRow)}
 
               {(yachtBonusTotal > 0 || (aiYachtBonusTotal ?? 0) > 0) && (
-                <View style={[styles.subtotalRow, { borderTopColor: colors.border }]}>
+                <View
+                  testID="yacht-bonus-row"
+                  style={[styles.subtotalRow, { borderTopColor: colors.border }]}
+                >
                   <Text style={[styles.subtotalLabel, { color: colors.textMuted }]}>
                     {t("bonus.yachtLabel")}
                   </Text>
@@ -251,8 +254,7 @@ export default function GameOverModal({
                       style={[
                         styles.subtotalVal,
                         {
-                          color:
-                            (aiYachtBonusTotal ?? 0) > 0 ? colors.bonus : colors.textMuted,
+                          color: (aiYachtBonusTotal ?? 0) > 0 ? colors.bonus : colors.textMuted,
                         },
                       ]}
                     >

--- a/frontend/src/components/yacht/GameOverModal.tsx
+++ b/frontend/src/components/yacht/GameOverModal.tsx
@@ -32,6 +32,7 @@ interface GameOverModalProps {
   aiTotalScore?: number;
   aiUpperBonus?: number;
   aiScores?: Record<string, number | null>;
+  aiYachtBonusTotal?: number;
 }
 
 function fmtScore(val: number | null | undefined): string {
@@ -51,6 +52,7 @@ export default function GameOverModal({
   aiTotalScore,
   aiUpperBonus,
   aiScores,
+  aiYachtBonusTotal,
 }: GameOverModalProps) {
   const { t } = useTranslation("yacht");
   const { colors } = useTheme();
@@ -230,6 +232,35 @@ export default function GameOverModal({
                 {t("section.lower")}
               </Text>
               {LOWER_CATEGORY_KEYS.map(renderScoreRow)}
+
+              {(yachtBonusTotal > 0 || (aiYachtBonusTotal ?? 0) > 0) && (
+                <View style={[styles.subtotalRow, { borderTopColor: colors.border }]}>
+                  <Text style={[styles.subtotalLabel, { color: colors.textMuted }]}>
+                    {t("bonus.yachtLabel")}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.subtotalVal,
+                      { color: yachtBonusTotal > 0 ? colors.bonus : colors.textMuted },
+                    ]}
+                  >
+                    {yachtBonusTotal > 0 ? `+${yachtBonusTotal}` : "—"}
+                  </Text>
+                  {isVs && (
+                    <Text
+                      style={[
+                        styles.subtotalVal,
+                        {
+                          color:
+                            (aiYachtBonusTotal ?? 0) > 0 ? colors.bonus : colors.textMuted,
+                        },
+                      ]}
+                    >
+                      {(aiYachtBonusTotal ?? 0) > 0 ? `+${aiYachtBonusTotal}` : "—"}
+                    </Text>
+                  )}
+                </View>
+              )}
 
               <View style={[styles.totalRow, { borderTopColor: colors.border }]}>
                 <Text style={[styles.totalLabel, { color: colors.text }]}>

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -187,12 +187,13 @@ export default function GameScreen({ navigation, route }: Props) {
       const diff = aiDifficultyRef.current!;
       let s = aiGameStateRef.current!;
 
-      // Initial roll (all dice free)
+      // Initial roll (all dice free) — compute result first so the animation
+      // plays over the final values and no post-spin snap occurs (#1842).
+      s = engineRoll(s, [false, false, false, false, false]);
+      setAiGameState(s);
       setAiRollingIndices([0, 1, 2, 3, 4]);
       await delay(1000);
       if (cancelled) return;
-      s = engineRoll(s, [false, false, false, false, false]);
-      setAiGameState(s);
       setAiRollingIndices([]);
       // Settle pause: let the player read the dice values
       await delay(800);
@@ -201,7 +202,7 @@ export default function GameScreen({ navigation, route }: Props) {
       // Up to two re-rolls using hold strategy
       while (s.rolls_used < 3) {
         const holds = holdStrategy(s, diff);
-        // Show held dice before rolling so the player can see the AI's decision
+        // Show hold decision on current values so the player sees the AI's choice
         setAiGameState({ ...s, held: holds });
         await delay(800);
         if (cancelled) return;
@@ -209,11 +210,12 @@ export default function GameScreen({ navigation, route }: Props) {
           if (!h) acc.push(i);
           return acc;
         }, []);
+        // Compute result before starting animation (#1842)
+        s = engineRoll(s, holds);
+        setAiGameState(s);
         setAiRollingIndices(rolledIdxs);
         await delay(1000);
         if (cancelled) return;
-        s = engineRoll(s, holds);
-        setAiGameState(s);
         setAiRollingIndices([]);
         await delay(800);
         if (cancelled) return;

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -187,8 +187,7 @@ export default function GameScreen({ navigation, route }: Props) {
       const diff = aiDifficultyRef.current!;
       let s = aiGameStateRef.current!;
 
-      // Initial roll (all dice free) — compute result first so the animation
-      // plays over the final values and no post-spin snap occurs (#1842).
+      // Initial roll (all dice free) — compute result first so animation plays over final values.
       s = engineRoll(s, [false, false, false, false, false]);
       setAiGameState(s);
       setAiRollingIndices([0, 1, 2, 3, 4]);
@@ -210,7 +209,7 @@ export default function GameScreen({ navigation, route }: Props) {
           if (!h) acc.push(i);
           return acc;
         }, []);
-        // Compute result before starting animation (#1842)
+        // Compute result before starting animation
         s = engineRoll(s, holds);
         setAiGameState(s);
         setAiRollingIndices(rolledIdxs);

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -511,6 +511,7 @@ export default function GameScreen({ navigation, route }: Props) {
         aiTotalScore={aiGameState?.total_score}
         aiUpperBonus={aiGameState?.upper_bonus}
         aiScores={aiGameState?.scores}
+        aiYachtBonusTotal={aiGameState?.yacht_bonus_total}
       />
 
       <NewGameConfirmModal

--- a/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Regression test for GH #1842 — CPU dice snap to new value after roll animation.
+ *
+ * Invariant: when aiRollingIndices is non-empty (animation active), aiGameState.dice
+ * must already hold the rolled values. In the broken code engineRoll was called 1000 ms
+ * AFTER setAiRollingIndices, so the die finished spinning on the old value and then
+ * snapped silently to the new one.
+ */
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import GameScreen from "../GameScreen";
+import { ThemeProvider } from "../../theme/ThemeContext";
+import { YachtScorecardProvider } from "../../game/yacht/ScorecardContext";
+import type { GameState } from "../../game/yacht/types";
+
+// Replace only `roll`; keep every other engine export (score, newGame, …) real.
+const mockRoll = jest.fn();
+jest.mock("../../game/yacht/engine", () => {
+  const actual = jest.requireActual("../../game/yacht/engine");
+  return { ...actual, roll: (...args: unknown[]) => mockRoll(...args) };
+});
+
+jest.mock("expo-blur", () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../../game/yacht/storage", () => ({
+  saveGame: jest.fn(),
+  clearGame: jest.fn().mockResolvedValue(undefined),
+  loadGame: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("../../game/_shared/gameEventClient", () => ({
+  gameEventClient: {
+    startGame: jest.fn().mockReturnValue("test-game-id"),
+    enqueueEvent: jest.fn(),
+    completeGame: jest.fn(),
+    init: jest.fn().mockResolvedValue(undefined),
+    reportBug: jest.fn(),
+    getQueueStats: jest.fn(),
+    clearAll: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const ALL_NULL_SCORES = {
+  ones: null, twos: null, threes: null, fours: null, fives: null, sixes: null,
+  three_of_a_kind: null, four_of_a_kind: null, full_house: null,
+  small_straight: null, large_straight: null, yacht: null, chance: null,
+};
+
+function makeGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    dice: [0, 0, 0, 0, 0],
+    held: [false, false, false, false, false],
+    rolls_used: 0,
+    round: 1,
+    scores: { ...ALL_NULL_SCORES },
+    game_over: false,
+    upper_subtotal: 0,
+    upper_bonus: 0,
+    yacht_bonus_count: 0,
+    yacht_bonus_total: 0,
+    total_score: 0,
+    ...overrides,
+  };
+}
+
+const mockNav = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+} as unknown as Parameters<typeof GameScreen>[0]["navigation"];
+
+// Recognisable rolled value — easy to assert against "showing blank" (value 0).
+const ROLLED_DICE: [number, number, number, number, number] = [6, 6, 6, 6, 6];
+
+describe("GameScreen VS mode — CPU animation ordering (GH #1842)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    // Every call to engineRoll returns state with dice [6,6,6,6,6].
+    mockRoll.mockImplementation((state: GameState) => ({
+      ...state,
+      dice: [...ROLLED_DICE],
+      rolls_used: state.rolls_used + 1,
+      held: [false, false, false, false, false],
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("CPU dice already show rolled values when rolling animation starts — no post-animation snap (#1842)", async () => {
+    // Player: already rolled once so they can score without another roll.
+    const playerState = makeGameState({ dice: [1, 1, 1, 1, 1], rolls_used: 1 });
+    // AI: blank dice, not yet rolled.
+    const aiState = makeGameState();
+
+    const { getByRole, getAllByTestId } = render(
+      <ThemeProvider>
+        <YachtScorecardProvider>
+          <GameScreen
+            navigation={mockNav}
+            route={
+              {
+                params: {
+                  initialState: playerState,
+                  aiDifficulty: "easy" as const,
+                  aiState,
+                },
+              } as unknown as Parameters<typeof GameScreen>[0]["route"]
+            }
+          />
+        </YachtScorecardProvider>
+      </ThemeProvider>
+    );
+
+    // Score "Ones" → handleScore → setIsAiTurn(true) → runAiTurn() fires.
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+
+    // At this point the AI turn loop's synchronous prefix has run and then
+    // suspended at the first `await delay(...)`. No timers have advanced.
+    //
+    // BROKEN (pre-fix): setAiRollingIndices([0,1,2,3,4]) was called before
+    //   engineRoll, so dice are still blank → accessibilityLabel "showing blank".
+    //
+    // FIXED: engineRoll + setAiGameState are called synchronously BEFORE
+    //   setAiRollingIndices, so dice are already [6,6,6,6,6] when the
+    //   animation starts → accessibilityLabel "showing 6".
+    const diceButtons = getAllByTestId(/^yacht-die-[0-4]$/);
+    expect(diceButtons).toHaveLength(5);
+    for (const die of diceButtons) {
+      expect(die.props.accessibilityLabel).toMatch(/showing 6/);
+    }
+  });
+});

--- a/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
@@ -1,11 +1,3 @@
-/**
- * Regression test for GH #1842 — CPU dice snap to new value after roll animation.
- *
- * Invariant: when aiRollingIndices is non-empty (animation active), aiGameState.dice
- * must already hold the rolled values. In the broken code engineRoll was called 1000 ms
- * AFTER setAiRollingIndices, so the die finished spinning on the old value and then
- * snapped silently to the new one.
- */
 import React from "react";
 import { render, fireEvent, act } from "@testing-library/react-native";
 import GameScreen from "../GameScreen";
@@ -43,9 +35,19 @@ jest.mock("../../game/_shared/gameEventClient", () => ({
 }));
 
 const ALL_NULL_SCORES = {
-  ones: null, twos: null, threes: null, fours: null, fives: null, sixes: null,
-  three_of_a_kind: null, four_of_a_kind: null, full_house: null,
-  small_straight: null, large_straight: null, yacht: null, chance: null,
+  ones: null,
+  twos: null,
+  threes: null,
+  fours: null,
+  fives: null,
+  sixes: null,
+  three_of_a_kind: null,
+  four_of_a_kind: null,
+  full_house: null,
+  small_straight: null,
+  large_straight: null,
+  yacht: null,
+  chance: null,
 };
 
 function makeGameState(overrides: Partial<GameState> = {}): GameState {
@@ -73,7 +75,7 @@ const mockNav = {
 // Recognisable rolled value — easy to assert against "showing blank" (value 0).
 const ROLLED_DICE: [number, number, number, number, number] = [6, 6, 6, 6, 6];
 
-describe("GameScreen VS mode — CPU animation ordering (GH #1842)", () => {
+describe("GameScreen VS mode — CPU animation ordering", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
@@ -90,7 +92,7 @@ describe("GameScreen VS mode — CPU animation ordering (GH #1842)", () => {
     jest.useRealTimers();
   });
 
-  it("CPU dice already show rolled values when rolling animation starts — no post-animation snap (#1842)", async () => {
+  it("CPU dice already show rolled values when rolling animation starts", async () => {
     // Player: already rolled once so they can score without another roll.
     const playerState = makeGameState({ dice: [1, 1, 1, 1, 1], rolls_used: 1 });
     // AI: blank dice, not yet rolled.
@@ -120,15 +122,7 @@ describe("GameScreen VS mode — CPU animation ordering (GH #1842)", () => {
       fireEvent.press(getByRole("button", { name: /ones/i }));
     });
 
-    // At this point the AI turn loop's synchronous prefix has run and then
-    // suspended at the first `await delay(...)`. No timers have advanced.
-    //
-    // BROKEN (pre-fix): setAiRollingIndices([0,1,2,3,4]) was called before
-    //   engineRoll, so dice are still blank → accessibilityLabel "showing blank".
-    //
-    // FIXED: engineRoll + setAiGameState are called synchronously BEFORE
-    //   setAiRollingIndices, so dice are already [6,6,6,6,6] when the
-    //   animation starts → accessibilityLabel "showing 6".
+    // Loop suspends at the first await; engineRoll ran synchronously before setAiRollingIndices.
     const diceButtons = getAllByTestId(/^yacht-die-[0-4]$/);
     expect(diceButtons).toHaveLength(5);
     for (const die of diceButtons) {


### PR DESCRIPTION
## Summary

- **#1842** Fix CPU dice snapping to a new value after the roll animation ends
- **#1841** Show the Yacht (joker) bonus row on the final game-over scorecard

---

## #1842 — CPU dice animation snap fix

**Root cause:** `engineRoll()` was called 1000 ms *after* `setAiRollingIndices()` started the spin animation. The animation only lasts 500 ms, so the die finished spinning on the old value and then silently snapped to the new one 500 ms later.

**Fix (`GameScreen.tsx`):** Call `engineRoll` + `setAiGameState` synchronously *before* `setAiRollingIndices`. The animation now plays over the already-correct value — no snap.

Applies to both the initial roll and each re-roll in the AI turn loop. The hold-preview step (showing which dice the CPU decided to keep) is unchanged.

**Regression test (`GameScreen.aiAnimation.test.tsx`):** Uses fake timers to pin the synchronous prefix of the async turn loop. Asserts that dice already show `"showing 6"` at the exact moment rolling indices are set.

---

## #1841 — Joker bonus row on final scorecard

**Problem:** The `GameOverModal` scorecard showed Upper Section, Upper Bonus (+35), and Lower Section rows, but no line item for joker (Yacht) bonuses — making the total score unexplained when jokers were earned.

**Fix (`GameOverModal.tsx`):**
- Added optional `aiYachtBonusTotal?: number` prop
- A **Yacht Bonus** row appears between the Lower Section and the Total row whenever `yachtBonusTotal > 0 || (aiYachtBonusTotal ?? 0) > 0`
- Value renders as `+N` (e.g. `+100`, `+200`) in accent/bonus color; the opposing column shows `—` in VS mode; the row is hidden entirely when neither side earned a joker bonus
- `GameScreen.tsx` forwards `aiYachtBonusTotal={aiGameState?.yacht_bonus_total}`

No new i18n strings — reuses the already-translated `bonus.yachtLabel` key across all 13 supported locales. No new styles — reuses `subtotalRow` / `subtotalVal`.

**Tests (`GameOverModal.test.tsx`, 9 new cases):** solo show/hide, multi-joker value (+200), VS mode player-only, CPU-only, both, and neither scenarios.

## Test plan

- [ ] All 2,678 frontend tests pass (`npm test`)
- [ ] Manual: play a VS game, earn a Yacht after the Yacht box is filled — verify `+100` (or `+200`) appears in the scorecard on the game-over modal for the correct player
- [ ] Manual: play a solo game with no jokers — verify the Yacht Bonus row is absent from the scorecard
- [ ] Manual: play a VS game — verify CPU dice spin smoothly to their final value with no post-animation snap

https://claude.ai/code/session_01HPt2DRkx3RNtzUbmmFhAp9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPt2DRkx3RNtzUbmmFhAp9)_