### PR TITLE
hearts: sort opponent dev-mode revealed cards by suit then rank

### DIFF
--- a/frontend/src/components/hearts/OpponentHand.tsx
+++ b/frontend/src/components/hearts/OpponentHand.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "../../theme/ThemeContext";
 import type { Card } from "../../game/hearts/types";
 import { rankLabel, suitEmoji } from "../../game/_shared/decks/cardId";
 import type { CanonicalSuit } from "../../game/_shared/decks/types";
+import { sortHand } from "./cardSort";
 
 interface Props {
   cardCount: number;
@@ -77,7 +78,7 @@ export default function OpponentHand({
         </View>
         {__DEV__ && revealCards && (
           <Text style={[styles.revealText, { color: colors.textMuted }]}>
-            {revealCards
+            {sortHand(revealCards)
               .map((c) => `${rankLabel(c.rank)}${suitEmoji(c.suit as CanonicalSuit)}`)
               .join(" ")}
           </Text>
@@ -115,7 +116,7 @@ export default function OpponentHand({
       </View>
       {__DEV__ && revealCards && (
         <Text style={[styles.revealText, { color: colors.textMuted }]}>
-          {revealCards
+          {sortHand(revealCards)
             .map((c) => `${rankLabel(c.rank)}${suitEmoji(c.suit as CanonicalSuit)}`)
             .join(" ")}
         </Text>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Import `sortHand()` from `cardSort.ts` into `OpponentHand.tsx`
- Apply `sortHand(revealCards)` before mapping to label strings in both the vertical (East/West) and horizontal (North) render branches

Opponent dev-mode card labels now group by suit (♣ ♦ ♠ ♥) and sort by rank ascending with Ace high, matching the human player's hand ordering.

Closes #1876

## Test plan

- [ ] Start a Hearts game in dev mode
- [ ] Confirm all three opponent hands display cards grouped by suit and sorted by rank (e.g. `2♣ K♣ 5♦ 2♥ 7♥ J♠`)
- [ ] Confirm human hand ordering is unchanged
- [ ] Confirm production builds are unaffected (reveal text is `__DEV__`-only)

https://claude.ai/code/session_018KLejyQLcax6S9WCivAhSY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018KLejyQLcax6S9WCivAhSY)_