### PR TITLE
fix(blackjack): make player score always visible by moving pill above cards

### DIFF
--- a/frontend/src/components/blackjack/HandDisplay.tsx
+++ b/frontend/src/components/blackjack/HandDisplay.tsx
@@ -51,6 +51,10 @@ export default function HandDisplay({
         </Text>
       )}
 
+      {showScore && variant === "player" && (
+        <ScorePill value={hand.value} soft={hand.soft} concealed={concealed} variant={variant} />
+      )}
+
       <View style={styles.rows}>
         {rows.map((rowCards, rowIndex) => (
           <View key={rowIndex} style={styles.row}>
@@ -70,7 +74,7 @@ export default function HandDisplay({
         ))}
       </View>
 
-      {showScore && (
+      {showScore && variant !== "player" && (
         <ScorePill value={hand.value} soft={hand.soft} concealed={concealed} variant={variant} />
       )}
     </View>


### PR DESCRIPTION
## Summary

- The player hand score (neon cyan pill) was rendered **below** the card rows in `HandDisplay`. Because `BlackjackTable` uses `justifyContent: "space-between"` this pushes the player area to the very bottom edge of `tableArea` (which has `overflow: "hidden"`). On real devices the pill was clipped and invisible.
- Moved the player `ScorePill` to render **above** the card rows (between the "YOUR HAND" label and the cards) — it can never be clipped there.
- Dealer score badge position is unchanged (still below dealer's cards, where it has always been visible).

## Test plan

- [ ] Start a Blackjack hand and confirm the player score (e.g. "14" for 6+8) is visible immediately after cards are dealt, above the player's card fan.
- [ ] Confirm the dealer's "?" badge still appears below the dealer's cards during the player phase.
- [ ] After dealer resolves, confirm dealer's score badge shows the correct total below the dealer's cards.
- [ ] Test on a compact-height device / simulator (Galaxy Fold, iPhone SE) to confirm score is still visible in compact mode.
- [ ] Test split hands — each split hand's score pill should render above its cards.

https://claude.ai/code/session_01MNGfFVsakPYwg4VM7w8NGE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNGfFVsakPYwg4VM7w8NGE)_