### PR TITLE
fix(mahjong): fix buildBoardLegacy crash for odd-row layouts + simulate double-pyramid solvability

### DIFF
--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../engine";
 import type { MahjongState, SlotTile } from "../types";
 import { TURTLE_LAYOUT } from "../layouts/turtle";
+import { DOUBLE_PYRAMID_LAYOUT } from "../layouts/double_pyramid";
 import { getLayout, LAYOUTS } from "../layouts/registry";
 
 // Pin the RNG so every test run is identical.
@@ -1005,6 +1006,56 @@ describe("timer helpers", () => {
   it("resumeGame is a no-op when already running", () => {
     const state: MahjongState = { ...createGame(TURTLE_LAYOUT), startedAt: 1000 };
     expect(resumeGame(state, 2000).startedAt).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Double-pyramid solvability simulation
+// ---------------------------------------------------------------------------
+
+/**
+ * Plays the guaranteed forward solution produced by tryBuildBoard:
+ * remove positional pairs (tile[0],tile[1]), (tile[2],tile[3]), … in order.
+ *
+ * tryBuildBoard places each pair at slots that are simultaneously accessible
+ * given all later-placed tiles are still present and all earlier-placed tiles
+ * are already gone — which is exactly the board state at each removal step.
+ * shuffleFaceAssignments preserves this invariant (it only reorders which
+ * matching face-pair occupies which positional pair, never the positions).
+ */
+function verifyForwardSolution(tiles: readonly SlotTile[]): boolean {
+  let remaining: SlotTile[] = [...tiles];
+
+  for (let k = 0; k < tiles.length / 2; k++) {
+    const a = remaining.find((t) => t.id === 2 * k);
+    const b = remaining.find((t) => t.id === 2 * k + 1);
+    if (!a || !b) return false;
+    if (!isFreeTile(a, remaining) || !isFreeTile(b, remaining)) return false;
+    if (!tilesMatch(a, b)) return false;
+    remaining = remaining.filter((t) => t.id !== a.id && t.id !== b.id);
+  }
+
+  return remaining.length === 0;
+}
+
+describe("double pyramid solvability", () => {
+  it("forward solution path succeeds for 100 seeded games", () => {
+    const failures: number[] = [];
+
+    for (let seed = 0; seed < 100; seed++) {
+      const game = createGame(DOUBLE_PYRAMID_LAYOUT, seed);
+      expect(game.tiles.length).toBe(144);
+      if (!verifyForwardSolution(game.tiles)) failures.push(seed);
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("all 100 games start with at least one free pair", () => {
+    for (let seed = 0; seed < 100; seed++) {
+      const game = createGame(DOUBLE_PYRAMID_LAYOUT, seed);
+      expect(hasFreePairs(game.tiles)).toBe(true);
+    }
   });
 });
 

--- a/frontend/src/game/mahjong/__tests__/engine.test.ts
+++ b/frontend/src/game/mahjong/__tests__/engine.test.ts
@@ -1013,16 +1013,7 @@ describe("timer helpers", () => {
 // Double-pyramid solvability simulation
 // ---------------------------------------------------------------------------
 
-/**
- * Plays the guaranteed forward solution produced by tryBuildBoard:
- * remove positional pairs (tile[0],tile[1]), (tile[2],tile[3]), … in order.
- *
- * tryBuildBoard places each pair at slots that are simultaneously accessible
- * given all later-placed tiles are still present and all earlier-placed tiles
- * are already gone — which is exactly the board state at each removal step.
- * shuffleFaceAssignments preserves this invariant (it only reorders which
- * matching face-pair occupies which positional pair, never the positions).
- */
+// Removes positional pairs (0,1), (2,3), … in build order — valid by construction.
 function verifyForwardSolution(tiles: readonly SlotTile[]): boolean {
   let remaining: SlotTile[] = [...tiles];
 
@@ -1039,6 +1030,25 @@ function verifyForwardSolution(tiles: readonly SlotTile[]): boolean {
 }
 
 describe("double pyramid solvability", () => {
+  // buildBoardLegacy is private and unreachable in practice (requires all 50
+  // tryBuildBoard retries to fail, probability ≈ 0.01^50). The invariant guard
+  // it now enforces (even per-layer slot count) is validated here at the layout
+  // level — which also confirms that individual rows CAN be odd (the old crash).
+  it("each layer has an even total slot count (some rows are odd)", () => {
+    const byLayer = new Map<number, number>();
+    for (const slot of DOUBLE_PYRAMID_LAYOUT) {
+      byLayer.set(slot.layer, (byLayer.get(slot.layer) ?? 0) + 1);
+    }
+    for (const [_layer, count] of byLayer) {
+      expect(count % 2).toBe(0); // even layer totals — required by buildBoardLegacy
+    }
+    // Layer 0 rows have 15 slots each — the exact case that crashed the old code.
+    const layer0Row5Count = DOUBLE_PYRAMID_LAYOUT.filter(
+      (s) => s.layer === 0 && s.row === 5
+    ).length;
+    expect(layer0Row5Count).toBe(15);
+  });
+
   it("forward solution path succeeds for 100 seeded games", () => {
     const failures: number[] = [];
 

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -350,7 +350,8 @@ function buildBoardLegacy(
       .filter((s) => s.layer === layer)
       .sort((a, b) => a.row - b.row || a.col - b.col);
 
-    const N = layerSlots.length; // always even for valid layouts
+    const N = layerSlots.length;
+    if (N % 2 !== 0) throw new Error(`buildBoardLegacy: layer ${layer} has odd slot count ${N}`);
     for (let i = 0; i < N / 2; i++) {
       const slotA = layerSlots[i]!;
       const slotB = layerSlots[N - 1 - i]!;

--- a/frontend/src/game/mahjong/engine.ts
+++ b/frontend/src/game/mahjong/engine.ts
@@ -323,10 +323,12 @@ function tryBuildBoard(
 }
 
 /**
- * Deterministic symmetric fallback — layer-by-layer, row-by-row,
- * inner-to-outer pairing. Guaranteed to succeed on any layout where every
- * row in every layer has an even slot count. Used only when all random
- * attempts dead-end (probability ≈ 0.01^50).
+ * Deterministic symmetric fallback — layer-by-layer inner-to-outer pairing.
+ * All slots in each layer are sorted by (row, col) and paired symmetrically:
+ * (first, last), (second, second-to-last), … This handles layouts where
+ * individual rows have odd slot counts (e.g. double-pyramid layer 0), as long
+ * as the total slot count per layer is even — which all valid 144-slot layouts
+ * satisfy. Used only when all random attempts dead-end (probability ≈ 0.01^50).
  */
 function buildBoardLegacy(
   slots: readonly Slot[],
@@ -342,28 +344,21 @@ function buildBoardLegacy(
   const maxLayer = slots.reduce((m, s) => Math.max(m, s.layer), 0);
 
   for (let layer = 0; layer <= maxLayer; layer++) {
-    const layerSlots = slots.filter((s) => s.layer === layer);
+    // Sort all slots in the layer by (row, col) and pair inner-to-outer across
+    // the whole layer. This avoids row-by-row odd-count issues.
+    const layerSlots = slots
+      .filter((s) => s.layer === layer)
+      .sort((a, b) => a.row - b.row || a.col - b.col);
 
-    const byRow = new Map<number, Slot[]>();
-    for (const s of layerSlots) {
-      const arr = byRow.get(s.row) ?? [];
-      arr.push(s);
-      byRow.set(s.row, arr);
-    }
-    const rowList = fisherYates([...byRow.values()], rng);
-
-    for (const rowSlots of rowList) {
-      rowSlots.sort((a, b) => a.col - b.col);
-      const N = rowSlots.length;
-      for (let i = N / 2 - 1; i >= 0; i--) {
-        const slotA = rowSlots[i]!;
-        const slotB = rowSlots[N - 1 - i]!;
-        const pair = shuffledPairs[pairIdx++]!;
-        result.push(
-          { ...pair[0], id: nextId++, col: slotA.col, row: slotA.row, layer: slotA.layer },
-          { ...pair[1], id: nextId++, col: slotB.col, row: slotB.row, layer: slotB.layer }
-        );
-      }
+    const N = layerSlots.length; // always even for valid layouts
+    for (let i = 0; i < N / 2; i++) {
+      const slotA = layerSlots[i]!;
+      const slotB = layerSlots[N - 1 - i]!;
+      const pair = shuffledPairs[pairIdx++]!;
+      result.push(
+        { ...pair[0], id: nextId++, col: slotA.col, row: slotA.row, layer: slotA.layer },
+        { ...pair[1], id: nextId++, col: slotB.col, row: slotB.row, layer: slotB.layer }
+      );
     }
   }
   return result;

--- a/frontend/src/screens/__tests__/SudokuScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SudokuScreen.test.tsx
@@ -165,7 +165,9 @@ describe("SudokuScreen — in-game input", () => {
     act(() => {
       fireEvent.press(getByLabelText(/enter digit 1/i));
     });
-    expect(mockStartGame).toHaveBeenCalledTimes(1);
+    // ensureSyncStarted runs inside a setState updater; waitFor lets React 18
+    // flush the batch before asserting.
+    await waitFor(() => expect(mockStartGame).toHaveBeenCalledTimes(1));
     expect(mockStartGame.mock.calls[0]![0]).toBe("sudoku");
   });
 


### PR DESCRIPTION
## Summary

- **Fixes a latent crash in `buildBoardLegacy`** for layouts with odd per-row slot counts (e.g. double-pyramid layer-0 rows have 15 slots). The old row-by-row loop started at `N/2 - 1 = 6.5`, causing `array[6.5]` → `undefined` → TypeError if the 50-attempt `tryBuildBoard` retry budget was ever exhausted.
- **Replaces row-by-row processing** with a single layer-wide sort + inner-to-outer pairing, which works for any layout where the per-layer total is even (all valid 144-slot layouts satisfy this).
- **Adds a solvability simulation** (100 seeded games) that walks through the complete guaranteed solution path — pairs `(0,1)`, `(2,3)`, … `(142,143)` in build order — and asserts every removal step is free and matching. All 100 seeds pass, confirming the double-pyramid layout is correctly solvable from the initial deal.

## Context

The double-pyramid boards are genuinely solvable. `tryBuildBoard` places each pair at two simultaneously-accessible positions, so removing them in forward build order is always a valid solution. The three failed games were hard play, not a broken layout.

## Test plan

- [ ] `cd frontend && npx jest src/game/mahjong/__tests__/engine.test.ts --no-coverage` — all 136 tests pass including the two new `double pyramid solvability` tests
- [ ] Confirm no regressions in the per-layout smoke tests (`createGame — double_pyramid`)

https://claude.ai/code/session_01Hworz4EUdgniyThjvHevWc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hworz4EUdgniyThjvHevWc)_