### PR TITLE
fix(hearts/web): suppress transform-origin React dev warning in HeartsBrokenAnimation

### DIFF
--- a/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
+++ b/frontend/src/components/hearts/HeartsBrokenAnimation.tsx
@@ -119,26 +119,32 @@ export function HeartsBrokenAnimation({ visible, onAnimationEnd }: Props) {
   const crack0Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[0]}deg` }, { scaleX: crack0.value }],
     opacity: crack0.value,
+    transformOrigin: "center",
   }));
   const crack1Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[1]}deg` }, { scaleX: crack1.value }],
     opacity: crack1.value,
+    transformOrigin: "center",
   }));
   const crack2Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[2]}deg` }, { scaleX: crack2.value }],
     opacity: crack2.value,
+    transformOrigin: "center",
   }));
   const crack3Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[3]}deg` }, { scaleX: crack3.value }],
     opacity: crack3.value,
+    transformOrigin: "center",
   }));
   const crack4Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[4]}deg` }, { scaleX: crack4.value }],
     opacity: crack4.value,
+    transformOrigin: "center",
   }));
   const crack5Style = useAnimatedStyle(() => ({
     transform: [{ rotate: `${CRACK_ANGLES[5]}deg` }, { scaleX: crack5.value }],
     opacity: crack5.value,
+    transformOrigin: "center",
   }));
   const crackStyles = [
     crack0Style,


### PR DESCRIPTION
## Summary

- Adds `transformOrigin: 'center'` to each of the six crack-line `useAnimatedStyle` calls in `HeartsBrokenAnimation`

## Root cause (investigation findings)

Reanimated's `PropsFilter.tsx` runs `initialUpdaterRun` synchronously and passes the resulting style object through React's reconciler on first render. The crack-line styles include `scaleX` transforms; somewhere in the reanimated → react-native-web style processing pipeline, this produces a hyphenated `transform-origin` key that React's dev-mode `validateProperty` check rejects with:

> Invalid DOM property 'transform-origin'. Did you mean 'transformOrigin'?

Sentry event `f110160e` — 6 events, 2 dev-mode users over 30 days.

The fix makes `transformOrigin` explicit (camelCase) in the initial animated style. Reanimated's style processors then handle it correctly, preventing the implicit hyphenated injection.

**Also confirmed not the source:** `expo-linear-gradient`'s web renderer uses `backgroundImage` with no transform-origin involvement.

## Test plan

- [ ] Navigate to Hearts screen in web dev mode — console should no longer show the `transform-origin` warning
- [ ] Visually confirm the hearts-broken animation still radiates crack lines correctly
- [ ] `npx tsc --noEmit` — no new type errors

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)