### PR TITLE
fix(yacht): show mode selector on Play Again; stop cancelling CPU turn on background

### DIFF
--- a/e2e/tests/yacht-errors.spec.ts
+++ b/e2e/tests/yacht-errors.spec.ts
@@ -229,8 +229,10 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
     await page.goto("/");
   });
 
+  type Page = Parameters<Parameters<typeof test>[1]>[0];
+
   /** Helper: play a full 13-round game and reach the game-over modal. */
-  async function playFullGame(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  async function playFullGame(page: Page) {
     await page.getByRole("button", { name: "Play Yacht" }).click();
     await page.getByRole("button", { name: /^Solo$/i }).click();
     for (let round = 0; round < 13; round++) {
@@ -243,10 +245,15 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
     await page.getByText("Game Over!").waitFor({ timeout: 10000 });
   }
 
+  /** Helper: click Play Again then select Solo to dismiss the mode selector. */
+  async function clickPlayAgainAsSolo(page: Page) {
+    await page.getByRole("button", { name: /play again/i }).click();
+    await page.getByRole("button", { name: /^Solo$/i }).click();
+  }
+
   test("Play Again resets to Round 1 / 13", async ({ page }) => {
     await playFullGame(page);
-
-    await page.getByRole("button", { name: /play again/i }).click();
+    await clickPlayAgainAsSolo(page);
 
     await expect(page.getByText("Round 1 / 13")).toBeVisible({
       timeout: 10000,
@@ -255,7 +262,7 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
 
   test("Play Again clears all scored categories", async ({ page }) => {
     await playFullGame(page);
-    await page.getByRole("button", { name: /play again/i }).click();
+    await clickPlayAgainAsSolo(page);
     await expect(page.getByText("Round 1 / 13")).toBeVisible({
       timeout: 10000,
     });
@@ -274,7 +281,7 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
     page,
   }) => {
     await playFullGame(page);
-    await page.getByRole("button", { name: /play again/i }).click();
+    await clickPlayAgainAsSolo(page);
     await expect(page.getByText("Round 1 / 13")).toBeVisible({
       timeout: 10000,
     });
@@ -291,7 +298,7 @@ test.describe("Yacht — Play Again reset regression (GH #225)", () => {
     page,
   }) => {
     await playFullGame(page);
-    await page.getByRole("button", { name: /play again/i }).click();
+    await clickPlayAgainAsSolo(page);
     await expect(page.getByText("Round 1 / 13")).toBeVisible({
       timeout: 10000,
     });

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -83,9 +83,6 @@ export default function GameScreen({ navigation, route }: Props) {
   const [aiRollingIndices, setAiRollingIndices] = useState<readonly number[]>([]);
   const isAiTurnRef = useRef(isAiTurn);
   const aiTurnCancelledRef = useRef(false);
-  const aiTurnInterruptedRef = useRef(false);
-  const aiTurnStartStateRef = useRef<GameState | null>(null);
-  const aiReplayPendingRef = useRef(false);
 
   // Keep refs in sync for use inside async AI turn loop and callbacks.
   const gameStateRef = useRef(gameState);
@@ -187,41 +184,21 @@ export default function GameScreen({ navigation, route }: Props) {
     () => setGameState((prev) => (prev === null ? prev : { ...prev, events: undefined }))
   );
 
-  // Single mount-time AppState listener — cancels on background, replays on foreground return.
-  // Using isAiTurnRef (not the state value) avoids re-subscribing on every turn.
+  // Single mount-time AppState listener — clears animation state on background.
+  // The async AI turn keeps running; no cancellation or replay needed.
   useEffect(() => {
     const sub = AppState.addEventListener("change", (next) => {
       if ((next === "background" || next === "inactive") && isAiTurnRef.current) {
-        aiTurnCancelledRef.current = true;
-        aiTurnInterruptedRef.current = true;
         setAiRollingIndices([]);
-      } else if (next === "active" && aiTurnInterruptedRef.current) {
-        aiTurnInterruptedRef.current = false;
-        if (aiTurnStartStateRef.current) {
-          setAiGameState(aiTurnStartStateRef.current);
-          aiTurnStartStateRef.current = null;
-        }
-        aiReplayPendingRef.current = true;
-        setIsAiTurn(false);
       }
     });
     return () => sub.remove();
   }, []);
 
-  // Re-fires the AI turn effect after isAiTurn settles to false with a replay pending.
-  // This avoids the setTimeout(50) toggle race from the original implementation.
-  useEffect(() => {
-    if (!isAiTurn && aiReplayPendingRef.current) {
-      aiReplayPendingRef.current = false;
-      setIsAiTurn(true);
-    }
-  }, [isAiTurn]);
-
   // AI turn loop: fires whenever isAiTurn becomes true.
   useEffect(() => {
     if (!isAiTurn || !aiDifficultyRef.current || !aiGameStateRef.current) return;
 
-    aiTurnStartStateRef.current = aiGameStateRef.current;
     aiTurnCancelledRef.current = false;
 
     async function runAiTurn() {
@@ -356,8 +333,9 @@ export default function GameScreen({ navigation, route }: Props) {
     const outcome = prev.game_over ? "completed" : "abandoned";
     syncComplete({ finalScore: prev.total_score, outcome }, endedPayload(prev, outcome));
     await clearGame();
+    setPendingDiff(aiDifficultyRef.current ?? "medium");
+    setDifficultyChosen(false);
     setGameState(newGame());
-    // Reset AI game state for replay — keep the same difficulty.
     setAiGameState(aiDifficultyRef.current ? newGame() : null);
     setIsAiTurn(false);
     setGameKey((k) => k + 1);

--- a/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.aiAnimation.test.tsx
@@ -235,57 +235,6 @@ describe("GameScreen VS mode — AppState interruption + replay", () => {
     expect(mockRoll.mock.calls.length).toBe(rollsBeforeBackground);
   });
 
-  it("foregrounding after background replays the AI turn (mockRoll called again)", async () => {
-    const { getByRole, getByText } = await renderVsGame();
-
-    await act(async () => {
-      await fireEvent.press(getByRole("button", { name: /ones/i }));
-    });
-
-    await act(async () => {
-      fireAppState("background");
-      jest.advanceTimersByTime(10_000);
-    });
-
-    mockRoll.mockClear();
-
-    await act(async () => {
-      fireAppState("active");
-    });
-
-    // The replay re-fires the AI turn effect: at minimum one roll runs synchronously.
-    expect(mockRoll.mock.calls.length).toBeGreaterThan(0);
-    expect(getByText("Computer's Turn")).toBeTruthy();
-  });
-
-  it("replay restores the pre-turn snapshot (first roll receives rolls_used=0)", async () => {
-    const { getByRole } = await renderVsGame();
-
-    await act(async () => {
-      await fireEvent.press(getByRole("button", { name: /ones/i }));
-    });
-
-    await act(async () => {
-      fireAppState("background");
-      jest.advanceTimersByTime(10_000);
-    });
-
-    mockRoll.mockClear();
-
-    await act(async () => {
-      fireAppState("active");
-    });
-
-    // The very first roll on replay must use the pre-turn snapshot (rolls_used=0).
-    expect(mockRoll).toHaveBeenCalledWith(expect.objectContaining({ rolls_used: 0 }), [
-      false,
-      false,
-      false,
-      false,
-      false,
-    ]);
-  });
-
   it("backgrounding when NOT in an AI turn does not start a spurious replay", async () => {
     const { queryByText } = await renderVsGame();
 

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -147,7 +147,10 @@ describe("GameScreen", () => {
   });
 
   it("play again button starts a new game in place", async () => {
-const { getByRole, getByText, queryByRole } = await renderScreen({ game_over: true, total_score: 100 });
+    const { getByRole, getByText, queryByRole } = await renderScreen({
+      game_over: true,
+      total_score: 100,
+    });
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
     });
@@ -225,7 +228,7 @@ describe("GameScreen — Play Again reset (GH #225)", () => {
   });
 
   it("Play Again resets round to 1", async () => {
-const { getByRole, getByText, queryByRole } = await renderScreen(makeGameOverState());
+    const { getByRole, getByText, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
     });
@@ -338,7 +341,7 @@ describe("GameScreen — New Game button (GH #393)", () => {
   });
 
   it("confirm modal 'Start new game' calls startNewGame and closes modal", async () => {
-const { getByRole, queryByText, queryByRole } = await renderScreen({ round: 2 });
+    const { getByRole, queryByText, queryByRole } = await renderScreen({ round: 2 });
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /new game/i }));
     });
@@ -578,7 +581,7 @@ describe("GameScreen — scorecard visual reset (GH #263)", () => {
   });
 
   it("Play Again resets all upper section rows to 'not available'", async () => {
-const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
+    const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
     });
@@ -593,7 +596,7 @@ const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
   });
 
   it("Play Again resets all lower section rows to 'not available'", async () => {
-const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
+    const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
     });
@@ -615,7 +618,8 @@ const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
   });
 
   it("Play Again resets upper bonus display to 0 / 63 progress", async () => {
-const { getByRole, getByText, queryByText, queryByRole } = await renderScreen(makeGameOverState());
+    const { getByRole, getByText, queryByText, queryByRole } =
+      await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
     });

--- a/frontend/src/screens/__tests__/GameScreen.test.tsx
+++ b/frontend/src/screens/__tests__/GameScreen.test.tsx
@@ -147,9 +147,14 @@ describe("GameScreen", () => {
   });
 
   it("play again button starts a new game in place", async () => {
-    const { getByRole, getByText } = await renderScreen({ game_over: true, total_score: 100 });
+const { getByRole, getByText, queryByRole } = await renderScreen({ game_over: true, total_score: 100 });
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    // Play Again now shows the mode selector; pick Solo to start the fresh game.
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     expect(mockNavigation.navigate).not.toHaveBeenCalled();
     expect(getByText(/round.*1/i)).toBeTruthy();
@@ -220,9 +225,13 @@ describe("GameScreen — Play Again reset (GH #225)", () => {
   });
 
   it("Play Again resets round to 1", async () => {
-    const { getByRole, getByText } = await renderScreen(makeGameOverState());
+const { getByRole, getByText, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     expect(getByText(/round.*1/i)).toBeTruthy();
   });
@@ -329,12 +338,17 @@ describe("GameScreen — New Game button (GH #393)", () => {
   });
 
   it("confirm modal 'Start new game' calls startNewGame and closes modal", async () => {
-    const { getByRole, queryByText } = await renderScreen({ round: 2 });
+const { getByRole, queryByText, queryByRole } = await renderScreen({ round: 2 });
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /new game/i }));
     });
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /start new game/i }));
+    });
+    // startNewGame shows the mode selector; pick Solo to complete the reset.
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     // Modal closes
     expect(queryByText("Start new game?")).toBeNull();
@@ -564,9 +578,13 @@ describe("GameScreen — scorecard visual reset (GH #263)", () => {
   });
 
   it("Play Again resets all upper section rows to 'not available'", async () => {
-    const { getByRole } = await renderScreen(makeGameOverState());
+const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     // rollsUsed=0 after reset → canScore=false → every ScoreRow shows "not available"
     for (const cat of ["Ones", "Twos", "Threes", "Fours", "Fives", "Sixes"]) {
@@ -575,9 +593,13 @@ describe("GameScreen — scorecard visual reset (GH #263)", () => {
   });
 
   it("Play Again resets all lower section rows to 'not available'", async () => {
-    const { getByRole } = await renderScreen(makeGameOverState());
+const { getByRole, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     for (const cat of [
       "Three of a Kind",
@@ -593,9 +615,13 @@ describe("GameScreen — scorecard visual reset (GH #263)", () => {
   });
 
   it("Play Again resets upper bonus display to 0 / 63 progress", async () => {
-    const { getByRole, getByText, queryByText } = await renderScreen(makeGameOverState());
+const { getByRole, getByText, queryByText, queryByRole } = await renderScreen(makeGameOverState());
     await act(async () => {
       await fireEvent.press(getByRole("button", { name: /play again/i }));
+    });
+    await act(async () => {
+      const soloBtn = queryByRole("button", { name: /^solo$/i });
+      if (soloBtn) fireEvent.press(soloBtn);
     });
     // After reset: upper_subtotal=0, upper_bonus=0 → progress display ("0 / 63")
     expect(getByText("0 / 63")).toBeTruthy();


### PR DESCRIPTION
## Summary

- **#1908** — `startNewGame()` now resets `difficultyChosen` to `false` and pre-seeds `pendingDiff` with the last-used difficulty. The mode/difficulty selector modal re-appears on every new game (Play Again, New Game button, mid-game New Game) instead of silently reusing the previous settings.
- **#1909** — Removed the `AppState` listener logic that cancelled and replayed the CPU's async turn when the app was backgrounded. The JS `setTimeout`/`await` chain runs regardless of app visibility, so the cancellation was unnecessary and caused the CPU to re-roll dice it had already decided. The listener now only clears `aiRollingIndices` to stop the visual animation. Removed three refs and a replay `useEffect` that existed solely to support the deleted cancel/replay flow (`aiTurnInterruptedRef`, `aiTurnStartStateRef`, `aiReplayPendingRef`).

## Test plan

- [ ] Open Yacht → mode selector appears
- [ ] Choose VS Computer (Hard) → play through to game over → press **Play Again** → mode selector re-appears with Hard pre-selected
- [ ] Pick **Solo** from the selector → new solo game starts with no CPU opponent
- [ ] Press **New Game** button mid-game → confirmation → mode selector re-appears
- [ ] Start a VS game, wait for CPU turn, background the app mid-roll → return → CPU turn completes from where it left off without restarting
- [ ] Start a VS game, press New Game during CPU turn → CPU turn aborts cleanly, mode selector shown

https://claude.ai/code/session_01EX2if2XM6CSgGNbJFNjBkC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EX2if2XM6CSgGNbJFNjBkC)_