### PR TITLE
ops(render): rename dev services to bc-arcade-api-dev / bc-arcade-frontend-dev

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -70,7 +70,7 @@ services:
 
   # --- Python FastAPI backend (dev environment) ---
   - type: web
-    name: gaming-app-api-dev
+    name: bc-arcade-api-dev
     runtime: python
     branch: dev
     rootDir: backend
@@ -91,7 +91,7 @@ services:
 
   # --- Expo Web static frontend (dev environment) ---
   - type: web
-    name: gaming-app-frontend-dev
+    name: bc-arcade-frontend-dev
     runtime: static
     branch: dev
     rootDir: frontend


### PR DESCRIPTION
## Summary

- Renames `gaming-app-api-dev` → `bc-arcade-api-dev` in `render.yaml`
- Renames `gaming-app-frontend-dev` → `bc-arcade-frontend-dev` in `render.yaml`

Services were already renamed in the Render dashboard. The Blueprint was failing on every sync because `render.yaml` on `main` still referenced the old names, causing Render to see them as missing and attempt to create conflicting new services.

## Test plan

- [ ] Merge to `dev`, then fast-merge `dev` → `main`
- [ ] Trigger Blueprint re-sync in Render dashboard — should move from `error` → `in_sync`
- [ ] Confirm `bc-arcade-api` and `bc-arcade-frontend` prod services are provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)