### PR TITLE
feat(hearts): __DEV__ hand debugger — full hand log, AI card reveal, Markdown export

### DIFF
--- a/frontend/src/components/hearts/HeartsDebugPanel.tsx
+++ b/frontend/src/components/hearts/HeartsDebugPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Modal,
   Platform,
@@ -9,16 +9,22 @@ import {
   TextInput,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "../../theme/ThemeContext";
 import type { HandDebugLog } from "../../game/hearts/debugLog";
-import { cardStr, formatSessionAsMarkdown } from "../../game/hearts/debugLog";
+import {
+  cardStr,
+  formatSessionAsMarkdown,
+  passDirectionLabel,
+  passOffset,
+} from "../../game/hearts/debugLog";
 
 interface Props {
   visible: boolean;
   onClose: () => void;
   logs: readonly HandDebugLog[];
-  notes: string[];
-  playerLabels: string[];
+  notes: readonly string[];
+  playerLabels: readonly string[];
   aiDifficulty: string;
   onNotesChange: (handIdx: number, text: string) => void;
 }
@@ -29,41 +35,23 @@ async function copyToClipboard(text: string): Promise<void> {
   }
 }
 
-function passLabel(dir: string): string {
-  const map: Record<string, string> = {
-    left: "Pass Left",
-    right: "Pass Right",
-    across: "Pass Across",
-    none: "No Pass",
-  };
-  return map[dir] ?? dir;
-}
-
-function passOffset(dir: string): number {
-  if (dir === "left") return 1;
-  if (dir === "right") return 3;
-  if (dir === "across") return 2;
-  return 0;
-}
-
 interface HandSectionProps {
   log: HandDebugLog;
   handIdx: number;
   note: string;
-  playerLabels: string[];
+  playerLabels: readonly string[];
   onNotesChange: (handIdx: number, text: string) => void;
 }
 
 function HandSection({ log, handIdx, note, playerLabels, onNotesChange }: HandSectionProps) {
   const { colors } = useTheme();
   const label = (i: number) => playerLabels[i] ?? `P${i}`;
-
   const offset = passOffset(log.passDirection);
 
   return (
     <View style={[styles.handSection, { borderColor: colors.border }]}>
       <Text style={[styles.handTitle, { color: colors.accent }]}>
-        Hand {log.handNumber} — {passLabel(log.passDirection)}
+        Hand {log.handNumber} — {passDirectionLabel(log.passDirection)}
       </Text>
 
       <Text style={[styles.sectionHeader, { color: colors.text }]}>Initial Deals</Text>
@@ -107,8 +95,7 @@ function HandSection({ log, handIdx, note, playerLabels, onNotesChange }: HandSe
         const byPlayer: string[] = ["—", "—", "—", "—"];
         for (const play of trick.plays) {
           const s = cardStr(play.card);
-          byPlayer[play.playerIndex] =
-            play.playerIndex === trick.winnerIndex ? `[${s}]` : s;
+          byPlayer[play.playerIndex] = play.playerIndex === trick.winnerIndex ? `[${s}]` : s;
         }
         return (
           <Text key={t} style={[styles.trickRow, { color: colors.textMuted }]}>
@@ -125,15 +112,11 @@ function HandSection({ log, handIdx, note, playerLabels, onNotesChange }: HandSe
 
       <Text style={[styles.sectionHeader, { color: colors.text }]}>Scores</Text>
       <Text style={[styles.handRow, { color: colors.textMuted }]}>
-        {[0, 1, 2, 3]
-          .map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`)
-          .join("  ")}
+        {[0, 1, 2, 3].map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`).join("  ")}
       </Text>
       <Text style={[styles.handRow, { color: colors.textMuted }]}>
         Running:{" "}
-        {[0, 1, 2, 3]
-          .map((i) => `${label(i)} ${log.cumulativeScoresAfter[i] ?? 0}`)
-          .join("  ")}
+        {[0, 1, 2, 3].map((i) => `${label(i)} ${log.cumulativeScoresAfter[i] ?? 0}`).join("  ")}
       </Text>
 
       <Text style={[styles.sectionHeader, { color: colors.text }]}>Notes</Text>
@@ -163,18 +146,29 @@ export default function HeartsDebugPanel({
   onNotesChange,
 }: Props) {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current !== null) clearTimeout(copiedTimerRef.current);
+    };
+  }, []);
 
   async function handleCopy() {
     const text = formatSessionAsMarkdown(logs, notes, playerLabels, aiDifficulty);
     try {
       await copyToClipboard(text);
+      if (copiedTimerRef.current !== null) clearTimeout(copiedTimerRef.current);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
-      // ignore
+      if (__DEV__) console.warn("[HeartsDebugPanel] clipboard copy failed");
     }
   }
+
+  const isNative = Platform.OS !== "web";
 
   return (
     <Modal
@@ -184,19 +178,33 @@ export default function HeartsDebugPanel({
       accessibilityViewIsModal
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>
-        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <View
+          style={[styles.header, { borderBottomColor: colors.border, paddingTop: insets.top + 12 }]}
+        >
           <Text style={[styles.headerTitle, { color: colors.text }]}>
-            Hearts Debugger{logs.length > 0 ? ` — ${logs.length} hand${logs.length !== 1 ? "s" : ""}` : ""}
+            Hearts Debugger
+            {logs.length > 0 ? ` — ${logs.length} hand${logs.length !== 1 ? "s" : ""}` : ""}
           </Text>
           <View style={styles.headerActions}>
             <Pressable
-              style={[styles.copyBtn, { backgroundColor: copied ? colors.accent : colors.surfaceAlt }]}
+              style={[
+                styles.copyBtn,
+                { backgroundColor: copied ? colors.accent : colors.surfaceAlt },
+              ]}
               onPress={() => void handleCopy()}
+              disabled={isNative}
               accessibilityRole="button"
-              accessibilityLabel="Copy session to clipboard"
+              accessibilityLabel={isNative ? "Copy (web only)" : "Copy session to clipboard"}
             >
-              <Text style={[styles.copyBtnText, { color: copied ? colors.textOnAccent : colors.text }]}>
-                {copied ? "Copied!" : "Copy"}
+              <Text
+                style={[
+                  styles.copyBtnText,
+                  {
+                    color: isNative ? colors.textMuted : copied ? colors.textOnAccent : colors.text,
+                  },
+                ]}
+              >
+                {copied ? "Copied!" : isNative ? "Copy (web)" : "Copy"}
               </Text>
             </Pressable>
             <Pressable
@@ -212,7 +220,7 @@ export default function HeartsDebugPanel({
 
         <ScrollView
           style={styles.scroll}
-          contentContainerStyle={styles.scrollContent}
+          contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 16 }]}
           keyboardShouldPersistTaps="handled"
         >
           {logs.length === 0 ? (
@@ -246,8 +254,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     paddingHorizontal: 16,
-    paddingVertical: 12,
-    paddingTop: 52,
+    paddingBottom: 12,
     borderBottomWidth: 1,
   },
   headerTitle: {
@@ -309,12 +316,12 @@ const styles = StyleSheet.create({
   },
   handRow: {
     fontSize: 12,
-    fontFamily: "monospace",
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
     flexWrap: "wrap",
   },
   trickRow: {
     fontSize: 11,
-    fontFamily: "monospace",
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
     flexWrap: "wrap",
   },
   noteInput: {

--- a/frontend/src/components/hearts/HeartsDebugPanel.tsx
+++ b/frontend/src/components/hearts/HeartsDebugPanel.tsx
@@ -1,0 +1,330 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useTheme } from "../../theme/ThemeContext";
+import type { HandDebugLog } from "../../game/hearts/debugLog";
+import { cardStr, formatSessionAsMarkdown } from "../../game/hearts/debugLog";
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  logs: readonly HandDebugLog[];
+  notes: string[];
+  playerLabels: string[];
+  aiDifficulty: string;
+  onNotesChange: (handIdx: number, text: string) => void;
+}
+
+async function copyToClipboard(text: string): Promise<void> {
+  if (Platform.OS === "web" && typeof navigator !== "undefined" && navigator.clipboard) {
+    await navigator.clipboard.writeText(text);
+  }
+}
+
+function passLabel(dir: string): string {
+  const map: Record<string, string> = {
+    left: "Pass Left",
+    right: "Pass Right",
+    across: "Pass Across",
+    none: "No Pass",
+  };
+  return map[dir] ?? dir;
+}
+
+function passOffset(dir: string): number {
+  if (dir === "left") return 1;
+  if (dir === "right") return 3;
+  if (dir === "across") return 2;
+  return 0;
+}
+
+interface HandSectionProps {
+  log: HandDebugLog;
+  handIdx: number;
+  note: string;
+  playerLabels: string[];
+  onNotesChange: (handIdx: number, text: string) => void;
+}
+
+function HandSection({ log, handIdx, note, playerLabels, onNotesChange }: HandSectionProps) {
+  const { colors } = useTheme();
+  const label = (i: number) => playerLabels[i] ?? `P${i}`;
+
+  const offset = passOffset(log.passDirection);
+
+  return (
+    <View style={[styles.handSection, { borderColor: colors.border }]}>
+      <Text style={[styles.handTitle, { color: colors.accent }]}>
+        Hand {log.handNumber} — {passLabel(log.passDirection)}
+      </Text>
+
+      <Text style={[styles.sectionHeader, { color: colors.text }]}>Initial Deals</Text>
+      {[0, 1, 2, 3].map((i) => (
+        <Text key={i} style={[styles.handRow, { color: colors.textMuted }]}>
+          <Text style={{ color: colors.text }}>{label(i)}: </Text>
+          {(log.initialHands[i] ?? []).map(cardStr).join(" ") || "—"}
+        </Text>
+      ))}
+
+      {log.passDirection !== "none" && (
+        <>
+          <Text style={[styles.sectionHeader, { color: colors.text }]}>Pass Selections</Text>
+          {[0, 1, 2, 3].map((from) => {
+            const to = (from + offset) % 4;
+            const sel = log.passSelections[from] ?? [];
+            return (
+              <Text key={from} style={[styles.handRow, { color: colors.textMuted }]}>
+                <Text style={{ color: colors.text }}>
+                  {label(from)} → {label(to)}:{" "}
+                </Text>
+                {sel.map(cardStr).join(" ") || "—"}
+              </Text>
+            );
+          })}
+
+          <Text style={[styles.sectionHeader, { color: colors.text }]}>Final Hands</Text>
+          {[0, 1, 2, 3].map((i) => (
+            <Text key={i} style={[styles.handRow, { color: colors.textMuted }]}>
+              <Text style={{ color: colors.text }}>{label(i)}: </Text>
+              {(log.finalHands[i] ?? []).map(cardStr).join(" ") || "—"}
+            </Text>
+          ))}
+        </>
+      )}
+
+      <Text style={[styles.sectionHeader, { color: colors.text }]}>
+        Tricks ({log.tricks.length})
+      </Text>
+      {log.tricks.map((trick, t) => {
+        const byPlayer: string[] = ["—", "—", "—", "—"];
+        for (const play of trick.plays) {
+          const s = cardStr(play.card);
+          byPlayer[play.playerIndex] =
+            play.playerIndex === trick.winnerIndex ? `[${s}]` : s;
+        }
+        return (
+          <Text key={t} style={[styles.trickRow, { color: colors.textMuted }]}>
+            <Text style={{ color: colors.text }}>T{t + 1} </Text>
+            {byPlayer.map((c, i) => `${label(i)}:${c}`).join("  ")}
+            {"  "}
+            <Text style={{ color: colors.accent }}>
+              → {label(trick.winnerIndex)}
+              {trick.pointsWon > 0 ? ` +${trick.pointsWon}` : ""}
+            </Text>
+          </Text>
+        );
+      })}
+
+      <Text style={[styles.sectionHeader, { color: colors.text }]}>Scores</Text>
+      <Text style={[styles.handRow, { color: colors.textMuted }]}>
+        {[0, 1, 2, 3]
+          .map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`)
+          .join("  ")}
+      </Text>
+      <Text style={[styles.handRow, { color: colors.textMuted }]}>
+        Running:{" "}
+        {[0, 1, 2, 3]
+          .map((i) => `${label(i)} ${log.cumulativeScoresAfter[i] ?? 0}`)
+          .join("  ")}
+      </Text>
+
+      <Text style={[styles.sectionHeader, { color: colors.text }]}>Notes</Text>
+      <TextInput
+        style={[
+          styles.noteInput,
+          { color: colors.text, borderColor: colors.border, backgroundColor: colors.surfaceAlt },
+        ]}
+        value={note}
+        onChangeText={(text) => onNotesChange(handIdx, text)}
+        placeholder="Observations about this hand..."
+        placeholderTextColor={colors.textMuted}
+        multiline
+        numberOfLines={3}
+      />
+    </View>
+  );
+}
+
+export default function HeartsDebugPanel({
+  visible,
+  onClose,
+  logs,
+  notes,
+  playerLabels,
+  aiDifficulty,
+  onNotesChange,
+}: Props) {
+  const { colors } = useTheme();
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    const text = formatSessionAsMarkdown(logs, notes, playerLabels, aiDifficulty);
+    try {
+      await copyToClipboard(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.header, { borderBottomColor: colors.border }]}>
+          <Text style={[styles.headerTitle, { color: colors.text }]}>
+            Hearts Debugger{logs.length > 0 ? ` — ${logs.length} hand${logs.length !== 1 ? "s" : ""}` : ""}
+          </Text>
+          <View style={styles.headerActions}>
+            <Pressable
+              style={[styles.copyBtn, { backgroundColor: copied ? colors.accent : colors.surfaceAlt }]}
+              onPress={() => void handleCopy()}
+              accessibilityRole="button"
+              accessibilityLabel="Copy session to clipboard"
+            >
+              <Text style={[styles.copyBtnText, { color: copied ? colors.textOnAccent : colors.text }]}>
+                {copied ? "Copied!" : "Copy"}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={styles.closeBtn}
+              onPress={onClose}
+              accessibilityRole="button"
+              accessibilityLabel="Close debugger"
+            >
+              <Text style={[styles.closeBtnText, { color: colors.text }]}>✕</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          {logs.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textMuted }]}>
+              No hands logged yet. Play a hand to see debug data here.
+            </Text>
+          ) : (
+            logs.map((log, i) => (
+              <HandSection
+                key={i}
+                log={log}
+                handIdx={i}
+                note={notes[i] ?? ""}
+                playerLabels={playerLabels}
+                onNotesChange={onNotesChange}
+              />
+            ))
+          )}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    paddingTop: 52,
+    borderBottomWidth: 1,
+  },
+  headerTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    flex: 1,
+  },
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  copyBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+  },
+  copyBtnText: {
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  closeBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+  },
+  closeBtnText: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    gap: 16,
+  },
+  emptyText: {
+    textAlign: "center",
+    marginTop: 40,
+    fontSize: 14,
+  },
+  handSection: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    gap: 4,
+  },
+  handTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  sectionHeader: {
+    fontSize: 12,
+    fontWeight: "700",
+    marginTop: 8,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  handRow: {
+    fontSize: 12,
+    fontFamily: "monospace",
+    flexWrap: "wrap",
+  },
+  trickRow: {
+    fontSize: 11,
+    fontFamily: "monospace",
+    flexWrap: "wrap",
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontSize: 13,
+    minHeight: 64,
+    textAlignVertical: "top",
+    marginTop: 4,
+  },
+});

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -4,7 +4,8 @@ import { LinearGradient } from "expo-linear-gradient";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 import type { Card } from "../../game/hearts/types";
-import { cardStr } from "../../game/hearts/debugLog";
+import { rankLabel, suitEmoji } from "../../game/_shared/decks/cardId";
+import type { CanonicalSuit } from "../../game/_shared/decks/types";
 
 interface Props {
   cardCount: number;
@@ -76,7 +77,9 @@ export default function OpponentHand({
         </View>
         {__DEV__ && revealCards && (
           <Text style={[styles.revealText, { color: colors.textMuted }]}>
-            {revealCards.map(cardStr).join(" ")}
+            {revealCards
+              .map((c) => `${rankLabel(c.rank)}${suitEmoji(c.suit as CanonicalSuit)}`)
+              .join(" ")}
           </Text>
         )}
       </View>
@@ -112,7 +115,9 @@ export default function OpponentHand({
       </View>
       {__DEV__ && revealCards && (
         <Text style={[styles.revealText, { color: colors.textMuted }]}>
-          {revealCards.map(cardStr).join(" ")}
+          {revealCards
+            .map((c) => `${rankLabel(c.rank)}${suitEmoji(c.suit as CanonicalSuit)}`)
+            .join(" ")}
         </Text>
       )}
     </View>

--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -3,6 +3,8 @@ import { View, Text, StyleSheet } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
+import type { Card } from "../../game/hearts/types";
+import { cardStr } from "../../game/hearts/debugLog";
 
 interface Props {
   cardCount: number;
@@ -10,6 +12,8 @@ interface Props {
   /** "horizontal" = North (portrait cards fanning left-to-right).
    *  "vertical"   = East/West (landscape cards stacked top-to-bottom). */
   layout?: "horizontal" | "vertical";
+  /** __DEV__ only: when provided, renders card identities as a text row below the hand. */
+  revealCards?: readonly Card[];
 }
 
 // Horizontal fan constants (North)
@@ -30,7 +34,12 @@ const cardShadow = {
   elevation: 2,
 } as const;
 
-export default function OpponentHand({ cardCount, label, layout = "horizontal" }: Props) {
+export default function OpponentHand({
+  cardCount,
+  label,
+  layout = "horizontal",
+  revealCards,
+}: Props) {
   const { t } = useTranslation("hearts");
   const { colors } = useTheme();
 
@@ -65,6 +74,11 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
             </View>
           ))}
         </View>
+        {__DEV__ && revealCards && (
+          <Text style={[styles.revealText, { color: colors.textMuted }]}>
+            {revealCards.map(cardStr).join(" ")}
+          </Text>
+        )}
       </View>
     );
   }
@@ -96,6 +110,11 @@ export default function OpponentHand({ cardCount, label, layout = "horizontal" }
           </View>
         ))}
       </View>
+      {__DEV__ && revealCards && (
+        <Text style={[styles.revealText, { color: colors.textMuted }]}>
+          {revealCards.map(cardStr).join(" ")}
+        </Text>
+      )}
     </View>
   );
 }
@@ -128,5 +147,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     overflow: "hidden",
     ...cardShadow,
+  },
+  revealText: {
+    fontSize: 9,
+    flexWrap: "wrap",
+    textAlign: "center",
+    maxWidth: 80,
+    marginTop: 2,
   },
 });

--- a/frontend/src/game/hearts/debugLog.ts
+++ b/frontend/src/game/hearts/debugLog.ts
@@ -33,7 +33,7 @@ function handStr(cards: readonly Card[]): string {
   return cards.length > 0 ? cards.map(cardStr).join(" ") : "—";
 }
 
-function passDirectionLabel(dir: PassDirection): string {
+export function passDirectionLabel(dir: PassDirection): string {
   const map: Record<PassDirection, string> = {
     left: "Pass Left",
     right: "Pass Right",
@@ -43,7 +43,7 @@ function passDirectionLabel(dir: PassDirection): string {
   return map[dir];
 }
 
-function passOffset(dir: PassDirection): number {
+export function passOffset(dir: PassDirection): number {
   if (dir === "left") return 1;
   if (dir === "right") return 3;
   if (dir === "across") return 2;
@@ -107,8 +107,7 @@ export function formatSessionAsMarkdown(
       const cellByPlayer: string[] = ["—", "—", "—", "—"];
       for (const play of trick.plays) {
         const s = cardStr(play.card);
-        cellByPlayer[play.playerIndex] =
-          play.playerIndex === trick.winnerIndex ? `**${s}**` : s;
+        cellByPlayer[play.playerIndex] = play.playerIndex === trick.winnerIndex ? `**${s}**` : s;
       }
       lines.push(
         `| ${t + 1} | ${cellByPlayer.join(" | ")} | ${label(trick.winnerIndex)} | ${trick.pointsWon} |`
@@ -116,9 +115,7 @@ export function formatSessionAsMarkdown(
     }
 
     lines.push("");
-    const deltaStr = [0, 1, 2, 3]
-      .map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`)
-      .join(", ");
+    const deltaStr = [0, 1, 2, 3].map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`).join(", ");
     const runningStr = [0, 1, 2, 3]
       .map((i) => `${label(i)} ${log.cumulativeScoresAfter[i] ?? 0}`)
       .join(", ");

--- a/frontend/src/game/hearts/debugLog.ts
+++ b/frontend/src/game/hearts/debugLog.ts
@@ -1,0 +1,135 @@
+import { rankLabel } from "../_shared/decks/cardId";
+import type { Card, PassDirection, TrickCard } from "./types";
+
+const SUIT_EMOJI: Record<string, string> = {
+  spades: "♠",
+  hearts: "♥",
+  diamonds: "♦",
+  clubs: "♣",
+};
+
+export interface DebugTrick {
+  readonly plays: readonly TrickCard[];
+  readonly winnerIndex: number;
+  readonly pointsWon: number;
+}
+
+export interface HandDebugLog {
+  readonly handNumber: number;
+  readonly passDirection: PassDirection;
+  readonly initialHands: readonly (readonly Card[])[];
+  readonly passSelections: readonly (readonly Card[])[];
+  readonly finalHands: readonly (readonly Card[])[];
+  readonly tricks: readonly DebugTrick[];
+  readonly scoreDeltas: readonly number[];
+  readonly cumulativeScoresAfter: readonly number[];
+}
+
+export function cardStr(card: Card): string {
+  return `${rankLabel(card.rank)}${SUIT_EMOJI[card.suit] ?? card.suit}`;
+}
+
+function handStr(cards: readonly Card[]): string {
+  return cards.length > 0 ? cards.map(cardStr).join(" ") : "—";
+}
+
+function passDirectionLabel(dir: PassDirection): string {
+  const map: Record<PassDirection, string> = {
+    left: "Pass Left",
+    right: "Pass Right",
+    across: "Pass Across",
+    none: "No Pass",
+  };
+  return map[dir];
+}
+
+function passOffset(dir: PassDirection): number {
+  if (dir === "left") return 1;
+  if (dir === "right") return 3;
+  if (dir === "across") return 2;
+  return 0;
+}
+
+export function formatSessionAsMarkdown(
+  logs: readonly HandDebugLog[],
+  notes: readonly string[],
+  playerLabels: readonly string[],
+  aiDifficulty: string
+): string {
+  const label = (i: number) => playerLabels[i] ?? `P${i}`;
+  const lines: string[] = [];
+
+  lines.push(
+    `# Hearts Debug Session — ${logs.length} hand${logs.length !== 1 ? "s" : ""} — Difficulty: ${aiDifficulty}`
+  );
+  lines.push("");
+  lines.push(`Players: ${[0, 1, 2, 3].map((i) => `${label(i)} (P${i})`).join(", ")}`);
+
+  for (let h = 0; h < logs.length; h++) {
+    const log = logs[h]!;
+    const note = notes[h] ?? "";
+
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+    lines.push(`## Hand ${log.handNumber} — ${passDirectionLabel(log.passDirection)}`);
+    lines.push("");
+
+    lines.push("### Initial Deals");
+    for (let i = 0; i < 4; i++) {
+      lines.push(`- **${label(i)}**: ${handStr(log.initialHands[i] ?? [])}`);
+    }
+
+    if (log.passDirection !== "none") {
+      lines.push("");
+      lines.push(`### Pass Selections (${passDirectionLabel(log.passDirection)})`);
+      const offset = passOffset(log.passDirection);
+      for (let from = 0; from < 4; from++) {
+        const to = (from + offset) % 4;
+        const sel = log.passSelections[from] ?? [];
+        lines.push(`- ${label(from)} → ${label(to)}: ${handStr(sel)}`);
+      }
+
+      lines.push("");
+      lines.push("### Final Hands (after pass)");
+      for (let i = 0; i < 4; i++) {
+        lines.push(`- **${label(i)}**: ${handStr(log.finalHands[i] ?? [])}`);
+      }
+    }
+
+    lines.push("");
+    lines.push("### Tricks");
+    const colLabels = [0, 1, 2, 3].map(label);
+    lines.push(`| # | ${colLabels.join(" | ")} | Winner | Pts |`);
+    lines.push(`|---|${colLabels.map(() => "---").join("|")}|--------|-----|`);
+    for (let t = 0; t < log.tricks.length; t++) {
+      const trick = log.tricks[t]!;
+      const cellByPlayer: string[] = ["—", "—", "—", "—"];
+      for (const play of trick.plays) {
+        const s = cardStr(play.card);
+        cellByPlayer[play.playerIndex] =
+          play.playerIndex === trick.winnerIndex ? `**${s}**` : s;
+      }
+      lines.push(
+        `| ${t + 1} | ${cellByPlayer.join(" | ")} | ${label(trick.winnerIndex)} | ${trick.pointsWon} |`
+      );
+    }
+
+    lines.push("");
+    const deltaStr = [0, 1, 2, 3]
+      .map((i) => `${label(i)} +${log.scoreDeltas[i] ?? 0}`)
+      .join(", ");
+    const runningStr = [0, 1, 2, 3]
+      .map((i) => `${label(i)} ${log.cumulativeScoresAfter[i] ?? 0}`)
+      .join(", ");
+    lines.push(`### Scores: ${deltaStr}`);
+    lines.push(`### Running: ${runningStr}`);
+
+    if (note.trim()) {
+      lines.push("");
+      lines.push(`> Note: ${note.trim()}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -45,12 +45,23 @@ import { HeartsMoonShotAnimation } from "../components/hearts/HeartsMoonShotAnim
 import { HeartsQueenOfSpadesAnimation } from "../components/hearts/HeartsQueenOfSpadesAnimation";
 import type { AiPreset, Card, HeartsState, TrickCard } from "../game/hearts/types";
 import { resolvePersona } from "../game/hearts/types";
+import type { HandDebugLog, DebugTrick } from "../game/hearts/debugLog";
+import HeartsDebugPanel from "../components/hearts/HeartsDebugPanel";
 
 const HUMAN = 0;
 const MAX_NAME_LENGTH = 32;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function buildDebugTrick(plays: readonly TrickCard[], winnerIndex: number): DebugTrick {
+  const pointsWon = plays.reduce((sum, tc) => {
+    if (tc.card.suit === "hearts") return sum + 1;
+    if (isQueenOfSpades(tc.card)) return sum + 13;
+    return sum;
+  }, 0);
+  return { plays, winnerIndex, pointsWon };
 }
 
 type LastTrick = { readonly trick: readonly TrickCard[]; readonly winnerIndex: number } | null;
@@ -78,6 +89,18 @@ export default function HeartsScreen() {
 
   // scoreHistory now lives on HeartsState (engine-authoritative, persisted).
   const scoreHistory = useMemo(() => gameState?.scoreHistory ?? [], [gameState?.scoreHistory]);
+
+  // ── Debug mode (__DEV__ only) ──────────────────────────────────────────────
+  const [debugMode, setDebugMode] = useState(false);
+  const [debugPanelOpen, setDebugPanelOpen] = useState(false);
+  const [handNotes, setHandNotes] = useState<string[]>([]);
+  const handLogRef = useRef<HandDebugLog[]>([]);
+  const dealSnapshotRef = useRef<{
+    initialHands: readonly (readonly Card[])[];
+    passSelections: readonly (readonly Card[])[];
+    finalHands: readonly (readonly Card[])[];
+  } | null>(null);
+  const trickLogBufferRef = useRef<DebugTrick[]>([]);
 
   const unmountedRef = useRef(false);
   const loopActiveRef = useRef(false);
@@ -139,6 +162,32 @@ export default function HeartsScreen() {
   useEffect(() => {
     if (gameState) reportIntegrity(gameState);
   }, [gameState, reportIntegrity]);
+
+  // ─── Commit hand log entry when a hand ends ───────────────────────────────
+  useEffect(() => {
+    if (!__DEV__ || !debugMode) return;
+    if (!gameState) return;
+    if (gameState.phase !== "dealing" && gameState.phase !== "game_over") return;
+    const snapshot = dealSnapshotRef.current;
+    if (!snapshot) return;
+    const histLen = gameState.scoreHistory.length;
+    if (histLen === 0) return;
+    const entry: HandDebugLog = {
+      handNumber: gameState.handNumber,
+      passDirection: gameState.passDirection,
+      initialHands: snapshot.initialHands,
+      passSelections: snapshot.passSelections,
+      finalHands: snapshot.finalHands,
+      tricks: [...trickLogBufferRef.current],
+      scoreDeltas: gameState.scoreHistory[histLen - 1] ?? [],
+      cumulativeScoresAfter: gameState.cumulativeScores,
+    };
+    handLogRef.current = [...handLogRef.current, entry];
+    setHandNotes((prev) => [...prev, ""]);
+    trickLogBufferRef.current = [];
+    dealSnapshotRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameState?.phase]);
 
   // ─── Save on blur ─────────────────────────────────────────────────────────
   // Tab switches unmount the Lobby HomeStack; without this, mid-trick or
@@ -241,6 +290,9 @@ export default function HeartsScreen() {
           if (completedTrick) {
             setLastTrick({ trick: completedTrick, winnerIndex: s.currentLeaderIndex });
             void saveGame(s);
+            if (__DEV__ && debugMode) {
+              trickLogBufferRef.current.push(buildDebugTrick(completedTrick, s.currentLeaderIndex));
+            }
           }
           setGameState(s);
           // Clear events so the next playCard call doesn't re-emit them via a new array reference.
@@ -258,7 +310,8 @@ export default function HeartsScreen() {
         loopActiveRef.current = false;
       }
     },
-    [playCardPlay]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [playCardPlay, debugMode]
   );
 
   // Trigger AI loop when it's their turn; wait for lastTrick display first.
@@ -312,6 +365,9 @@ export default function HeartsScreen() {
     const newState = playCard(gameState, HUMAN, card);
 
     if (completedTrick) {
+      if (__DEV__ && debugMode) {
+        trickLogBufferRef.current.push(buildDebugTrick(completedTrick, newState.currentLeaderIndex));
+      }
       void saveGame(newState);
       if (newState.phase === "playing") {
         setLastTrick({ trick: completedTrick, winnerIndex: newState.currentLeaderIndex });
@@ -358,7 +414,15 @@ export default function HeartsScreen() {
         s = selectPassCard(s, i, c);
       }
     }
-    setGameState(commitPass(s));
+    const committed = commitPass(s);
+    if (__DEV__ && debugMode && dealSnapshotRef.current) {
+      dealSnapshotRef.current = {
+        ...dealSnapshotRef.current,
+        passSelections: s.passSelections,
+        finalHands: committed.playerHands,
+      };
+    }
+    setGameState(committed);
   }
 
   // ─── Hand end / next hand ─────────────────────────────────────────────────
@@ -369,6 +433,14 @@ export default function HeartsScreen() {
     setShowHeartsBroken(false);
     setShowQueenOfSpades(false);
     const next = dealNextHand(gameState);
+    if (__DEV__ && debugMode) {
+      dealSnapshotRef.current = {
+        initialHands: next.playerHands,
+        passSelections: [[], [], [], []],
+        finalHands: next.playerHands,
+      };
+      trickLogBufferRef.current = [];
+    }
     setGameState(next);
     void saveGame(next);
   }
@@ -400,6 +472,14 @@ export default function HeartsScreen() {
     gameOverFiredRef.current = false;
     clearGame().catch(() => {});
     const fresh = dealGame(difficulty);
+    if (__DEV__) {
+      handLogRef.current = [];
+      trickLogBufferRef.current = [];
+      dealSnapshotRef.current = debugMode
+        ? { initialHands: fresh.playerHands, passSelections: [[], [], [], []], finalHands: fresh.playerHands }
+        : null;
+      setHandNotes([]);
+    }
     setGameState(fresh);
   }
 
@@ -413,6 +493,12 @@ export default function HeartsScreen() {
     loopActiveRef.current = false;
     gameOverFiredRef.current = false;
     clearGame().catch(() => {});
+    if (__DEV__) {
+      handLogRef.current = [];
+      trickLogBufferRef.current = [];
+      dealSnapshotRef.current = null;
+      setHandNotes([]);
+    }
     setGameState(null);
   }
 
@@ -488,6 +574,7 @@ export default function HeartsScreen() {
           <OpponentHand
             cardCount={gameState.playerHands[2]?.length ?? 0}
             label={playerLabels[2] ?? ""}
+            revealCards={__DEV__ && debugMode ? gameState.playerHands[2] : undefined}
           />
           <OpponentCapturedPile
             cards={gameState.wonCards[2] ?? []}
@@ -502,6 +589,7 @@ export default function HeartsScreen() {
               cardCount={gameState.playerHands[1]?.length ?? 0}
               label={playerLabels[1] ?? ""}
               layout="vertical"
+              revealCards={__DEV__ && debugMode ? gameState.playerHands[1] : undefined}
             />
             <OpponentCapturedPile
               cards={gameState.wonCards[1] ?? []}
@@ -526,6 +614,7 @@ export default function HeartsScreen() {
               cardCount={gameState.playerHands[3]?.length ?? 0}
               label={playerLabels[3] ?? ""}
               layout="vertical"
+              revealCards={__DEV__ && debugMode ? gameState.playerHands[3] : undefined}
             />
             <OpponentCapturedPile
               cards={gameState.wonCards[3] ?? []}
@@ -564,6 +653,24 @@ export default function HeartsScreen() {
           takerLabel={queenOfSpadesLabel}
           onAnimationEnd={() => setShowQueenOfSpades(false)}
         />
+        {__DEV__ && (
+          <Pressable
+            style={[
+              styles.devButton,
+              { backgroundColor: debugMode ? colors.accent : colors.surfaceAlt },
+            ]}
+            onPress={() => {
+              setDebugMode((d) => !d);
+              setDebugPanelOpen(true);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Toggle Hearts debugger"
+          >
+            <Text style={[styles.devButtonText, { color: debugMode ? colors.textOnAccent : colors.textMuted }]}>
+              {debugMode ? "DBG ON" : "DBG"}
+            </Text>
+          </Pressable>
+        )}
       </View>
 
       {/* ── Hand-end overlay (dealing phase = hand just finished) ──── */}
@@ -743,6 +850,25 @@ export default function HeartsScreen() {
             </View>
           </View>
         </Modal>
+      )}
+
+      {/* ── Hearts debug panel (__DEV__ only) ────────────────────── */}
+      {__DEV__ && (
+        <HeartsDebugPanel
+          visible={debugPanelOpen}
+          onClose={() => setDebugPanelOpen(false)}
+          logs={handLogRef.current}
+          notes={handNotes}
+          playerLabels={playerLabels}
+          aiDifficulty={gameState.aiDifficulty}
+          onNotesChange={(idx, text) =>
+            setHandNotes((prev) => {
+              const next = [...prev];
+              next[idx] = text;
+              return next;
+            })
+          }
+        />
       )}
 
       {/* ── Rename players modal ───────────────────────────────────── */}
@@ -952,6 +1078,19 @@ const styles = StyleSheet.create({
   },
   preGameTitle: {
     fontSize: 18,
+    fontWeight: "700",
+  },
+  devButton: {
+    position: "absolute",
+    bottom: 8,
+    right: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    opacity: 0.8,
+  },
+  devButtonText: {
+    fontSize: 10,
     fontWeight: "700",
   },
 });

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -94,7 +94,7 @@ export default function HeartsScreen() {
   const [debugMode, setDebugMode] = useState(false);
   const [debugPanelOpen, setDebugPanelOpen] = useState(false);
   const [handNotes, setHandNotes] = useState<string[]>([]);
-  const handLogRef = useRef<HandDebugLog[]>([]);
+  const [handLogs, setHandLogs] = useState<HandDebugLog[]>([]);
   const dealSnapshotRef = useRef<{
     initialHands: readonly (readonly Card[])[];
     passSelections: readonly (readonly Card[])[];
@@ -182,7 +182,7 @@ export default function HeartsScreen() {
       scoreDeltas: gameState.scoreHistory[histLen - 1] ?? [],
       cumulativeScoresAfter: gameState.cumulativeScores,
     };
-    handLogRef.current = [...handLogRef.current, entry];
+    setHandLogs((prev) => [...prev, entry]);
     setHandNotes((prev) => [...prev, ""]);
     trickLogBufferRef.current = [];
     dealSnapshotRef.current = null;
@@ -310,7 +310,6 @@ export default function HeartsScreen() {
         loopActiveRef.current = false;
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [playCardPlay, debugMode]
   );
 
@@ -366,7 +365,9 @@ export default function HeartsScreen() {
 
     if (completedTrick) {
       if (__DEV__ && debugMode) {
-        trickLogBufferRef.current.push(buildDebugTrick(completedTrick, newState.currentLeaderIndex));
+        trickLogBufferRef.current.push(
+          buildDebugTrick(completedTrick, newState.currentLeaderIndex)
+        );
       }
       void saveGame(newState);
       if (newState.phase === "playing") {
@@ -473,10 +474,14 @@ export default function HeartsScreen() {
     clearGame().catch(() => {});
     const fresh = dealGame(difficulty);
     if (__DEV__) {
-      handLogRef.current = [];
+      setHandLogs([]);
       trickLogBufferRef.current = [];
       dealSnapshotRef.current = debugMode
-        ? { initialHands: fresh.playerHands, passSelections: [[], [], [], []], finalHands: fresh.playerHands }
+        ? {
+            initialHands: fresh.playerHands,
+            passSelections: [[], [], [], []],
+            finalHands: fresh.playerHands,
+          }
         : null;
       setHandNotes([]);
     }
@@ -494,7 +499,7 @@ export default function HeartsScreen() {
     gameOverFiredRef.current = false;
     clearGame().catch(() => {});
     if (__DEV__) {
-      handLogRef.current = [];
+      setHandLogs([]);
       trickLogBufferRef.current = [];
       dealSnapshotRef.current = null;
       setHandNotes([]);
@@ -660,13 +665,19 @@ export default function HeartsScreen() {
               { backgroundColor: debugMode ? colors.accent : colors.surfaceAlt },
             ]}
             onPress={() => {
-              setDebugMode((d) => !d);
-              setDebugPanelOpen(true);
+              const next = !debugMode;
+              setDebugMode(next);
+              if (next) setDebugPanelOpen(true);
             }}
             accessibilityRole="button"
             accessibilityLabel="Toggle Hearts debugger"
           >
-            <Text style={[styles.devButtonText, { color: debugMode ? colors.textOnAccent : colors.textMuted }]}>
+            <Text
+              style={[
+                styles.devButtonText,
+                { color: debugMode ? colors.textOnAccent : colors.textMuted },
+              ]}
+            >
               {debugMode ? "DBG ON" : "DBG"}
             </Text>
           </Pressable>
@@ -857,7 +868,7 @@ export default function HeartsScreen() {
         <HeartsDebugPanel
           visible={debugPanelOpen}
           onClose={() => setDebugPanelOpen(false)}
-          logs={handLogRef.current}
+          logs={handLogs}
           notes={handNotes}
           playerLabels={playerLabels}
           aiDifficulty={gameState.aiDifficulty}


### PR DESCRIPTION
Closes #1844

## Summary

Adds a `__DEV__`-only debug mode to the Hearts game for analyzing hand logic and AI strategy. Zero production impact — all code is gated by `__DEV__` and stripped by Metro in release builds.

- **DEV button** — small toggle in the bottom-right corner of the game table; first press enables debug mode and opens the log panel
- **Full hand logging** — captures initial deal, pass selections (all 4 players), final hands post-pass, and all 13 tricks per hand
- **AI card reveal** — opponent hands show card identities as a small text row when debug mode is active
- **Per-hand notes** — inline `TextInput` in the log panel for observations on each hand
- **Markdown export** — "Copy" button formats the full session as Markdown (deal tables, trick tables, running scores, notes) for pasting into Claude

## Files

| File | Change |
|------|--------|
| `src/game/hearts/debugLog.ts` | New — `HandDebugLog` / `DebugTrick` types + `formatSessionAsMarkdown` (pure TS, no React) |
| `src/components/hearts/HeartsDebugPanel.tsx` | New — full-screen slide modal |
| `src/components/hearts/OpponentHand.tsx` | Add optional `revealCards` prop |
| `src/screens/HeartsScreen.tsx` | DEV button, capture hooks, hand-commit `useEffect` |

## Test plan

- [ ] Run in Expo dev client; confirm `DBG` button is visible in the game
- [ ] Press `DBG` — debug mode on, panel opens
- [ ] Confirm AI hands show card identities as text below their card fans
- [ ] Play through a hand; open panel; verify initial deal (13 cards × 4 players, no overlap), pass selections, final hands, 13 tricks
- [ ] Moon shot hand: verify loser shows +26 (or +0 after inversion), others +0 (or +26)
- [ ] Add notes to a hand; close and reopen panel — notes preserved
- [ ] Press "Copy" — paste into a text editor and confirm valid Markdown
- [ ] Press `DBG` again — debug mode off, AI hands hidden again
- [ ] Confirm `DBG` button absent in a production bundle (`__DEV__ === false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)