### PR TITLE
fix(yacht-ai): score full_house before upper par pursuit in Hard

### DIFF
--- a/frontend/src/game/yacht/__tests__/ai.test.ts
+++ b/frontend/src/game/yacht/__tests__/ai.test.ts
@@ -323,15 +323,24 @@ describe("scoreStrategy — Hard", () => {
   });
 
   it("takes full_house over upper par pursuit when full_house is in hand", () => {
-    // [5,5,5,6,6]: full_house (25 pts); fives open with cnt=3 fires par pursuit first without fix
+    // Fresh game: all upper cats open, toBonus=63 → par pursuit is active.
+    // [5,5,5,6,6]: fives open, cnt=3 ≥ 3 would fire par pursuit (fives=15) without fix.
     const state = makeGame([5, 5, 5, 6, 6], 3);
     expect(scoreStrategy(state, "hard", 0)).toBe("full_house");
   });
 
   it("takes full_house over par pursuit with two high-value face in full_house", () => {
-    // [6,6,3,3,3]: full_house (25 pts); sixes open, cnt=2 face=6≥5 fires par pursuit first without fix
+    // Fresh game: all upper cats open, toBonus=63 → par pursuit is active.
+    // [6,6,3,3,3]: sixes open, cnt=2 face=6≥5 would fire par pursuit (sixes=12) without fix.
     const state = makeGame([6, 6, 3, 3, 3], 3);
     expect(scoreStrategy(state, "hard", 0)).toBe("full_house");
+  });
+
+  it("falls through to par pursuit when full_house is already scored", () => {
+    // full_house scored → new check skipped; par pursuit fires correctly for open upper cat.
+    // [5,5,5,2,1]: fives open, cnt=3 → par pursuit returns fives (15 pts).
+    const state = withScores(makeGame([5, 5, 5, 2, 1], 3), { full_house: 25 });
+    expect(scoreStrategy(state, "hard", 0)).toBe("fives");
   });
 
   it("takes bonus-closing upper category over three_of_a_kind", () => {

--- a/frontend/src/game/yacht/__tests__/ai.test.ts
+++ b/frontend/src/game/yacht/__tests__/ai.test.ts
@@ -322,6 +322,18 @@ describe("scoreStrategy — Hard", () => {
     expect(scoreStrategy(state, "hard", 0)).toBe("ones");
   });
 
+  it("takes full_house over upper par pursuit when full_house is in hand", () => {
+    // [5,5,5,6,6]: full_house (25 pts); fives open with cnt=3 fires par pursuit first without fix
+    const state = makeGame([5, 5, 5, 6, 6], 3);
+    expect(scoreStrategy(state, "hard", 0)).toBe("full_house");
+  });
+
+  it("takes full_house over par pursuit with two high-value face in full_house", () => {
+    // [6,6,3,3,3]: full_house (25 pts); sixes open, cnt=2 face=6≥5 fires par pursuit first without fix
+    const state = makeGame([6, 6, 3, 3, 3], 3);
+    expect(scoreStrategy(state, "hard", 0)).toBe("full_house");
+  });
+
   it("takes bonus-closing upper category over three_of_a_kind", () => {
     // upper=54 (ones=3,twos=6,fours=20,fives=15,sixes=10), toBonus=9
     // dice [3,3,3,1,2]: three_of_a_kind=10 pts, but threes (9) closes bonus → +35 deferred

--- a/frontend/src/game/yacht/ai.ts
+++ b/frontend/src/game/yacht/ai.ts
@@ -425,7 +425,11 @@ function scoreHard(
   // Four of a kind
   if ("four_of_a_kind" in legal && (legal["four_of_a_kind"] ?? 0) > 18) return "four_of_a_kind";
 
-  // Aggressively pursue upper bonus before full_house — the deferred +35 outweighs 25 pts
+  // Full house — scored before par pursuit because no upper cat at par (≤18 pts for 3×face ≤6)
+  // beats the guaranteed 25. Par pursuit below only fires when full_house is unavailable.
+  if ("full_house" in legal && (legal["full_house"] ?? 0) > 0) return "full_house";
+
+  // Upper bonus pursuit at par — fires only when full_house is not in hand
   if (toBonus > 0) {
     for (const cat of ["sixes", "fives", "fours", "threes", "twos", "ones"] as Category[]) {
       if (cat in legal) {
@@ -435,9 +439,6 @@ function scoreHard(
       }
     }
   }
-
-  // Full house
-  if ("full_house" in legal && (legal["full_house"] ?? 0) > 0) return "full_house";
 
   // Three of a kind with high sum
   if ("three_of_a_kind" in legal && (legal["three_of_a_kind"] ?? 0) >= 18) return "three_of_a_kind";


### PR DESCRIPTION
## Summary

Fixes #1882. Part of epic #1879.

The Hard AI was scoring an upper category (≤18 pts) over a guaranteed full_house (25 pts) on any roll where `cnt ≥ 3` or `face ≥ 5 && cnt ≥ 2` — including dice that formed a full_house. For example, `[3,3,3,5,5]` scored `fives` (10 pts) instead of `full_house` (25 pts) because the par pursuit block iterated upper categories before the full_house check.

Fix: moved `full_house` immediately after `four_of_a_kind`, before the par pursuit loop. Par pursuit still fires correctly when no full_house is available.

## Results (n=500)

| Metric | Before | After | Target |
|---|---|---|---|
| Hard full_house rate (vs Hard) | 69.0% | **88.4%** | ≥ 80% ✓ |
| Hard full_house rate (vs Medium) | 87.6% | **89.4%** | ≥ 80% ✓ |
| Hard vs Hard win rate | 47.6% | 51.2% | [45%, 55%] ✓ |
| Hard vs Medium win rate | 51.2% | 55.4% | [58%, 72%] — closed by #1881 |

## Test plan

- [x] `jest --testPathPattern="yacht/__tests__/ai\.test"` — 40 tests, all green
- [x] Two new regression tests covering both failure modes (`[5,5,5,6,6]` and `[6,6,3,3,3]`)
- [x] `simulate-yacht.ts --count 500` — Hard full_house band passes