### PR TITLE
fix(deps): bump PyJWT 2.12.0 → 2.13.0 (PYSEC-2026-175–179)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,6 @@ asyncpg==0.30.0
 psycopg2-binary==2.9.10
 aiosqlite==0.20.0
 alembic==1.14.0
-PyJWT==2.12.0
+PyJWT==2.13.0
 cryptography==46.0.7
 PyYAML==6.0.3


### PR DESCRIPTION
## Summary

- Bumps `PyJWT` from `2.12.0` to `2.13.0` in `backend/requirements.txt`
- Fixes 5 advisories published against 2.12.0: PYSEC-2026-175, PYSEC-2026-176, PYSEC-2026-177, PYSEC-2026-178, PYSEC-2026-179
- Caught by the `pip-audit` CI gate added in #846

This PR is unrelated to any feature work — the vulnerability was published in the 4 days since the last clean `dev` run and surfaced when PR #1929 ran CI.

## Test plan

- [x] `pip install PyJWT==2.13.0` installs cleanly in the backend venv
- [x] `pytest tests/` — 572 passed, 2 skipped (96% coverage)
- [ ] CI `cve-python` check passes green

## Related

- Closes (unblocks) pip-audit gate failure on #1929
- Ref #846 — security: pip-audit + npm audit gates in CI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)