### PR TITLE
fix(ios): remove isDevApiUrl guard — URL correctness is an infrastructure concern

### DIFF
--- a/frontend/src/game/_shared/__tests__/httpClient.test.ts
+++ b/frontend/src/game/_shared/__tests__/httpClient.test.ts
@@ -119,32 +119,16 @@ describe("httpClient — BASE_URL configuration", () => {
     }
   });
 
-  it("throws at module load when a dev-* API URL is used in a non-dev build (#1854)", () => {
+  it("does not throw for a dev-* URL in a non-dev build — URL is an infrastructure concern", () => {
     process.env.EXPO_PUBLIC_API_URL = "https://dev-games-api.buffingchi.com";
     const g = globalThis as { __DEV__?: boolean };
     const originalDev = g.__DEV__;
     g.__DEV__ = false;
     try {
-      expect(() => loadClient()).toThrow(/points to a dev API host/);
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const Sentry = require("@sentry/react-native");
-      expect(Sentry.captureMessage).toHaveBeenCalledWith(
-        expect.stringContaining("points to a dev API host"),
-        expect.objectContaining({
-          level: "fatal",
-          tags: expect.objectContaining({ issue: "dev-api-in-prod" }),
-        })
-      );
+      expect(() => loadClient()).not.toThrow();
     } finally {
       g.__DEV__ = originalDev;
     }
-  });
-
-  it("does not throw for a dev-* URL when __DEV__ is true (#1854)", async () => {
-    process.env.EXPO_PUBLIC_API_URL = "https://dev-games-api.buffingchi.com";
-    // __DEV__ is true by default in the test environment.
-    expect((globalThis as { __DEV__?: boolean }).__DEV__).toBe(true);
-    expect(() => loadClient()).not.toThrow();
   });
 });
 

--- a/frontend/src/game/_shared/httpClient.ts
+++ b/frontend/src/game/_shared/httpClient.ts
@@ -53,15 +53,6 @@ function isLocalhost(url: string): boolean {
   }
 }
 
-function isDevApiUrl(url: string): boolean {
-  try {
-    const { hostname } = new URL(url);
-    return hostname.startsWith("dev-");
-  } catch {
-    return false;
-  }
-}
-
 function resolveBaseUrl(): string {
   const raw = process.env.EXPO_PUBLIC_API_URL;
   if (raw) {
@@ -83,21 +74,6 @@ function resolveBaseUrl(): string {
         });
         throw new Error(msg);
       }
-    }
-    // Catch dev-API-in-prod: a production Sentry environment tag with a
-    // dev-* hostname means .env.production was misconfigured (issue #1854).
-    if (!__DEV__ && !isTestBuild && isDevApiUrl(resolved)) {
-      const msg =
-        "EXPO_PUBLIC_API_URL points to a dev API host in a non-dev build (" +
-        resolved +
-        "). Set EXPO_PUBLIC_API_URL to the production API URL in .env.production " +
-        "and in the Render build environment (see render.yaml).";
-      Sentry.captureMessage(msg, {
-        level: "fatal",
-        tags: { subsystem: "httpClient", issue: "dev-api-in-prod" },
-        extra: { raw },
-      });
-      throw new Error(msg);
     }
     return resolved;
   }


### PR DESCRIPTION
## Problem

After #1991 merged, TestFlight users see a blank white screen on boot. The lobby never renders and no games are accessible.

## Root Cause

`httpClient.ts` had a guard (added in 9163bca6, May 29) that throws a fatal error at module load when it sees a `dev-*` hostname in a non-dev build:

```typescript
if (!__DEV__ && !isTestBuild && isDevApiUrl(resolved)) {
  throw new Error("EXPO_PUBLIC_API_URL points to a dev API host in a non-dev build...")
}
```

`isDevApiUrl` checks `hostname.startsWith("dev-")`. After #1991 correctly restored `EXPO_PUBLIC_API_URL=https://dev-games-api.buffingchi.com` for Xcode Cloud builds, this guard fires because Xcode Cloud produces release builds (`!__DEV__ = true`) and the dev URL starts with `dev-`. The guard throws → React Native never renders → blank screen.

## Why the guard was wrong

`EXPO_PUBLIC_API_URL` is an infrastructure concern, not an app-level concern. The URL is baked into the JS bundle at `expo export` time by whichever system runs the build:

| Build | Who controls the URL |
|---|---|
| iOS TestFlight / App Store | `ci_post_clone.sh` writes `.env` before export |
| Web (dev/prod) | `render.yaml` env var → `fetch-render-env.js` |
| Android | env var set in Android CI |

TestFlight is intentionally a release build using the dev backend (`dev-games-api.buffingchi.com`). The infrastructure already ensures the correct URL is set; the guard contradicted it.

## Fix

Remove `isDevApiUrl` helper and guard from `httpClient.ts`. The two remaining guards stay — they catch genuine app-level errors no deployment would produce intentionally:
- Localhost URL in a non-dev build
- Missing `EXPO_PUBLIC_API_URL` entirely

## History

- **Before May 29**: No guard. TestFlight used dev URL. Everything worked.
- **May 29 (9163bca6)**: Added `isDevApiUrl` guard + changed `.env.production` to prod URL → TestFlight NXDOMAIN → Sentry error 94e63fbd.
- **#1991**: Deleted `.env.production` in `ci_post_clone.sh` → correct dev URL, but guard fires → blank screen.
- **This PR**: Removes the guard → TestFlight boots correctly again.

## Testing

- 23/23 `httpClient` unit tests pass
- New test: `does not throw for a dev-* URL in a non-dev build — URL is an infrastructure concern`
- Old test asserting the guard threw has been removed

Closes #1992