### PR TITLE
chore: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Frontend (npm)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      expo:
+        patterns: ["expo*", "@expo/*"]
+      react-navigation:
+        patterns: ["@react-navigation/*"]
+
+  # Backend (pip)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` covering npm (frontend), pip (backend), and GitHub Actions
- Weekly schedule for all three ecosystems
- Expo and React Navigation bumps grouped into single PRs to reduce noise
- `open-pull-requests-limit` set to 10 (npm) and 5 (pip/actions) to cap noise

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML and passes GitHub's schema validation
- [ ] After merge, verify Dependabot appears under **Insights → Dependency graph → Dependabot** in the repo

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)