### PR TITLE
fix(yacht): center celebration dice around badge overlay

### DIFF
--- a/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
+++ b/frontend/src/components/yacht/YachtCelebrationAnimation.tsx
@@ -138,6 +138,11 @@ export function YachtCelebrationAnimation({ visible, onDismiss, variant = "yacht
 
 const styles = StyleSheet.create({
   content: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
     alignItems: "center",
     justifyContent: "center",
   },


### PR DESCRIPTION
## Summary

- `styles.content` in `YachtCelebrationAnimation` lacked explicit dimensions, so `left: "50%"` / `top: "50%"` on the absolute-positioned dice resolved relative to the badge's size rather than the overlay
- Added `position: "absolute", top/left/right/bottom: 0` to fill the overlay, making the percentage anchor the true screen center
- Dice now burst symmetrically around the badge on all screen sizes

## Test plan

- [ ] Score a Yacht in-game and confirm the 8 emoji dice radiate evenly around the "YACHT!" badge
- [ ] Verify the Joker variant (`showJokerCelebration`) looks correct as well
- [ ] Check on both small and large screen sizes / simulators

Closes #1864

https://claude.ai/code/session_0163TXm2s1ThwS2T9ShXT8zP

---
_Generated by [Claude Code](https://claude.ai/code/session_0163TXm2s1ThwS2T9ShXT8zP)_