### PR TITLE
fix(yacht): AI hold/score bugs + joker bonus in VS scorecard

### DIFF
--- a/frontend/src/components/yacht/VsScorecard.tsx
+++ b/frontend/src/components/yacht/VsScorecard.tsx
@@ -15,9 +15,11 @@ export interface VsScorecardProps {
   playerRollsUsed: number;
   playerGameOver: boolean;
   playerUpperBonus: number;
+  playerYachtBonusTotal: number;
   playerTotalScore: number;
   cpuScores: Record<string, number | null>;
   cpuUpperBonus: number;
+  cpuYachtBonusTotal: number;
   cpuTotalScore: number;
   isAiTurn: boolean;
   onScore: (category: string) => void;
@@ -29,9 +31,11 @@ export default function VsScorecard({
   playerRollsUsed,
   playerGameOver,
   playerUpperBonus,
+  playerYachtBonusTotal,
   playerTotalScore,
   cpuScores,
   cpuUpperBonus,
+  cpuYachtBonusTotal,
   cpuTotalScore,
   isAiTurn,
   onScore,
@@ -248,6 +252,41 @@ export default function VsScorecard({
     );
   }
 
+  function renderJokerBonusRow() {
+    if (playerYachtBonusTotal === 0 && cpuYachtBonusTotal === 0) return null;
+    return (
+      <View style={[styles.vsRow, styles.vsBonusRow, { borderBottomColor: colors.border }]}>
+        <View style={styles.vsRowLeft}>
+          <Text style={[styles.vsBonusLbl, { color: colors.textMuted }]}>
+            {t("bonus.yachtLabel")}
+          </Text>
+        </View>
+        <View style={[styles.vsCell, { backgroundColor: "transparent" }]}>
+          <Text
+            style={{
+              color: playerYachtBonusTotal > 0 ? colors.bonus : colors.textMuted,
+              fontSize: 15,
+              fontWeight: "700",
+            }}
+          >
+            {playerYachtBonusTotal > 0 ? `+${playerYachtBonusTotal}` : "—"}
+          </Text>
+        </View>
+        <View style={[styles.vsCell, { backgroundColor: "transparent" }]}>
+          <Text
+            style={{
+              color: cpuYachtBonusTotal > 0 ? colors.bonus : colors.textMuted,
+              fontSize: 15,
+              fontWeight: "700",
+            }}
+          >
+            {cpuYachtBonusTotal > 0 ? `+${cpuYachtBonusTotal}` : "—"}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <ScrollView
       focusable={Platform.OS === "web"}
@@ -276,6 +315,7 @@ export default function VsScorecard({
         {(LOWER_CATEGORY_KEYS as readonly string[]).map((key, i) =>
           renderCategoryRow(key, "lower", i === LOWER_CATEGORY_KEYS.length - 1)
         )}
+        {renderJokerBonusRow()}
         {renderSubtotalRow(t("vsMode.lowerSubtotal"), playerLowerSubtotal, cpuLowerSubtotal, false)}
       </View>
 

--- a/frontend/src/game/yacht/__tests__/ai.test.ts
+++ b/frontend/src/game/yacht/__tests__/ai.test.ts
@@ -110,6 +110,44 @@ describe("holdStrategy — Medium", () => {
     expect(heldDice.every((d) => d === 4)).toBe(true);
   });
 
+  it("holds only trips (not all 5) when full_house is already scored", () => {
+    const state = withScores(makeGame([3, 3, 3, 5, 5]), { full_house: 25 });
+    const held = holdStrategy(state, "medium");
+    const heldDice = state.dice.filter((_, i) => held[i]);
+    expect(heldDice.every((d) => d === 3)).toBe(true);
+    expect(heldDice).toHaveLength(3);
+  });
+
+  it("does not hold 5-run when both large_straight and small_straight are already scored", () => {
+    const state = withScores(makeGame([1, 2, 3, 4, 5]), {
+      large_straight: 40,
+      small_straight: 30,
+    });
+    const held = holdStrategy(state, "medium");
+    expect(held).not.toEqual([true, true, true, true, true]);
+  });
+
+  it("does not hold 4-run when both straights are already scored", () => {
+    const state = withScores(makeGame([1, 2, 3, 4, 6]), {
+      large_straight: 40,
+      small_straight: 30,
+    });
+    const held = holdStrategy(state, "medium");
+    const heldDice = state.dice.filter((_, i) => held[i]).sort((a, b) => a - b);
+    expect(heldDice).not.toEqual([1, 2, 3, 4]);
+  });
+
+  it("does not hold 3-run when both straights are already scored", () => {
+    const state = withScores(makeGame([1, 2, 3, 5, 5]), {
+      large_straight: 40,
+      small_straight: 30,
+    });
+    const held = holdStrategy(state, "medium");
+    // With both straights gone, run is useless — should hold the pair of 5s instead
+    const heldDice = state.dice.filter((_, i) => held[i]);
+    expect(heldDice.every((d) => d === 5)).toBe(true);
+  });
+
   it("pursues upper bonus when toBonus > 0 — holds open face appearing ≥2 times", () => {
     // upperSubtotal = ones(3)+twos(6) = 9 → toBonus = 54
     // dice [4,4,1,6,2]: no run ≥3, no trips; fours is open and appears twice → hold 4s
@@ -297,6 +335,21 @@ describe("scoreStrategy — Medium", () => {
     });
     expect(scoreStrategy(state, "medium")).toBe("fives");
   });
+
+  it("Joker: picks highest-value open lower cat, not hard-coded full_house (25 pts)", () => {
+    // yacht=50 (joker active), sixes filled, large_straight filled, four_of_a_kind scored 0
+    // Joker legal set: three_of_a_kind=30, full_house=25, small_straight=30, chance=30
+    // Without the fix, scoreMedium's "always take full_house" branch fires → 25 pts.
+    // With the fix, bestInLegal returns one of the 30-pt options.
+    const state = withScores(makeGame([6, 6, 6, 6, 6], 3), {
+      yacht: 50,
+      sixes: 30,
+      large_straight: 40,
+      four_of_a_kind: 0,
+    });
+    const cat = scoreStrategy(state, "medium");
+    expect(cat).not.toBe("full_house");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -370,6 +423,18 @@ describe("scoreStrategy — Hard", () => {
     // [5,5,5,2,1]: fives open, cnt=3 → par pursuit returns fives (15 pts).
     const state = withScores(makeGame([5, 5, 5, 2, 1], 3), { full_house: 25 });
     expect(scoreStrategy(state, "hard", 0)).toBe("fives");
+  });
+
+  it("Joker: picks highest-value open lower cat, not hard-coded full_house (25 pts)", () => {
+    // Same setup as Medium Joker test — verifies Hard also short-circuits to bestInLegal.
+    const state = withScores(makeGame([6, 6, 6, 6, 6], 3), {
+      yacht: 50,
+      sixes: 30,
+      large_straight: 40,
+      four_of_a_kind: 0,
+    });
+    const cat = scoreStrategy(state, "hard", 0);
+    expect(cat).not.toBe("full_house");
   });
 
   it("takes bonus-closing upper category over three_of_a_kind", () => {

--- a/frontend/src/game/yacht/ai.ts
+++ b/frontend/src/game/yacht/ai.ts
@@ -59,6 +59,12 @@ function isOpen(scores: GameState["scores"], cat: Category): boolean {
   return scores[cat] === null || scores[cat] === undefined;
 }
 
+/** True when the current roll is a Joker (all-same dice with yacht already scored). */
+function isJokerRoll(dice: readonly number[], scores: GameState["scores"]): boolean {
+  const c = faceCounts(dice);
+  return c.size === 1 && (dice[0] ?? 0) > 0 && scores.yacht === 50;
+}
+
 /** Returns the highest-scoring category from a pre-computed legal move set. */
 function bestInLegal(legal: Record<string, number>): Category | null {
   let bestCat: Category | null = null;
@@ -184,29 +190,30 @@ function holdEasy(dice: readonly number[]): boolean[] {
 function holdMedium(dice: readonly number[], scores: GameState["scores"]): boolean[] {
   const counts = faceCounts(dice);
   const toBonus = Math.max(0, 63 - upperSubtotal(scores));
+  const straightOpen = isOpen(scores, "large_straight") || isOpen(scores, "small_straight");
 
   // 4+ of a kind: lock those
   for (const [face, cnt] of counts) {
     if (cnt >= 4) return holdFace(dice, face);
   }
 
-  // Full house already in hand (3+2): keep all
+  // Full house already in hand (3+2): keep all — only if full_house is still open
   const sortedCnts = [...counts.values()].sort((a, b) => b - a);
-  if (sortedCnts[0] === 3 && (sortedCnts[1] ?? 0) >= 2) {
+  if (sortedCnts[0] === 3 && (sortedCnts[1] ?? 0) >= 2 && isOpen(scores, "full_house")) {
     return [true, true, true, true, true];
   }
 
-  // 5-run: keep all
-  if (longestRunFaces(dice, 5)) return [true, true, true, true, true];
+  // 5-run: keep all — only if a straight category is still open
+  if (longestRunFaces(dice, 5) && straightOpen) return [true, true, true, true, true];
 
   // Trips: hold the 3
   for (const [face, cnt] of counts) {
     if (cnt === 3) return holdFace(dice, face);
   }
 
-  // 4-run: hold the run to complete a large straight
+  // 4-run: hold the run to complete a large straight — only if a straight is open
   const run4 = longestRunFaces(dice, 4);
-  if (run4) return holdForRun(dice, run4);
+  if (run4 && straightOpen) return holdForRun(dice, run4);
 
   // Upper bonus pursuit: hold the best open upper face.
   // Threshold: ≥2 of any face, or ≥1 for high-value faces (5,6) whose par scores
@@ -227,9 +234,9 @@ function holdMedium(dice: readonly number[], scores: GameState["scores"]): boole
     if (bestFace > 0 && bestCnt >= minCnt) return holdFace(dice, bestFace);
   }
 
-  // 3-run: keep for potential small/large straight
+  // 3-run: keep for potential small/large straight — only if a straight is open
   const run3 = longestRunFaces(dice, 3);
-  if (run3) return holdForRun(dice, run3);
+  if (run3 && straightOpen) return holdForRun(dice, run3);
 
   // Highest pair
   let bestPairFace = 0;
@@ -332,6 +339,9 @@ function scoreMedium(
   const s = diceSum(dice);
   const counts = faceCounts(dice);
 
+  // Joker: jokerPossibleScores already enforces priority rules; just pick highest value.
+  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
+
   // Yacht — always take 50 pts
   if ("yacht" in legal && legal["yacht"] === 50) return "yacht";
 
@@ -404,6 +414,9 @@ function scoreHard(
   const myScore = Object.values(scores).reduce<number>((acc, v) => acc + (v ?? 0), 0);
   const trailing = myScore < opponentScore - 30;
   const leading = myScore > opponentScore + 50;
+
+  // Joker: jokerPossibleScores already enforces priority rules; just pick highest value.
+  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
 
   // Always take Yacht
   if ("yacht" in legal && legal["yacht"] === 50) return "yacht";

--- a/frontend/src/game/yacht/ai.ts
+++ b/frontend/src/game/yacht/ai.ts
@@ -266,10 +266,8 @@ function holdHard(
     // Only the final hold (rollsUsed === 2) warrants full EV enumeration.
     // For earlier holds — or if called unexpectedly at rollsUsed === 0 —
     // fall back to the medium heuristic. 2-step lookahead is O(6^10) and
-    // infeasible at runtime.
-    // Note: the bonus proximity override below does NOT apply here; holdMedium's
-    // 4-run check fires before its bonus pursuit, so Hard still chases straights
-    // on rolls 1 and 2. Fixing that path is a separate concern.
+    // infeasible at runtime. The holdMedium already-scored-category guards
+    // (full_house, straights) therefore apply to Hard rolls 1 and 2 as well.
     return holdMedium(dice, scores);
   }
 
@@ -339,11 +337,12 @@ function scoreMedium(
   const s = diceSum(dice);
   const counts = faceCounts(dice);
 
-  // Joker: jokerPossibleScores already enforces priority rules; just pick highest value.
-  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
-
   // Yacht — always take 50 pts
   if ("yacht" in legal && legal["yacht"] === 50) return "yacht";
+
+  // Joker: yacht is already scored when isJokerRoll is true, so the Yacht branch above is
+  // unreachable for jokers. jokerPossibleScores enforces priority rules; just pick highest value.
+  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
 
   // Bonus-closing: scoring this upper cat reaches ≥ 63; the deferred +35 beats most combos.
   // cnt >= 3 of any face makes a legal large straight impossible, so this safely fires before
@@ -415,11 +414,12 @@ function scoreHard(
   const trailing = myScore < opponentScore - 30;
   const leading = myScore > opponentScore + 50;
 
-  // Joker: jokerPossibleScores already enforces priority rules; just pick highest value.
-  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
-
   // Always take Yacht
   if ("yacht" in legal && legal["yacht"] === 50) return "yacht";
+
+  // Joker: yacht is already scored when isJokerRoll is true, so the Yacht branch above is
+  // unreachable for jokers. jokerPossibleScores enforces priority rules; just pick highest value.
+  if (isJokerRoll(dice, scores)) return bestInLegal(legal) ?? open[0]!;
 
   // Always take Large Straight
   if ("large_straight" in legal && (legal["large_straight"] ?? 0) > 0) return "large_straight";

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -515,9 +515,11 @@ export default function GameScreen({ navigation, route }: Props) {
             playerRollsUsed={gameState.rolls_used}
             playerGameOver={gameState.game_over}
             playerUpperBonus={gameState.upper_bonus}
+            playerYachtBonusTotal={gameState.yacht_bonus_total}
             playerTotalScore={gameState.total_score}
             cpuScores={aiGameState.scores}
             cpuUpperBonus={aiGameState.upper_bonus}
+            cpuYachtBonusTotal={aiGameState.yacht_bonus_total}
             cpuTotalScore={aiGameState.total_score}
             isAiTurn={isAiTurn}
             onScore={handleScore}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **AI hold bugs fixed:** `holdMedium` no longer locks Full House dice when `full_house` is already scored (falls through to trips hold instead), and no longer pursues straight holds (5-run, 4-run, 3-run) when both `large_straight` and `small_straight` are already scored.
- **AI Joker scoring fixed:** `scoreMedium` and `scoreHard` now short-circuit to `bestInLegal` when a Joker is active, ensuring the AI always picks the highest-value legal category (e.g. `small_straight` at 30 pts rather than `full_house` at 25).
- **Joker bonus row in VS scorecard:** `VsScorecard` now shows a Yacht Bonus row during gameplay for both player and CPU, matching the existing solo `Scorecard` behaviour.

## Test plan

- [ ] Play VS mode and score Yacht, then roll a Joker — verify AI applies it to the highest-value open lower category (large_straight > small_straight/three_of_a_kind/chance > full_house)
- [ ] Fill `full_house` early in a VS game; roll a 3+2 — verify AI holds only the 3-of-a-kind, not all 5 dice
- [ ] Fill both straights; roll a 4-run — verify AI does not lock the run, re-rolls instead
- [ ] Score a Joker in VS mode — verify a "Yacht Bonus" row appears in the scorecard with the correct value for both player and CPU
- [ ] Solo mode scorecard joker bonus row still shows correctly (no regression)

Closes #1973

https://claude.ai/code/session_015AYXr7Hgu4jLLtoUWzw6ep
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AYXr7Hgu4jLLtoUWzw6ep)_