### PR TITLE
fix(network): add withRetry and apply to screen loaders (closes #1861 #1862 #1874)

### DIFF
--- a/frontend/src/game/_shared/__tests__/useLeaderboard.test.ts
+++ b/frontend/src/game/_shared/__tests__/useLeaderboard.test.ts
@@ -1,0 +1,146 @@
+/**
+ * useLeaderboard — unit tests.
+ *
+ * Covers the retry-on-TypeError path added to defend against transient
+ * network failures (#1874, #1861, #1862).
+ */
+
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useLeaderboard } from "../useLeaderboard";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../NetworkContext", () => ({
+  useNetwork: () => ({ isOnline: true, isInitialized: true }),
+}));
+
+const asyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FakeData {
+  scores: { rank: number }[];
+}
+
+function makeFetcher(fn: jest.Mock): () => Promise<FakeData> {
+  return fn as () => Promise<FakeData>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  asyncStorage.getItem.mockResolvedValue(null);
+  asyncStorage.setItem.mockResolvedValue(undefined);
+});
+
+describe("useLeaderboard — happy path", () => {
+  it("returns data after a successful fetch", async () => {
+    const data: FakeData = { scores: [{ rank: 1 }] };
+    const fetcher = jest.fn().mockResolvedValue(data);
+
+    const { result } = renderHook(() =>
+      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(data);
+    expect(result.current.offline).toBe(false);
+  });
+
+  it("returns cached data immediately when the cache is fresh", async () => {
+    const cached: FakeData = { scores: [{ rank: 2 }] };
+    asyncStorage.getItem.mockResolvedValue(
+      JSON.stringify({ data: cached, fetchedAt: Date.now() })
+    );
+    const fetcher = jest.fn(); // should not be called
+
+    const { result } = renderHook(() =>
+      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(cached);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});
+
+describe("useLeaderboard — TypeError retry", () => {
+  it("retries on TypeError and resolves without marking offline", async () => {
+    jest.useFakeTimers();
+    const data: FakeData = { scores: [{ rank: 1 }] };
+    const fetcher = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() =>
+      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    expect(result.current.offline).toBe(false);
+    expect(result.current.data).toEqual(data);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
+  it("marks offline after all retries fail and no cache exists", async () => {
+    jest.useFakeTimers();
+    const fetcher = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
+
+    const { result } = renderHook(() =>
+      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.offline).toBe(true);
+    expect(result.current.data).toBeNull();
+
+    jest.useRealTimers();
+  });
+
+  it("returns stale cache after all retries fail when cache exists", async () => {
+    jest.useFakeTimers();
+    const staleData: FakeData = { scores: [{ rank: 99 }] };
+    // Cache is older than TTL so network fetch is attempted, but expired cache is still available.
+    asyncStorage.getItem.mockResolvedValue(
+      JSON.stringify({ data: staleData, fetchedAt: Date.now() - 10 * 60 * 1000 })
+    );
+    const fetcher = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
+
+    const { result } = renderHook(() =>
+      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
+    );
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(staleData);
+    expect(result.current.offline).toBe(false);
+
+    jest.useRealTimers();
+  });
+});

--- a/frontend/src/game/_shared/__tests__/useLeaderboard.test.ts
+++ b/frontend/src/game/_shared/__tests__/useLeaderboard.test.ts
@@ -51,9 +51,7 @@ describe("useLeaderboard — happy path", () => {
     const data: FakeData = { scores: [{ rank: 1 }] };
     const fetcher = jest.fn().mockResolvedValue(data);
 
-    const { result } = renderHook(() =>
-      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
-    );
+    const { result } = renderHook(() => useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key"));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.data).toEqual(data);
@@ -62,14 +60,10 @@ describe("useLeaderboard — happy path", () => {
 
   it("returns cached data immediately when the cache is fresh", async () => {
     const cached: FakeData = { scores: [{ rank: 2 }] };
-    asyncStorage.getItem.mockResolvedValue(
-      JSON.stringify({ data: cached, fetchedAt: Date.now() })
-    );
+    asyncStorage.getItem.mockResolvedValue(JSON.stringify({ data: cached, fetchedAt: Date.now() }));
     const fetcher = jest.fn(); // should not be called
 
-    const { result } = renderHook(() =>
-      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
-    );
+    const { result } = renderHook(() => useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key"));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.data).toEqual(cached);
@@ -86,9 +80,7 @@ describe("useLeaderboard — TypeError retry", () => {
       .mockRejectedValueOnce(new TypeError("Network request failed"))
       .mockResolvedValueOnce(data);
 
-    const { result } = renderHook(() =>
-      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
-    );
+    const { result } = renderHook(() => useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key"));
 
     await act(async () => {
       await jest.runAllTimersAsync();
@@ -105,9 +97,7 @@ describe("useLeaderboard — TypeError retry", () => {
     jest.useFakeTimers();
     const fetcher = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
 
-    const { result } = renderHook(() =>
-      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
-    );
+    const { result } = renderHook(() => useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key"));
 
     await act(async () => {
       await jest.runAllTimersAsync();
@@ -129,9 +119,7 @@ describe("useLeaderboard — TypeError retry", () => {
     );
     const fetcher = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
 
-    const { result } = renderHook(() =>
-      useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key")
-    );
+    const { result } = renderHook(() => useLeaderboard<FakeData>(makeFetcher(fetcher), "test_key"));
 
     await act(async () => {
       await jest.runAllTimersAsync();

--- a/frontend/src/game/_shared/__tests__/withRetry.test.ts
+++ b/frontend/src/game/_shared/__tests__/withRetry.test.ts
@@ -1,0 +1,68 @@
+import { withRetry } from "../withRetry";
+
+describe("withRetry", () => {
+  it("returns the result on first success without retrying", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, { baseDelayMs: 0 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on TypeError and returns on second success", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withRetry(fn, { maxRetries: 3, baseDelayMs: 0 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("exhausts maxRetries on persistent TypeError and throws", async () => {
+    const networkErr = new TypeError("Network request failed");
+    const fn = jest.fn().mockRejectedValue(networkErr);
+
+    await expect(withRetry(fn, { maxRetries: 2, baseDelayMs: 0 })).rejects.toBe(networkErr);
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("throws immediately on non-TypeError errors without retrying", async () => {
+    const apiErr = new Error("ApiError: 404");
+    const fn = jest.fn().mockRejectedValue(apiErr);
+
+    await expect(withRetry(fn, { maxRetries: 3, baseDelayMs: 0 })).rejects.toBe(apiErr);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects maxRetries = 0 (no retries at all)", async () => {
+    const fn = jest.fn().mockRejectedValue(new TypeError("fail"));
+    await expect(withRetry(fn, { maxRetries: 0, baseDelayMs: 0 })).rejects.toBeInstanceOf(
+      TypeError
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects positive baseDelayMs: runs all retries and rejects with fake timers", async () => {
+    jest.useFakeTimers();
+
+    const networkErr = new TypeError("fail");
+    const fn = jest.fn().mockRejectedValue(networkErr);
+
+    // Attach .catch immediately so Node never sees an unhandled rejection while
+    // fake timers are draining — the rejection happens inside runAllTimersAsync()
+    // before the outer `await expect(...)` handler is registered.
+    let caughtError: unknown;
+    const promise = withRetry(fn, { maxRetries: 2, baseDelayMs: 500 }).catch((e) => {
+      caughtError = e;
+    });
+
+    await jest.runAllTimersAsync();
+    await promise;
+
+    expect(caughtError).toBe(networkErr);
+    expect(fn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+
+    jest.useRealTimers();
+  });
+});

--- a/frontend/src/game/_shared/useLeaderboard.ts
+++ b/frontend/src/game/_shared/useLeaderboard.ts
@@ -15,6 +15,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useNetwork } from "./NetworkContext";
+import { withRetry } from "./withRetry";
 
 export interface UseLeaderboardResult<T> {
   data: T | null;
@@ -63,9 +64,9 @@ export function useLeaderboard<T>(
       // Cache miss — proceed to network fetch.
     }
 
-    // Network fetch.
+    // Network fetch — retry up to 3× on transient TypeError failures.
     try {
-      const result = await fetcherRef.current();
+      const result = await withRetry(() => fetcherRef.current());
       setData(result);
       setOffline(false);
       const entry: CacheEntry<T> = { data: result, fetchedAt: Date.now() };

--- a/frontend/src/game/_shared/withRetry.ts
+++ b/frontend/src/game/_shared/withRetry.ts
@@ -4,6 +4,11 @@
  * offline, DNS, CORS, "Failed to fetch"). All other error types are
  * re-thrown immediately without any retry.
  *
+ * The check is intentionally broad — any TypeError triggers a retry, not
+ * just those from `fetch`. All current call sites are thin API wrappers, so
+ * this is safe in practice; avoid wrapping logic that can throw TypeError
+ * from non-network sources.
+ *
  * Exponential back-off: baseDelayMs × 2^attempt (500 ms → 1 s → 2 s).
  */
 export async function withRetry<T>(
@@ -18,9 +23,7 @@ export async function withRetry<T>(
       if (!(e instanceof TypeError)) throw e;
       lastError = e;
       if (attempt < maxRetries) {
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, baseDelayMs * 2 ** attempt)
-        );
+        await new Promise<void>((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
       }
     }
   }

--- a/frontend/src/game/_shared/withRetry.ts
+++ b/frontend/src/game/_shared/withRetry.ts
@@ -1,0 +1,28 @@
+/**
+ * Retries an async function up to `maxRetries` times when it throws a
+ * `TypeError` (the error class `fetch` uses for network-layer failures:
+ * offline, DNS, CORS, "Failed to fetch"). All other error types are
+ * re-thrown immediately without any retry.
+ *
+ * Exponential back-off: baseDelayMs × 2^attempt (500 ms → 1 s → 2 s).
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  { maxRetries = 3, baseDelayMs = 500 }: { maxRetries?: number; baseDelayMs?: number } = {}
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;
+      lastError = e;
+      if (attempt < maxRetries) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, baseDelayMs * 2 ** attempt)
+        );
+      }
+    }
+  }
+  throw lastError;
+}

--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -48,6 +48,7 @@ import {
 } from "../game/daily_word/engine";
 import type { DailyWordState, TileStatus } from "../game/daily_word/types";
 import { dailyWordApi } from "../game/daily_word/api";
+import { withRetry } from "../game/_shared/withRetry";
 import { loadState, saveState, clearState } from "../game/daily_word/storage";
 import { ApiError } from "../game/_shared/httpClient";
 import { devLog } from "../game/daily_word/devLog";
@@ -704,7 +705,7 @@ export default function DailyWordScreen() {
     async function load() {
       try {
         const [todayMeta, saved] = await Promise.all([
-          dailyWordApi.getToday(tzOffset, language),
+          withRetry(() => dailyWordApi.getToday(tzOffset, language)),
           loadState(),
         ]);
 

--- a/frontend/src/screens/LeaderboardScreen.tsx
+++ b/frontend/src/screens/LeaderboardScreen.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "../theme/ThemeContext";
 import { AppHeader, APP_HEADER_HEIGHT } from "../components/shared/AppHeader";
 import { starSwarmApi } from "../game/starswarm/api";
 import type { LeaderboardEntry } from "../game/starswarm/api";
+import { withRetry } from "../game/_shared/withRetry";
 import { formatDate } from "../utils/formatTimestamp";
 
 export default function LeaderboardScreen() {
@@ -20,7 +21,7 @@ export default function LeaderboardScreen() {
   const load = useCallback(async () => {
     setError(null);
     try {
-      const data = await starSwarmApi.getLeaderboard();
+      const data = await withRetry(() => starSwarmApi.getLeaderboard());
       setEntries(data.scores);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -35,6 +35,7 @@ import SortBoard, { POUR_PER_UNIT_MS } from "../game/sort/components/SortBoard";
 import { TILT_IN_MS, TILT_HOLD_MS, TILT_OUT_MS } from "../game/sort/components/BottleView";
 import LevelSelectScreen from "../game/sort/components/LevelSelectScreen";
 import { sortApi, type LevelData, type ScoreEntry } from "../game/sort/api";
+import { withRetry } from "../game/_shared/withRetry";
 import { loadProgress, saveProgress, type SortProgress } from "../game/sort/storage";
 import { useNetwork } from "../game/_shared/NetworkContext";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
@@ -116,7 +117,7 @@ export default function SortScreen() {
     setLoadError(false);
     setView("loading");
     const [levelsResult, prog] = await Promise.all([
-      sortApi.getLevels().catch(() => null),
+      withRetry(() => sortApi.getLevels()).catch(() => null),
       loadProgress(),
     ]);
     if (!levelsResult) {

--- a/frontend/src/screens/SortScreen.tsx
+++ b/frontend/src/screens/SortScreen.tsx
@@ -117,6 +117,8 @@ export default function SortScreen() {
     setLoadError(false);
     setView("loading");
     const [levelsResult, prog] = await Promise.all([
+      // .catch converts both retry-exhausted TypeErrors and non-network errors
+      // into null so the caller can show the error state unconditionally.
       withRetry(() => sortApi.getLevels()).catch(() => null),
       loadProgress(),
     ]);

--- a/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
+++ b/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import DailyWordScreen from "../DailyWordScreen";
 import type { DailyWordState } from "../../game/daily_word/types";
@@ -229,5 +229,45 @@ describe("DailyWordScreen — error state", () => {
 
     const { findByText } = renderScreen();
     await expect(findByText("Could not load today's puzzle")).resolves.toBeTruthy();
+  });
+});
+
+describe("DailyWordScreen — TypeError auto-retry (#1861)", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("auto-retries a transient TypeError and loads the puzzle without showing an error", async () => {
+    jest.useFakeTimers();
+    dailyWordApi.getToday
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce(TODAY_META);
+
+    const { findByTestId, queryByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await findByTestId("tile-0-0");
+    expect(queryByText("Could not load today's puzzle")).toBeNull();
+    expect(dailyWordApi.getToday).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows load error only after all retries are exhausted", async () => {
+    jest.useFakeTimers();
+    dailyWordApi.getToday.mockRejectedValue(new TypeError("Network request failed"));
+
+    const { queryByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(queryByText("Could not load today's puzzle")).toBeTruthy();
+    });
+    // 1 initial + 3 retries = 4 total calls
+    expect(dailyWordApi.getToday).toHaveBeenCalledTimes(4);
   });
 });

--- a/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
+++ b/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from "react";
-import { act, render, waitFor } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import DailyWordScreen from "../DailyWordScreen";
 import type { DailyWordState } from "../../game/daily_word/types";
@@ -258,15 +258,13 @@ describe("DailyWordScreen — TypeError auto-retry (#1861)", () => {
     jest.useFakeTimers();
     dailyWordApi.getToday.mockRejectedValue(new TypeError("Network request failed"));
 
-    const { queryByText } = renderScreen();
+    const { findByText } = renderScreen();
 
     await act(async () => {
       await jest.runAllTimersAsync();
     });
 
-    await waitFor(() => {
-      expect(queryByText("Could not load today's puzzle")).toBeTruthy();
-    });
+    await findByText("Could not load today's puzzle");
     // 1 initial + 3 retries = 4 total calls
     expect(dailyWordApi.getToday).toHaveBeenCalledTimes(4);
   });

--- a/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
@@ -80,9 +80,7 @@ describe("LeaderboardScreen — TypeError auto-retry (#1874)", () => {
       await jest.runAllTimersAsync();
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("leaderboard.error")).toBeTruthy();
-    });
+    await screen.findByText("leaderboard.error");
     // 1 initial + 3 retries = 4 total calls
     expect(mockGetLeaderboard).toHaveBeenCalledTimes(4);
   });

--- a/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
+++ b/frontend/src/screens/__tests__/LeaderboardScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react-native";
+import { act, render, screen, waitFor } from "@testing-library/react-native";
 import { ThemeProvider } from "../../theme/ThemeContext";
 import LeaderboardScreen from "../LeaderboardScreen";
 
@@ -48,5 +48,42 @@ describe("LeaderboardScreen", () => {
     await waitFor(() => {
       expect(screen.getByText("leaderboard.empty")).toBeTruthy();
     });
+  });
+});
+
+describe("LeaderboardScreen — TypeError auto-retry (#1874)", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("auto-retries a transient TypeError and displays data without showing an error", async () => {
+    jest.useFakeTimers();
+    mockGetLeaderboard
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce({ scores: [] });
+
+    renderScreen();
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    expect(screen.queryByText("leaderboard.error")).toBeNull();
+    expect(mockGetLeaderboard).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows error UI only after all retries are exhausted", async () => {
+    jest.useFakeTimers();
+    mockGetLeaderboard.mockRejectedValue(new TypeError("Network request failed"));
+
+    renderScreen();
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("leaderboard.error")).toBeTruthy();
+    });
+    // 1 initial + 3 retries = 4 total calls
+    expect(mockGetLeaderboard).toHaveBeenCalledTimes(4);
   });
 });

--- a/frontend/src/screens/__tests__/SortScreen.test.tsx
+++ b/frontend/src/screens/__tests__/SortScreen.test.tsx
@@ -287,3 +287,41 @@ describe("SortScreen — pour completion callback (regression #1567)", () => {
     expect(await findByLabelText(/^Bottle 1, 2 of/)).toBeTruthy();
   });
 });
+
+describe("SortScreen — TypeError auto-retry (#1862)", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("auto-retries a transient TypeError and loads levels without showing an error", async () => {
+    jest.useFakeTimers();
+    sortApi.getLevels
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValueOnce({ levels: MOCK_LEVELS });
+
+    const { findByText, queryByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await findByText("Choose a Level");
+    expect(queryByText("Could not load this level.")).toBeNull();
+    expect(sortApi.getLevels).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows error UI only after all retries are exhausted", async () => {
+    jest.useFakeTimers();
+    sortApi.getLevels.mockRejectedValue(new TypeError("Network request failed"));
+
+    const { findByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await findByText("Could not load this level.");
+    // 1 initial + 3 retries = 4 total calls
+    expect(sortApi.getLevels).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Root cause

Every screen-level data fetch was a single attempt with no retry. When a device hits a transient network hiccup (cell handoff, app backgrounded/foregrounded, Render cold-start window), `fetch` throws `TypeError: Network request failed`. `httpClient.ts` correctly classifies this as a recoverable network failure and logs it to Sentry as a warning — but then **rethrows immediately**. The result: the user lands in a hard error state and has to manually tap Retry.

The `syncWorker` already has exponential back-off but it's isolated to the score-sync pipeline. Screen loaders had nothing.

## Fix

New `frontend/src/game/_shared/withRetry.ts` utility:

- Retries the fetcher up to **3 times** on `TypeError` only (network failures)
- Exponential back-off: **500 ms → 1 s → 2 s** between attempts
- All other error types (`ApiError`, HTTP 4xx/5xx, unexpected JS errors) pass through immediately — no change to those paths

Applied to:
| Location | Issue |
|---|---|
| `useLeaderboard.ts` network fetch | foundation for all leaderboard screens |
| `LeaderboardScreen.tsx` `load` callback | #1874 |
| `DailyWordScreen.tsx` `getToday` call | #1861 |
| `SortScreen.tsx` `getLevels` call | #1862 |

## Tests

- `withRetry.test.ts` — 6 cases: success, single retry, exhausted retries, non-TypeError passthrough, maxRetries=0, fake-timer drain
- `useLeaderboard.test.ts` — 5 cases: happy path, fresh cache, TypeError retry, full exhaustion → offline, stale-cache fallback after exhaustion
- `LeaderboardScreen.test.tsx` — 2 new cases: auto-retry recovers, error shown only after all retries fail
- `DailyWordScreen.test.tsx` — 2 new cases: same pattern
- `SortScreen.test.tsx` — 2 new cases: same pattern

**2727 tests, 145 suites — all green.**

## What's not changed

- Sentry warning behaviour is unchanged: each attempt that fails fires a Sentry `captureMessage` at `warning` level (existing path in `httpClient`). In practice, most transient failures will succeed on retry 1–2 so total warning volume will drop, which was the stated goal in #1874.
- Manual Retry buttons on all three screens remain — they handle the case where all auto-retries are exhausted.

Closes #1861, #1862, #1874

🤖 Generated with [Claude Code](https://claude.com/claude-code)