### PR TITLE
fix(ci): add conflict-marker hygiene gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,11 @@ jobs:
       - uses: actions/checkout@v6
       - name: Check for merge conflict markers
         run: |
-          if grep -rn -E "^(<<<<<<<|=======|>>>>>>>)" \
+          if grep -rn \
+              -e "^<<<<<<< " -e "^=======$" -e "^>>>>>>> " \
               --include="*.ts" --include="*.tsx" --include="*.py" \
               --include="*.js" --include="*.jsx" \
+              --include="*.json" --include="*.yml" --include="*.yaml" \
               --exclude-dir=node_modules --exclude-dir=.git \
               .; then
             echo "::error::Merge conflict markers found — resolve before merging"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,27 @@ jobs:
       working-directory: frontend
     secrets: inherit
 
+  conflict-markers:
+    name: Conflict marker check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for merge conflict markers
+        run: |
+          if grep -rn -E "^(<<<<<<<|=======|>>>>>>>)" \
+              --include="*.ts" --include="*.tsx" --include="*.py" \
+              --include="*.js" --include="*.jsx" \
+              --exclude-dir=node_modules --exclude-dir=.git \
+              .; then
+            echo "::error::Merge conflict markers found — resolve before merging"
+            exit 1
+          fi
+          echo "No conflict markers found"
+
   # === Tier 1: Substantive fast checks (need lint + secret-scan) ===========
 
   backend-health:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-backend-health.yml@main
     with:
       # Direct Render origin intentionally used here instead of dev-games-api.buffingchi.com.
@@ -54,14 +71,14 @@ jobs:
     secrets: inherit
 
   expo-compat:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-expo-compat.yml@main
     with:
       working-directory: frontend
     secrets: inherit
 
   sentry-check:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-sentry-check.yml@main
     with:
       working-directory: backend
@@ -69,7 +86,7 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_BC_GAMES }}
 
   local-path-check:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-local-path-check.yml@main
     with:
       scan-paths: "frontend/ios/GamingApp.xcodeproj,frontend/android"
@@ -77,21 +94,21 @@ jobs:
     secrets: inherit
 
   test-python:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-python.yml@main
     with:
       working-directory: backend
     secrets: inherit
 
   test-frontend:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-frontend.yml@main
     with:
       working-directory: frontend
     secrets: inherit
 
   cve-python:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-cve-python.yml@main
     with:
       working-directory: backend
@@ -99,7 +116,7 @@ jobs:
     secrets: inherit
 
   cve-frontend:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-cve-frontend.yml@main
     with:
       working-directory: frontend
@@ -107,7 +124,7 @@ jobs:
 
   detect-e2e-scope:
     name: Detect E2E scope
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     runs-on: ubuntu-latest
     outputs:
       projects: ${{ steps.scope.outputs.projects }}
@@ -278,7 +295,7 @@ jobs:
 
   check-i18n:
     name: i18n completeness check
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -295,17 +312,17 @@ jobs:
         working-directory: frontend
 
   openai-policy:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
     secrets: inherit
 
   feedback-token-lint:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-feedback-token-lint.yml@main
     secrets: inherit
 
   provenance-coverage:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     uses: wcmchenry3-stack/.github/.github/workflows/called-provenance-coverage.yml@main
     secrets: inherit
 
@@ -315,7 +332,7 @@ jobs:
   # so it cannot detect issues with the JS bundler or entry-point resolution.
 
   android-bundle-check:
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -493,7 +510,7 @@ jobs:
 
   sentry-cli-check:
     if: github.event_name == 'pull_request'
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -529,7 +546,7 @@ jobs:
 
   gradle-wrapper-check:
     if: github.event_name == 'pull_request'
-    needs: [lint-python, lint-frontend, secret-scan]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Adds a Tier 0 `conflict-markers` CI job that scans `.ts`, `.tsx`, `.py`, `.js`, `.jsx` files for `<<<<<<<`, `=======`, and `>>>>>>>` at line start
- Wired into all 14 Tier 1 `needs` arrays so no substantive check can run past it
- Would have caught the `HeartsScreen.tsx` merge conflict incident from #1847

Closes #1852

## Test plan
- [ ] CI runs and `conflict-markers` job passes on this clean branch
- [ ] Manually introduce a conflict marker to verify the job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)