### PR TITLE
chore(deps-dev): bump prettier from 3.8.1 to 3.8.3 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,7 @@
         "fast-check": "^3.23.2",
         "jest": "^29.7.0",
         "jest-expo": "~56.0.4",
-        "prettier": "^3.4.0",
+        "prettier": "^3.8.3",
         "sharp": "^0.34.5",
         "source-map-explorer": "^2.5.3",
         "typescript": "~6.0.3"
@@ -14684,9 +14684,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -111,7 +111,7 @@
     "fast-check": "^3.23.2",
     "jest": "^29.7.0",
     "jest-expo": "~56.0.4",
-    "prettier": "^3.4.0",
+    "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "source-map-explorer": "^2.5.3",
     "typescript": "~6.0.3"


### PR DESCRIPTION
Clean resolution of Dependabot PR #1972. Bumps prettier 3.8.1 → 3.8.3 without the yarn.lock conflict.