### PR TITLE
fix(privacy): declare Sentry data types in iOS manifest and disable sendDefaultPii

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -58,7 +58,7 @@ if (!dsn) {
     Sentry.init({
       dsn,
       environment: process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? "production",
-      sendDefaultPii: true,
+      sendDefaultPii: false,
     });
     installSentryConsoleErrorCapture();
   } catch (e) {

--- a/frontend/ios/GamingApp/PrivacyInfo.xcprivacy
+++ b/frontend/ios/GamingApp/PrivacyInfo.xcprivacy
@@ -41,7 +41,44 @@
 		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeCrashData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 	<key>NSPrivacyTrackingDomains</key>


### PR DESCRIPTION
## Summary
- Populates `NSPrivacyCollectedDataTypes` in `PrivacyInfo.xcprivacy` with the three types Sentry transmits (`CrashData`, `PerformanceData`, `OtherDiagnosticData`), all unlinked, non-tracking, with `AppFunctionality` purpose — matching the Sentry pod's own manifest
- Sets `sendDefaultPii: false` in `App.tsx`; the app is session-based with no user identity so the flag was never appropriate

## Test plan
- [ ] Verify `Sentry.init` still fires successfully in dev (check Sentry dashboard receives events)
- [ ] Open Xcode and confirm `PrivacyInfo.xcprivacy` shows three data type entries with no validation warnings
- [ ] Confirm no crash/regression on iOS simulator after the `sendDefaultPii` change

Closes #1921

🤖 Generated with [Claude Code](https://claude.com/claude-code)