### PR TITLE
fix(ios): bump minimum deployment target 15.1 → 16.4 (unblocks Xcode Cloud)

### DIFF
--- a/frontend/ios/GamingApp.xcodeproj/project.pbxproj
+++ b/frontend/ios/GamingApp.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = GamingApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -380,7 +380,7 @@
 				CODE_SIGN_ENTITLEMENTS = GamingApp/GamingApp.entitlements;
 				CURRENT_PROJECT_VERSION = 10009;
 				INFOPLIST_FILE = GamingApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -448,7 +448,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -506,7 +506,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/frontend/ios/Podfile.properties.json
+++ b/frontend/ios/Podfile.properties.json
@@ -1,4 +1,5 @@
 {
   "expo.jsEngine": "hermes",
-  "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true"
+  "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
+  "ios.deploymentTarget": "16.4"
 }


### PR DESCRIPTION
## Summary

- Xcode Cloud Build 76 failed on all 3 `pod install` attempts — `expo` and 13 other Expo packages require iOS 16.4 but the project was still targeting 15.1
- Add `"ios.deploymentTarget": "16.4"` to `Podfile.properties.json` (used by the `platform :ios` line in `Podfile`)
- Update all 4 `IPHONEOS_DEPLOYMENT_TARGET = 15.1` entries in `project.pbxproj` → `16.4`

Closes #1986

## Root cause (from ci_post_clone.log)

```
[!] CocoaPods could not find compatible versions for pod "Expo"
Specs satisfying the dependency were found, but they required a higher minimum deployment target.

[!] [Expo] expo was not linked: requires iOS 16.4 but app targets 15.1
[!] [Expo] expo-modules-core was not linked: requires iOS 16.4 but app targets 15.1
... (14 packages total)
pod install failed after 3 attempts
```

## Files changed

| File | Change |
|------|--------|
| `frontend/ios/Podfile.properties.json` | Added `"ios.deploymentTarget": "16.4"` |
| `frontend/ios/GamingApp.xcodeproj/project.pbxproj` | 4× `IPHONEOS_DEPLOYMENT_TARGET` 15.1 → 16.4 |

## Test plan

- [ ] Xcode Cloud triggers a new build after merge — `pod install` succeeds
- [ ] Archive build completes successfully
- [ ] App runs on device/simulator targeting iOS 16.4+

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArR8TFBsf7TJvro3YtyAoJ)_