### PR TITLE
fix(starswarm): prevent ship getting stuck at right edge after wave-clear cinematic

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -59,30 +59,22 @@ export default function Controls({
     onNewGame();
   }, [resetPlayerX, onNewGame]);
 
-  // When WinTransition ends the AI autopilot has moved the ship to a new X.
-  // GameCanvas syncs inputRef.current.playerX, but playerXRef here is stale
-  // (frozen at the pre-cinematic user position). Without this sync the first
-  // drag of the new wave uses the stale position as its anchor, snapping the
-  // ship to the old edge and making it appear stuck.
-  const prevPhaseRef = useRef<GamePhase>(phase);
-  useEffect(() => {
-    if (prevPhaseRef.current === "WinTransition" && phase !== "WinTransition") {
-      const syncedX = canvasRef.current?.getState()?.player.x ?? CANVAS_W / 2;
-      playerXRef.current = syncedX;
-      shipXAtDragStartRef.current = syncedX;
-    }
-    prevPhaseRef.current = phase;
-  }, [phase, canvasRef]);
-
   const panGesture = Gesture.Pan()
     .runOnJS(true)
     .minDistance(0)
     .onBegin((e) => {
       activeDragRef.current = e.y > dragZoneY;
       if (activeDragRef.current) {
-        // Capture ship X at gesture start so we use total translation (not
-        // per-event changeX accumulation) — avoids drift over long gestures.
-        shipXAtDragStartRef.current = playerXRef.current;
+        // Sync from the engine's actual player.x rather than playerXRef. During
+        // WinTransition the engine ignores drag input and moves the ship via
+        // autopilot, then resets inputRef to the AI-parked position — but
+        // playerXRef is stale (wherever the user was dragging during the
+        // cinematic). Using the stale anchor causes the first gesture of the
+        // new wave to snap the ship to the wrong edge ("stuck at right" bug).
+        const engineX = canvasRef.current?.getState()?.player.x;
+        const anchorX = engineX ?? playerXRef.current;
+        playerXRef.current = anchorX;
+        shipXAtDragStartRef.current = anchorX;
       }
     })
     .onChange((e) => {

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -65,12 +65,8 @@ export default function Controls({
     .onBegin((e) => {
       activeDragRef.current = e.y > dragZoneY;
       if (activeDragRef.current) {
-        // Sync from the engine's actual player.x rather than playerXRef. During
-        // WinTransition the engine ignores drag input and moves the ship via
-        // autopilot, then resets inputRef to the AI-parked position — but
-        // playerXRef is stale (wherever the user was dragging during the
-        // cinematic). Using the stale anchor causes the first gesture of the
-        // new wave to snap the ship to the wrong edge ("stuck at right" bug).
+        // Use engine's authoritative player.x — playerXRef is stale when
+        // autopilot moves the ship during the WinTransition cinematic.
         const engineX = canvasRef.current?.getState()?.player.x;
         const anchorX = engineX ?? playerXRef.current;
         playerXRef.current = anchorX;

--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -59,6 +59,21 @@ export default function Controls({
     onNewGame();
   }, [resetPlayerX, onNewGame]);
 
+  // When WinTransition ends the AI autopilot has moved the ship to a new X.
+  // GameCanvas syncs inputRef.current.playerX, but playerXRef here is stale
+  // (frozen at the pre-cinematic user position). Without this sync the first
+  // drag of the new wave uses the stale position as its anchor, snapping the
+  // ship to the old edge and making it appear stuck.
+  const prevPhaseRef = useRef<GamePhase>(phase);
+  useEffect(() => {
+    if (prevPhaseRef.current === "WinTransition" && phase !== "WinTransition") {
+      const syncedX = canvasRef.current?.getState()?.player.x ?? CANVAS_W / 2;
+      playerXRef.current = syncedX;
+      shipXAtDragStartRef.current = syncedX;
+    }
+    prevPhaseRef.current = phase;
+  }, [phase, canvasRef]);
+
   const panGesture = Gesture.Pan()
     .runOnJS(true)
     .minDistance(0)

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -170,19 +170,11 @@ describe("player boundary clamping", () => {
     expect(s.player.x).toBe(parkedX);
   });
 
-  // Regression (Controls.tsx desync): when the autopilot actually moves the ship
-  // during WinTransition the engine's player.x at wave-start differs from the
-  // pre-cinematic position. This is the exact condition that caused playerXRef in
-  // Controls.tsx to be stale, snapping the ship to the wrong edge on the first
-  // drag of the new wave.
-  //
-  // Bullet placement: BULLET_E_VY = 0.35 px/ms, freeze lasts WIN_FREEZE_MS = 900 ms.
-  // Bullets are NOT advanced during the freeze stage, so the bullet's y is unchanged
-  // when autopilot starts. Placing it at y = 150 means the AI has to wait ~380 ms of
-  // autopilot before the bullet enters the threat window [currentShipY-220, currentShipY+30].
-  // advanceMs cannot be used here: once wave 2 starts each tick re-applies playerX = 180
-  // via NO_INPUT, immediately overwriting the AI-parked position. We loop tick-by-tick
-  // and capture player.x at the instant the wave increments.
+  // Regression: autopilot must move the ship when a bullet threatens during
+  // WinTransition — this is the desync that made playerXRef stale in Controls.tsx.
+  // Bullet at y=150 gives the AI time to dodge before the wave increments.
+  // Loop tick-by-tick (not advanceMs) so we capture parked X before wave-2
+  // re-clamps it via NO_INPUT.
   it("autopilot moves ship laterally when an enemy bullet threatens during WinTransition", () => {
     let s = initStarSwarm(CANVAS_W, CANVAS_H, 1);
     s = advanceMs(s, 8000);
@@ -218,9 +210,6 @@ describe("player boundary clamping", () => {
     }
 
     expect(parkedX).not.toBeNull();
-    // AI dodge moved the ship — player.x at wave-start must differ from the
-    // pre-cinematic value. Controls.tsx re-syncs playerXRef from this value
-    // (via getState().player.x in onBegin) to prevent the stuck-right bug.
     expect(parkedX!).not.toBeCloseTo(xBeforeCinematic, 0);
     expect(parkedX!).toBeGreaterThanOrEqual(hw);
     expect(parkedX!).toBeLessThanOrEqual(CANVAS_W - hw);

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -135,6 +135,40 @@ describe("player boundary clamping", () => {
     }
     expect(s.player.x).toBe(CANVAS_W - hw);
   });
+
+  // Regression: after the cinematic WinTransition the engine's player.x must be
+  // within valid bounds, and using that position as subsequent input must be a
+  // no-op (no spurious jump). Controls.tsx relies on this contract when it syncs
+  // playerXRef after WinTransition to prevent the "stuck at right edge" bug.
+  it("player.x stays within valid bounds through a complete WinTransition", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1);
+    // Drive ship to right edge for the duration of the wave
+    const rightEdgeInput: StarSwarmInput = { playerX: CANVAS_W - hw, fire: false };
+    s = advanceMs(s, 8000, rightEdgeInput);
+    // Kill remaining enemies to trigger WinTransition
+    s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
+    s = tick(s, 16, rightEdgeInput);
+    expect(s.phase).toBe("WinTransition");
+    // Advance through the full cinematic; autopilot moves the ship
+    s = advanceMs(s, 3000, rightEdgeInput);
+    expect(s.wave).toBe(2);
+    expect(s.phase).toBe("SwoopIn");
+    expect(s.player.x).toBeGreaterThanOrEqual(hw);
+    expect(s.player.x).toBeLessThanOrEqual(CANVAS_W - hw);
+  });
+
+  it("first tick of new wave with engine-parked X does not move the ship", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1);
+    s = advanceMs(s, 8000);
+    s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
+    s = tick(s, 16, NO_INPUT);
+    s = advanceMs(s, 3000);
+    expect(s.wave).toBe(2);
+    // Using the engine's own player.x as the input must be a no-op
+    const parkedX = s.player.x;
+    s = tick(s, 16, { playerX: parkedX, fire: false });
+    expect(s.player.x).toBe(parkedX);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/game/starswarm/__tests__/engine.test.ts
+++ b/frontend/src/game/starswarm/__tests__/engine.test.ts
@@ -169,6 +169,62 @@ describe("player boundary clamping", () => {
     s = tick(s, 16, { playerX: parkedX, fire: false });
     expect(s.player.x).toBe(parkedX);
   });
+
+  // Regression (Controls.tsx desync): when the autopilot actually moves the ship
+  // during WinTransition the engine's player.x at wave-start differs from the
+  // pre-cinematic position. This is the exact condition that caused playerXRef in
+  // Controls.tsx to be stale, snapping the ship to the wrong edge on the first
+  // drag of the new wave.
+  //
+  // Bullet placement: BULLET_E_VY = 0.35 px/ms, freeze lasts WIN_FREEZE_MS = 900 ms.
+  // Bullets are NOT advanced during the freeze stage, so the bullet's y is unchanged
+  // when autopilot starts. Placing it at y = 150 means the AI has to wait ~380 ms of
+  // autopilot before the bullet enters the threat window [currentShipY-220, currentShipY+30].
+  // advanceMs cannot be used here: once wave 2 starts each tick re-applies playerX = 180
+  // via NO_INPUT, immediately overwriting the AI-parked position. We loop tick-by-tick
+  // and capture player.x at the instant the wave increments.
+  it("autopilot moves ship laterally when an enemy bullet threatens during WinTransition", () => {
+    let s = initStarSwarm(CANVAS_W, CANVAS_H, 1);
+    s = advanceMs(s, 8000);
+    s = { ...s, enemies: s.enemies.map((e) => ({ ...e, isAlive: false, hp: 0 })) };
+
+    // Bullet 50 px to the ship's left → AI dodges right, shifting player.x.
+    const threatBullet: Bullet = {
+      id: 99998,
+      x: s.player.x - 50,
+      y: 150,
+      vx: 0,
+      vy: BULLET_E_VY,
+      owner: "enemy",
+      width: 5,
+      height: 14,
+      damage: 1,
+    };
+    s = { ...s, enemyBullets: [threatBullet] };
+    s = tick(s, 16, NO_INPUT);
+    expect(s.phase).toBe("WinTransition");
+    const xBeforeCinematic = s.player.x;
+
+    // Tick one frame at a time and capture player.x the instant wave increments.
+    // Using advanceMs would overwrite the parked position (tickPlayer re-clamps to 180).
+    let parkedX: number | null = null;
+    for (let i = 0; i < 300; i++) {
+      const prevWave = s.wave;
+      s = tick(s, 16, NO_INPUT);
+      if (s.wave !== prevWave) {
+        parkedX = s.player.x;
+        break;
+      }
+    }
+
+    expect(parkedX).not.toBeNull();
+    // AI dodge moved the ship — player.x at wave-start must differ from the
+    // pre-cinematic value. Controls.tsx re-syncs playerXRef from this value
+    // (via getState().player.x in onBegin) to prevent the stuck-right bug.
+    expect(parkedX!).not.toBeCloseTo(xBeforeCinematic, 0);
+    expect(parkedX!).toBeGreaterThanOrEqual(hw);
+    expect(parkedX!).toBeLessThanOrEqual(CANVAS_W - hw);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1152,17 +1152,29 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
-"@img/sharp-darwin-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz"
-  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-x64" "1.2.4"
-
-"@img/sharp-libvips-darwin-x64@1.2.4":
+"@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz"
-  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
+  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
+  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
+
+"@img/sharp-linux-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
+  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+
+"@img/sharp-linuxmusl-x64@0.34.5":
+  version "0.34.5"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
+  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
 
 "@isaacs/ttlcache@^1.4.1":
   version "1.4.1"
@@ -1475,10 +1487,10 @@
     lighthouse "12.6.1"
     tree-kill "^1.2.1"
 
-"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
+"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4":
   version "3.0.4"
-  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz"
-  integrity sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==
+  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz"
+  integrity sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1764,10 +1776,10 @@
     "@sentry-internal/replay-canvas" "10.53.1"
     "@sentry/core" "10.53.1"
 
-"@sentry/cli-darwin@3.4.3":
+"@sentry/cli-linux-x64@3.4.3":
   version "3.4.3"
-  resolved "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.3.tgz"
-  integrity sha512-KUeP9d0rQ9L/A4SU9U6K8fMeRaWLV24FVH9JE6V6tbi4S9feJwKjfXXCpsqTk87Do5k0sohaz4SFiOkbypePLA==
+  resolved "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.3.tgz"
+  integrity sha512-2opnMFIx/c1lRqW0SiKMy2q3ChuB7tCadfS8WEJKAMdfQLQrSQmyW/9fhBGK9fDSMqGFVoxU6aaSS89GKnkN8g==
 
 "@sentry/cli@3.4.3":
   version "3.4.3"
@@ -4500,11 +4512,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -6084,10 +6091,15 @@ lighthouse@12.6.1:
     yargs "^17.3.1"
     yargs-parser "^21.0.0"
 
-lightningcss-darwin-x64@1.32.0:
+lightningcss-linux-x64-gnu@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz"
-  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz"
+  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
+
+lightningcss-linux-x64-musl@1.32.0:
+  version "1.32.0"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz"
+  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
 
 lightningcss@^1.30.1:
   version "1.32.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1152,29 +1152,17 @@
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
-"@img/sharp-libvips-linux-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz"
-  integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
-
-"@img/sharp-libvips-linuxmusl-x64@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz"
-  integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
-
-"@img/sharp-linux-x64@0.34.5":
+"@img/sharp-darwin-x64@0.34.5":
   version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz"
-  integrity sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==
+  resolved "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz"
+  integrity sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==
   optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.2.4"
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
 
-"@img/sharp-linuxmusl-x64@0.34.5":
-  version "0.34.5"
-  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz"
-  integrity sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==
-  optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+"@img/sharp-libvips-darwin-x64@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz"
+  integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
 
 "@isaacs/ttlcache@^1.4.1":
   version "1.4.1"
@@ -1487,10 +1475,10 @@
     lighthouse "12.6.1"
     tree-kill "^1.2.1"
 
-"@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4":
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
   version "3.0.4"
-  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz"
-  integrity sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==
+  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz"
+  integrity sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1776,10 +1764,10 @@
     "@sentry-internal/replay-canvas" "10.53.1"
     "@sentry/core" "10.53.1"
 
-"@sentry/cli-linux-x64@3.4.3":
+"@sentry/cli-darwin@3.4.3":
   version "3.4.3"
-  resolved "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.3.tgz"
-  integrity sha512-2opnMFIx/c1lRqW0SiKMy2q3ChuB7tCadfS8WEJKAMdfQLQrSQmyW/9fhBGK9fDSMqGFVoxU6aaSS89GKnkN8g==
+  resolved "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.3.tgz"
+  integrity sha512-KUeP9d0rQ9L/A4SU9U6K8fMeRaWLV24FVH9JE6V6tbi4S9feJwKjfXXCpsqTk87Do5k0sohaz4SFiOkbypePLA==
 
 "@sentry/cli@3.4.3":
   version "3.4.3"
@@ -4512,6 +4500,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -6091,15 +6084,10 @@ lighthouse@12.6.1:
     yargs "^17.3.1"
     yargs-parser "^21.0.0"
 
-lightningcss-linux-x64-gnu@1.32.0:
+lightningcss-darwin-x64@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz"
-  integrity sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==
-
-lightningcss-linux-x64-musl@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz"
-  integrity sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==
+  resolved "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz"
+  integrity sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==
 
 lightningcss@^1.30.1:
   version "1.32.0"


### PR DESCRIPTION
Closes #2004

## Summary

- **Root cause:** The `WinTransition` cinematic (#1976) introduced a drag-anchor desync. `StarSwarmScreen` never sets `phase = "WinTransition"` (only `"WaveClear"` / `"SwoopIn"` / `"GameOver"`), so the `if (phaseRef.current === "WinTransition") return` guard in `Controls.tsx` `onChange` was dead code — pan events were always processed during the cinematic. The user could drag the ship right during the cinematic, updating `playerXRef` to the right edge. Then `GameCanvas` reset `inputRef.current.playerX` to the AI-parked position after the cinematic. On the first pan of the new wave, `onBegin` captured the stale `playerXRef` (right edge) as the gesture anchor, causing the ship to snap back to the right edge and appear stuck.
- **Fix:** `onBegin` now reads `canvasRef.current?.getState()?.player.x` and uses the engine's actual player position as the drag anchor, discarding any stale `playerXRef`. Works correctly on iOS (native `GameCanvas`) and web.
- **Also removes** a broken `useEffect` from the first fix attempt that checked for `phase === "WinTransition"` — which, as above, is a value that prop never takes.

## Test plan

- [ ] Play a wave to completion on iOS — complete the cinematic with ship at the right edge — verify first drag of the new wave moves the ship immediately without snapping or sticking
- [ ] Drag ship to right edge mid-wave and confirm boundary clamping still works (existing regression tests)
- [ ] All 943 engine tests pass (`cd frontend && npx jest "engine.test.ts"`)
- [ ] Three new engine regression tests verify: (1) player.x stays in bounds through a full WinTransition, (2) first tick of new wave with parked X is a no-op, (3) autopilot actually moves the ship when a bullet threatens (the desync condition the fix corrects)

https://claude.ai/code/session_014KbY9G7uHM3nesEkkeH7YX

---
_Generated by [Claude Code](https://claude.ai/code/session_014KbY9G7uHM3nesEkkeH7YX)_