### PR TITLE
fix(android): remove unused RECORD_AUDIO and SYSTEM_ALERT_WINDOW permissions

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
-  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" tools:replace="android:maxSdkVersion"/>
   <queries>


### PR DESCRIPTION
## Summary
- Removes `RECORD_AUDIO` permission — app uses `expo-audio` / `react-native-audio-api` for playback only; `iosMicrophonePermission: false` in `app.json` confirms no recording; no runtime `PermissionsAndroid` calls found in source
- Removes `SYSTEM_ALERT_WINDOW` permission — no draw-over-other-apps feature exists in the app
- Both were Google Play policy flags that could trigger rejection on first submission

Closes #1920
Part of #1916 — App Store & Google Play First Submission Readiness

## Test plan
- [ ] Verify all game audio (sound effects, background music) plays correctly on device
- [ ] Confirm no `PermissionsAndroid` runtime requests for mic or overlay appear
- [ ] CI build passes

> Note: `./gradlew assembleDebug` fails locally due to a pre-existing JDK 25 / Gradle 8.13 incompatibility — confirmed it fails identically on unmodified `dev`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)