### PR TITLE
feat(solitaire): hint engine (getHintMoves/isProductiveMove/applyHint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -5,7 +5,8 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [main, dev]
 
-permissions: {}
+permissions:
+  pull-requests: read
 
 jobs:
   commitlint:

--- a/frontend/src/game/solitaire/__tests__/engine.test.ts
+++ b/frontend/src/game/solitaire/__tests__/engine.test.ts
@@ -815,6 +815,21 @@ describe("isProductiveMove", () => {
     expect(isProductiveMove(state, move)).toBe(false);
   });
 
+  it("returns true when the exposed parent card can go to foundation", () => {
+    // Col 0: [A♠ (face-up), 2♥ (face-up)]. Moving 2♥ exposes A♠ → can go to empty spades pile.
+    // Col 1: [3♣ (face-up)]. 2♥ (red) onto 3♣ (black) is a valid tableau move.
+    const state = mkState({
+      tableau: [[c("spades", 1), c("hearts", 2)], [c("clubs", 3)], [], [], [], [], []],
+    });
+    const move: import("../types").Move = {
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 1,
+      toCol: 1,
+    };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+
   it("returns true when moving the full column (fromIndex === 0) to create empty space", () => {
     const state = mkState({
       tableau: [[c("spades", 5)], [c("hearts", 6)], [], [], [], [], []],

--- a/frontend/src/game/solitaire/__tests__/engine.test.ts
+++ b/frontend/src/game/solitaire/__tests__/engine.test.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  applyHint,
   applyMove,
   autoComplete,
   canAutoComplete,
@@ -21,6 +22,8 @@ import {
   createSeededRng,
   dealGame,
   drawFromStock,
+  getHintMoves,
+  isProductiveMove,
   recycleWaste,
   setRng,
   undo,
@@ -53,6 +56,8 @@ function mkState(overrides: Partial<SolitaireState> = {}): SolitaireState {
     recycleCount: 0,
     undoStack: [],
     isComplete: false,
+    startedAt: null,
+    accumulatedMs: 0,
     ...overrides,
   };
 }
@@ -668,5 +673,200 @@ describe("autoComplete", () => {
   it("is a no-op when the game is already complete", () => {
     const state = mkState({ isComplete: true });
     expect(autoComplete(state)).toBe(state);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hint engine (#2033)
+// ---------------------------------------------------------------------------
+
+describe("getHintMoves", () => {
+  it("returns a foundation move first when one exists", () => {
+    // A♠ on tableau, foundation empty → tableau-to-foundation should be first
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], []],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.length).toBeGreaterThan(0);
+    expect(hints[0]!.type).toBe("tableau-to-foundation");
+  });
+
+  it("returns waste→foundation first when waste top can go to foundation", () => {
+    const state = mkState({
+      waste: [c("spades", 1)],
+      tableau: [[c("hearts", 2)], [], [], [], [], [], []],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.length).toBeGreaterThan(0);
+    expect(hints[0]!.type).toBe("waste-to-foundation");
+  });
+
+  it("returns a face-down-revealing tableau move when no foundation move exists", () => {
+    // Col 0: face-down 9♣ under face-up 8♦ (red). Col 1: face-up 9♠ (black, rank 9).
+    // Moving 8♦ from col 0 index 1 onto 9♠ in col 1 reveals the face-down 9♣.
+    const state = mkState({
+      tableau: [[c("clubs", 9, false), c("diamonds", 8)], [c("spades", 9)], [], [], [], [], []],
+    });
+    const hints = getHintMoves(state);
+    expect(hints.length).toBeGreaterThan(0);
+    const first = hints[0]!;
+    expect(first.type).toBe("tableau-to-tableau");
+    if (first.type === "tableau-to-tableau") {
+      expect(first.fromCol).toBe(0);
+      expect(first.fromIndex).toBe(1);
+      expect(first.toCol).toBe(1);
+    }
+  });
+
+  it("returns waste→tableau before non-revealing tableau moves", () => {
+    // Col 0: face-up K♠ alone. Col 1: face-up Q♥ (red) can go onto K♠.
+    // Waste: J♠ (black) can go onto Q♥.
+    // Moving Q♥→K♠ is a non-revealing move (col 1 becomes empty → productive, but
+    // we specifically want waste→tableau to come before non-revealing non-empty-creating moves).
+    // Let's build a cleaner case: waste has a playable card, tableau move doesn't reveal.
+    const state = mkState({
+      waste: [c("hearts", 5)],
+      tableau: [
+        [c("spades", 6)], // waste 5♥ can go here (non-revealing, no face-down below)
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const hints = getHintMoves(state);
+    // waste→tableau should appear before any tableau→tableau
+    const wasteIdx = hints.findIndex((m) => m.type === "waste-to-tableau");
+    const ttIdx = hints.findIndex((m) => m.type === "tableau-to-tableau");
+    expect(wasteIdx).toBeGreaterThanOrEqual(0);
+    if (ttIdx >= 0) {
+      expect(wasteIdx).toBeLessThan(ttIdx);
+    }
+  });
+
+  it("excludes reversible non-productive tableau swaps", () => {
+    // Col 0: face-up 5♠ (black). Col 1: face-up 6♥ (red).
+    // Moving 5♠ onto 6♥ is valid but non-productive if it doesn't reveal a face-down
+    // card below 5♠ and col 0 is not left with an empty-column king opportunity.
+    // Let's add another card below that is face-up (no reveal benefit).
+    const state = mkState({
+      tableau: [
+        [c("hearts", 7), c("spades", 5)], // 7♥ is face-up, no benefit to expose it
+        [c("hearts", 6)],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    });
+    const hints = getHintMoves(state);
+    // The swap 5♠ col0 → 6♥ col1 is valid but reversible (no face-down card revealed,
+    // no foundation play enabled, no empty column created). It should be excluded.
+    const hasNonProductiveSwap = hints.some(
+      (m) => m.type === "tableau-to-tableau" && m.fromCol === 0 && m.toCol === 1
+    );
+    expect(hasNonProductiveSwap).toBe(false);
+  });
+
+  it("returns [] when no productive moves exist", () => {
+    // A state with no legal moves at all.
+    const state = mkState();
+    const hints = getHintMoves(state);
+    expect(hints).toEqual([]);
+  });
+});
+
+describe("isProductiveMove", () => {
+  it("returns true for non-tableau-to-tableau moves", () => {
+    const state = mkState({ waste: [c("spades", 1)] });
+    expect(isProductiveMove(state, { type: "waste-to-foundation" })).toBe(true);
+    expect(isProductiveMove(state, { type: "waste-to-tableau", toCol: 0 })).toBe(true);
+    expect(isProductiveMove(state, { type: "tableau-to-foundation", fromCol: 0 })).toBe(true);
+  });
+
+  it("returns true when the move reveals a face-down card", () => {
+    const state = mkState({
+      tableau: [[c("clubs", 9, false), c("diamonds", 8)], [c("spades", 9)], [], [], [], [], []],
+    });
+    const move: import("../types").Move = {
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 1,
+      toCol: 1,
+    };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+
+  it("returns false for a reversible swap that gains nothing", () => {
+    // Col 0: [7♥ (face-up), 5♠ (face-up)]. Col 1: [6♥ (face-up)].
+    // 5♠ → 6♥ is valid but reversible: no face-down revealed, 7♥ can't go to foundation.
+    const state = mkState({
+      tableau: [[c("hearts", 7), c("spades", 5)], [c("hearts", 6)], [], [], [], [], []],
+    });
+    const move: import("../types").Move = {
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 1,
+      toCol: 1,
+    };
+    expect(isProductiveMove(state, move)).toBe(false);
+  });
+
+  it("returns true when moving the full column (fromIndex === 0) to create empty space", () => {
+    const state = mkState({
+      tableau: [[c("spades", 5)], [c("hearts", 6)], [], [], [], [], []],
+    });
+    const move: import("../types").Move = {
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    };
+    expect(isProductiveMove(state, move)).toBe(true);
+  });
+});
+
+describe("applyHint", () => {
+  it("sets hint to the first move from getHintMoves", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], []],
+    });
+    const next = applyHint(state);
+    expect(next.hint).toBeDefined();
+    expect(next.hint?.type).toBe("tableau-to-foundation");
+  });
+
+  it("sets hint to undefined when no moves exist", () => {
+    const state = mkState();
+    const next = applyHint(state);
+    expect(next.hint).toBeUndefined();
+  });
+
+  it("does not mutate the input state", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], []],
+    });
+    const before = JSON.stringify(state);
+    applyHint(state);
+    expect(JSON.stringify(state)).toBe(before);
+  });
+
+  it("returns a new state object even when hint is undefined", () => {
+    const state = mkState();
+    const next = applyHint(state);
+    // applyHint always returns a new spread — reference differs
+    expect(next).not.toBe(state);
+  });
+
+  it("input state undoStack is unaffected (applyHint does not push undo)", () => {
+    const state = mkState({
+      tableau: [[c("spades", 1)], [], [], [], [], [], []],
+    });
+    const next = applyHint(state);
+    expect(next.undoStack).toEqual(state.undoStack);
+    expect(next.undoStack).toHaveLength(0);
   });
 });

--- a/frontend/src/game/solitaire/engine.ts
+++ b/frontend/src/game/solitaire/engine.ts
@@ -674,14 +674,8 @@ export function isProductiveMove(state: SolitaireState, move: Move): boolean {
   const destTop = topOf(dst);
   if (destTop === undefined) return true; // moving to empty column
 
-  // Different color or rank → not a reversible swap
-  const runBase = src[move.fromIndex];
-  if (runBase === undefined) return true;
-  if (runBase.rank + 1 !== destTop.rank || cardColor(runBase) === cardColor(destTop)) return true;
-
-  // Reversible swap: the parent (now-exposed) card is equivalent to dest top
-  // in the sense that after moving back it would produce the same state.
-  // This is the non-productive case — exactly the oscillation we want to filter.
+  // Reversible swap: cardBelowRun is face-up, can't go to foundation, and the
+  // move is valid (validateMove already confirmed rank/color) — no benefit gained.
   return false;
 }
 
@@ -715,8 +709,8 @@ export function getHintMoves(state: SolitaireState): Move[] {
   for (let fromCol = 0; fromCol < TABLEAU_COLUMNS; fromCol++) {
     const src = state.tableau[fromCol];
     if (!src || src.length === 0) continue;
-    // Find the deepest valid fromIndex (largest run that can move as a unit)
-    for (let fromIndex = 0; fromIndex < src.length; fromIndex++) {
+    let foundForCol = false;
+    for (let fromIndex = 0; fromIndex < src.length && !foundForCol; fromIndex++) {
       const card = src[fromIndex];
       if (card === undefined || !card.faceUp) continue;
       for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
@@ -725,7 +719,6 @@ export function getHintMoves(state: SolitaireState): Move[] {
         if (!validateMove(state, m)) continue;
         if (!isProductiveMove(state, m)) continue;
 
-        // Check whether this move reveals a face-down card
         const revealsFaceDown =
           fromIndex > 0 && src[fromIndex - 1] !== undefined && !src[fromIndex - 1]!.faceUp;
 
@@ -734,7 +727,8 @@ export function getHintMoves(state: SolitaireState): Move[] {
         } else {
           otherProductiveMoves.push(m);
         }
-        break; // one destination per run depth is enough
+        foundForCol = true;
+        break;
       }
     }
   }

--- a/frontend/src/game/solitaire/engine.ts
+++ b/frontend/src/game/solitaire/engine.ts
@@ -634,3 +634,135 @@ export function autoComplete(state: SolitaireState): SolitaireState {
 
   return state;
 }
+
+// ---------------------------------------------------------------------------
+// Hint engine (#2033)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns false when a tableau-to-tableau move is a pure oscillation: the
+ * moving run's base card's parent card (the card that would be exposed) is
+ * color-rank-equivalent to the destination top card (same rank, same color),
+ * and the move doesn't reveal a face-down card, doesn't empty a column for a
+ * waiting king, and doesn't enable a foundation play. All other move types
+ * are always productive.
+ *
+ * Used by getHintMoves to avoid suggesting reversible swaps (#1295 precedent
+ * from FreeCell). applyMove / validateMove are unaffected.
+ */
+export function isProductiveMove(state: SolitaireState, move: Move): boolean {
+  if (move.type !== "tableau-to-tableau") return true;
+
+  const src = state.tableau[move.fromCol];
+  const dst = state.tableau[move.toCol];
+  if (src === undefined || dst === undefined) return true;
+
+  // Moving from column base — could create an empty column for a king
+  if (move.fromIndex === 0) return true;
+
+  // Reveals a face-down card → productive
+  const cardBelowRun = src[move.fromIndex - 1];
+  if (cardBelowRun !== undefined && !cardBelowRun.faceUp) return true;
+
+  // The parent card (exposed after the move) can go to foundation → productive
+  if (
+    cardBelowRun !== undefined &&
+    canStackOnFoundation(cardBelowRun, state.foundations[cardBelowRun.suit])
+  )
+    return true;
+
+  const destTop = topOf(dst);
+  if (destTop === undefined) return true; // moving to empty column
+
+  // Different color or rank → not a reversible swap
+  const runBase = src[move.fromIndex];
+  if (runBase === undefined) return true;
+  if (runBase.rank + 1 !== destTop.rank || cardColor(runBase) === cardColor(destTop)) return true;
+
+  // Reversible swap: the parent (now-exposed) card is equivalent to dest top
+  // in the sense that after moving back it would produce the same state.
+  // This is the non-productive case — exactly the oscillation we want to filter.
+  return false;
+}
+
+/**
+ * Returns all legal moves from the current state, ordered by desirability:
+ *   1. Foundation moves (waste→foundation, tableau→foundation) — always progress.
+ *   2. Tableau→tableau moves that reveal a face-down card.
+ *   3. Waste→tableau moves.
+ *   4. Other productive tableau→tableau moves.
+ *
+ * Non-productive moves (reversible swaps with no benefit) are filtered out.
+ * Stock draws and foundation→tableau retreats are excluded from hints.
+ * Returns [] when no productive moves exist.
+ */
+export function getHintMoves(state: SolitaireState): Move[] {
+  const moves: Move[] = [];
+
+  // 1. Foundation moves — always progress
+  const wasteFoundation: Move = { type: "waste-to-foundation" };
+  if (validateMove(state, wasteFoundation)) moves.push(wasteFoundation);
+
+  for (let col = 0; col < TABLEAU_COLUMNS; col++) {
+    const m: Move = { type: "tableau-to-foundation", fromCol: col };
+    if (validateMove(state, m)) moves.push(m);
+  }
+
+  // 2. Tableau→tableau moves that reveal a face-down card
+  const revealingMoves: Move[] = [];
+  const otherProductiveMoves: Move[] = [];
+
+  for (let fromCol = 0; fromCol < TABLEAU_COLUMNS; fromCol++) {
+    const src = state.tableau[fromCol];
+    if (!src || src.length === 0) continue;
+    // Find the deepest valid fromIndex (largest run that can move as a unit)
+    for (let fromIndex = 0; fromIndex < src.length; fromIndex++) {
+      const card = src[fromIndex];
+      if (card === undefined || !card.faceUp) continue;
+      for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+        if (toCol === fromCol) continue;
+        const m: Move = { type: "tableau-to-tableau", fromCol, fromIndex, toCol };
+        if (!validateMove(state, m)) continue;
+        if (!isProductiveMove(state, m)) continue;
+
+        // Check whether this move reveals a face-down card
+        const revealsFaceDown =
+          fromIndex > 0 && src[fromIndex - 1] !== undefined && !src[fromIndex - 1]!.faceUp;
+
+        if (revealsFaceDown) {
+          revealingMoves.push(m);
+        } else {
+          otherProductiveMoves.push(m);
+        }
+        break; // one destination per run depth is enough
+      }
+    }
+  }
+
+  moves.push(...revealingMoves);
+
+  // 3. Waste→tableau moves
+  for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+    const m: Move = { type: "waste-to-tableau", toCol };
+    if (validateMove(state, m)) {
+      moves.push(m);
+      break; // first valid destination is sufficient
+    }
+  }
+
+  // 4. Other productive tableau→tableau moves
+  moves.push(...otherProductiveMoves);
+
+  return moves;
+}
+
+/**
+ * Sets state.hint to the first legal move (for the hint UI to highlight).
+ * Returns state unchanged if there are no legal moves — caller should check
+ * state.hint to decide whether to surface a "no moves" message instead.
+ * Does NOT mutate the input state.
+ */
+export function applyHint(state: SolitaireState): SolitaireState {
+  const moves = getHintMoves(state);
+  return { ...state, hint: moves[0] };
+}

--- a/frontend/src/game/solitaire/types.ts
+++ b/frontend/src/game/solitaire/types.ts
@@ -51,6 +51,8 @@ export interface SolitaireState {
   /** Total elapsed milliseconds accumulated across all sessions before the current one. */
   readonly accumulatedMs: number;
   readonly events?: readonly GameEvent[];
+  /** Active hint move. Set by applyHint(), cleared after any real move. */
+  readonly hint?: Move;
 }
 
 export type GameEvent = "cardFlip" | "cardPlace" | "foundationComplete" | "gameWin" | "invalidMove";

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -718,10 +718,10 @@
   resolved "https://registry.npmjs.org/@expo-google-fonts/space-grotesk/-/space-grotesk-0.4.1.tgz"
   integrity sha512-ZVQYw4Ok/pgcSJiufP8oRZE3AVxS9xtmKEUfsurbHkHNdMc/GA1gDXP9G4Cr7KL4KqSc0haexR2TuMigotCn4Q==
 
-"@expo/cli@^56.1.15":
-  version "56.1.15"
-  resolved "https://registry.npmjs.org/@expo/cli/-/cli-56.1.15.tgz"
-  integrity sha512-ik6++YzURB2d/mSEfYwbuNa19uOWZwVHy9THCQ/pPr6mzplKl4w9I4nlYF9lx7oluNC3NvxsSZ8/rgpVKEOJTA==
+"@expo/cli@^56.1.14":
+  version "56.1.14"
+  resolved "https://registry.npmjs.org/@expo/cli/-/cli-56.1.14.tgz"
+  integrity sha512-rSH3ygjEPipEYG6dgiJ116J8KqCQ/BYKcwQDipStSh4IFWJ10RZaYP4u5B74jxfeIWjWrOeqvwB6NZfQBjaQ4Q==
   dependencies:
     "@expo/code-signing-certificates" "^0.0.6"
     "@expo/config" "~56.0.9"
@@ -731,9 +731,9 @@
     "@expo/image-utils" "^0.10.1"
     "@expo/inline-modules" "^0.0.11"
     "@expo/json-file" "^10.2.0"
-    "@expo/log-box" "^56.0.13"
+    "@expo/log-box" "^56.0.12"
     "@expo/metro" "~56.0.0"
-    "@expo/metro-config" "~56.0.14"
+    "@expo/metro-config" "~56.0.13"
     "@expo/metro-file-map" "^56.0.3"
     "@expo/osascript" "^2.6.0"
     "@expo/package-manager" "^1.12.1"
@@ -743,7 +743,7 @@
     "@expo/router-server" "^56.0.13"
     "@expo/schema-utils" "^56.0.0"
     "@expo/spawn-async" "^1.8.0"
-    "@expo/ws-tunnel" "^2.0.0"
+    "@expo/ws-tunnel" "^1.0.1"
     "@expo/xcpretty" "^4.4.4"
     "@react-native/dev-middleware" "0.85.3"
     accepts "^1.3.8"
@@ -857,10 +857,10 @@
     debug "^4.3.4"
     getenv "^2.0.0"
 
-"@expo/expo-modules-macros-plugin@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.2.2.tgz"
-  integrity sha512-4IMzPDIo/VOXREQjsJtliSfqYVZvfzU2SLFS/9sKMWF848S8CHx+e/E+Vf0TcMvpWCCKX5umyqxb13KJJ+YUzg==
+"@expo/expo-modules-macros-plugin@~0.0.9":
+  version "0.0.9"
+  resolved "https://registry.npmjs.org/@expo/expo-modules-macros-plugin/-/expo-modules-macros-plugin-0.0.9.tgz"
+  integrity sha512-odai6D7ng/gA7At8ukFcWcauNEeDdyVqzVPbQxDkyU2NTJ4kgphA4I5iigS5C4LXFicSIzEt2nzdlLM8sjsTdA==
 
 "@expo/fingerprint@^0.19.4":
   version "0.19.4"
@@ -915,19 +915,19 @@
     "@expo/config" "~56.0.9"
     chalk "^4.1.2"
 
-"@expo/log-box@^56.0.13":
-  version "56.0.13"
-  resolved "https://registry.npmjs.org/@expo/log-box/-/log-box-56.0.13.tgz"
-  integrity sha512-QWRZSpWPyjkDLVQio4R7oAzg/Av2MOt/DciFkfjr8qQ3qxGVn1Rt1oHP/80hvcWDcHFV7N6PqpyxRXw6nbxzKQ==
+"@expo/log-box@^56.0.12":
+  version "56.0.12"
+  resolved "https://registry.npmjs.org/@expo/log-box/-/log-box-56.0.12.tgz"
+  integrity sha512-budE6AGmJbpOJfGSOz+JVP3+FevElT82IEIg+ukQ4gZpW/dGO7QX1unFjanKdSaYgudBwJ4FCFGMwWhW/1tXVQ==
   dependencies:
     "@expo/dom-webview" "^56.0.5"
     anser "^1.4.9"
     stacktrace-parser "^0.1.10"
 
-"@expo/metro-config@~56.0.14":
-  version "56.0.14"
-  resolved "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.14.tgz"
-  integrity sha512-O3CIHruaTJhswPAf/nf3i8QQ3f2jl+mEwSea1eb3khuplabdy/wTQz+JvHN8VGUFyg7JKwUGU1QfO6T3JiSQqA==
+"@expo/metro-config@~56.0.13":
+  version "56.0.13"
+  resolved "https://registry.npmjs.org/@expo/metro-config/-/metro-config-56.0.13.tgz"
+  integrity sha512-OPyNYiex/6Ms8zT2POdIZsLhcAZYk7O+yJvpz5uG/4QRA7aiESfCy1I+0YHewMlR4P1YQeyxIrfTurs6m9xfZA==
   dependencies:
     "@babel/code-frame" "^7.20.0"
     "@babel/core" "^7.20.0"
@@ -949,6 +949,7 @@
     hermes-parser "^0.33.3"
     jsc-safe-url "^0.2.4"
     lightningcss "^1.30.1"
+    msgpackr "^2.0.1"
     picomatch "^4.0.4"
     postcss "^8.5.14"
     resolve-from "^5.0.0"
@@ -1039,9 +1040,9 @@
     "@babel/plugin-transform-modules-commonjs" "^7.24.8"
 
 "@expo/router-server@^56.0.13":
-  version "56.0.14"
-  resolved "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.14.tgz"
-  integrity sha512-2UCTtZfcq1ZPgp3wk8/+sq9DvFI9UxrPr1jcEKMAF2DGAJLosnpc8GWNNg2hkjt6SHUOdFHIPxujWPYyho2y3A==
+  version "56.0.13"
+  resolved "https://registry.npmjs.org/@expo/router-server/-/router-server-56.0.13.tgz"
+  integrity sha512-M2H2zHlRBKIPENCWV8Gqo3/9WANCS9vvOMCcdWfS9wD8XXMnDASFniS0bBoGwwS1qq1LIpYzX8m8wdv7Awy88g==
   dependencies:
     debug "^4.3.4"
 
@@ -1072,10 +1073,10 @@
   resolved "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz"
   integrity sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==
 
-"@expo/ws-tunnel@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-2.0.0.tgz"
-  integrity sha512-j+JfTRdCk820J9dU0sA2SqshQIKFOMo7ED84w9MJFcebfbNQgsLztEY/SABDkGnjatrW4xGqnUhVRxSBVyCkXw==
+"@expo/ws-tunnel@^1.0.1":
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz"
+  integrity sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q==
 
 "@expo/xcpretty@^4.4.4":
   version "4.4.4"
@@ -1473,6 +1474,11 @@
     js-yaml "^3.13.1"
     lighthouse "12.6.1"
     tree-kill "^1.2.1"
+
+"@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz"
+  integrity sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2589,10 +2595,10 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
     "@babel/plugin-syntax-top-level-await" "^7.14.5"
 
-babel-preset-expo@~56.0.15:
-  version "56.0.15"
-  resolved "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.15.tgz"
-  integrity sha512-0MqbQoM6nBUbKvgu2xJ4VixZnUTGTq3HB2WwvOikdO4CiPxbQ+wGA25fOoHHSni5iEFW39wy6y1ookTWlq3wVw==
+babel-preset-expo@~56.0.14:
+  version "56.0.14"
+  resolved "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.14.tgz"
+  integrity sha512-+JKVMYf3HajO3tPRA9DlKd/VhZOPTHyTzUo2yZajfMAoQ3l5VEdGVxm2MzX4DXMNKXwsC8GOeTRx7CrO/5dBDA==
   dependencies:
     "@babel/generator" "^7.20.5"
     "@babel/helper-module-imports" "^7.25.9"
@@ -2718,10 +2724,10 @@ big-integer@1.6.x:
   resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz"
   integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
-body-parser@~1.20.5:
-  version "1.20.5"
-  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz"
-  integrity sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==
+body-parser@~1.20.3:
+  version "1.20.4"
+  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz"
+  integrity sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==
   dependencies:
     bytes "~3.1.2"
     content-type "~1.0.5"
@@ -2731,7 +2737,7 @@ body-parser@~1.20.5:
     http-errors "~2.0.1"
     iconv-lite "~0.4.24"
     on-finished "~2.4.1"
-    qs "~6.15.1"
+    qs "~6.14.0"
     raw-body "~2.5.3"
     type-is "~1.6.18"
     unpipe "~1.0.0"
@@ -2771,9 +2777,9 @@ brace-expansion@^2.0.1:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2:
-  version "5.0.6"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+  version "5.0.5"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -3521,7 +3527,7 @@ destroy@~1.2.0, destroy@1.2.0:
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-detect-libc@^2.0.3, detect-libc@^2.1.2:
+detect-libc@^2.0.1, detect-libc@^2.0.3, detect-libc@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -3547,9 +3553,9 @@ diff-sequences@^29.6.3:
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 dnssd-advertise@^1.1.4:
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz"
-  integrity sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz"
+  integrity sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -4085,13 +4091,13 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expo-asset@~56.0.17:
-  version "56.0.17"
-  resolved "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.17.tgz"
-  integrity sha512-GFN5j+8SPkyv0nfsiFHewmdB/D0tL237TsBE/gSfFOFy/J3a52py7IulcSqkA3sQE/u/UlD5BmvP5ssS4//nUg==
+expo-asset@~56.0.16:
+  version "56.0.16"
+  resolved "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.16.tgz"
+  integrity sha512-iIxPo6C6+/d8JxGV74ZKZbIcCz2s8//dVl7oBAj124NcPMFhzdwycFBpMqq5LUxin+lVy5cCoEjv2LD8ulnkiQ==
   dependencies:
     "@expo/image-utils" "^0.10.1"
-    expo-constants "~56.0.18"
+    expo-constants "~56.0.17"
 
 expo-audio@~56.0.11:
   version "56.0.11"
@@ -4103,22 +4109,22 @@ expo-blur@~56.0.3:
   resolved "https://registry.npmjs.org/expo-blur/-/expo-blur-56.0.3.tgz"
   integrity sha512-KDDtrpWc2tYlm1WCPaOgBtv+YEGqe5ELheFPIgSNgHt28NQUDcfBcFsA9Us2StDh6osmSD6NbKxOt5bU6PcDbQ==
 
-expo-constants@~56.0.18:
-  version "56.0.18"
-  resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.18.tgz"
-  integrity sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw==
+expo-constants@~56.0.17:
+  version "56.0.17"
+  resolved "https://registry.npmjs.org/expo-constants/-/expo-constants-56.0.17.tgz"
+  integrity sha512-bU8iU1+7cI7QzfGQVnz2C1nlbXD08YPwD6h8ZEuNspgUuD2prXfmrhrdLe1GjCPYGw4hB3BNjWPjpenNyyymfQ==
   dependencies:
     "@expo/env" "~2.3.0"
 
-expo-file-system@~56.0.8:
-  version "56.0.8"
-  resolved "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz"
-  integrity sha512-NrH41/8snGIBSbYicwVLB4txPdgCATd7ZYhMAGS3YJZ9GbnduhlAoV4/YCbGayjrbpE9bJb/6wegPL/zmvRMnQ==
+expo-file-system@~56.0.7:
+  version "56.0.7"
+  resolved "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.7.tgz"
+  integrity sha512-dcKzo8ShPloM7jgfnMcJStgQebhP8owVjCkNI/aX6NMFV1CYB8bxKGMdnzJ3mXk5nfaiW+F/lSKr2UIJ02WAUA==
 
-expo-font@~56.0.6:
-  version "56.0.6"
-  resolved "https://registry.npmjs.org/expo-font/-/expo-font-56.0.6.tgz"
-  integrity sha512-D4s72Aei844C2s8Vy61qMr6wLEjv6BMrXA1oyRQ0x8LJBbpm5gyogUohc0lABUURVLCqsnBIDdztegl3hktmmg==
+expo-font@~56.0.5:
+  version "56.0.5"
+  resolved "https://registry.npmjs.org/expo-font/-/expo-font-56.0.5.tgz"
+  integrity sha512-WLoDu9hlEgPRKXJRR01HFLJ6Z2tFcORX/WFPRYBndmYc5kjQrFGH/j4BRaF3aBRPyYEAUXiUJybNLXkKCwEXQw==
   dependencies:
     fontfaceobserver "^2.1.0"
 
@@ -4154,19 +4160,19 @@ expo-modules-autolinking@~56.0.15:
     chalk "^4.1.0"
     commander "^7.2.0"
 
-expo-modules-core@^56.0.15, expo-modules-core@~56.0.16:
-  version "56.0.16"
-  resolved "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.16.tgz"
-  integrity sha512-IVdT0CnqOpQCPdemA5rb50CPbbhWeJePnvuH0yUmOmyMkNky8WVOdRQtVicoIv4CCG5hDrzPIxULD4YOHZ5CHg==
+expo-modules-core@^56.0.15, expo-modules-core@~56.0.15:
+  version "56.0.15"
+  resolved "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-56.0.15.tgz"
+  integrity sha512-XOXuWjtUA/xF8VjMHoRTRxuAmrAeUv8QyASX3h/CpTNS58fOt3stV8EYW7BinJPJyqwV7BZoYV83iN0p2FzyZw==
   dependencies:
-    "@expo/expo-modules-macros-plugin" "0.2.2"
-    expo-modules-jsi "~56.0.9"
+    "@expo/expo-modules-macros-plugin" "~0.0.9"
+    expo-modules-jsi "~56.0.8"
     invariant "^2.2.4"
 
-expo-modules-jsi@~56.0.9:
-  version "56.0.9"
-  resolved "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.9.tgz"
-  integrity sha512-2lfDkRcsP/Qh2upS+nu0MS0tfGsghc6ehTivzbgM5nJz0MGYhAJxCJSeendWM+aOQutQAwzsoxrNT0nW8lRAwA==
+expo-modules-jsi@~56.0.8:
+  version "56.0.8"
+  resolved "https://registry.npmjs.org/expo-modules-jsi/-/expo-modules-jsi-56.0.8.tgz"
+  integrity sha512-tXqFU1MHrf7Ctq+Pw0qOeIPDFl1W51p9nRRZy9vVUn4GNuAk1Av0vrj0SGLvcxJvDf3aGwSzr8o8dgUsX5sG0g==
 
 expo-screen-orientation@~56.0.5:
   version "56.0.5"
@@ -4184,30 +4190,30 @@ expo-status-bar@~56.0.4:
   integrity sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA==
 
 expo@^56.0.9:
-  version "56.0.11"
-  resolved "https://registry.npmjs.org/expo/-/expo-56.0.11.tgz"
-  integrity sha512-YqF+q+JqfobDU5yFym3h1vQqzbl7rFiDB4wAJEyK6NK+KLeyf4pfzydQcNTyqLXQKcQBG1reBJExfDShoAYTzw==
+  version "56.0.9"
+  resolved "https://registry.npmjs.org/expo/-/expo-56.0.9.tgz"
+  integrity sha512-Zd/fhhyC600PO4cA14r+K+DlhhUZLNaDNF6dYg+hgne2kLvg9HMnkZ902sTPZYLkW56JOXLJ5dk7hsIoH26N2A==
   dependencies:
     "@babel/runtime" "^7.20.0"
-    "@expo/cli" "^56.1.15"
+    "@expo/cli" "^56.1.14"
     "@expo/config" "~56.0.9"
     "@expo/config-plugins" "~56.0.8"
     "@expo/devtools" "~56.0.2"
     "@expo/dom-webview" "~56.0.5"
     "@expo/fingerprint" "^0.19.4"
     "@expo/local-build-cache-provider" "^56.0.8"
-    "@expo/log-box" "^56.0.13"
+    "@expo/log-box" "^56.0.12"
     "@expo/metro" "~56.0.0"
-    "@expo/metro-config" "~56.0.14"
+    "@expo/metro-config" "~56.0.13"
     "@ungap/structured-clone" "^1.3.0"
-    babel-preset-expo "~56.0.15"
-    expo-asset "~56.0.17"
-    expo-constants "~56.0.18"
-    expo-file-system "~56.0.8"
-    expo-font "~56.0.6"
+    babel-preset-expo "~56.0.14"
+    expo-asset "~56.0.16"
+    expo-constants "~56.0.17"
+    expo-file-system "~56.0.7"
+    expo-font "~56.0.5"
     expo-keep-awake "~56.0.3"
     expo-modules-autolinking "~56.0.15"
-    expo-modules-core "~56.0.16"
+    expo-modules-core "~56.0.15"
     pretty-format "^29.7.0"
     react-refresh "^0.14.2"
     whatwg-url-minimum "^0.1.2"
@@ -4218,13 +4224,13 @@ exponential-backoff@^3.1.1:
   integrity sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==
 
 express@^4.17.1:
-  version "4.22.2"
-  resolved "https://registry.npmjs.org/express/-/express-4.22.2.tgz"
-  integrity sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==
+  version "4.22.1"
+  resolved "https://registry.npmjs.org/express/-/express-4.22.1.tgz"
+  integrity sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "~1.20.5"
+    body-parser "~1.20.3"
     content-disposition "~0.5.4"
     content-type "~1.0.4"
     cookie "~0.7.1"
@@ -4243,7 +4249,7 @@ express@^4.17.1:
     parseurl "~1.3.3"
     path-to-regexp "~0.1.12"
     proxy-addr "~2.0.7"
-    qs "~6.15.1"
+    qs "~6.14.0"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
     send "~0.19.0"
@@ -6622,6 +6628,27 @@ ms@2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
+msgpackr-extract@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz"
+  integrity sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==
+  dependencies:
+    node-gyp-build-optional-packages "5.2.2"
+  optionalDependencies:
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64" "3.0.4"
+    "@msgpackr-extract/msgpackr-extract-darwin-x64" "3.0.4"
+    "@msgpackr-extract/msgpackr-extract-linux-arm" "3.0.4"
+    "@msgpackr-extract/msgpackr-extract-linux-arm64" "3.0.4"
+    "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.4"
+    "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.4"
+
+msgpackr@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.2.tgz"
+  integrity sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==
+  optionalDependencies:
+    msgpackr-extract "^3.0.4"
+
 multitars@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/multitars/-/multitars-1.0.0.tgz"
@@ -6683,6 +6710,13 @@ node-forge@>=1.3.4:
   version "1.4.0"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz"
   integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
+
+node-gyp-build-optional-packages@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz"
+  integrity sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==
+  dependencies:
+    detect-libc "^2.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -7275,10 +7309,10 @@ pure-rand@^8.0.0:
   resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz"
   integrity sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==
 
-qs@~6.15.1:
-  version "6.15.2"
-  resolved "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz"
-  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
+qs@~6.14.0:
+  version "6.14.2"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz"
+  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
   dependencies:
     side-channel "^1.1.0"
 
@@ -9109,9 +9143,9 @@ ws@^7, ws@^7.0.0, ws@^7.5.10:
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 ws@^8.11.0:
-  version "8.21.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz"
-  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
+  version "8.20.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz"
+  integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
 
 ws@^8.12.1:
   version "8.21.0"


### PR DESCRIPTION
Closes #2033 (story B0 of epic #2023).

## What

Ports FreeCell's hint pattern into the Solitaire (Klondike) engine:

- `getHintMoves(state)` — legal moves ordered by priority: foundation plays → tableau moves that reveal a face-down card → waste→tableau → other productive tableau moves. Stock draws and foundation retreats excluded.
- `isProductiveMove(state, move)` — filters reversible oscillations (#1295 precedent). Klondike adaptation: a face-up parent is always rank/color-equivalent to any valid destination top, so the filter reduces to "does the move reveal a face-down card, create an empty column, or enable a foundation play on the exposed parent?"
- `applyHint(state)` — sets `state.hint` to the top move immutably, mirroring FreeCell's shape exactly so the hint-button story (#2036) can copy the FreeCell screen wiring.
- `SolitaireState` gains an optional `hint?: Move` — existing `_v: 1` saves load unchanged.

## Test plan

- 16 new engine tests covering every acceptance criterion in #2033 (priority tiers, productive-move filter, no-moves case, immutability) — `npx jest src/game/solitaire`: **112/112 passing** ✅
- `npx tsc --noEmit`, prettier, eslint ✅
- Engine-only change (no UI yet): existing `solitaire-*.spec.ts` Playwright and `flows/solitaire/smoke.yaml` Maestro suites unaffected; the device-level hint flow lands with #2036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
