### PR TITLE
feat(daily-word): cache today's puzzle metadata for offline play (#1886)

### DIFF
--- a/frontend/src/game/daily_word/__tests__/storage.test.ts
+++ b/frontend/src/game/daily_word/__tests__/storage.test.ts
@@ -1,6 +1,13 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import { saveState, loadState, clearState, looksValid, saveTodayMeta, loadTodayMeta } from "../storage";
+import {
+  saveState,
+  loadState,
+  clearState,
+  looksValid,
+  saveTodayMeta,
+  loadTodayMeta,
+} from "../storage";
 import { initialState } from "../engine";
 
 const STORAGE_KEY = "daily_word_state_v1";

--- a/frontend/src/game/daily_word/__tests__/storage.test.ts
+++ b/frontend/src/game/daily_word/__tests__/storage.test.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
-import { saveState, loadState, clearState, looksValid } from "../storage";
+import { saveState, loadState, clearState, looksValid, saveTodayMeta, loadTodayMeta } from "../storage";
 import { initialState } from "../engine";
 
 const STORAGE_KEY = "daily_word_state_v1";
@@ -75,5 +75,35 @@ describe("looksValid", () => {
   it("rejects rows.length > 6", () => {
     const s = initialState("2026-05-03:en", 5, "en");
     expect(looksValid({ ...s, rows: [...s.rows, ...s.rows] })).toBe(false);
+  });
+});
+
+describe("saveTodayMeta / loadTodayMeta", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it("round-trip save/load for today's date key", async () => {
+    const meta = { puzzle_id: "2026-05-31:en", word_length: 5 };
+    await saveTodayMeta("2026-05-31_en", meta);
+    const loaded = await loadTodayMeta("2026-05-31_en");
+    expect(loaded).toEqual(meta);
+  });
+
+  it("returns null for a different date key (cache miss)", async () => {
+    const meta = { puzzle_id: "2026-05-30:en", word_length: 5 };
+    await saveTodayMeta("2026-05-30_en", meta);
+    expect(await loadTodayMeta("2026-05-31_en")).toBeNull();
+  });
+
+  it("returns null when nothing has been saved", async () => {
+    expect(await loadTodayMeta("2026-05-31_en")).toBeNull();
+  });
+
+  it("overwrites previous entry for the same date key", async () => {
+    await saveTodayMeta("2026-05-31_en", { puzzle_id: "2026-05-31:en", word_length: 5 });
+    const updated = { puzzle_id: "2026-05-31:en", word_length: 6 };
+    await saveTodayMeta("2026-05-31_en", updated);
+    expect(await loadTodayMeta("2026-05-31_en")).toEqual(updated);
   });
 });

--- a/frontend/src/game/daily_word/storage.ts
+++ b/frontend/src/game/daily_word/storage.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Sentry from "@sentry/react-native";
 import type { DailyWordState } from "./types";
+import type { TodayResponse } from "./api";
 
 const STORAGE_KEY = "daily_word_state_v1";
 
@@ -51,5 +52,25 @@ export async function clearState(): Promise<void> {
     await AsyncStorage.removeItem(STORAGE_KEY);
   } catch (e) {
     Sentry.captureException(e, { tags: { subsystem: "daily_word.storage", op: "clear" } });
+  }
+}
+
+const TODAY_META_KEY_PREFIX = "daily_word_today_";
+
+export async function saveTodayMeta(dateKey: string, meta: TodayResponse): Promise<void> {
+  try {
+    await AsyncStorage.setItem(`${TODAY_META_KEY_PREFIX}${dateKey}`, JSON.stringify(meta));
+  } catch (e) {
+    Sentry.captureException(e, { tags: { subsystem: "daily_word.storage", op: "saveTodayMeta" } });
+  }
+}
+
+export async function loadTodayMeta(dateKey: string): Promise<TodayResponse | null> {
+  try {
+    const raw = await AsyncStorage.getItem(`${TODAY_META_KEY_PREFIX}${dateKey}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as TodayResponse;
+  } catch {
+    return null;
   }
 }

--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -49,7 +49,13 @@ import {
 import type { DailyWordState, TileStatus } from "../game/daily_word/types";
 import { dailyWordApi } from "../game/daily_word/api";
 import { withRetry } from "../game/_shared/withRetry";
-import { loadState, saveState, clearState, saveTodayMeta, loadTodayMeta } from "../game/daily_word/storage";
+import {
+  loadState,
+  saveState,
+  clearState,
+  saveTodayMeta,
+  loadTodayMeta,
+} from "../game/daily_word/storage";
 import { ApiError } from "../game/_shared/httpClient";
 import { devLog } from "../game/daily_word/devLog";
 import type { DevLogEntry } from "../game/daily_word/devLog";

--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -49,7 +49,7 @@ import {
 import type { DailyWordState, TileStatus } from "../game/daily_word/types";
 import { dailyWordApi } from "../game/daily_word/api";
 import { withRetry } from "../game/_shared/withRetry";
-import { loadState, saveState, clearState } from "../game/daily_word/storage";
+import { loadState, saveState, clearState, saveTodayMeta, loadTodayMeta } from "../game/daily_word/storage";
 import { ApiError } from "../game/_shared/httpClient";
 import { devLog } from "../game/daily_word/devLog";
 import type { DevLogEntry } from "../game/daily_word/devLog";
@@ -95,6 +95,16 @@ function msUntilMidnight(tzOffsetMinutes: number): number {
   const localMs = nowMs + tzOffsetMs;
   const startOfLocalDayMs = Math.floor(localMs / 86400000) * 86400000;
   return startOfLocalDayMs + 86400000 - localMs;
+}
+
+function localDateKey(tzOffsetMinutes: number, lang: string): string {
+  const localMs = Date.now() + tzOffsetMinutes * 60_000;
+  const dayMs = Math.floor(localMs / 86_400_000) * 86_400_000;
+  const d = new Date(dayMs);
+  const y = d.getUTCFullYear();
+  const mo = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dy = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${mo}-${dy}_${lang}`;
 }
 
 function formatCountdown(ms: number): string {
@@ -703,13 +713,27 @@ export default function DailyWordScreen() {
     let alive = true;
 
     async function load() {
+      const dateKey = localDateKey(tzOffset, language);
       try {
         const [todayMeta, saved] = await Promise.all([
-          withRetry(() => dailyWordApi.getToday(tzOffset, language)),
+          withRetry(() => dailyWordApi.getToday(tzOffset, language))
+            .then((meta) => {
+              saveTodayMeta(dateKey, meta).catch(() => {});
+              return meta;
+            })
+            // Only serve cached meta on network failures (TypeError). HTTP errors
+            // such as 401 mean the server is actively denying access — falling
+            // back to cache would bypass that.
+            .catch((e) => (e instanceof TypeError ? loadTodayMeta(dateKey) : null)),
           loadState(),
         ]);
 
         if (!alive) return;
+
+        if (!todayMeta) {
+          setLoadError(t("error.couldNotLoad"));
+          return;
+        }
 
         hasLoadedRef.current = true;
 

--- a/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
+++ b/frontend/src/screens/__tests__/DailyWordScreen.test.tsx
@@ -45,6 +45,8 @@ jest.mock("../../game/daily_word/storage", () => ({
   loadState: jest.fn(),
   saveState: jest.fn(),
   clearState: jest.fn(),
+  saveTodayMeta: jest.fn().mockResolvedValue(undefined),
+  loadTodayMeta: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock("expo-haptics", () => ({
@@ -68,6 +70,8 @@ const storage = jest.requireMock("../../game/daily_word/storage") as {
   loadState: jest.Mock;
   saveState: jest.Mock;
   clearState: jest.Mock;
+  saveTodayMeta: jest.Mock;
+  loadTodayMeta: jest.Mock;
 };
 
 // ---------------------------------------------------------------------------
@@ -153,6 +157,8 @@ beforeEach(() => {
   storage.loadState.mockResolvedValue(null);
   storage.saveState.mockResolvedValue(undefined);
   storage.clearState.mockResolvedValue(undefined);
+  storage.saveTodayMeta.mockResolvedValue(undefined);
+  storage.loadTodayMeta.mockResolvedValue(null); // cold cache by default
 });
 
 // ---------------------------------------------------------------------------
@@ -267,5 +273,71 @@ describe("DailyWordScreen — TypeError auto-retry (#1861)", () => {
     await findByText("Could not load today's puzzle");
     // 1 initial + 3 retries = 4 total calls
     expect(dailyWordApi.getToday).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("DailyWordScreen — offline today-meta cache (#1886)", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("serves cached meta when API fails and cache is warm", async () => {
+    jest.useFakeTimers();
+    dailyWordApi.getToday.mockRejectedValue(new TypeError("Network request failed"));
+    storage.loadTodayMeta.mockResolvedValue(TODAY_META);
+
+    const { findByTestId, queryByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await findByTestId("tile-0-0");
+    expect(queryByText("Could not load today's puzzle")).toBeNull();
+  });
+
+  it("shows error when API fails and cache is cold", async () => {
+    jest.useFakeTimers();
+    dailyWordApi.getToday.mockRejectedValue(new TypeError("Network request failed"));
+    storage.loadTodayMeta.mockResolvedValue(null);
+
+    const { findByText } = renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await findByText("Could not load today's puzzle");
+  });
+
+  it("writes the cache on a successful fetch", async () => {
+    const { findByTestId } = renderScreen();
+    await findByTestId("tile-0-0");
+    expect(storage.saveTodayMeta).toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}_en$/),
+      TODAY_META
+    );
+  });
+
+  it("does not write the cache when the fetch fails", async () => {
+    jest.useFakeTimers();
+    dailyWordApi.getToday.mockRejectedValue(new TypeError("Network request failed"));
+
+    renderScreen();
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    expect(storage.saveTodayMeta).not.toHaveBeenCalled();
+  });
+
+  it("does not serve cache on non-network errors", async () => {
+    dailyWordApi.getToday.mockRejectedValue(new Error("ApiError: 401 Unauthorized"));
+    storage.loadTodayMeta.mockResolvedValue(TODAY_META);
+
+    const { findByText } = renderScreen();
+
+    await findByText("Could not load today's puzzle");
+    expect(storage.loadTodayMeta).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `saveTodayMeta` / `loadTodayMeta` to `game/daily_word/storage.ts`, keyed by `daily_word_today_YYYY-MM-DD_lang` so yesterday's cache is never silently reused
- On a successful `getToday` response, writes the meta to AsyncStorage (fire-and-forget)
- On network failure (TypeError) after all `withRetry` attempts exhaust, falls back to the cached meta so a returning user can see the puzzle grid offline
- HTTP errors (401, 404, etc.) bypass the cache — server-side denials are respected
- Guess submission remains online-only (out of scope per issue)

## Test plan

- [x] `storage.test.ts`: round-trip, cache miss (wrong date key), overwrite, empty
- [x] `DailyWordScreen.test.tsx`: warm cache → grid renders, cold cache → error shown, successful fetch → cache written, failed fetch → cache not written, non-network error → cache not consulted

Closes #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)