### PR TITLE
fix(hearts): debugger logging for saved games + UX improvements

### DIFF
--- a/frontend/src/components/hearts/HeartsDebugPanel.tsx
+++ b/frontend/src/components/hearts/HeartsDebugPanel.tsx
@@ -18,6 +18,8 @@ import {
   passDirectionLabel,
   passOffset,
 } from "../../game/hearts/debugLog";
+import type { AiPreset } from "../../game/hearts/types";
+import { resolvePersona } from "../../game/hearts/types";
 
 interface Props {
   visible: boolean;
@@ -25,7 +27,7 @@ interface Props {
   logs: readonly HandDebugLog[];
   notes: readonly string[];
   playerLabels: readonly string[];
-  aiDifficulty: string;
+  aiDifficulty: AiPreset;
   onNotesChange: (handIdx: number, text: string) => void;
 }
 
@@ -180,41 +182,55 @@ export default function HeartsDebugPanel({
         <View
           style={[styles.header, { borderBottomColor: colors.border, paddingTop: insets.top + 12 }]}
         >
-          <Text style={[styles.headerTitle, { color: colors.text }]}>
-            Hearts Debugger
-            {logs.length > 0 ? ` — ${logs.length} hand${logs.length !== 1 ? "s" : ""}` : ""}
-          </Text>
-          <View style={styles.headerActions}>
-            <Pressable
-              style={[
-                styles.copyBtn,
-                { backgroundColor: copied ? colors.accent : colors.surfaceAlt },
-              ]}
-              onPress={() => void handleCopy()}
-              disabled={isNative}
-              accessibilityRole="button"
-              accessibilityLabel={isNative ? "Copy (web only)" : "Copy session to clipboard"}
-            >
-              <Text
+          <View style={styles.headerTop}>
+            <Text style={[styles.headerTitle, { color: colors.text }]}>
+              Hearts Debugger
+              {logs.length > 0 ? ` — ${logs.length} hand${logs.length !== 1 ? "s" : ""}` : ""}
+            </Text>
+            <View style={styles.headerActions}>
+              <Pressable
                 style={[
-                  styles.copyBtnText,
-                  {
-                    color: isNative ? colors.textMuted : copied ? colors.textOnAccent : colors.text,
-                  },
+                  styles.copyBtn,
+                  { backgroundColor: copied ? colors.accent : colors.surfaceAlt },
                 ]}
+                onPress={() => void handleCopy()}
+                disabled={isNative}
+                accessibilityRole="button"
+                accessibilityLabel={isNative ? "Copy (web only)" : "Copy session to clipboard"}
               >
-                {copied ? "Copied!" : isNative ? "Copy (web)" : "Copy"}
-              </Text>
-            </Pressable>
-            <Pressable
-              style={styles.closeBtn}
-              onPress={onClose}
-              accessibilityRole="button"
-              accessibilityLabel="Close debugger"
-            >
-              <Text style={[styles.closeBtnText, { color: colors.text }]}>✕</Text>
-            </Pressable>
+                <Text
+                  style={[
+                    styles.copyBtnText,
+                    {
+                      color: isNative
+                        ? colors.textMuted
+                        : copied
+                          ? colors.textOnAccent
+                          : colors.text,
+                    },
+                  ]}
+                >
+                  {copied ? "Copied!" : isNative ? "Copy (web)" : "Copy"}
+                </Text>
+              </Pressable>
+              <Pressable
+                style={styles.closeBtn}
+                onPress={onClose}
+                accessibilityRole="button"
+                accessibilityLabel="Close debugger"
+              >
+                <Text style={[styles.closeBtnText, { color: colors.text }]}>✕</Text>
+              </Pressable>
+            </View>
           </View>
+          <Text style={[styles.personaLine, { color: colors.textMuted }]}>
+            {[1, 2, 3]
+              .map(
+                (seat) =>
+                  `${playerLabels[seat] ?? `P${seat}`}: ${resolvePersona(aiDifficulty, seat)}`
+              )
+              .join("  ·  ")}
+          </Text>
         </View>
 
         <ScrollView
@@ -249,12 +265,16 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   header: {
+    flexDirection: "column",
+    paddingHorizontal: 16,
+    paddingBottom: 10,
+    borderBottomWidth: 1,
+    gap: 4,
+  },
+  headerTop: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: 16,
-    paddingBottom: 12,
-    borderBottomWidth: 1,
   },
   headerTitle: {
     fontSize: 16,
@@ -265,6 +285,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
+  },
+  personaLine: {
+    fontSize: 11,
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
   },
   copyBtn: {
     paddingHorizontal: 12,

--- a/frontend/src/components/hearts/HeartsDebugPanel.tsx
+++ b/frontend/src/components/hearts/HeartsDebugPanel.tsx
@@ -91,24 +91,23 @@ function HandSection({ log, handIdx, note, playerLabels, onNotesChange }: HandSe
       <Text style={[styles.sectionHeader, { color: colors.text }]}>
         Tricks ({log.tricks.length})
       </Text>
-      {log.tricks.map((trick, t) => {
-        const byPlayer: string[] = ["—", "—", "—", "—"];
-        for (const play of trick.plays) {
-          const s = cardStr(play.card);
-          byPlayer[play.playerIndex] = play.playerIndex === trick.winnerIndex ? `[${s}]` : s;
-        }
-        return (
-          <Text key={t} style={[styles.trickRow, { color: colors.textMuted }]}>
-            <Text style={{ color: colors.text }}>T{t + 1} </Text>
-            {byPlayer.map((c, i) => `${label(i)}:${c}`).join("  ")}
-            {"  "}
-            <Text style={{ color: colors.accent }}>
-              → {label(trick.winnerIndex)}
-              {trick.pointsWon > 0 ? ` +${trick.pointsWon}` : ""}
-            </Text>
+      {log.tricks.map((trick, t) => (
+        <Text key={t} style={[styles.trickRow, { color: colors.textMuted }]}>
+          <Text style={{ color: colors.text }}>T{t + 1} </Text>
+          {trick.plays
+            .map((play) => {
+              const s = cardStr(play.card);
+              const cell = play.playerIndex === trick.winnerIndex ? `[${s}]` : s;
+              return `${label(play.playerIndex)}:${cell}`;
+            })
+            .join("  ")}
+          {"  "}
+          <Text style={{ color: colors.accent }}>
+            → {label(trick.winnerIndex)}
+            {trick.pointsWon > 0 ? ` +${trick.pointsWon}` : ""}
           </Text>
-        );
-      })}
+        </Text>
+      ))}
 
       <Text style={[styles.sectionHeader, { color: colors.text }]}>Scores</Text>
       <Text style={[styles.handRow, { color: colors.textMuted }]}>

--- a/frontend/src/game/hearts/debugLog.ts
+++ b/frontend/src/game/hearts/debugLog.ts
@@ -99,19 +99,17 @@ export function formatSessionAsMarkdown(
 
     lines.push("");
     lines.push("### Tricks");
-    const colLabels = [0, 1, 2, 3].map(label);
-    lines.push(`| # | ${colLabels.join(" | ")} | Winner | Pts |`);
-    lines.push(`|---|${colLabels.map(() => "---").join("|")}|--------|-----|`);
     for (let t = 0; t < log.tricks.length; t++) {
       const trick = log.tricks[t]!;
-      const cellByPlayer: string[] = ["—", "—", "—", "—"];
-      for (const play of trick.plays) {
-        const s = cardStr(play.card);
-        cellByPlayer[play.playerIndex] = play.playerIndex === trick.winnerIndex ? `**${s}**` : s;
-      }
-      lines.push(
-        `| ${t + 1} | ${cellByPlayer.join(" | ")} | ${label(trick.winnerIndex)} | ${trick.pointsWon} |`
-      );
+      const plays = trick.plays
+        .map((play) => {
+          const s = cardStr(play.card);
+          const cell = play.playerIndex === trick.winnerIndex ? `**${s}**` : s;
+          return `${label(play.playerIndex)}:${cell}`;
+        })
+        .join("  ");
+      const pts = trick.pointsWon > 0 ? ` +${trick.pointsWon}` : "";
+      lines.push(`T${t + 1} ${plays}  → ${label(trick.winnerIndex)}${pts}`);
     }
 
     lines.push("");

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -139,6 +139,8 @@ export default function HeartsScreen() {
         setGameState(saved);
         setSelectedDifficulty(saved.aiDifficulty);
         if (__DEV__ && (saved.phase === "playing" || saved.phase === "passing")) {
+          // Best-effort: saved state doesn't preserve the original deal, so
+          // playerHands approximates both initial and final hands for resumed games.
           dealSnapshotRef.current = {
             initialHands: saved.playerHands,
             passSelections: saved.passSelections ?? [[], [], [], []],
@@ -297,7 +299,7 @@ export default function HeartsScreen() {
           if (completedTrick) {
             setLastTrick({ trick: completedTrick, winnerIndex: s.currentLeaderIndex });
             void saveGame(s);
-            if (__DEV__ && debugMode) {
+            if (__DEV__) {
               trickLogBufferRef.current.push(buildDebugTrick(completedTrick, s.currentLeaderIndex));
             }
           }
@@ -317,7 +319,7 @@ export default function HeartsScreen() {
         loopActiveRef.current = false;
       }
     },
-    [playCardPlay, debugMode]
+    [playCardPlay]
   );
 
   // Trigger AI loop when it's their turn; wait for lastTrick display first.

--- a/frontend/src/screens/HeartsScreen.tsx
+++ b/frontend/src/screens/HeartsScreen.tsx
@@ -91,7 +91,7 @@ export default function HeartsScreen() {
   const scoreHistory = useMemo(() => gameState?.scoreHistory ?? [], [gameState?.scoreHistory]);
 
   // ── Debug mode (__DEV__ only) ──────────────────────────────────────────────
-  const [debugMode] = useState(__DEV__);
+  const debugMode = __DEV__;
   const [debugPanelOpen, setDebugPanelOpen] = useState(false);
   const [handNotes, setHandNotes] = useState<string[]>([]);
   const [handLogs, setHandLogs] = useState<HandDebugLog[]>([]);
@@ -138,6 +138,13 @@ export default function HeartsScreen() {
       if (!unmountedRef.current && saved) {
         setGameState(saved);
         setSelectedDifficulty(saved.aiDifficulty);
+        if (__DEV__ && (saved.phase === "playing" || saved.phase === "passing")) {
+          dealSnapshotRef.current = {
+            initialHands: saved.playerHands,
+            passSelections: saved.passSelections ?? [[], [], [], []],
+            finalHands: saved.playerHands,
+          };
+        }
       }
     });
     loadPlayerNames().then((names) => {


### PR DESCRIPTION
## Summary

- **Root cause:** when a saved game was restored via `loadGame()`, `dealSnapshotRef` was never initialised — the hand-end effect's `if (!snapshot) return` guard silently bailed on every completed hand regardless of tricks played
- **Fix:** initialise `dealSnapshotRef` from the restored game state in the `loadGame` effect for any in-progress game (`playing` or `passing` phase)
- Rolls in UX improvements from #1847: `const debugMode = __DEV__` (plain constant, no state), button toggles panel directly (▴/▾), always-accent background

## Test plan

- [ ] Start a fresh game — play a hand — open panel — log entry appears
- [ ] Start a game, navigate away, return — play a hand — log entry appears (saved-game path)
- [ ] DBG ▴ opens panel, DBG ▾ closes it — no off/on cycle needed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)