### PR TITLE
feat(hearts): debugger on by default, button toggles panel open/closed

### DIFF
--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -91,7 +91,7 @@ export default function HeartsScreen() {
   const scoreHistory = useMemo(() => gameState?.scoreHistory ?? [], [gameState?.scoreHistory]);
 
   // ── Debug mode (__DEV__ only) ──────────────────────────────────────────────
-  const [debugMode, setDebugMode] = useState(false);
+  const [debugMode] = useState(__DEV__);
   const [debugPanelOpen, setDebugPanelOpen] = useState(false);
   const [handNotes, setHandNotes] = useState<string[]>([]);
   const [handLogs, setHandLogs] = useState<HandDebugLog[]>([]);
@@ -660,25 +660,13 @@ export default function HeartsScreen() {
         />
         {__DEV__ && (
           <Pressable
-            style={[
-              styles.devButton,
-              { backgroundColor: debugMode ? colors.accent : colors.surfaceAlt },
-            ]}
-            onPress={() => {
-              const next = !debugMode;
-              setDebugMode(next);
-              if (next) setDebugPanelOpen(true);
-            }}
+            style={[styles.devButton, { backgroundColor: colors.accent }]}
+            onPress={() => setDebugPanelOpen((prev) => !prev)}
             accessibilityRole="button"
-            accessibilityLabel="Toggle Hearts debugger"
+            accessibilityLabel="Toggle Hearts debugger panel"
           >
-            <Text
-              style={[
-                styles.devButtonText,
-                { color: debugMode ? colors.textOnAccent : colors.textMuted },
-              ]}
-            >
-              {debugMode ? "DBG ON" : "DBG"}
+            <Text style={[styles.devButtonText, { color: colors.textOnAccent }]}>
+              {debugPanelOpen ? "DBG ▾" : "DBG ▴"}
             </Text>
           </Pressable>
         )}


### PR DESCRIPTION
## Summary

- Debugger mode is now active by default in `__DEV__` builds — no need to tap the button to start logging or reveal AI cards
- DBG button now toggles the panel open/closed (▴ = closed, ▾ = open) instead of toggling debug mode on/off — eliminates the off→on cycle previously required to reopen the panel
- Button always renders with accent background since mode is always on in dev
- Removes unused `setDebugMode` setter

## Test plan

- [ ] Open Hearts in dev — AI cards should be face-up immediately without tapping DBG
- [ ] Tap **DBG ▴** → panel opens
- [ ] Tap **DBG ▾** → panel closes without disrupting the game
- [ ] Play a hand — log entry appears in the panel on next open

🤖 Generated with [Claude Code](https://claude.ai/claude-code)