### PR TITLE
fix(hearts): first-trick highest club + pass filler strips Q♠ cover

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -2280,11 +2280,17 @@ describe("selectCardToPlay — first trick, play highest club (all personas)", (
       const trick: TrickCard[] = [{ card: c("clubs", 2), playerIndex: 1 }];
       const state = mkTrick0State([[], hand2, hand2, []]);
       // currentTrick must match trick so getValidPlays sees a following situation.
-      const pick = selectCardToPlay(hand2, trick, {
-        ...state,
-        currentPlayerIndex: 2,
-        currentTrick: trick,
-      }, 2, persona);
+      const pick = selectCardToPlay(
+        hand2,
+        trick,
+        {
+          ...state,
+          currentPlayerIndex: 2,
+          currentTrick: trick,
+        },
+        2,
+        persona
+      );
       expect(pick).toEqual(c("clubs", 6));
     });
 
@@ -2296,11 +2302,17 @@ describe("selectCardToPlay — first trick, play highest club (all personas)", (
         { card: c("clubs", 5), playerIndex: 2 },
       ];
       const state = mkTrick0State([[], [], [], hand3]);
-      const pick = selectCardToPlay(hand3, trick, {
-        ...state,
-        currentPlayerIndex: 3,
-        currentTrick: trick,
-      }, 3, persona);
+      const pick = selectCardToPlay(
+        hand3,
+        trick,
+        {
+          ...state,
+          currentPlayerIndex: 3,
+          currentTrick: trick,
+        },
+        3,
+        persona
+      );
       expect(pick).toEqual(c("clubs", 13));
     });
 
@@ -2313,11 +2325,17 @@ describe("selectCardToPlay — first trick, play highest club (all personas)", (
         { card: c("clubs", 11), playerIndex: 3 },
       ];
       const state = mkTrick0State([hand0, [], [], []]);
-      const pick = selectCardToPlay(hand0, trick, {
-        ...state,
-        currentPlayerIndex: 0,
-        currentTrick: trick,
-      }, 0, persona);
+      const pick = selectCardToPlay(
+        hand0,
+        trick,
+        {
+          ...state,
+          currentPlayerIndex: 0,
+          currentTrick: trick,
+        },
+        0,
+        persona
+      );
       expect(pick).toEqual(c("clubs", 1)); // Ace (rank 1) is highest
     });
   }
@@ -2356,7 +2374,7 @@ describe("selectCardsToPass — Schemer filler does not strip Q♠ protection", 
   it("does not pass A♠ as filler when A♠ is Q♠ cover and no K♠ present (passing left)", () => {
     const hand = [
       c("spades", 12), // Q♠
-      c("spades", 1),  // A♠ — only cover
+      c("spades", 1), // A♠ — only cover
       c("spades", 7),
       c("hearts", 9),
       c("hearts", 6),
@@ -2371,6 +2389,28 @@ describe("selectCardsToPass — Schemer filler does not strip Q♠ protection", 
     ];
     const passed = selectCardsToPass(hand, "left", "schemer");
     expect(passed.some((card) => card.suit === "spades" && card.rank === 12)).toBe(false);
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 1)).toBe(false);
+  });
+
+  it("does not pass K♠ or A♠ as filler when holding Q♠ + K♠ + A♠ (double-cover)", () => {
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 13), // K♠
+      c("spades", 1), // A♠
+      c("spades", 7),
+      c("hearts", 9),
+      c("hearts", 6),
+      c("diamonds", 10),
+      c("diamonds", 8),
+      c("clubs", 11),
+      c("clubs", 9),
+      c("clubs", 8),
+      c("clubs", 7),
+      c("clubs", 6),
+    ];
+    const passed = selectCardsToPass(hand, "left", "schemer");
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 12)).toBe(false);
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 13)).toBe(false);
     expect(passed.some((card) => card.suit === "spades" && card.rank === 1)).toBe(false);
   });
 });

--- a/frontend/src/game/hearts/__tests__/ai.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.test.ts
@@ -2257,3 +2257,120 @@ describe("selectCardToPlay — Daring difficulty, adversarial void discard (edge
     expect(pick).toEqual(c("spades", 12));
   });
 });
+
+// ---------------------------------------------------------------------------
+// First-trick club play — all personas should play highest club (#firstTrick)
+// ---------------------------------------------------------------------------
+
+describe("selectCardToPlay — first trick, play highest club (all personas)", () => {
+  function mkTrick0State(playerHands: Card[][]): HeartsState {
+    return mkState({
+      playerHands,
+      tricksPlayedInHand: 0,
+      heartsBroken: false,
+    });
+  }
+
+  const personas = ["cautious", "schemer", "daring"] as const;
+
+  for (const persona of personas) {
+    it(`${persona}: 2nd follower plays highest club, not lowest`, () => {
+      // Player 1 leads 2♣; player 2 (2nd follower, not last) has 6♣ 5♣ 3♣.
+      const hand2 = [c("clubs", 6), c("clubs", 5), c("clubs", 3)];
+      const trick: TrickCard[] = [{ card: c("clubs", 2), playerIndex: 1 }];
+      const state = mkTrick0State([[], hand2, hand2, []]);
+      // currentTrick must match trick so getValidPlays sees a following situation.
+      const pick = selectCardToPlay(hand2, trick, {
+        ...state,
+        currentPlayerIndex: 2,
+        currentTrick: trick,
+      }, 2, persona);
+      expect(pick).toEqual(c("clubs", 6));
+    });
+
+    it(`${persona}: 3rd follower plays highest club, not lowest`, () => {
+      // Player 1 leads 2♣, player 2 played 5♣; player 3 has K♣ J♣ 10♣ — should play K♣.
+      const hand3 = [c("clubs", 13), c("clubs", 11), c("clubs", 10)];
+      const trick: TrickCard[] = [
+        { card: c("clubs", 2), playerIndex: 1 },
+        { card: c("clubs", 5), playerIndex: 2 },
+      ];
+      const state = mkTrick0State([[], [], [], hand3]);
+      const pick = selectCardToPlay(hand3, trick, {
+        ...state,
+        currentPlayerIndex: 3,
+        currentTrick: trick,
+      }, 3, persona);
+      expect(pick).toEqual(c("clubs", 13));
+    });
+
+    it(`${persona}: last follower (4th) plays highest club`, () => {
+      // Last to play — should also play highest club (A♣ over 4♣).
+      const hand0 = [c("clubs", 1), c("clubs", 9), c("clubs", 4)];
+      const trick: TrickCard[] = [
+        { card: c("clubs", 2), playerIndex: 1 },
+        { card: c("clubs", 7), playerIndex: 2 },
+        { card: c("clubs", 11), playerIndex: 3 },
+      ];
+      const state = mkTrick0State([hand0, [], [], []]);
+      const pick = selectCardToPlay(hand0, trick, {
+        ...state,
+        currentPlayerIndex: 0,
+        currentTrick: trick,
+      }, 0, persona);
+      expect(pick).toEqual(c("clubs", 1)); // Ace (rank 1) is highest
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Schemer passing — filler (step 6) must not strip K♠/A♠ cover from Q♠
+// ---------------------------------------------------------------------------
+
+describe("selectCardsToPass — Schemer filler does not strip Q♠ protection", () => {
+  it("does not pass K♠ as filler when K♠ is the only Q♠ cover (passing left)", () => {
+    // Hand: Q♠ K♠ + a bunch of medium/high cards. Direction left → protection fires (K♠ alone).
+    // Step 6 filler used to pick K♠ (highest safe card), stripping Q♠ cover.
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 13), // K♠ — only cover
+      c("spades", 7),
+      c("hearts", 9),
+      c("hearts", 6),
+      c("diamonds", 10),
+      c("diamonds", 8),
+      c("clubs", 11), // J♣ — would be filler pick before fix
+      c("clubs", 9),
+      c("clubs", 8),
+      c("clubs", 7),
+      c("clubs", 6),
+      c("clubs", 3),
+    ];
+    const passed = selectCardsToPass(hand, "left", "schemer");
+    // Q♠ must be kept (protected by K♠)
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 12)).toBe(false);
+    // K♠ must NOT be passed as filler — it's the cover card
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 13)).toBe(false);
+  });
+
+  it("does not pass A♠ as filler when A♠ is Q♠ cover and no K♠ present (passing left)", () => {
+    const hand = [
+      c("spades", 12), // Q♠
+      c("spades", 1),  // A♠ — only cover
+      c("spades", 7),
+      c("hearts", 9),
+      c("hearts", 6),
+      c("diamonds", 10),
+      c("diamonds", 8),
+      c("clubs", 11),
+      c("clubs", 9),
+      c("clubs", 8),
+      c("clubs", 7),
+      c("clubs", 6),
+      c("clubs", 3),
+    ];
+    const passed = selectCardsToPass(hand, "left", "schemer");
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 12)).toBe(false);
+    expect(passed.some((card) => card.suit === "spades" && card.rank === 1)).toBe(false);
+  });
+});

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -241,8 +241,16 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
   }
 
   // 6. Filler: highest remaining safe card.
+  // When protecting Q♠, exclude Q♠ itself plus K♠/A♠ cover cards — step 4.5 skips them
+  // intentionally, and passing them here would strip the cover Q♠ needs on future spade leads.
   if (selected.length < 3) {
-    const candidates = hand.filter(safe).sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
+    const candidates = hand
+      .filter(safe)
+      .filter(
+        (c) =>
+          !(keepingQSpade && c.suit === "spades" && (c.rank === 1 || c.rank === 12 || c.rank === 13))
+      )
+      .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
       if (selected.length >= 3) break;
       selected.push(c);
@@ -474,6 +482,9 @@ function selectCardToPlayEasy(
   // Void in led suit — discard lowest
   if (inSuit.length === 0) return lowest(valid) ?? valid[0]!;
 
+  // First trick: play highest club — burns dangerous high clubs before they can win later tricks.
+  if (state.tricksPlayedInHand === 0) return highest(inSuit) ?? valid[0]!;
+
   return lowest(inSuit) ?? valid[0]!;
 }
 
@@ -544,6 +555,12 @@ function selectCardToPlayMedium(
     }
     for (const tc of state.currentTrick) seenMedium.add(`${tc.card.suit}:${tc.card.rank}`);
     return chooseLead(valid, seenMedium.has("spades:12"));
+  }
+
+  // First trick: play highest club — burns dangerous high clubs before they can win later tricks.
+  if (state.tricksPlayedInHand === 0) {
+    const clubs = valid.filter((c) => c.suit === "clubs");
+    if (clubs.length > 0) return highest(clubs) ?? valid[0]!;
   }
 
   return chooseFollow(valid, trick);
@@ -744,6 +761,12 @@ function selectCardToPlayHard(
 
   if (isLeading) {
     return chooseLeadHard(valid, seenKeys);
+  }
+
+  // First trick: play highest club — burns dangerous high clubs before they can win later tricks.
+  if (state.tricksPlayedInHand === 0) {
+    const clubs = valid.filter((c) => c.suit === "clubs");
+    if (clubs.length > 0) return highest(clubs) ?? valid[0]!;
   }
 
   return chooseFollow(valid, trick, isMoonAttempt);

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -241,14 +241,19 @@ function selectCardsToPassMedium(hand: Card[], direction: PassDirection): Card[]
   }
 
   // 6. Filler: highest remaining safe card.
-  // When protecting Q♠, exclude Q♠ itself plus K♠/A♠ cover cards — step 4.5 skips them
-  // intentionally, and passing them here would strip the cover Q♠ needs on future spade leads.
+  // When protecting Q♠, exclude Q♠ itself plus K♠/A♠ cover cards — the void-suit step above
+  // skips them intentionally, and passing them here would strip the cover Q♠ needs on future
+  // spade leads.
   if (selected.length < 3) {
     const candidates = hand
       .filter(safe)
       .filter(
         (c) =>
-          !(keepingQSpade && c.suit === "spades" && (c.rank === 1 || c.rank === 12 || c.rank === 13))
+          !(
+            keepingQSpade &&
+            c.suit === "spades" &&
+            (c.rank === 1 || c.rank === 12 || c.rank === 13)
+          )
       )
       .sort((a, b) => aceHigh(b.rank) - aceHigh(a.rank));
     for (const c of candidates) {
@@ -483,6 +488,7 @@ function selectCardToPlayEasy(
   if (inSuit.length === 0) return lowest(valid) ?? valid[0]!;
 
   // First trick: play highest club — burns dangerous high clubs before they can win later tricks.
+  // inSuit is always clubs on trick 1 (leader is forced to play 2♣ by getValidPlays).
   if (state.tricksPlayedInHand === 0) return highest(inSuit) ?? valid[0]!;
 
   return lowest(inSuit) ?? valid[0]!;


### PR DESCRIPTION
## Summary

- **First-trick club play (all personas):** Non-leader positions were playing their *lowest* club on trick 1 instead of highest. Cautious always played lowest valid; Schemer/Daring fell through to `lowestNonPoint` because every club beats 2♣ (no "losing" cards exist). Standard Hearts strategy is to burn dangerous high clubs (A♣, K♣, Q♣) on this safe 0-point trick before they win points later.
- **Schemer pass filler strips Q♠ cover:** Step 1 correctly kept Q♠ when holding K♠ or A♠ (direction-aware protection), but step 6 (filler = highest remaining safe card) then passed K♠ or A♠ anyway, defeating that intent. Worst case: hold Q♠ + K♠ only → K♠ passed as filler → naked Q♠ entering the hand.

## Changes

- `ai.ts` — added `tricksPlayedInHand === 0` guard in all three `selectCardToPlay*` functions to return `highest(clubs)` before delegating to `chooseFollow`
- `ai.ts` — Schemer step 6 filler now excludes Q♠, K♠, and A♠ from candidates when `keepingQSpade` is true
- `ai.test.ts` — 11 new tests: 9 covering first-trick highest-club for all personas × positions, 2 covering the pass-filler protection scenario

## Test plan

- [ ] `cd frontend && node_modules/.bin/jest src/game/hearts/ --no-coverage` → 228 tests pass
- [ ] Play a Hearts game and verify trick 1 shows high clubs (A♣, K♣, Q♣) being played by AI opponents
- [ ] Observe that when Schemer keeps Q♠ on a left pass, it no longer also gives away its cover spade

https://claude.ai/code/session_01663FLJBrFAsPYvBgrxXxpt

---
_Generated by [Claude Code](https://claude.ai/code/session_01663FLJBrFAsPYvBgrxXxpt)_