### PR TITLE
fix(ios): add NSMicrophoneUsageDescription to resolve ITMS-90683

### DIFF
--- a/frontend/ios/GamingApp/Info.plist
+++ b/frontend/ios/GamingApp/Info.plist
@@ -37,6 +37,8 @@
 	<string>12.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>BC Arcade uses audio for game sound effects and music playback. Microphone access is not used.</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
## Summary

- Adds `NSMicrophoneUsageDescription` to `frontend/ios/GamingApp/Info.plist`
- Resolves App Store Connect rejection ITMS-90683 on build 80 (v1.0.0)
- `react-native-audio-api` references microphone APIs internally, triggering Apple's static analysis requirement — the app itself never requests mic access at runtime

## Test plan

- [ ] Trigger a new Xcode Cloud build
- [ ] Confirm build passes App Store Connect validation (no ITMS-90683)
- [ ] Verify audio playback (sound effects, background music) still works correctly on device

Closes #2017

https://claude.ai/code/session_01DocC8hBfhNTdt2cSTHJbnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DocC8hBfhNTdt2cSTHJbnM)_