### PR TITLE
fix(yacht): replay AI turn animation after iOS notification interruption

### DIFF
--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
-import { Modal, ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
+import { AppState, Modal, ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -81,6 +81,10 @@ export default function GameScreen({ navigation, route }: Props) {
   const [aiGameState, setAiGameState] = useState<GameState | null>(route.params.aiState ?? null);
   const [isAiTurn, setIsAiTurn] = useState(false);
   const [aiRollingIndices, setAiRollingIndices] = useState<readonly number[]>([]);
+  // Tracks whether the AI turn was interrupted by app backgrounding so it can be replayed.
+  const aiTurnInterruptedRef = useRef(false);
+  // Snapshot of AI game state at the start of each turn, used to replay from scratch on resume.
+  const aiTurnStartStateRef = useRef<GameState | null>(null);
 
   // Keep refs in sync for use inside async AI turn loop and callbacks.
   const gameStateRef = useRef(gameState);
@@ -182,7 +186,20 @@ export default function GameScreen({ navigation, route }: Props) {
   useEffect(() => {
     if (!isAiTurn || !aiDifficultyRef.current || !aiGameStateRef.current) return;
 
+    // Snapshot the pre-turn state so we can replay cleanly from scratch if interrupted.
+    aiTurnStartStateRef.current = aiGameStateRef.current;
+
     let cancelled = false;
+
+    // Cancel and mark interrupted if the app leaves the foreground mid-animation.
+    const appStateSub = AppState.addEventListener("change", (next) => {
+      if (next === "background" || next === "inactive") {
+        cancelled = true;
+        aiTurnInterruptedRef.current = true;
+        setAiRollingIndices([]);
+      }
+    });
+
     async function runAiTurn() {
       const diff = aiDifficultyRef.current!;
       let s = aiGameStateRef.current!;
@@ -232,8 +249,26 @@ export default function GameScreen({ navigation, route }: Props) {
     void runAiTurn();
     return () => {
       cancelled = true;
+      appStateSub.remove();
     };
   }, [isAiTurn]);
+
+  // When the app returns to the foreground after interrupting an AI turn, replay it.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "active" && aiTurnInterruptedRef.current) {
+        aiTurnInterruptedRef.current = false;
+        // Restore the pre-turn snapshot so the loop starts from rolls_used=0,
+        // then toggle isAiTurn to re-fire the AI turn effect.
+        if (aiTurnStartStateRef.current) {
+          setAiGameState(aiTurnStartStateRef.current);
+        }
+        setIsAiTurn(false);
+        setTimeout(() => setIsAiTurn(true), 50);
+      }
+    });
+    return () => sub.remove();
+  }, []);
 
   function handleRoll() {
     if (isAiTurn) return;

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -81,10 +81,11 @@ export default function GameScreen({ navigation, route }: Props) {
   const [aiGameState, setAiGameState] = useState<GameState | null>(route.params.aiState ?? null);
   const [isAiTurn, setIsAiTurn] = useState(false);
   const [aiRollingIndices, setAiRollingIndices] = useState<readonly number[]>([]);
-  // Tracks whether the AI turn was interrupted by app backgrounding so it can be replayed.
+  const isAiTurnRef = useRef(isAiTurn);
+  const aiTurnCancelledRef = useRef(false);
   const aiTurnInterruptedRef = useRef(false);
-  // Snapshot of AI game state at the start of each turn, used to replay from scratch on resume.
   const aiTurnStartStateRef = useRef<GameState | null>(null);
+  const aiReplayPendingRef = useRef(false);
 
   // Keep refs in sync for use inside async AI turn loop and callbacks.
   const gameStateRef = useRef(gameState);
@@ -101,6 +102,10 @@ export default function GameScreen({ navigation, route }: Props) {
   useEffect(() => {
     aiGameStateRef.current = aiGameState;
   }, [aiGameState]);
+
+  useEffect(() => {
+    isAiTurnRef.current = isAiTurn;
+  }, [isAiTurn]);
 
   // Game event instrumentation (#368 / #549).
   const {
@@ -182,23 +187,42 @@ export default function GameScreen({ navigation, route }: Props) {
     () => setGameState((prev) => (prev === null ? prev : { ...prev, events: undefined }))
   );
 
+  // Single mount-time AppState listener — cancels on background, replays on foreground return.
+  // Using isAiTurnRef (not the state value) avoids re-subscribing on every turn.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if ((next === "background" || next === "inactive") && isAiTurnRef.current) {
+        aiTurnCancelledRef.current = true;
+        aiTurnInterruptedRef.current = true;
+        setAiRollingIndices([]);
+      } else if (next === "active" && aiTurnInterruptedRef.current) {
+        aiTurnInterruptedRef.current = false;
+        if (aiTurnStartStateRef.current) {
+          setAiGameState(aiTurnStartStateRef.current);
+          aiTurnStartStateRef.current = null;
+        }
+        aiReplayPendingRef.current = true;
+        setIsAiTurn(false);
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  // Re-fires the AI turn effect after isAiTurn settles to false with a replay pending.
+  // This avoids the setTimeout(50) toggle race from the original implementation.
+  useEffect(() => {
+    if (!isAiTurn && aiReplayPendingRef.current) {
+      aiReplayPendingRef.current = false;
+      setIsAiTurn(true);
+    }
+  }, [isAiTurn]);
+
   // AI turn loop: fires whenever isAiTurn becomes true.
   useEffect(() => {
     if (!isAiTurn || !aiDifficultyRef.current || !aiGameStateRef.current) return;
 
-    // Snapshot the pre-turn state so we can replay cleanly from scratch if interrupted.
     aiTurnStartStateRef.current = aiGameStateRef.current;
-
-    let cancelled = false;
-
-    // Cancel and mark interrupted if the app leaves the foreground mid-animation.
-    const appStateSub = AppState.addEventListener("change", (next) => {
-      if (next === "background" || next === "inactive") {
-        cancelled = true;
-        aiTurnInterruptedRef.current = true;
-        setAiRollingIndices([]);
-      }
-    });
+    aiTurnCancelledRef.current = false;
 
     async function runAiTurn() {
       const diff = aiDifficultyRef.current!;
@@ -209,11 +233,11 @@ export default function GameScreen({ navigation, route }: Props) {
       setAiGameState(s);
       setAiRollingIndices([0, 1, 2, 3, 4]);
       await delay(1000);
-      if (cancelled) return;
+      if (aiTurnCancelledRef.current) return;
       setAiRollingIndices([]);
       // Settle pause: let the player read the dice values
       await delay(800);
-      if (cancelled) return;
+      if (aiTurnCancelledRef.current) return;
 
       // Up to two re-rolls using hold strategy
       while (s.rolls_used < 3) {
@@ -221,7 +245,7 @@ export default function GameScreen({ navigation, route }: Props) {
         // Show hold decision on current values so the player sees the AI's choice
         setAiGameState({ ...s, held: holds });
         await delay(800);
-        if (cancelled) return;
+        if (aiTurnCancelledRef.current) return;
         const rolledIdxs = holds.reduce<number[]>((acc, h, i) => {
           if (!h) acc.push(i);
           return acc;
@@ -231,15 +255,15 @@ export default function GameScreen({ navigation, route }: Props) {
         setAiGameState(s);
         setAiRollingIndices(rolledIdxs);
         await delay(1000);
-        if (cancelled) return;
+        if (aiTurnCancelledRef.current) return;
         setAiRollingIndices([]);
         await delay(800);
-        if (cancelled) return;
+        if (aiTurnCancelledRef.current) return;
       }
 
       // Beat before the AI locks in its category
       await delay(1000);
-      if (cancelled) return;
+      if (aiTurnCancelledRef.current) return;
       const cat = scoreStrategy(s, diff, gameStateRef.current.total_score);
       s = engineScore(s, cat);
       setAiGameState(s);
@@ -248,27 +272,9 @@ export default function GameScreen({ navigation, route }: Props) {
 
     void runAiTurn();
     return () => {
-      cancelled = true;
-      appStateSub.remove();
+      aiTurnCancelledRef.current = true;
     };
   }, [isAiTurn]);
-
-  // When the app returns to the foreground after interrupting an AI turn, replay it.
-  useEffect(() => {
-    const sub = AppState.addEventListener("change", (next) => {
-      if (next === "active" && aiTurnInterruptedRef.current) {
-        aiTurnInterruptedRef.current = false;
-        // Restore the pre-turn snapshot so the loop starts from rolls_used=0,
-        // then toggle isAiTurn to re-fire the AI turn effect.
-        if (aiTurnStartStateRef.current) {
-          setAiGameState(aiTurnStartStateRef.current);
-        }
-        setIsAiTurn(false);
-        setTimeout(() => setIsAiTurn(true), 50);
-      }
-    });
-    return () => sub.remove();
-  }, []);
 
   function handleRoll() {
     if (isAiTurn) return;

--- a/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, fireEvent, act } from "@testing-library/react-native";
+import { AppState } from "react-native";
 import GameScreen from "../GameScreen";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import { YachtScorecardProvider } from "../../game/yacht/ScorecardContext";
@@ -75,6 +76,36 @@ const mockNav = {
 // Recognisable rolled value — easy to assert against "showing blank" (value 0).
 const ROLLED_DICE: [number, number, number, number, number] = [6, 6, 6, 6, 6];
 
+// ---------------------------------------------------------------------------
+// Shared VS-game render helper used by both describe blocks below.
+// ---------------------------------------------------------------------------
+
+function renderVsGame(
+  playerOverrides: Partial<GameState> = {},
+  aiOverrides: Partial<GameState> = {}
+) {
+  const playerState = makeGameState({ dice: [1, 1, 1, 1, 1], rolls_used: 1, ...playerOverrides });
+  const aiState = makeGameState(aiOverrides);
+  return render(
+    <ThemeProvider>
+      <YachtScorecardProvider>
+        <GameScreen
+          navigation={mockNav}
+          route={
+            {
+              params: {
+                initialState: playerState,
+                aiDifficulty: "easy" as const,
+                aiState,
+              },
+            } as unknown as Parameters<typeof GameScreen>[0]["route"]
+          }
+        />
+      </YachtScorecardProvider>
+    </ThemeProvider>
+  );
+}
+
 describe("GameScreen VS mode — CPU animation ordering", () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -128,5 +159,142 @@ describe("GameScreen VS mode — CPU animation ordering", () => {
     for (const die of diceButtons) {
       expect(die.props.accessibilityLabel).toMatch(/showing 6/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AppState interruption + replay (GH #1850 / PR #1851)
+// ---------------------------------------------------------------------------
+
+describe("GameScreen VS mode — AppState interruption + replay", () => {
+  let appStateListeners: Array<(state: string) => void>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appStateListeners = [];
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_event: string, handler: (state: string) => void) => {
+        appStateListeners.push(handler);
+        return { remove: jest.fn() };
+      }
+    );
+    mockRoll.mockImplementation((state: GameState) => ({
+      ...state,
+      dice: [...ROLLED_DICE],
+      rolls_used: state.rolls_used + 1,
+      held: [false, false, false, false, false],
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function fireAppState(state: string) {
+    appStateListeners.forEach((h) => h(state));
+  }
+
+  it("registers exactly one AppState listener on mount (single combined listener)", () => {
+    renderVsGame();
+    expect(appStateListeners).toHaveLength(1);
+  });
+
+  it("no additional AppState listener is registered when an AI turn starts", async () => {
+    const { getByRole } = renderVsGame();
+    expect(appStateListeners).toHaveLength(1);
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+
+    // Still exactly one listener — no per-turn subscription added.
+    expect(appStateListeners).toHaveLength(1);
+  });
+
+  it("backgrounding mid-AI-turn stops the animation loop (no further rolls)", async () => {
+    const { getByRole } = renderVsGame();
+    mockRoll.mockClear();
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+    // One roll happens synchronously before the first await in the loop.
+    const rollsBeforeBackground = mockRoll.mock.calls.length;
+    expect(rollsBeforeBackground).toBe(1);
+
+    await act(async () => {
+      fireAppState("background");
+    });
+
+    // Advance all timers — the cancelled loop should exit without rolling again.
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(mockRoll.mock.calls.length).toBe(rollsBeforeBackground);
+  });
+
+  it("foregrounding after background replays the AI turn (mockRoll called again)", async () => {
+    const { getByRole, getByText } = renderVsGame();
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+
+    await act(async () => {
+      fireAppState("background");
+      jest.advanceTimersByTime(10_000);
+    });
+
+    mockRoll.mockClear();
+
+    await act(async () => {
+      fireAppState("active");
+    });
+
+    // The replay re-fires the AI turn effect: at minimum one roll runs synchronously.
+    expect(mockRoll.mock.calls.length).toBeGreaterThan(0);
+    expect(getByText("Computer's Turn")).toBeTruthy();
+  });
+
+  it("replay restores the pre-turn snapshot (first roll receives rolls_used=0)", async () => {
+    const { getByRole } = renderVsGame();
+
+    await act(async () => {
+      fireEvent.press(getByRole("button", { name: /ones/i }));
+    });
+
+    await act(async () => {
+      fireAppState("background");
+      jest.advanceTimersByTime(10_000);
+    });
+
+    mockRoll.mockClear();
+
+    await act(async () => {
+      fireAppState("active");
+    });
+
+    // The very first roll on replay must use the pre-turn snapshot (rolls_used=0).
+    expect(mockRoll).toHaveBeenCalledWith(expect.objectContaining({ rolls_used: 0 }), [
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("backgrounding when NOT in an AI turn does not start a spurious replay", async () => {
+    const { queryByText } = renderVsGame();
+
+    // Background and foreground with no AI turn running.
+    await act(async () => {
+      fireAppState("background");
+      fireAppState("active");
+    });
+
+    expect(queryByText("Computer's Turn")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes Yacht computer player animation breaking when an iOS notification interrupts the AI's turn (closes #1850, closes #1853)
- Consolidates two AppState subscriptions into a single mount-time listener — eliminates the per-AI-turn subscription that added a second listener and left a race window
- Replaces the fragile `setTimeout(50)` toggle with an effect-based replay: a `aiReplayPendingRef` flag is consumed by a `useEffect` watching `isAiTurn`, guaranteeing `aiGameStateRef` is committed before the AI loop re-fires
- Adds `isAiTurnRef` so the listener guards against spurious background events when no AI turn is active
- Clears `aiTurnStartStateRef` after snapshot restoration to avoid stale-ref confusion

## How it works

When a notification arrives mid-animation, Reanimated's native thread freezes while the JS `setTimeout` loop keeps running. The fix catches this at the source:

1. **On background/inactive:** `aiTurnCancelledRef` stops the loop, `aiTurnInterruptedRef` is flagged, and rolling indices are cleared. The pre-turn `aiGameState` (with `rolls_used = 0`) is snapshotted before the loop starts.
2. **On foreground return:** the snapshot is restored via `setAiGameState`, `isAiTurn` is toggled `false` → `true` via a deterministic `useEffect` (not a timer), re-running the AI turn effect from the beginning so the full animation replays cleanly from `rolls_used = 0`.

Game logic is unaffected — score is only committed at the end of a fully completed turn.

## Resolves #1853

The "No rolls remaining" crash (#1853) occurred because the original `setTimeout(50)` replay could fire before React committed the restored snapshot to `aiGameStateRef.current`, causing the re-fired AI loop to see stale `rolls_used = 3`. The effect-based replay guarantees `aiGameStateRef` is updated before the AI turn loop fires (declarative `useEffect` ordering within a single commit).

## Test plan

- [ ] Start a VS game, wait for computer turn, trigger a notification banner — confirm animation replays correctly when returning to the app
- [ ] Verify the AI's score is recorded correctly after the replayed turn
- [ ] Confirm normal (uninterrupted) computer turns still animate as expected
- [ ] Confirm navigating away and back mid-AI-turn still works correctly
- [ ] Confirm no new Sentry events for `roll → "No rolls remaining"` after merge

## Tests added (6)

- Single AppState listener registered on mount
- No additional listener registered when AI turn starts
- Background mid-turn stops the animation loop (no further rolls)
- Foreground after background replays the AI turn (`mockRoll` called again)
- Replay restores pre-turn snapshot (`first roll receives rolls_used=0`)
- Background when not in AI turn does not trigger spurious replay

https://claude.ai/code/session_01KjHFrtsPBZhXdwSBZydsop

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjHFrtsPBZhXdwSBZydsop)_