### PR TITLE
fix(entitlements): correct prod API URL and guard against dev-API-in-prod (#1854)

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,4 +1,4 @@
-EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com
+EXPO_PUBLIC_API_URL=https://games-api.buffingchi.com
 EXPO_PUBLIC_SENTRY_DSN=https://4e8b2bd816cbce3f73b0cd6923530d53@o4511129011093504.ingest.us.sentry.io/4511129020334080
 EXPO_PUBLIC_SENTRY_ENVIRONMENT=production
 

--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -118,6 +118,34 @@ describe("httpClient — BASE_URL configuration", () => {
       g.__DEV__ = originalDev;
     }
   });
+
+  it("throws at module load when a dev-* API URL is used in a non-dev build (#1854)", () => {
+    process.env.EXPO_PUBLIC_API_URL = "https://dev-games-api.buffingchi.com";
+    const g = globalThis as { __DEV__?: boolean };
+    const originalDev = g.__DEV__;
+    g.__DEV__ = false;
+    try {
+      expect(() => loadClient()).toThrow(/points to a dev API host/);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Sentry = require("@sentry/react-native");
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining("points to a dev API host"),
+        expect.objectContaining({
+          level: "fatal",
+          tags: expect.objectContaining({ issue: "dev-api-in-prod" }),
+        })
+      );
+    } finally {
+      g.__DEV__ = originalDev;
+    }
+  });
+
+  it("does not throw for a dev-* URL when __DEV__ is true (#1854)", async () => {
+    process.env.EXPO_PUBLIC_API_URL = "https://dev-games-api.buffingchi.com";
+    // __DEV__ is true by default in the test environment.
+    expect((globalThis as { __DEV__?: boolean }).__DEV__).toBe(true);
+    expect(() => loadClient()).not.toThrow();
+  });
 });
 
 describe("httpClient — error handling", () => {

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -53,6 +53,15 @@ function isLocalhost(url: string): boolean {
   }
 }
 
+function isDevApiUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname.startsWith("dev-");
+  } catch {
+    return false;
+  }
+}
+
 function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
   if (raw) {
@@ -74,6 +83,21 @@ function resolveBaseUrl(): string {
         });
         throw new Error(msg);
       }
+    }
+    // Catch dev-API-in-prod: a production Sentry environment tag with a
+    // dev-* hostname means .env.production was misconfigured (issue #1854).
+    if (!__DEV__ && !isTestBuild && isDevApiUrl(resolved)) {
+      const msg =
+        "EXPO_PUBLIC_API_URL points to a dev API host in a non-dev build (" +
+        resolved +
+        "). Set EXPO_PUBLIC_API_URL to the production API URL in .env.production " +
+        "and in the Render build environment (see render.yaml).";
+      Sentry.captureMessage(msg, {
+        level: "fatal",
+        tags: { subsystem: "httpClient", issue: "dev-api-in-prod" },
+        extra: { raw },
+      });
+      throw new Error(msg);
     }
     return resolved;
   }


### PR DESCRIPTION
## Summary

- **Root cause:** `frontend/.env.production` had `EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com` — the dev API URL was baked into every production web export, causing 399 Sentry events across 25 users over 18 days
- **Fix:** Corrected the URL to `https://games-api.buffingchi.com` (production, per `render.yaml`)
- **Guard:** Added a `isDevApiUrl()` check in `httpClient.ts` that throws a `fatal`-level Sentry event at boot if a `dev-*` hostname is detected in a non-dev build — same pattern as the existing localhost guard — so this class of misconfiguration fails fast instead of silently misfiring in production

## Test plan

- [ ] All 24 `httpClient.test.ts` tests pass (2 new: `#1854` guard throws in non-dev, does not throw in dev)
- [ ] Verify next production web export hits `games-api.buffingchi.com` in Sentry `api.config` breadcrumbs
- [ ] Confirm Sentry issue `5ed74505` stops receiving new events after deploy

Closes #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)