### PR TITLE
Mahjong: clean up header layout and fix hint visibility

### DIFF
--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -325,10 +325,10 @@ export default function GameCanvas({
               {/* Blue glow behind matching free tiles */}
               {isHint && (
                 <Rect
-                  x={x - 2}
-                  y={y - 2}
-                  width={faceWidth + 4}
-                  height={faceHeight + 4}
+                  x={x - 4}
+                  y={y - 4}
+                  width={faceWidth + 8}
+                  height={faceHeight + 8}
                   color={MAHJONG_HINT_GLOW_BG}
                 />
               )}

--- a/frontend/src/components/mahjong/GameCanvas.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.tsx
@@ -18,6 +18,7 @@ import type { MahjongState, SlotTile } from "../../game/mahjong/types";
 import { TILE_REQUIRES } from "./tileAssets";
 import {
   MAHJONG_GLOW_BG,
+  MAHJONG_HINT_COLOR,
   MAHJONG_HINT_GLOW_BG,
   MAHJONG_TILE_FACE_SELECTED,
 } from "../../theme/theme.constants";
@@ -33,7 +34,7 @@ const TILE_FACE_SELECTED = MAHJONG_TILE_FACE_SELECTED;
 const TILE_FACE_LOCKED = "#d0c8b8";
 const BORDER_NORMAL = "#8b7355";
 const BORDER_SELECTED = "#ffd700";
-const BORDER_HINT = "#5dbcd2";
+const BORDER_HINT = MAHJONG_HINT_COLOR;
 const SIDE_R = "#a89070";
 const SIDE_B = "#987860";
 const SHADOW = "rgba(0,0,0,0.35)";

--- a/frontend/src/components/mahjong/GameCanvas.web.tsx
+++ b/frontend/src/components/mahjong/GameCanvas.web.tsx
@@ -16,6 +16,7 @@ import { loadTileAssets } from "./tileAssetLoader";
 import {
   MAHJONG_BOARD_BG,
   MAHJONG_GLOW_SHADOW,
+  MAHJONG_HINT_COLOR,
   MAHJONG_HINT_GLOW_SHADOW,
   MAHJONG_TILE_FACE_SELECTED,
 } from "../../theme/theme.constants";
@@ -31,7 +32,7 @@ const TILE_FACE_SELECTED = MAHJONG_TILE_FACE_SELECTED;
 const TILE_FACE_LOCKED = "#d0c8b8";
 const BORDER_NORMAL = "#8b7355";
 const BORDER_SELECTED = "#ffd700";
-const BORDER_HINT = "#5dbcd2";
+const BORDER_HINT = MAHJONG_HINT_COLOR;
 const SIDE_R = "#a89070";
 const SIDE_B = "#987860";
 

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -860,91 +860,97 @@ export default function MahjongScreen() {
       onLevelSelect={goToLevelSelect}
       onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "mahjong" })}
       rightSlot={
-        <Pressable
-          onPress={handleUndo}
-          disabled={undoDisabled}
-          style={[
-            styles.headerBtn,
-            { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel={t("action.undoLabel")}
-          accessibilityState={{ disabled: undoDisabled }}
-          testID="mahjong-undo-button"
-        >
-          <Text style={[styles.headerBtnText, { color: colors.accent }]}>{t("action.undo")}</Text>
-        </Pressable>
+        <View style={styles.headerBtnRow}>
+          <Pressable
+            onPress={handleUndo}
+            disabled={undoDisabled}
+            style={[
+              styles.headerBtn,
+              { borderColor: colors.accent, opacity: undoDisabled ? 0.4 : 1 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={t("action.undoLabel")}
+            accessibilityState={{ disabled: undoDisabled }}
+            testID="mahjong-undo-button"
+          >
+            <Text style={[styles.headerBtnText, { color: colors.accent }]}>{t("action.undo")}</Text>
+          </Pressable>
+          <Pressable
+            onPress={handleHint}
+            disabled={state?.isComplete || state?.isDeadlocked}
+            style={[
+              styles.headerBtn,
+              {
+                borderColor: "#5dbcd2",
+                opacity: state?.isComplete || state?.isDeadlocked ? 0.3 : 1,
+              },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={t("action.hintLabel")}
+            accessibilityState={{ disabled: state?.isComplete || state?.isDeadlocked }}
+            testID="mahjong-hint-button"
+          >
+            <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
+          </Pressable>
+        </View>
       }
     >
       {state !== null && (
         <View style={{ flex: 1, alignItems: "center" }}>
           <View style={styles.hudRow} accessibilityRole="summary">
-            {__DEV__ ? (
-              <Pressable onLongPress={() => setDevPanelOpen((o) => !o)} accessibilityRole="none">
+            <View style={styles.hudGroup}>
+              {__DEV__ ? (
+                <Pressable onLongPress={() => setDevPanelOpen((o) => !o)} accessibilityRole="none">
+                  <Text style={[styles.hudText, { color: colors.text }]}>
+                    {t("hud.score")} {state.score}
+                  </Text>
+                </Pressable>
+              ) : (
                 <Text style={[styles.hudText, { color: colors.text }]}>
                   {t("hud.score")} {state.score}
                 </Text>
-              </Pressable>
-            ) : (
-              <Text style={[styles.hudText, { color: colors.text }]}>
-                {t("hud.score")} {state.score}
+              )}
+              <Text style={[styles.hudText, { color: colors.textMuted }]}>
+                {t("hud.pairs")} {state.pairsRemoved}/72
               </Text>
-            )}
-            <Text style={[styles.hudText, { color: colors.textMuted }]}>
-              {t("hud.pairs")} {state.pairsRemoved}/72
-            </Text>
-            <Pressable
-              onPress={handleShuffle}
-              disabled={state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked}
-              style={[
-                styles.headerBtn,
-                {
-                  borderColor: "#ffd700",
-                  opacity:
-                    state.shufflesLeft > 0 && !state.isComplete && !state.isDeadlocked ? 1 : 0.3,
-                },
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel={t("action.shuffleLabel")}
-              accessibilityState={{
-                disabled: state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked,
-              }}
-              testID="mahjong-shuffle-button"
-            >
-              <Text style={[styles.headerBtnText, { color: "#ffd700" }]}>
-                {t("action.shuffle")} {state.shufflesLeft}
-              </Text>
-            </Pressable>
-            <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
-              {t("hud.deal")} #{state.dealId}
-            </Text>
-            <Pressable
-              onPress={handleHint}
-              disabled={state.isComplete || state.isDeadlocked}
-              style={[
-                styles.headerBtn,
-                {
-                  borderColor: "#5dbcd2",
-                  opacity: state.isComplete || state.isDeadlocked ? 0.3 : 1,
-                },
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel={t("action.hintLabel")}
-              accessibilityState={{ disabled: state.isComplete || state.isDeadlocked }}
-              testID="mahjong-hint-button"
-            >
-              <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
-            </Pressable>
-            {__DEV__ && (
+            </View>
+            <View style={styles.hudGroup}>
               <Pressable
-                onPress={() => setDevPanelOpen((o) => !o)}
-                style={[styles.headerBtn, { borderColor: "rgba(255,128,0,0.8)" }]}
+                onPress={handleShuffle}
+                disabled={state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked}
+                style={[
+                  styles.headerBtn,
+                  {
+                    borderColor: "#ffd700",
+                    opacity:
+                      state.shufflesLeft > 0 && !state.isComplete && !state.isDeadlocked ? 1 : 0.3,
+                  },
+                ]}
                 accessibilityRole="button"
-                accessibilityLabel="Toggle dev panel"
+                accessibilityLabel={t("action.shuffleLabel")}
+                accessibilityState={{
+                  disabled: state.shufflesLeft === 0 || state.isComplete || state.isDeadlocked,
+                }}
+                testID="mahjong-shuffle-button"
               >
-                <Text style={[styles.headerBtnText, { color: "rgba(255,128,0,1)" }]}>DEV</Text>
+                <Text style={[styles.headerBtnText, { color: "#ffd700" }]}>
+                  {t("action.shuffle")} {state.shufflesLeft}
+                </Text>
               </Pressable>
-            )}
+              <Text style={[styles.hudText, styles.dealIdText, { color: colors.textMuted }]}>
+                {t("hud.deal")} #{state.dealId}
+              </Text>
+              {__DEV__ && (
+                <Pressable
+                  onPress={() => setDevPanelOpen((o) => !o)}
+                  style={[styles.headerBtn, { borderColor: "rgba(255,128,0,0.8)" }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Toggle dev panel"
+                >
+                  <Text style={[styles.headerBtnText, { color: "rgba(255,128,0,1)" }]}>DEV</Text>
+                </Pressable>
+              )}
+            </View>
           </View>
 
           {noHintVisible && (
@@ -1247,9 +1253,20 @@ const styles = StyleSheet.create({
   hudRow: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
     alignSelf: "stretch",
     paddingHorizontal: 4,
     paddingVertical: 8,
+  },
+  hudGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  headerBtnRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
   noHintToast: {
     fontFamily: typography.heading,

--- a/frontend/src/screens/MahjongScreen.tsx
+++ b/frontend/src/screens/MahjongScreen.tsx
@@ -48,6 +48,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { HomeStackParamList } from "../types/navigation";
 import { loadTileAssets } from "../components/mahjong/tileAssetLoader";
 import { useTheme } from "../theme/ThemeContext";
+import { MAHJONG_HINT_COLOR } from "../theme/theme.constants";
 import { typography } from "../theme/typography";
 import { GameShell } from "../components/shared/GameShell";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
@@ -860,7 +861,7 @@ export default function MahjongScreen() {
       onLevelSelect={goToLevelSelect}
       onOpenScoreboard={() => navigation.navigate("Scoreboard", { gameKey: "mahjong" })}
       rightSlot={
-        <View style={styles.headerBtnRow}>
+        <View style={styles.hudGroup}>
           <Pressable
             onPress={handleUndo}
             disabled={undoDisabled}
@@ -881,7 +882,7 @@ export default function MahjongScreen() {
             style={[
               styles.headerBtn,
               {
-                borderColor: "#5dbcd2",
+                borderColor: MAHJONG_HINT_COLOR,
                 opacity: state?.isComplete || state?.isDeadlocked ? 0.3 : 1,
               },
             ]}
@@ -890,7 +891,9 @@ export default function MahjongScreen() {
             accessibilityState={{ disabled: state?.isComplete || state?.isDeadlocked }}
             testID="mahjong-hint-button"
           >
-            <Text style={[styles.headerBtnText, { color: "#5dbcd2" }]}>{t("action.hint")}</Text>
+            <Text style={[styles.headerBtnText, { color: MAHJONG_HINT_COLOR }]}>
+              {t("action.hint")}
+            </Text>
           </Pressable>
         </View>
       }
@@ -1263,17 +1266,12 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
-  headerBtnRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
   noHintToast: {
     fontFamily: typography.heading,
     fontSize: 12,
     letterSpacing: 0.5,
     paddingBottom: 4,
-    color: "#5dbcd2",
+    color: MAHJONG_HINT_COLOR,
   },
   hudText: {
     fontFamily: typography.heading,

--- a/frontend/src/theme/theme.constants.ts
+++ b/frontend/src/theme/theme.constants.ts
@@ -48,8 +48,8 @@ export const MAHJONG_GLOW_BG = "rgba(255,215,0,0.35)";
 /** Mahjong selected tile glow — stronger gold shadow effect. */
 export const MAHJONG_GLOW_SHADOW = "rgba(255,215,0,0.7)";
 
-/** Mahjong hint tile glow — subtle blue background for matching free tiles. */
-export const MAHJONG_HINT_GLOW_BG = "rgba(93,188,210,0.35)";
+/** Mahjong hint tile glow — blue background for matching free tiles. */
+export const MAHJONG_HINT_GLOW_BG = "rgba(93,188,210,0.65)";
 
-/** Mahjong hint tile glow — stronger blue shadow effect (web canvas). */
-export const MAHJONG_HINT_GLOW_SHADOW = "rgba(93,188,210,0.7)";
+/** Mahjong hint tile glow — blue shadow effect (web canvas). */
+export const MAHJONG_HINT_GLOW_SHADOW = "rgba(93,188,210,0.9)";

--- a/frontend/src/theme/theme.constants.ts
+++ b/frontend/src/theme/theme.constants.ts
@@ -48,6 +48,9 @@ export const MAHJONG_GLOW_BG = "rgba(255,215,0,0.35)";
 /** Mahjong selected tile glow — stronger gold shadow effect. */
 export const MAHJONG_GLOW_SHADOW = "rgba(255,215,0,0.7)";
 
+/** Mahjong hint tile accent colour — used for borders, text, and glow tints. */
+export const MAHJONG_HINT_COLOR = "#5dbcd2";
+
 /** Mahjong hint tile glow — blue background for matching free tiles. */
 export const MAHJONG_HINT_GLOW_BG = "rgba(93,188,210,0.65)";
 


### PR DESCRIPTION
## Summary

- Moves the HINT button from the cluttered HUD row into the AppHeader `rightSlot` alongside UNDO, so all game-action buttons live together in the top bar
- Splits the HUD row into two logical groups — stats (SCORE / PAIRS) on the left, controls (SHUFFLE / DEAL #) on the right — using gap-based spacing instead of cramming five items with `space-between`
- Increases hint glow opacity (0.35 → 0.65) and expands the glow rect (±2 px → ±4 px) so the hint highlight is clearly visible on small mobile tiles

Closes #1888, closes #1889

## Before / After

**Before:**
- AppHeader: `← Back | Mahjong Solit... | [UNDO] | [⊙]`
- HUD row: `SCORE 0   PAIRS 0/72   [SHUFFLE 3]   DEAL #02ED   [HINT]`

**After:**
- AppHeader: `← Back | Mahjong Solitaire | [UNDO] [HINT] | [⊙]`
- HUD row: `SCORE 0   PAIRS 0/72` ············ `[SHUFFLE 3]   DEAL #02ED`

## Test plan

- [ ] Start a Mahjong game — verify header shows UNDO + HINT together in top-right, and HUD row has two clean groups
- [ ] Press HINT — two tiles should glow blue visibly for ~2 seconds
- [ ] Press HINT on a deadlocked board — "No hints available" toast appears
- [ ] UNDO still works normally
- [ ] SHUFFLE button and DEAL # display correctly in HUD

https://claude.ai/code/session_01CLcYzPxCPRoHEzD81nY4HA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLcYzPxCPRoHEzD81nY4HA)_