### PR TITLE
fix(star-swarm): recenter pause menu RESUME and NEW GAME buttons

### DIFF
--- a/frontend/src/components/starswarm/Controls.tsx
+++ b/frontend/src/components/starswarm/Controls.tsx
@@ -247,6 +247,8 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderRadius: 8,
     backgroundColor: "#00ffcc",
+    minWidth: 180,
+    alignItems: "center",
   },
   pauseResumeBtnText: {
     color: "#000010",
@@ -261,6 +263,8 @@ const styles = StyleSheet.create({
     borderColor: "rgba(255,255,255,0.35)",
     paddingHorizontal: 18,
     paddingVertical: 7,
+    minWidth: 180,
+    alignItems: "center",
   },
   pauseNewGameBtnText: {
     color: "rgba(255,255,255,0.55)",


### PR DESCRIPTION
## Summary

- `pauseResumeBtn` had `paddingHorizontal: 32`, making it ~180pt wide.
- `pauseNewGameBtn` (merged on top of `newGameBtn`) resolved to `paddingHorizontal: 18`, making it ~100pt wide.
- Both buttons are centred via `alignItems: "center"` on the parent overlay, but their **different widths** made the narrower NEW GAME button appear visually left-shifted relative to RESUME.
- Added `minWidth: 180` and `alignItems: "center"` to both pause button styles so they share the same minimum footprint and their text is centred within it.

Closes #2010

## Test plan

- [ ] Pause a Star Swarm game and confirm RESUME and NEW GAME buttons are horizontally centred within the game canvas.
- [ ] Confirm both buttons are the same width (RESUME text centred in its pill, NEW GAME text centred in its outlined pill).
- [ ] Tap RESUME — game resumes correctly.
- [ ] Tap NEW GAME — difficulty picker appears and a new game can be started.
- [ ] Verify on a narrow device (iPhone SE) that the buttons still fit without overflow.

https://claude.ai/code/session_01MNGfFVsakPYwg4VM7w8NGE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNGfFVsakPYwg4VM7w8NGE)_