### PR TITLE
fix(starswarm): make power-up lifespan indicator visible and clear of score

### DIFF
--- a/frontend/src/components/starswarm/GameCanvas.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.tsx
@@ -826,7 +826,19 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
             {Array.from({ length: player.lives }, (_, i) => (
               <View key={i} style={styles.lifeIndicator} />
             ))}
-            {state.activePowerUp !== null && (
+          </View>
+
+          {/* Power-up indicator — independent bottom-left block, above the lives row */}
+          {state.activePowerUp !== null && (
+            <View style={styles.powerUpIndicator} pointerEvents="none">
+              <Text
+                style={[
+                  styles.powerUpLabel,
+                  { color: state.activePowerUp.type === "shield" ? "#00aaff" : "#ffee00" },
+                ]}
+              >
+                {state.activePowerUp.type === "shield" ? "SHIELD" : "LIGHTNING"}
+              </Text>
               <View style={styles.powerUpBarWrap}>
                 <View
                   style={[
@@ -839,8 +851,8 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
                   ]}
                 />
               </View>
-            )}
-          </View>
+            </View>
+          )}
         </View>
       </View>
     );
@@ -884,20 +896,27 @@ const styles = StyleSheet.create({
     height: 14,
     backgroundColor: "#00ffcc",
   },
-  powerUpBarWrap: {
+  powerUpIndicator: {
     position: "absolute",
-    bottom: 20,
-    left: 0,
+    bottom: 26,
+    left: 10,
+  },
+  powerUpLabel: {
+    fontSize: 8,
+    fontWeight: "bold",
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  powerUpBarWrap: {
     width: 60,
-    height: 4,
+    height: 6,
     backgroundColor: "rgba(255,255,255,0.18)",
-    borderRadius: 2,
+    borderRadius: 3,
     overflow: "hidden",
   },
   powerUpBar: {
-    height: 4,
-    backgroundColor: "#ffee00",
-    borderRadius: 2,
+    height: 6,
+    borderRadius: 3,
   },
   phaseOverlay: {
     ...StyleSheet.absoluteFillObject,

--- a/frontend/src/components/starswarm/GameCanvas.web.tsx
+++ b/frontend/src/components/starswarm/GameCanvas.web.tsx
@@ -787,13 +787,21 @@ const GameCanvas = forwardRef<GameCanvasHandle, Props>(
         ctx.fillRect(10 + i * 16, height - 18, 10, 14);
       }
 
-      // Power-up countdown bar — above lives
+      // Power-up indicator — label + bar, above lives at bottom-left
       if (state.activePowerUp !== null) {
         const ratio = state.activePowerUp.remainingMs / POWERUP_DURATION;
+        const barColor =
+          state.activePowerUp.type === "shield" ? C.powerBarFillShield : C.powerBarFill;
+        const label = state.activePowerUp.type === "shield" ? "SHIELD" : "LIGHTNING";
+        ctx.font = "bold 8px 'Courier New', monospace";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "top";
+        ctx.fillStyle = barColor;
+        ctx.fillText(label, 10, height - 44);
         ctx.fillStyle = C.powerBarBg;
-        ctx.fillRect(10, height - 26, 60, 4);
-        ctx.fillStyle = C.powerBarFill;
-        ctx.fillRect(10, height - 26, 60 * ratio, 4);
+        ctx.fillRect(10, height - 34, 60, 6);
+        ctx.fillStyle = barColor;
+        ctx.fillRect(10, height - 34, 60 * ratio, 6);
       }
 
       ctx.restore();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Moves the active power-up indicator out of `hudBottom` into its own `position: absolute` view anchored at `bottom: 26, left: 10` — permanently above the lives row and well clear of the top score HUD under all circumstances
- Adds a small all-caps label (`LIGHTNING` / `SHIELD`) tinted in the power-up's accent colour so the indicator is self-explanatory at a glance
- Increases bar height 4 px → 6 px on both native (Skia) and web renderers
- Fixes a pre-existing bug in the web renderer where the Shield power-up bar always rendered yellow instead of cyan (`#00aaff`)

Closes #2007

## Test plan

- [ ] Collect a Lightning power-up in Star Swarm — confirm `LIGHTNING` label + yellow bar appears at bottom-left, clearly above the lives row
- [ ] Collect a Shield power-up — confirm `SHIELD` label + cyan bar appears at bottom-left
- [ ] Let the power-up expire — confirm the indicator disappears cleanly
- [ ] Verify indicator is visible during WaveClear, WinTransition, and GameOver overlays (rendered on top)
- [ ] Verify no overlap with the score row at the top on small-viewport devices / web

https://claude.ai/code/session_01YF3QbEckojqrz9uujwhM1b
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YF3QbEckojqrz9uujwhM1b)_