### PR TITLE
fix: add jinja2 dependency — resolves Render deploy crash

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.135.2
+jinja2==3.1.6
 python-dotenv==1.2.2
 sentry-sdk[fastapi]==2.27.0
 starlette==1.2.1


### PR DESCRIPTION
## Summary

- Adds `jinja2==3.1.6` to `backend/requirements.txt`
- Fixes the Render deploy crash introduced by the Sentry Starlette integration unconditionally importing `Jinja2Templates` at startup

## Root Cause

`sentry_sdk.init()` calls `StarletteIntegration.setup_once()` → `patch_templates()` → `from starlette.templating import Jinja2Templates`. Starlette treats `jinja2` as optional and raises `ImportError` when it's absent — but Sentry triggers the import regardless of whether the app uses templates.

Closes #1984

## Test plan

- [ ] Render deploy succeeds (service starts and `/health` returns 200)
- [ ] `python -m pytest tests/ -v` passes locally

https://claude.ai/code/session_01UxuMrybPdLTMwPQhATGBBL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxuMrybPdLTMwPQhATGBBL)_