### PR TITLE
fix(entitlements): dev override no longer requires a running database

### DIFF
--- a/backend/entitlements/router.py
+++ b/backend/entitlements/router.py
@@ -19,9 +19,12 @@ router = APIRouter()
 async def get_entitlements(request: Request) -> EntitlementsResponse:
     """Return a signed RS256 JWT listing games this session may access."""
     sid = get_session_id(request)
-    factory = get_session_factory()
-    async with factory() as db:
-        entitled_games = await service.get_entitled_games(db, sid)
+    if service.is_dev_override_active():
+        entitled_games = await service.get_entitled_games(None, sid)
+    else:
+        factory = get_session_factory()
+        async with factory() as db:
+            entitled_games = await service.get_entitled_games(db, sid)
     token, expires_at = service.issue_token(sid, entitled_games)
     return EntitlementsResponse(
         token=token,

--- a/backend/entitlements/service.py
+++ b/backend/entitlements/service.py
@@ -16,7 +16,11 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy import select
 
-from db.models import GameEntitlement, GameType
+from db.models import GameEntitlement
+
+# Sourced from migrations 0014 + 0016. Used when ENTITLEMENT_DEV_OVERRIDE is active
+# and no DB is available so the override doesn't require a running database.
+_ALL_PREMIUM_SLUGS = ["cascade", "hearts", "sort", "starswarm", "sudoku", "yacht"]
 
 TOKEN_TTL_HOURS = 24
 ALGORITHM = "RS256"
@@ -87,14 +91,9 @@ def issue_token(session_id: str, entitled_games: list[str]) -> tuple[str, dateti
 
 
 async def get_entitled_games(db_session, session_id: str) -> list[str]:
-    """Return entitled game slugs; when DEV_OVERRIDE is active, returns all premium slugs (#1052)."""
+    """Return entitled game slugs; when DEV_OVERRIDE is active, returns all premium slugs."""
     if is_dev_override_active():
-        rows = (
-            (await db_session.execute(select(GameType.name).where(GameType.is_premium.is_(True))))
-            .scalars()
-            .all()
-        )
-        return list(rows)
+        return list(_ALL_PREMIUM_SLUGS)
     rows = (
         (
             await db_session.execute(

--- a/backend/entitlements/service.py
+++ b/backend/entitlements/service.py
@@ -15,11 +15,11 @@ import jwt
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import GameEntitlement
 
-# Sourced from migrations 0014 + 0016. Used when ENTITLEMENT_DEV_OVERRIDE is active
-# and no DB is available so the override doesn't require a running database.
+# Keep in sync with is_premium=True rows (migrations 0014, 0016) — update when adding a premium game.
 _ALL_PREMIUM_SLUGS = ["cascade", "hearts", "sort", "starswarm", "sudoku", "yacht"]
 
 TOKEN_TTL_HOURS = 24
@@ -90,7 +90,7 @@ def issue_token(session_id: str, entitled_games: list[str]) -> tuple[str, dateti
     return token, exp
 
 
-async def get_entitled_games(db_session, session_id: str) -> list[str]:
+async def get_entitled_games(db_session: AsyncSession | None, session_id: str) -> list[str]:
     """Return entitled game slugs; when DEV_OVERRIDE is active, returns all premium slugs."""
     if is_dev_override_active():
         return list(_ALL_PREMIUM_SLUGS)

--- a/backend/tests/test_entitlements.py
+++ b/backend/tests/test_entitlements.py
@@ -134,6 +134,22 @@ def test_dev_override_returns_all_premium_games(
     assert set(decoded["entitled_games"]) == _PREMIUM_GAMES
 
 
+def test_dev_override_does_not_require_database(
+    client: TestClient, session_id: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Override must work even when DATABASE_URL is not configured (no DB available)."""
+    monkeypatch.setenv("ENTITLEMENT_DEV_OVERRIDE", "true")
+    monkeypatch.setattr(
+        "entitlements.router.get_session_factory",
+        lambda: (_ for _ in ()).throw(RuntimeError("DATABASE_URL is not configured")),
+    )
+    r = client.get("/entitlements", headers=_headers(session_id))
+    assert r.status_code == 200
+    pub_pem = entitlements_service.get_public_key_pem()
+    decoded = jwt.decode(r.json()["token"], pub_pem, algorithms=["RS256"])
+    assert set(decoded["entitled_games"]) == _PREMIUM_GAMES
+
+
 def test_dev_override_false_gives_normal_path(
     client: TestClient, session_id: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- `ENTITLEMENT_DEV_OVERRIDE=true` printed the override-active startup message but the endpoint was still calling `get_session_factory()` → `get_engine()` → `RuntimeError("DATABASE_URL is not configured")` before the override logic was reached
- The frontend caught the 500 silently in its `init()` catch block, fell back to an empty cached token, and locked all premium games — making the override a no-op when running without a local DB
- `service.py`: dev override now returns a hardcoded `_ALL_PREMIUM_SLUGS` list (sourced from migrations 0014 + 0016) — no DB query needed
- `router.py`: skips `get_session_factory()` entirely when override is active

## Test plan

- [x] `curl /entitlements` with `ENTITLEMENT_DEV_OVERRIDE=true` and no `DATABASE_URL` returns a JWT with all 6 premium games in `entitled_games`
- [ ] `python -m pytest tests/ -v` passes (entitlement enforcement + override tests)
- [ ] Expo Web: premium games accessible when running local backend with override active

🤖 Generated with [Claude Code](https://claude.ai/claude-code)