### PR TITLE
fix(ios): remove misleading NSMicrophoneUsageDescription (#1919)

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -54,7 +54,7 @@
         "react-native-audio-api",
         {
           "disableFFmpeg": true,
-          "iosMicrophonePermission": "Audio playback libraries used for game sound effects and background music require this permission."
+          "iosMicrophonePermission": false
         }
       ]
     ]

--- a/frontend/ios/GamingApp/Info.plist
+++ b/frontend/ios/GamingApp/Info.plist
@@ -72,7 +72,5 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Audio playback libraries used for game sound effects and background music require this permission.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Removes `NSMicrophoneUsageDescription` from `frontend/ios/GamingApp/Info.plist` — `AVAudioSession` playback does not require the microphone entitlement
- Sets `iosMicrophonePermission: false` in `app.json` so the `react-native-audio-api` plugin does not re-inject the key on future `expo prebuild` runs

## Test plan
- [ ] Build and run on a physical iOS device — confirm no microphone permission prompt appears at launch
- [ ] Verify all game sound effects and background music play correctly without granting mic access

Closes #1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)