### PR TITLE
fix(drag): pre-cache drop-zone bounds + synchronous hit-test to eliminate iOS/Android snap-back

### DIFF
--- a/frontend/src/game/_shared/drag/DragContainer.tsx
+++ b/frontend/src/game/_shared/drag/DragContainer.tsx
@@ -15,14 +15,17 @@ export function DragContainer({ children, style, onLayout: externalOnLayout }: D
 
   const onLayout = useCallback(
     (e: LayoutChangeEvent) => {
-      // measureInWindow is more reliable than measure on iOS for first-render window coords.
-      (
-        containerRef.current as unknown as {
-          measureInWindow?: (cb: (x: number, y: number) => void) => void;
-        }
-      )?.measureInWindow?.((x, y) => {
-        containerOffsetX.value = x;
-        containerOffsetY.value = y;
+      // requestAnimationFrame defers measureInWindow until after the native view
+      // is painted — calling it synchronously inside onLayout returns 0,0 on Android.
+      requestAnimationFrame(() => {
+        (
+          containerRef.current as unknown as {
+            measureInWindow?: (cb: (x: number, y: number) => void) => void;
+          }
+        )?.measureInWindow?.((x, y) => {
+          containerOffsetX.value = x;
+          containerOffsetY.value = y;
+        });
       });
       externalOnLayout?.(e);
     },

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -31,11 +31,9 @@ export interface DragState {
 /** Return true if the drop was accepted, false to trigger snap-back. */
 export type DropHandler = (source: DragSource, cards: DragCard[]) => boolean;
 
-type Bounds = { x: number; y: number; width: number; height: number };
+export type Bounds = { x: number; y: number; width: number; height: number };
 
 interface DropZoneEntry {
-  /** Measure the zone's window bounds right now, calling cb when ready. */
-  measureFresh: (cb: (bounds: Bounds | null) => void) => void;
   onDrop: DropHandler;
 }
 
@@ -67,6 +65,7 @@ export interface DragContextValue {
   // Drop zone registry
   registerDropZone: (id: string, entry: DropZoneEntry) => void;
   unregisterDropZone: (id: string) => void;
+  updateDropZoneLayout: (id: string, bounds: Bounds) => void;
 }
 
 const DragContext = createContext<DragContextValue | null>(null);
@@ -101,6 +100,7 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
   const containerRef = useAnimatedRef<Animated.View>();
 
   const dropZonesRef = useRef<Map<string, DropZoneEntry>>(new Map());
+  const dropZoneBoundsRef = useRef<Map<string, Bounds>>(new Map());
   const dragStateRef = useRef<DragState | null>(null);
 
   const clearDrag = useCallback(() => {
@@ -123,9 +123,12 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
 
   const snapBackAndClear = useCallback(() => {
     cardX.value = withSpring(originX.value, SNAP_SPRING);
-    cardY.value = withSpring(originY.value, SNAP_SPRING, (finished) => {
+    // Always clear drag state regardless of whether the animation completes
+    // normally — an interrupted spring (new gesture, unmount) must not leave
+    // the board stuck in drag-active state indefinitely.
+    cardY.value = withSpring(originY.value, SNAP_SPRING, () => {
       "worklet";
-      if (finished) runOnJS(clearDrag)();
+      runOnJS(clearDrag)();
     });
   }, [cardX, cardY, clearDrag, originX, originY]);
 
@@ -134,59 +137,26 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
       const state = dragStateRef.current;
       if (!state) return;
 
-      // Take a snapshot of zones at this moment (Map entry order = registration order).
-      const zones = Array.from(dropZonesRef.current.values());
-      if (zones.length === 0) {
-        snapBackAndClear();
-        return;
-      }
-
-      // Measure every zone fresh via measureInWindow so we always use current
-      // window coordinates — cached onLayout values can be stale or zero on iOS.
-      let remaining = zones.length;
-      const results: { bounds: Bounds | null; zone: DropZoneEntry }[] = zones.map((zone) => ({
-        bounds: null,
-        zone,
-      }));
-
-      // Safety net: if any measureInWindow callback never fires (e.g. view unmounted
-      // mid-drag on Android) the card must not stay frozen on screen indefinitely.
-      const timeout = setTimeout(() => {
-        if (remaining > 0) snapBackAndClear();
-      }, 300);
-
-      results.forEach((entry) => {
-        entry.zone.measureFresh((bounds) => {
-          // No-op if the timeout already fired and snapped back.
-          if (remaining <= 0) return;
-          entry.bounds = bounds;
-          remaining--;
-          if (remaining > 0) return;
-
-          clearTimeout(timeout);
-
-          // All measurements received — run hit-test.
-          // Guard against a second drag starting before this callback fires.
-          if (dragStateRef.current !== state) return;
-
-          for (const { bounds: b, zone } of results) {
-            if (!b) continue;
-            if (
-              absoluteX >= b.x &&
-              absoluteX <= b.x + b.width &&
-              absoluteY >= b.y &&
-              absoluteY <= b.y + b.height
-            ) {
-              const accepted = zone.onDrop(state.source, state.cards);
-              if (accepted) {
-                clearDrag();
-                return;
-              }
-            }
+      // Synchronous hit-test against pre-cached bounds (populated via onLayout in
+      // DropTarget). No async bridge calls at drop time — eliminates the race
+      // against the old 300 ms safety-net timeout that caused snap-back on iOS/Android.
+      for (const [id, entry] of dropZonesRef.current) {
+        const b = dropZoneBoundsRef.current.get(id);
+        if (!b) continue;
+        if (
+          absoluteX >= b.x &&
+          absoluteX <= b.x + b.width &&
+          absoluteY >= b.y &&
+          absoluteY <= b.y + b.height
+        ) {
+          const accepted = entry.onDrop(state.source, state.cards);
+          if (accepted) {
+            clearDrag();
+            return;
           }
-          snapBackAndClear();
-        });
-      });
+        }
+      }
+      snapBackAndClear();
     },
     [clearDrag, snapBackAndClear]
   );
@@ -197,6 +167,11 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
 
   const unregisterDropZone = useCallback((id: string) => {
     dropZonesRef.current.delete(id);
+    dropZoneBoundsRef.current.delete(id);
+  }, []);
+
+  const updateDropZoneLayout = useCallback((id: string, bounds: Bounds) => {
+    dropZoneBoundsRef.current.set(id, bounds);
   }, []);
 
   const value: DragContextValue = {
@@ -214,6 +189,7 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
     snapBackAndClear,
     registerDropZone,
     unregisterDropZone,
+    updateDropZoneLayout,
   };
 
   return <DragContext.Provider value={value}>{children}</DragContext.Provider>;

--- a/frontend/src/game/_shared/drag/DragContext.tsx
+++ b/frontend/src/game/_shared/drag/DragContext.tsx
@@ -98,6 +98,9 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
   const containerOffsetX = useSharedValue(0);
   const containerOffsetY = useSharedValue(0);
   const containerRef = useAnimatedRef<Animated.View>();
+  // Incremented each time a new drag starts; the snap-back callback compares
+  // against the generation it captured to avoid clearing a superseding drag.
+  const dragGeneration = useSharedValue(0);
 
   const dropZonesRef = useRef<Map<string, DropZoneEntry>>(new Map());
   const dropZoneBoundsRef = useRef<Map<string, Bounds>>(new Map());
@@ -111,6 +114,7 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
 
   const startDrag = useCallback(
     (source: DragSource, cards: DragCard[]) => {
+      dragGeneration.value += 1;
       const state: DragState = { cards, source };
       dragStateRef.current = state;
       setDragState(state);
@@ -118,19 +122,22 @@ export function DragProvider({ children, getLegalDropIds }: DragProviderProps) {
         setLegalTargetIds(new Set(getLegalDropIds(source, cards)));
       }
     },
-    [getLegalDropIds]
+    [dragGeneration, getLegalDropIds]
   );
 
   const snapBackAndClear = useCallback(() => {
+    // Capture the generation at the moment snap-back starts. If a new drag
+    // begins before the spring callback fires (interrupting it), the generation
+    // will have incremented and clearDrag will be skipped — the new drag's own
+    // lifecycle owns the cleanup. Without this guard, the snap-back callback
+    // could clear a drag that started after this one.
+    const gen = dragGeneration.value;
     cardX.value = withSpring(originX.value, SNAP_SPRING);
-    // Always clear drag state regardless of whether the animation completes
-    // normally — an interrupted spring (new gesture, unmount) must not leave
-    // the board stuck in drag-active state indefinitely.
     cardY.value = withSpring(originY.value, SNAP_SPRING, () => {
       "worklet";
-      runOnJS(clearDrag)();
+      if (dragGeneration.value === gen) runOnJS(clearDrag)();
     });
-  }, [cardX, cardY, clearDrag, originX, originY]);
+  }, [cardX, cardY, clearDrag, dragGeneration, originX, originY]);
 
   const endDrag = useCallback(
     (absoluteX: number, absoluteY: number) => {

--- a/frontend/src/game/_shared/drag/DraggableCard.tsx
+++ b/frontend/src/game/_shared/drag/DraggableCard.tsx
@@ -65,10 +65,11 @@ export function DraggableCard({
 
   const panActivated = useSharedValue(false);
 
+  // minDistance(5) replaces activeOffsetX/Y([-12,12]) — 12 px was too coarse for
+  // FreeCell's narrower cards, causing drags to feel unresponsive.
   const pan = Gesture.Pan()
     .minPointers(1)
-    .activeOffsetX([-12, 12])
-    .activeOffsetY([-12, 12])
+    .minDistance(5)
     .enabled(draggable)
     .onStart((e) => {
       "worklet";
@@ -82,7 +83,6 @@ export function DraggableCard({
       }
       // rnMeasure can return null on iOS/Android before the first native layout pass.
       // RNGH guarantee: e.absoluteX - e.x = absolute window X of the gesture view's origin.
-      // Assumes GestureDetector + innerEl share the same origin as viewRef (no intervening padding).
       const pageX = cardMeasured?.pageX ?? e.absoluteX - e.x;
       const pageY = cardMeasured?.pageY ?? e.absoluteY - e.y;
       const localX = pageX - containerOffsetX.value;
@@ -109,7 +109,7 @@ export function DraggableCard({
     });
 
   // For non-draggable (face-down) cards, RNGH tap works correctly and is unchanged.
-  // For draggable cards, pan-only in GestureDetector: when pan fails (< 12 px movement),
+  // For draggable cards, pan-only in GestureDetector: when pan fails (< 5 px movement),
   // the touch is released and the native onPress cloned onto the child below handles tap.
   // This avoids the Simultaneous/requireExternalGestureToFail iOS UIGestureRecognizer
   // deadlock that kept both tap and drag broken (#1101, #1102).

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { View } from "react-native";
 import type { ViewStyle } from "react-native";
 import { useTheme } from "../../../theme/ThemeContext";
@@ -36,25 +36,29 @@ export function DropTarget({
     onDropRef.current = onDrop;
   });
 
-  const { dragState, legalTargetIds, registerDropZone, unregisterDropZone } = useDragContext();
+  const { dragState, legalTargetIds, registerDropZone, unregisterDropZone, updateDropZoneLayout } =
+    useDragContext();
 
   useEffect(() => {
     registerDropZone(id, {
-      // Always measure fresh via measureInWindow so the hit-test uses current
-      // window coordinates — cached onLayout values can be stale or zero on iOS.
-      measureFresh: (cb) => {
-        if (!viewRef.current) {
-          cb(null);
-          return;
-        }
-        viewRef.current.measureInWindow((x, y, w, h) => {
-          cb({ x, y, width: w, height: h });
-        });
-      },
       onDrop: (source, cards) => onDropRef.current(source, cards),
     });
     return () => unregisterDropZone(id);
   }, [id, registerDropZone, unregisterDropZone]);
+
+  // Proactively cache absolute window bounds whenever React Native recalculates
+  // layout. requestAnimationFrame defers the measureInWindow call until after
+  // the native view is actually painted — calling it synchronously inside onLayout
+  // returns 0,0 on Android before the first paint.
+  const handleLayout = useCallback(() => {
+    requestAnimationFrame(() => {
+      viewRef.current?.measureInWindow((x, y, w, h) => {
+        if (w > 0 && h > 0) {
+          updateDropZoneLayout(id, { x, y, width: w, height: h });
+        }
+      });
+    });
+  }, [id, updateDropZoneLayout]);
 
   const isDragActive = dragState !== null;
   const isLegal = legalTargetIds.has(id);
@@ -64,6 +68,7 @@ export function DropTarget({
     <View
       ref={viewRef}
       testID={testID}
+      onLayout={handleLayout}
       style={[
         style,
         isDragActive && isLegal && { backgroundColor: colors.accent + "33" },

--- a/frontend/src/game/_shared/drag/DropTarget.tsx
+++ b/frontend/src/game/_shared/drag/DropTarget.tsx
@@ -28,6 +28,7 @@ export function DropTarget({
   testID,
 }: DropTargetProps) {
   const viewRef = useRef<View>(null);
+  const rafRef = useRef<ReturnType<typeof requestAnimationFrame>>();
   const { colors } = useTheme();
 
   // Keep the latest onDrop in a ref so re-renders don't force re-registration.
@@ -49,9 +50,12 @@ export function DropTarget({
   // Proactively cache absolute window bounds whenever React Native recalculates
   // layout. requestAnimationFrame defers the measureInWindow call until after
   // the native view is actually painted — calling it synchronously inside onLayout
-  // returns 0,0 on Android before the first paint.
+  // returns 0,0 on Android before the first paint. Cancelling the previous rAF
+  // prevents stale callbacks from piling up on rapid re-renders.
   const handleLayout = useCallback(() => {
-    requestAnimationFrame(() => {
+    if (rafRef.current !== undefined) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = undefined;
       viewRef.current?.measureInWindow((x, y, w, h) => {
         if (w > 0 && h > 0) {
           updateDropZoneLayout(id, { x, y, width: w, height: h });

--- a/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
@@ -32,23 +32,22 @@ function SnapBackTrigger() {
   );
 }
 
+/** Registers a drop zone with optional pre-cached bounds. */
 function DropZoneRegistrar({
   id,
-  onMeasureFresh,
+  bounds,
+  onDrop = () => false,
 }: {
   id: string;
-  onMeasureFresh?: (
-    cb: (bounds: { x: number; y: number; width: number; height: number } | null) => void
-  ) => void;
+  bounds?: { x: number; y: number; width: number; height: number };
+  onDrop?: (source: DragSource, cards: DragCard[]) => boolean;
 }) {
-  const { registerDropZone, unregisterDropZone } = useDragContext();
+  const { registerDropZone, unregisterDropZone, updateDropZoneLayout } = useDragContext();
   React.useEffect(() => {
-    registerDropZone(id, {
-      measureFresh: onMeasureFresh ?? ((cb) => cb(null)),
-      onDrop: () => false,
-    });
+    registerDropZone(id, { onDrop });
+    if (bounds) updateDropZoneLayout(id, bounds);
     return () => unregisterDropZone(id);
-  }, [id, onMeasureFresh, registerDropZone, unregisterDropZone]);
+  }, [id, bounds, onDrop, registerDropZone, unregisterDropZone, updateDropZoneLayout]);
   return null;
 }
 
@@ -71,37 +70,6 @@ describe("DragContext", () => {
 
     expect(withSpring).toHaveBeenCalled();
     withSpring.mockRestore();
-  });
-
-  it("endDrag calls measureFresh on every registered drop zone", () => {
-    const measure1 = jest.fn((cb: (b: null) => void) => cb(null));
-    const measure2 = jest.fn((cb: (b: null) => void) => cb(null));
-
-    function EndDragTrigger() {
-      const { endDrag } = useDragContext();
-      return (
-        <Text accessibilityLabel="end" onPress={() => endDrag(999, 999)}>
-          end
-        </Text>
-      );
-    }
-
-    const { getByLabelText } = render(
-      <DragProvider>
-        <ThemeProvider>
-          <DropZoneRegistrar id="zone-a" onMeasureFresh={measure1} />
-          <DropZoneRegistrar id="zone-b" onMeasureFresh={measure2} />
-          <StartDragTrigger />
-          <EndDragTrigger />
-        </ThemeProvider>
-      </DragProvider>
-    );
-
-    fireEvent.press(getByLabelText("start"));
-    fireEvent.press(getByLabelText("end"));
-
-    expect(measure1).toHaveBeenCalledTimes(1);
-    expect(measure2).toHaveBeenCalledTimes(1);
   });
 
   it("endDrag snaps back immediately when no drop zones are registered", () => {
@@ -129,21 +97,8 @@ describe("DragContext", () => {
     withSpring.mockRestore();
   });
 
-  it("endDrag calls onDrop and clears drag when finger lands inside a zone", () => {
+  it("endDrag calls onDrop synchronously when finger lands inside pre-cached bounds", () => {
     const onDrop = jest.fn().mockReturnValue(true);
-    const measureFresh = jest.fn(
-      (cb: (b: { x: number; y: number; width: number; height: number }) => void) =>
-        cb({ x: 0, y: 0, width: 1000, height: 1000 })
-    );
-
-    function HitZoneRegistrar() {
-      const { registerDropZone, unregisterDropZone } = useDragContext();
-      React.useEffect(() => {
-        registerDropZone("zone-hit", { measureFresh, onDrop });
-        return () => unregisterDropZone("zone-hit");
-      }, [registerDropZone, unregisterDropZone]);
-      return null;
-    }
 
     function StartEndTrigger() {
       const { startDrag, endDrag } = useDragContext();
@@ -162,7 +117,11 @@ describe("DragContext", () => {
     const { getByLabelText } = render(
       <DragProvider>
         <ThemeProvider>
-          <HitZoneRegistrar />
+          <DropZoneRegistrar
+            id="zone-hit"
+            bounds={{ x: 0, y: 0, width: 1000, height: 1000 }}
+            onDrop={onDrop}
+          />
           <StartEndTrigger />
         </ThemeProvider>
       </DragProvider>
@@ -173,5 +132,72 @@ describe("DragContext", () => {
 
     expect(onDrop).toHaveBeenCalledTimes(1);
     expect(onDrop).toHaveBeenCalledWith(dragSource, dragCards);
+  });
+
+  it("endDrag snaps back when finger is outside all cached bounds", () => {
+    const withSpring = jest.spyOn(Reanimated, "withSpring");
+
+    function StartEndTrigger() {
+      const { startDrag, endDrag } = useDragContext();
+      return (
+        <>
+          <Text accessibilityLabel="start4" onPress={() => startDrag(dragSource, dragCards)}>
+            start
+          </Text>
+          {/* Drop at (9999, 9999) — outside the 100x100 zone */}
+          <Text accessibilityLabel="end4" onPress={() => endDrag(9999, 9999)}>
+            end
+          </Text>
+        </>
+      );
+    }
+
+    const { getByLabelText } = render(
+      <DragProvider>
+        <ThemeProvider>
+          <DropZoneRegistrar id="zone-miss" bounds={{ x: 0, y: 0, width: 100, height: 100 }} />
+          <StartEndTrigger />
+        </ThemeProvider>
+      </DragProvider>
+    );
+
+    fireEvent.press(getByLabelText("start4"));
+    fireEvent.press(getByLabelText("end4"));
+
+    expect(withSpring).toHaveBeenCalled();
+    withSpring.mockRestore();
+  });
+
+  it("endDrag skips zones with no cached bounds rather than crashing", () => {
+    const onDrop = jest.fn().mockReturnValue(true);
+
+    function StartEndTrigger() {
+      const { startDrag, endDrag } = useDragContext();
+      return (
+        <>
+          <Text accessibilityLabel="start5" onPress={() => startDrag(dragSource, dragCards)}>
+            start
+          </Text>
+          <Text accessibilityLabel="end5" onPress={() => endDrag(50, 50)}>
+            end
+          </Text>
+        </>
+      );
+    }
+
+    const { getByLabelText } = render(
+      <DragProvider>
+        <ThemeProvider>
+          {/* No bounds provided — layout hasn't fired yet */}
+          <DropZoneRegistrar id="zone-no-bounds" onDrop={onDrop} />
+          <StartEndTrigger />
+        </ThemeProvider>
+      </DragProvider>
+    );
+
+    fireEvent.press(getByLabelText("start5"));
+    expect(() => fireEvent.press(getByLabelText("end5"))).not.toThrow();
+    // onDrop should NOT be called because no bounds were cached
+    expect(onDrop).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DragContext.test.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Text } from "react-native";
 import { render, fireEvent } from "@testing-library/react-native";
 import * as Reanimated from "react-native-reanimated";
 
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import { DragProvider, useDragContext } from "../DragContext";
-import type { DragCard, DragSource } from "../DragContext";
+import type { Bounds, DragCard, DragSource, DropHandler } from "../DragContext";
 
 const dragCards: DragCard[] = [{ suit: "hearts", rank: 5, faceDown: false, width: 60, height: 90 }];
 const dragSource: DragSource = { game: "solitaire", type: "waste" };
@@ -32,32 +32,28 @@ function SnapBackTrigger() {
   );
 }
 
-/** Registers a drop zone with optional pre-cached bounds. */
+/**
+ * Registers a drop zone with optional pre-cached bounds.
+ * Uses refs for onDrop and bounds to keep effect deps stable across re-renders.
+ */
 function DropZoneRegistrar({
   id,
   bounds,
-  onDrop = () => false,
+  onDrop,
 }: {
   id: string;
-  bounds?: { x: number; y: number; width: number; height: number };
-  onDrop?: (source: DragSource, cards: DragCard[]) => boolean;
+  bounds?: Bounds;
+  onDrop?: DropHandler;
 }) {
   const { registerDropZone, unregisterDropZone, updateDropZoneLayout } = useDragContext();
+  const onDropRef = useRef<DropHandler>(onDrop ?? (() => false));
+  const boundsRef = useRef(bounds);
   React.useEffect(() => {
-    registerDropZone(id, { onDrop });
-    if (bounds) updateDropZoneLayout(id, bounds);
+    registerDropZone(id, { onDrop: (s, c) => onDropRef.current(s, c) });
+    if (boundsRef.current) updateDropZoneLayout(id, boundsRef.current);
     return () => unregisterDropZone(id);
-  }, [id, bounds, onDrop, registerDropZone, unregisterDropZone, updateDropZoneLayout]);
+  }, [id, registerDropZone, unregisterDropZone, updateDropZoneLayout]);
   return null;
-}
-
-function StartDragTrigger() {
-  const { startDrag } = useDragContext();
-  return (
-    <Text accessibilityLabel="start" onPress={() => startDrag(dragSource, dragCards)}>
-      start
-    </Text>
-  );
 }
 
 describe("DragContext", () => {
@@ -69,6 +65,44 @@ describe("DragContext", () => {
     fireEvent.press(getByLabelText("snap"));
 
     expect(withSpring).toHaveBeenCalled();
+    withSpring.mockRestore();
+  });
+
+  it("snapBackAndClear clears drag state when spring callback fires (finished=false)", () => {
+    // Override withSpring to immediately call the completion callback simulating
+    // an interrupted animation (finished=false) — the original `if (finished)` guard
+    // would have silently dropped this, leaving the board stuck in drag-active state.
+    const withSpring = jest
+      .spyOn(Reanimated, "withSpring")
+      .mockImplementation(
+        (toValue: unknown, _config: unknown, cb?: (finished: boolean) => void) => {
+          cb?.(false);
+          return toValue as number;
+        }
+      );
+
+    function Checker() {
+      const { startDrag, snapBackAndClear, dragState } = useDragContext();
+      return (
+        <>
+          <Text accessibilityLabel="start-c" onPress={() => startDrag(dragSource, dragCards)}>
+            s
+          </Text>
+          <Text accessibilityLabel="snap-c" onPress={() => snapBackAndClear()}>
+            snap
+          </Text>
+          <Text testID="state-c">{dragState ? "active" : "idle"}</Text>
+        </>
+      );
+    }
+
+    const { getByLabelText, getByTestId } = render(wrap(<Checker />));
+    fireEvent.press(getByLabelText("start-c"));
+    expect(getByTestId("state-c").props.children).toBe("active");
+
+    fireEvent.press(getByLabelText("snap-c"));
+    expect(getByTestId("state-c").props.children).toBe("idle");
+
     withSpring.mockRestore();
   });
 
@@ -98,7 +132,7 @@ describe("DragContext", () => {
   });
 
   it("endDrag calls onDrop synchronously when finger lands inside pre-cached bounds", () => {
-    const onDrop = jest.fn().mockReturnValue(true);
+    const onDrop = jest.fn<boolean, [DragSource, DragCard[]]>().mockReturnValue(true);
 
     function StartEndTrigger() {
       const { startDrag, endDrag } = useDragContext();
@@ -169,7 +203,7 @@ describe("DragContext", () => {
   });
 
   it("endDrag skips zones with no cached bounds rather than crashing", () => {
-    const onDrop = jest.fn().mockReturnValue(true);
+    const onDrop = jest.fn<boolean, [DragSource, DragCard[]]>().mockReturnValue(true);
 
     function StartEndTrigger() {
       const { startDrag, endDrag } = useDragContext();
@@ -197,7 +231,7 @@ describe("DragContext", () => {
 
     fireEvent.press(getByLabelText("start5"));
     expect(() => fireEvent.press(getByLabelText("end5"))).not.toThrow();
-    // onDrop should NOT be called because no bounds were cached
+    // onDrop must NOT be called because no bounds were cached
     expect(onDrop).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
-import { render, fireEvent } from "@testing-library/react-native";
+import { render, fireEvent, act } from "@testing-library/react-native";
 
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import { DragProvider, useDragContext } from "../DragContext";
@@ -72,9 +72,9 @@ describe("DropTarget", () => {
     expect(merged.backgroundColor).toMatch(/33$/);
   });
 
-  it("calls measureFresh without throwing when endDrag fires", () => {
-    // measureFresh calls viewRef.current.measureInWindow — in the test
-    // environment the ref is null so the cb is called with null. Verify no crash.
+  it("does not throw when endDrag fires with a registered zone that has no cached bounds", () => {
+    // Simulates the case where onLayout hasn't fired yet — bounds are absent from
+    // the cache. endDrag should skip the zone gracefully and snap back.
     function EndDragTrigger() {
       const { endDrag } = useDragContext();
       return (
@@ -98,6 +98,37 @@ describe("DropTarget", () => {
 
     fireEvent.press(getByLabelText("start-drag"));
     expect(() => fireEvent.press(getByLabelText("end-drag"))).not.toThrow();
+  });
+
+  it("calls measureInWindow via requestAnimationFrame when onLayout fires", async () => {
+    const measureInWindow = jest.fn();
+
+    const { getByTestId } = render(
+      wrap(
+        <DropTarget id="pile-layout" onDrop={() => false} testID="target">
+          <Text>Content</Text>
+        </DropTarget>
+      )
+    );
+
+    // Inject measureInWindow spy onto the native instance.
+    const target = getByTestId("target");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (target as any).measureInWindow = measureInWindow;
+
+    await act(async () => {
+      fireEvent(target, "layout", {
+        nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 50 } },
+      });
+      // Flush the requestAnimationFrame callback.
+      await Promise.resolve();
+    });
+
+    // measureInWindow is called asynchronously via requestAnimationFrame;
+    // in jsdom/jest the rAF callback is not auto-flushed, so we verify the
+    // call was scheduled (target.measureInWindow was referenced) rather than
+    // asserting a specific invocation count that depends on rAF scheduling.
+    expect(target).toBeTruthy();
   });
 
   it("applies dimStyle when drag is active and this target is not legal", () => {

--- a/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
+++ b/frontend/src/game/_shared/drag/__tests__/DropTarget.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Text } from "react-native";
-import { render, fireEvent, act } from "@testing-library/react-native";
+import { render, fireEvent } from "@testing-library/react-native";
 
 import { ThemeProvider } from "../../../../theme/ThemeContext";
 import { DragProvider, useDragContext } from "../DragContext";
@@ -100,8 +100,10 @@ describe("DropTarget", () => {
     expect(() => fireEvent.press(getByLabelText("end-drag"))).not.toThrow();
   });
 
-  it("calls measureInWindow via requestAnimationFrame when onLayout fires", async () => {
-    const measureInWindow = jest.fn();
+  it("schedules measureInWindow via requestAnimationFrame on layout, not synchronously", () => {
+    jest.useFakeTimers();
+    const rafSpy = jest.spyOn(global, "requestAnimationFrame");
+    const countBefore = rafSpy.mock.calls.length;
 
     const { getByTestId } = render(
       wrap(
@@ -111,24 +113,41 @@ describe("DropTarget", () => {
       )
     );
 
-    // Inject measureInWindow spy onto the native instance.
-    const target = getByTestId("target");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (target as any).measureInWindow = measureInWindow;
-
-    await act(async () => {
-      fireEvent(target, "layout", {
-        nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 50 } },
-      });
-      // Flush the requestAnimationFrame callback.
-      await Promise.resolve();
+    fireEvent(getByTestId("target"), "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 50 } },
     });
 
-    // measureInWindow is called asynchronously via requestAnimationFrame;
-    // in jsdom/jest the rAF callback is not auto-flushed, so we verify the
-    // call was scheduled (target.measureInWindow was referenced) rather than
-    // asserting a specific invocation count that depends on rAF scheduling.
-    expect(target).toBeTruthy();
+    // A new rAF should have been scheduled (measureInWindow is NOT called synchronously)
+    expect(rafSpy.mock.calls.length).toBeGreaterThan(countBefore);
+
+    rafSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it("cancels a pending rAF before scheduling a new one on rapid re-layout", () => {
+    jest.useFakeTimers();
+    const cancelSpy = jest.spyOn(global, "cancelAnimationFrame");
+
+    const { getByTestId } = render(
+      wrap(
+        <DropTarget id="pile-cancel" onDrop={() => false} testID="target">
+          <Text>Content</Text>
+        </DropTarget>
+      )
+    );
+
+    const target = getByTestId("target");
+    const layoutEvent = { nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 50 } } };
+
+    // First layout fires a rAF
+    fireEvent(target, "layout", layoutEvent);
+    // Second layout before first rAF runs — should cancel the first
+    fireEvent(target, "layout", layoutEvent);
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+
+    cancelSpy.mockRestore();
+    jest.useRealTimers();
   });
 
   it("applies dimStyle when drag is active and this target is not legal", () => {


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `endDrag` was dispatching 11–16 simultaneous async `measureInWindow` bridge calls at drop time; the hardcoded 300 ms safety-net `setTimeout` fired first → snap-back on every valid drop on iOS/Android. Replaced with proactive layout caching via `onLayout` + `requestAnimationFrame` in `DropTarget`. `endDrag` is now a synchronous JS hit-test with zero bridge calls.
- **Orphaned drag state fixed**: `snapBackAndClear` only called `clearDrag()` when the spring animation completed with `finished === true`; interrupted springs (new gesture, unmount) left the board permanently stuck in drag-active state. Now always clears.
- **Android DragContainer offset fixed**: `measureInWindow` was called synchronously inside `onLayout`, returning `0,0` before the native view was painted. Wrapped in `requestAnimationFrame`.
- **Activation threshold reduced**: `activeOffsetX/Y([-12,12])` → `minDistance(5)` — 12 px was too coarse for FreeCell's ~40 px wide cards.

## Files changed

| File | Change |
|------|--------|
| `DragContext.tsx` | Add `dropZoneBoundsRef` + `updateDropZoneLayout`; rewrite `endDrag` to synchronous; fix `snapBackAndClear` |
| `DropTarget.tsx` | Add `onLayout` handler with rAF + `measureInWindow`; remove `measureFresh` |
| `DragContainer.tsx` | Wrap `measureInWindow` in `requestAnimationFrame` |
| `DraggableCard.tsx` | `minDistance(5)` instead of `activeOffsetX/Y` |
| `__tests__/DragContext.test.tsx` | Remove `measureFresh` mocks; add synchronous hit-test tests |
| `__tests__/DropTarget.test.tsx` | Replace `measureFresh` test with layout-cache tests |

## Closes

#1870 #1871 #1873 — ref #1872 #1837

## Test plan

- [ ] All 4 drag test suites pass (`npx jest --testPathPattern="src/game/_shared/drag"`)
- [ ] Drag a card to a valid drop zone on iOS simulator — card lands without snap-back
- [ ] Drag a card then lift finger over empty space — card springs back cleanly, board exits drag-active state
- [ ] Tap a face-up card — `onTap` fires exactly once
- [ ] Rotate device — `onLayout` re-fires, bounds update, subsequent drops still land correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)