### PR TITLE
fix: remove trademark references, add forbidden-terms CI gate, entitlements regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,55 @@ jobs:
           fi
           echo "No conflict markers found"
 
+  forbidden-terms:
+    name: Forbidden brand/trademark terms
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan for trademarked or competitor brand references
+        run: |
+          # Third-party trademarks and competitor brands must not appear in source,
+          # docs, or config. To add a term, append it to TERMS below.
+          # Use \b word-boundary anchors where a term could appear as a substring
+          # of a legitimate word (e.g. "Fruit Merge" vs "fruit merged").
+          #
+          # Intentional exclusions:
+          #   .github/    — this file contains the terms as grep patterns
+          #   .claude/    — tool-config files, not product code
+          #   BRANDING.md — anti-guidance doc ("never say X")
+          #   CLAUDE.md   — project guide that lists prohibited names
+          #   alembic/    — DB migration history; old display names are immutable
+          TERMS=(
+            "Yahtzee"
+            "\bFruit Merge\b"
+            "Galaga"
+            "Neon Arcade"
+          )
+          PATTERN=$(printf "%s\n" "${TERMS[@]}" | paste -sd "|")
+          if grep -rniE "$PATTERN" \
+              --include="*.ts" --include="*.tsx" \
+              --include="*.py" \
+              --include="*.js" --include="*.jsx" \
+              --include="*.json" \
+              --include="*.yml" --include="*.yaml" \
+              --include="*.md" \
+              --exclude-dir=node_modules \
+              --exclude-dir=.git \
+              --exclude-dir=.github \
+              --exclude-dir=.claude \
+              --exclude-dir=alembic \
+              --exclude=BRANDING.md \
+              --exclude=CLAUDE.md \
+              .; then
+            echo "::error::Forbidden brand/trademark references found — remove before merging"
+            exit 1
+          fi
+          echo "No forbidden terms found"
+
   # === Tier 1: Substantive fast checks (need lint + secret-scan) ===========
 
   backend-health:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-backend-health.yml@main
     with:
       # Direct Render origin intentionally used here instead of dev-games-api.buffingchi.com.
@@ -73,14 +118,14 @@ jobs:
     secrets: inherit
 
   expo-compat:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-expo-compat.yml@main
     with:
       working-directory: frontend
     secrets: inherit
 
   sentry-check:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-sentry-check.yml@main
     with:
       working-directory: backend
@@ -88,7 +133,7 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_BC_GAMES }}
 
   local-path-check:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-local-path-check.yml@main
     with:
       scan-paths: "frontend/ios/GamingApp.xcodeproj,frontend/android"
@@ -96,21 +141,21 @@ jobs:
     secrets: inherit
 
   test-python:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-python.yml@main
     with:
       working-directory: backend
     secrets: inherit
 
   test-frontend:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-test-frontend.yml@main
     with:
       working-directory: frontend
     secrets: inherit
 
   cve-python:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-cve-python.yml@main
     with:
       working-directory: backend
@@ -118,7 +163,7 @@ jobs:
     secrets: inherit
 
   cve-frontend:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-cve-frontend.yml@main
     with:
       working-directory: frontend
@@ -126,7 +171,7 @@ jobs:
 
   detect-e2e-scope:
     name: Detect E2E scope
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     runs-on: ubuntu-latest
     outputs:
       projects: ${{ steps.scope.outputs.projects }}
@@ -297,7 +342,7 @@ jobs:
 
   check-i18n:
     name: i18n completeness check
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -314,17 +359,17 @@ jobs:
         working-directory: frontend
 
   openai-policy:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
     secrets: inherit
 
   feedback-token-lint:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-feedback-token-lint.yml@main
     secrets: inherit
 
   provenance-coverage:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     uses: wcmchenry3-stack/.github/.github/workflows/called-provenance-coverage.yml@main
     secrets: inherit
 
@@ -334,7 +379,7 @@ jobs:
   # so it cannot detect issues with the JS bundler or entry-point resolution.
 
   android-bundle-check:
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -512,7 +557,7 @@ jobs:
 
   sentry-cli-check:
     if: github.event_name == 'pull_request'
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -548,7 +593,7 @@ jobs:
 
   gradle-wrapper-check:
     if: github.event_name == 'pull_request'
-    needs: [lint-python, lint-frontend, secret-scan, conflict-markers]
+    needs: [lint-python, lint-frontend, secret-scan, conflict-markers, forbidden-terms]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -426,9 +426,9 @@ A game must be built as a standalone app if it meets **any** of the following th
 5. If assets are 10–20 MB (approaching threshold) → bring to team for review before starting
 6. Document the evaluation result in the game's design document and `GAME-CONTRACT.md` checklist
 
-### Galaga-style game evaluation (worked example)
+### Arcade shooter evaluation (worked example)
 
-A Galaga-style arcade shooter is listed as a potential future paid game. Evaluated against the criteria above:
+A vertical arcade shooter is listed as a potential future paid game. Evaluated against the criteria above:
 
 | Requirement                                           | Estimate                 | Budget impact                |
 | ----------------------------------------------------- | ------------------------ | ---------------------------- |
@@ -439,7 +439,7 @@ A Galaga-style arcade shooter is listed as a potential future paid game. Evaluat
 | Potential native library (GPU particles, 3D elements) | 8–15 MB per ABI          | Standalone trigger           |
 | **Estimated total**                                   | **10–38 MB**             | **Likely exceeds threshold** |
 
-**Provisional verdict:** A Galaga-style game almost certainly exceeds the 20 MB asset threshold and may require a unique native rendering library. **Build as a standalone app if pursued.** Confirm this evaluation against the actual design spec before development begins.
+**Provisional verdict:** An arcade shooter almost certainly exceeds the 20 MB asset threshold and may require a unique native rendering library. **Build as a standalone app if pursued.** Confirm this evaluation against the actual design spec before development begins.
 
 ### Pachisi decision
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -28,7 +28,7 @@ All games are in active development. Nothing is released yet.
 
 | Game        | Category | Notes                                   |
 | ----------- | -------- | --------------------------------------- |
-| Yacht       | Dice     | Yahtzee variant, 3 AI difficulty levels |
+| Yacht       | Dice     | Dice scoring game, 3 AI difficulty levels |
 | Hearts      | Card     | Trick-taking, avoid hearts + queen      |
 | Blackjack   | Card     | 3 table tiers, chip progression         |
 | Solitaire   | Card     | Klondike, draw-3 mode, undo             |

--- a/docs/games/yacht.md
+++ b/docs/games/yacht.md
@@ -6,7 +6,7 @@
 
 ## How to Play
 
-Yacht is a Yahtzee-style dice game. Each turn the player rolls 5 dice and may re-roll any subset up to two more times. After the third roll the player must assign the result to one of 13 scoring categories. Each category can only be scored once per game. The game ends when all 13 categories are filled.
+Yacht is a classic dice scoring game. Each turn the player rolls 5 dice and may re-roll any subset up to two more times. After the third roll the player must assign the result to one of 13 scoring categories. Each category can only be scored once per game. The game ends when all 13 categories are filled.
 
 BC Arcade's Yacht mode is 1v1 against an AI opponent. Both players alternate turns under the same rules.
 

--- a/frontend/src/entitlements/__tests__/EntitlementContext.test.tsx
+++ b/frontend/src/entitlements/__tests__/EntitlementContext.test.tsx
@@ -262,6 +262,78 @@ describe("EntitlementProvider", () => {
       expect(ctx.canPlay("starswarm")).toBe(true);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Dev-override cache persistence (regression: Sentry GAMESAPI-4D9816B4)
+  //
+  // When ENTITLEMENT_DEV_OVERRIDE was active in Render, the backend issued JWTs
+  // listing all premium games. Devices cached those tokens. After the override was
+  // removed, network failures prevented fetching a corrected token, so the stale
+  // all-games cache remained in effect for up to 7 days.
+  // ---------------------------------------------------------------------------
+
+  describe("dev-override cache persistence (Sentry GAMESAPI-4D9816B4)", () => {
+    const ALL_PREMIUM = ["yacht", "cascade", "hearts", "sudoku", "starswarm", "sort"];
+
+    it("all-games token from dev-override period still grants access on cold-launch network failure within grace period", async () => {
+      // Simulate a device that cached an all-games token while ENTITLEMENT_DEV_OVERRIDE was active
+      await AsyncStorage.setItem(TOKEN_STORAGE_KEY, makeToken(makePayload(ALL_PREMIUM)));
+      await AsyncStorage.setItem(CACHED_AT_STORAGE_KEY, new Date().toISOString());
+      mockRequest.mockRejectedValue(new TypeError("Network request failed"));
+
+      await renderProvider();
+
+      // The cached token is still within its 7-day grace period, so all premium games unlock.
+      // This is the expected (by-design) offline grace behavior — any change to deny access
+      // here would break legitimate offline users. The fix is to ensure the server can be
+      // reached so the stale token is replaced.
+      for (const slug of ALL_PREMIUM) {
+        expect(ctx.canPlay(slug)).toBe(true);
+      }
+    });
+
+    it("foreground refresh network failure preserves fresh in-memory state and does not regress to stale cache", async () => {
+      // Seed an all-games cache (simulates what a dev-override period left behind)
+      await AsyncStorage.setItem(TOKEN_STORAGE_KEY, makeToken(makePayload(ALL_PREMIUM)));
+      await AsyncStorage.setItem(CACHED_AT_STORAGE_KEY, new Date().toISOString());
+
+      // First init succeeds with a clean no-entitlements token (override now off on server)
+      mockRequest.mockResolvedValueOnce({
+        token: makeToken(makePayload([])),
+        expires_at: "2099-01-01T00:00:00Z",
+      });
+
+      await renderProvider();
+      expect(ctx.canPlay("cascade")).toBe(false);
+
+      // Foreground refresh fails at the network level
+      mockRequest.mockRejectedValue(new TypeError("Network request failed"));
+      const listener = getAppStateListener();
+      await act(async () => {
+        listener("active");
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      });
+
+      // refresh() preserves the last successful in-memory state; it does NOT re-load from cache
+      expect(ctx.canPlay("cascade")).toBe(false);
+    });
+
+    it("all-games dev-override cache is denied once the 7-day grace period expires", async () => {
+      const expiredPayload = makePayload(ALL_PREMIUM, -3_600_000); // token itself expired
+      await AsyncStorage.setItem(TOKEN_STORAGE_KEY, makeToken(expiredPayload));
+      await AsyncStorage.setItem(
+        CACHED_AT_STORAGE_KEY,
+        new Date(Date.now() - (OFFLINE_GRACE_MS + 24 * 60 * 60 * 1000)).toISOString()
+      );
+      mockRequest.mockRejectedValue(new TypeError("Network request failed"));
+
+      await renderProvider();
+
+      for (const slug of ALL_PREMIUM) {
+        expect(ctx.canPlay(slug)).toBe(false);
+      }
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/simulate-yacht.ts
+++ b/scripts/simulate-yacht.ts
@@ -99,8 +99,8 @@ interface GameResult {
   winner: 0 | 1;
   upperBonusHuman: boolean;
   upperBonusAi: boolean;
-  yahtzeeCountHuman: number;
-  yahtzeeCountAi: number;
+  yachtCountHuman: number;
+  yachtCountAi: number;
   chanceHuman: number;
   /** Whether the AI scored > 0 in each lower-section category */
   lowerHitAi: Record<LowerCat, boolean>;
@@ -127,12 +127,12 @@ function simulateGame(
     winner: humanScore >= aiScore ? 0 : 1,
     upperBonusHuman: humanState.upper_bonus === 35,
     upperBonusAi: aiState.upper_bonus === 35,
-    // yacht_bonus_count counts bonus Yahtzees only (2nd, 3rd, …).
-    // Adding 1 when scores["yacht"] === 50 includes the first Yahtzee.
-    yahtzeeCountHuman:
+    // yacht_bonus_count counts bonus Yachts only (2nd, 3rd, …).
+    // Adding 1 when scores["yacht"] === 50 includes the first Yacht.
+    yachtCountHuman:
       humanState.yacht_bonus_count +
       (humanState.scores["yacht"] === 50 ? 1 : 0),
-    yahtzeeCountAi:
+    yachtCountAi:
       aiState.yacht_bonus_count + (aiState.scores["yacht"] === 50 ? 1 : 0),
     chanceHuman: humanState.scores["chance"] ?? 0,
     lowerHitAi,
@@ -392,8 +392,8 @@ const batchResults: Array<{
   avgAiScore: number;
   upperBonusRateHuman: number;
   upperBonusRateAi: number;
-  avgYahtzeeHuman: number;
-  avgYahtzeeAi: number;
+  avgYachtHuman: number;
+  avgYachtAi: number;
   avgChanceHuman: number;
   lowerHitRateAi: Record<LowerCat, number>;
   lowerBandPassCount: number;
@@ -419,8 +419,8 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const aiScores = results.map((r) => r.aiScore);
   const upperHuman = results.map((r) => (r.upperBonusHuman ? 1 : 0));
   const upperAi = results.map((r) => (r.upperBonusAi ? 1 : 0));
-  const yahtzeeHuman = results.map((r) => r.yahtzeeCountHuman);
-  const yahtzeeAi = results.map((r) => r.yahtzeeCountAi);
+  const yachtHuman = results.map((r) => r.yachtCountHuman);
+  const yachtAi = results.map((r) => r.yachtCountAi);
   const chanceHuman = results.map((r) => r.chanceHuman);
 
   const winRate = mean(wins);
@@ -431,8 +431,8 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const sdAiScore = stdDev(aiScores, avgAiScore);
   const upperBonusRateHuman = mean(upperHuman);
   const upperBonusRateAi = mean(upperAi);
-  const avgYahtzeeHuman = mean(yahtzeeHuman);
-  const avgYahtzeeAi = mean(yahtzeeAi);
+  const avgYachtHuman = mean(yachtHuman);
+  const avgYachtAi = mean(yachtAi);
   const avgChanceHuman = mean(chanceHuman);
 
   const lowerHitRateAi = {} as Record<LowerCat, number>;
@@ -452,8 +452,8 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
     avgAiScore,
     upperBonusRateHuman,
     upperBonusRateAi,
-    avgYahtzeeHuman,
-    avgYahtzeeAi,
+    avgYachtHuman,
+    avgYachtAi,
     avgChanceHuman,
     lowerHitRateAi,
     lowerBandPassCount,
@@ -480,7 +480,7 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
     `  Upper Bonus Rate: human ${pct(upperBonusRateHuman)}, AI ${pct(upperBonusRateAi)}  ${check(inBonusBandAi)} expected AI [${pct(batch.expectedBonusBandAi[0])}, ${pct(batch.expectedBonusBandAi[1])}]`,
   );
   console.log(
-    `  Avg Yahtzees/game: human ${avgYahtzeeHuman.toFixed(2)}, AI ${avgYahtzeeAi.toFixed(2)}`,
+    `  Avg Yachts/game: human ${avgYachtHuman.toFixed(2)}, AI ${avgYachtAi.toFixed(2)}`,
   );
   console.log(`  Avg Chance score (human): ${avgChanceHuman.toFixed(1)}`);
   console.log(`  AI lower-section hit rates (% of games scored > 0):`);


### PR DESCRIPTION
## Summary

- **Branding / trademark cleanup**: remove all "Yahtzee", "Galaga-style", and related third-party references from docs, game metadata, and scripts; replace with accurate neutral language ("Yacht", "classic dice scoring game", "arcade shooter")
- **Forbidden-terms Tier-0 CI job**: grep gate in `.github/workflows/ci.yml` that blocks PRs reintroducing Yahtzee, Fruit Merge, Galaga, or Neon Arcade across source/docs/config; wired into all Tier-1 `needs` arrays
- **Entitlements regression tests** (Sentry `GAMESAPI-4D9816B4`): three new tests covering the dev-override cache-persistence scenarios that caused premium games to appear unlocked in TestFlight:
  1. Cold-launch network failure within 7-day grace → stale all-games cache still unlocks (expected offline behavior; root fix is restoring server connectivity)
  2. Foreground refresh failure preserves fresh in-memory state; does not regress to stale cache
  3. All-games cache is denied once grace period expires

## Files changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | Add `forbidden-terms` Tier-0 job; wire into all Tier-1 `needs` |
| `docs/PERFORMANCE.md` | "Galaga-style" → "arcade shooter" |
| `docs/PRODUCT.md` | "Yahtzee variant" → "Dice scoring game" |
| `docs/games/yacht.md` | "Yahtzee-style" → "classic dice scoring game" |
| `scripts/simulate-yacht.ts` | Rename `yahtzeeCount*`/`avgYahtzee*` → `yachtCount*`/`avgYacht*` |
| `frontend/src/entitlements/__tests__/EntitlementContext.test.tsx` | +3 regression tests |

## Test plan

- [ ] `cd frontend && npx jest src/entitlements/__tests__/EntitlementContext.test.tsx` — all 27 tests pass
- [ ] CI `forbidden-terms` job passes on this PR (no remaining banned terms)
- [ ] Confirm no Yahtzee/Galaga/Neon Arcade references remain: `grep -rniE "Yahtzee|Galaga|Neon Arcade" --include="*.ts" --include="*.tsx" --include="*.md" .`

## Related

- Sentry issue: `GAMESAPI-4D9816B4` — API entitlements network failure (227 events, 5 users)
- Production root cause: `games-api.buffingchi.com` DNS missing + Blueprint in error state (tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)