### PR TITLE
fix(ios): remove .env.production in ci_post_clone.sh to prevent prod URL override

### DIFF
--- a/frontend/ios/ci_scripts/ci_post_clone.sh
+++ b/frontend/ios/ci_scripts/ci_post_clone.sh
@@ -31,13 +31,17 @@ echo "export PATH=\"/usr/local/opt/node@22/bin:/usr/local/bin:/opt/homebrew/bin:
 
 # -------------------------------------------------------
 # 3. Write environment variables for the JS bundle
+#    Remove .env.production so Expo CLI does not load it and
+#    override the dev URL below (APP_ENV=production is set in
+#    Xcode Cloud, causing .env.production to win otherwise).
 # -------------------------------------------------------
 cd "$CI_PRIMARY_REPOSITORY_PATH/frontend"
+rm -f .env.production
 cat > .env <<'DOTENV'
 EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com
 EXPO_PUBLIC_SENTRY_DSN=https://4e8b2bd816cbce3f73b0cd6923530d53@o4511129011093504.ingest.us.sentry.io/4511129020334080
 DOTENV
-echo "=== .env written ==="
+echo "=== .env written (.env.production removed) ==="
 cat .env
 
 # -------------------------------------------------------


### PR DESCRIPTION
## Problem

Every Xcode Cloud TestFlight build since May 29 (9163bca6) has baked \`https://games-api.buffingchi.com\` (the prod API URL) into the iOS bundle instead of the dev URL, causing Sentry error 94e63fbd:

> \`fetch failed: A server with the specified hostname could not be found\` on \`GET /entitlements\`

**Root cause:** \`ci_post_clone.sh\` writes \`frontend/.env\` with the correct dev URL, but Xcode Cloud has \`APP_ENV=production\` set. Expo CLI loads env files in order — \`.env\` then \`.env.production\` — with later files winning. The committed \`.env.production\` contains \`EXPO_PUBLIC_API_URL=https://games-api.buffingchi.com\`, which silently overrides the dev URL. That hostname has no DNS record (prod Render not yet provisioned) → NXDOMAIN → fetch failed.

**Introduced by:** 9163bca6 fixed \`.env.production\` for web exports (correct) but didn't account for Xcode Cloud also loading \`.env.production\` via the dotenv cascade.

## Fix

One line added to \`ci_post_clone.sh\` — delete \`.env.production\` before writing \`.env\`:

\`\`\`sh
rm -f .env.production
\`\`\`

This makes \`.env\` the only source of truth for iOS CI builds and is safe: \`.env.production\` only applies to web (Render) exports, where it is re-read from the repo on each deploy.

## Verification

1. Trigger a new Xcode Cloud build — confirm log shows \`.env.production removed\`
2. Install the new TestFlight build
3. Confirm \`/entitlements\` hits \`dev-games-api.buffingchi.com\` (resolves, returns 200)
4. No new Sentry events for \`games-api.buffingchi.com\`

## Related

- Closes #1988
- #1989 is a separate follow-up (add frontend-to-backend connectivity smoke test to CI) and is not addressed here