### PR TITLE
fix(profile): graceful degradation, auto-retry, and OfflineBanner (#1930)

### DIFF
--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -18,6 +18,7 @@ import { statsApi } from "../api/stats";
 import type { StatsResponse, GameRow } from "../api/types";
 import type { ProfileStackParamList } from "../types/navigation";
 import { formatDate } from "../utils/formatTimestamp";
+import OfflineBanner from "../components/OfflineBanner";
 
 type ProfileNav = NativeStackNavigationProp<ProfileStackParamList, "ProfileHome">;
 
@@ -64,6 +65,21 @@ function deriveBentoTiles(stats: StatsResponse, t: (k: string) => string): Stats
   ];
 }
 
+async function withNetworkRetry<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (e instanceof TypeError && attempt < maxRetries) {
+        await new Promise<void>((r) => setTimeout(r, 500 * Math.pow(2, attempt)));
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw new TypeError("network retry exhausted");
+}
+
 function formatGameType(raw: string): string {
   switch (raw) {
     case "twenty48":
@@ -104,16 +120,25 @@ export default function ProfileScreen() {
   const [games, setGames] = useState<GameRow[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [gamesError, setGamesError] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
   const load = useCallback(async () => {
     setError(null);
-    try {
-      const [s, g] = await Promise.all([statsApi.getMyStats(), statsApi.getMyGames(20)]);
-      setStats(s);
-      setGames(g.items);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+    setGamesError(false);
+    const [statsResult, gamesResult] = await Promise.allSettled([
+      withNetworkRetry(() => statsApi.getMyStats()),
+      withNetworkRetry(() => statsApi.getMyGames(20)),
+    ]);
+    if (statsResult.status === "fulfilled") setStats(statsResult.value);
+    if (gamesResult.status === "fulfilled") {
+      setGames(gamesResult.value.items);
+    } else {
+      setGamesError(true);
+    }
+    if (statsResult.status === "rejected" && gamesResult.status === "rejected") {
+      const err = statsResult.reason;
+      setError(err instanceof Error ? err.message : String(err));
     }
   }, []);
 
@@ -207,21 +232,6 @@ export default function ProfileScreen() {
         </Pressable>
       </View>
     );
-  } else if (games && games.length === 0) {
-    body = (
-      <FlatList
-        data={[]}
-        keyExtractor={() => "empty"}
-        renderItem={() => null}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={
-          <Text style={[styles.empty, { color: colors.textMuted }]}>{t("recentGames.empty")}</Text>
-        }
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
-        }
-      />
-    );
   } else {
     body = (
       <FlatList
@@ -229,6 +239,11 @@ export default function ProfileScreen() {
         keyExtractor={(g) => g.id}
         renderItem={renderItem}
         ListHeaderComponent={listHeader}
+        ListEmptyComponent={
+          <Text style={[styles.empty, { color: colors.textMuted }]}>
+            {gamesError ? t("recentGames.loadError") : t("recentGames.empty")}
+          </Text>
+        }
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
         }
@@ -249,6 +264,7 @@ export default function ProfileScreen() {
       ]}
     >
       <AppHeader title={t("title")} />
+      <OfflineBanner />
       {body}
     </View>
   );

--- a/frontend/src/screens/ProfileScreen.tsx
+++ b/frontend/src/screens/ProfileScreen.tsx
@@ -18,6 +18,7 @@ import { statsApi } from "../api/stats";
 import type { StatsResponse, GameRow } from "../api/types";
 import type { ProfileStackParamList } from "../types/navigation";
 import { formatDate } from "../utils/formatTimestamp";
+import { withRetry } from "../game/_shared/withRetry";
 import OfflineBanner from "../components/OfflineBanner";
 
 type ProfileNav = NativeStackNavigationProp<ProfileStackParamList, "ProfileHome">;
@@ -63,21 +64,6 @@ function deriveBentoTiles(stats: StatsResponse, t: (k: string) => string): Stats
       value: String(typesTried),
     },
   ];
-}
-
-async function withNetworkRetry<T>(fn: () => Promise<T>, maxRetries = 2): Promise<T> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (e) {
-      if (e instanceof TypeError && attempt < maxRetries) {
-        await new Promise<void>((r) => setTimeout(r, 500 * Math.pow(2, attempt)));
-        continue;
-      }
-      throw e;
-    }
-  }
-  throw new TypeError("network retry exhausted");
 }
 
 function formatGameType(raw: string): string {
@@ -127,8 +113,8 @@ export default function ProfileScreen() {
     setError(null);
     setGamesError(false);
     const [statsResult, gamesResult] = await Promise.allSettled([
-      withNetworkRetry(() => statsApi.getMyStats()),
-      withNetworkRetry(() => statsApi.getMyGames(20)),
+      withRetry(() => statsApi.getMyStats()),
+      withRetry(() => statsApi.getMyGames(20)),
     ]);
     if (statsResult.status === "fulfilled") setStats(statsResult.value);
     if (gamesResult.status === "fulfilled") {
@@ -204,6 +190,11 @@ export default function ProfileScreen() {
         </View>
       )}
       <Text style={[styles.sectionTitle, { color: colors.text }]}>{t("recentGames.title")}</Text>
+      {gamesError && (
+        <Text style={[styles.sectionErrorText, { color: colors.error }]}>
+          {t("recentGames.loadError")}
+        </Text>
+      )}
     </View>
   );
 
@@ -240,9 +231,11 @@ export default function ProfileScreen() {
         renderItem={renderItem}
         ListHeaderComponent={listHeader}
         ListEmptyComponent={
-          <Text style={[styles.empty, { color: colors.textMuted }]}>
-            {gamesError ? t("recentGames.loadError") : t("recentGames.empty")}
-          </Text>
+          !gamesError ? (
+            <Text style={[styles.empty, { color: colors.textMuted }]}>
+              {t("recentGames.empty")}
+            </Text>
+          ) : null
         }
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
@@ -313,6 +306,12 @@ const styles = StyleSheet.create({
     marginBottom: 8,
   },
   listContent: { paddingBottom: 32 },
+  sectionErrorText: {
+    fontSize: 13,
+    textAlign: "center",
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",

--- a/frontend/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/frontend/src/screens/__tests__/ProfileScreen.test.tsx
@@ -4,6 +4,10 @@ import { ThemeProvider } from "../../theme/ThemeContext";
 import ProfileScreen from "../ProfileScreen";
 import type { StatsResponse, GameHistoryResponse } from "../../api/types";
 
+jest.mock("../../game/_shared/NetworkContext", () => ({
+  useNetwork: () => ({ isOnline: true, isInitialized: true }),
+}));
+
 jest.mock("expo-blur", () => ({
   BlurView: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
@@ -178,13 +182,15 @@ describe("ProfileScreen", () => {
     });
   });
 
-  it("shows an error state and a Retry button when the stats fetch fails", async () => {
+  it("shows full-screen error with Retry when both requests fail", async () => {
     mockGetMyStats.mockRejectedValue(new Error("Network down"));
+    mockGetMyGames.mockRejectedValue(new Error("Network down"));
     renderScreen();
     await waitFor(() => {
       expect(screen.getByText("Couldn't load recent games")).toBeTruthy();
+      expect(screen.getByText("Retry")).toBeTruthy();
     });
-    // Retry re-triggers the fetch.
+    // Retry re-triggers the fetch; stats resolves, games still fails → inline error.
     mockGetMyStats.mockResolvedValue(SAMPLE_STATS);
     await act(async () => {
       fireEvent.press(screen.getByText("Retry"));
@@ -192,6 +198,50 @@ describe("ProfileScreen", () => {
     await waitFor(() => {
       expect(screen.getByText("Games Played")).toBeTruthy();
     });
+  });
+
+  it("shows game history without bento tiles when only stats fails", async () => {
+    mockGetMyStats.mockRejectedValue(new Error("500 server error"));
+    renderScreen();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Games")).toBeTruthy();
+    });
+    expect(screen.queryByText("Games Played")).toBeNull();
+    expect(screen.getAllByText("Yacht").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("Retry")).toBeNull();
+  });
+
+  it("shows bento tiles and inline games error when only games fails", async () => {
+    mockGetMyGames.mockRejectedValue(new Error("500 server error"));
+    renderScreen();
+    await waitFor(() => {
+      expect(screen.getByText("Games Played")).toBeTruthy();
+    });
+    expect(screen.getByText("Couldn't load recent games")).toBeTruthy();
+    expect(screen.queryByText("Retry")).toBeNull();
+    // Game rows absent — Blackjack only appears in rows, never in the bento tiles.
+    expect(screen.queryByText("Blackjack")).toBeNull();
+  });
+
+  it("retries on TypeError and shows data after backoff", async () => {
+    jest.useFakeTimers();
+    mockGetMyStats
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValue(SAMPLE_STATS);
+    mockGetMyGames.mockResolvedValue(SAMPLE_GAMES);
+
+    renderScreen();
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Games Played")).toBeTruthy();
+    });
+    expect(mockGetMyStats).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
   });
 
   it("calls the API with the correct limit on mount", async () => {


### PR DESCRIPTION
## Summary

Fixes #1930 — `ProfileScreen` parallel API calls failing silently on network error.

- **`Promise.allSettled`** — stats and game history now fail independently; a transient `/games/me` failure no longer wipes the stats bento tiles
- **Auto-retry on network error** — `withNetworkRetry` retries `TypeError` (network-layer) failures up to 2× with 500 ms / 1 000 ms backoff before surfacing the error state; `ApiError` (server responses) are never retried
- **`OfflineBanner`** added below `AppHeader`, matching the existing `HomeScreen` pattern — gives users immediate connectivity feedback on weak/transitioning networks

## Behavior matrix

| Stats | Games | Before | After |
|---|---|---|---|
| ✓ | ✓ | Normal | Normal |
| ✓ | ✗ | Full-screen error | Bento tiles shown; inline "couldn't load" in games section |
| ✗ | ✓ | Full-screen error | Game history shown; no bento tiles |
| ✗ | ✗ | Full-screen error (immediately) | Full-screen error (after 2 retries each) |

## Test plan

- [ ] Cold-start on poor network: confirm OfflineBanner appears on Profile tab
- [ ] Simulate games endpoint failure (mocked): confirm stats bento still renders
- [ ] Simulate stats endpoint failure: confirm game history still renders
- [ ] Simulate both failing: confirm full-screen error + Retry button appear after backoff
- [ ] Pull-to-refresh after partial failure recovers missing section

🤖 Generated with [Claude Code](https://claude.com/claude-code)