### PR TITLE
feat(hearts): consideration evaluators for utility AI (A6 #2030)

### DIFF
--- a/frontend/src/game/hearts/__tests__/aiConsiderations.test.ts
+++ b/frontend/src/game/hearts/__tests__/aiConsiderations.test.ts
@@ -287,6 +287,13 @@ describe("rateQueenSpadesRisk", () => {
     expect(aScore).toBeLessThan(0.5);
     expect(kScore).toBeLessThan(0.5);
   });
+
+  it("returns 0.5 for leading a lower spade while holding Q♠", () => {
+    // 6♠ is not a cover card — leading it while holding Q♠ is risky but not catastrophic
+    const hand = [c("spades", 12), c("spades", 6)];
+    const info = mkInfo(hand, []);
+    expect(rateQueenSpadesRisk(info, c("spades", 6))).toBe(0.5);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -341,6 +348,20 @@ describe("rateMoonThreat", () => {
     const info = buildHeartsInfoSet([c("clubs", 5)], [], state, 0);
     expect(rateMoonThreat(info, c("clubs", 5))).toBe(0.5); // no opponent threat
   });
+
+  it("following in-suit point card that probably loses scores near 0.95", () => {
+    // Hearts led. We have K♥ (rank 13, ace-high=13). A♥ is in seenKeys → K♥ is top.
+    // P_win = 1.0 → score = 0.5 + (1 - 1.0) * 0.45 = 0.5. That's not right for this case.
+    // Actually we want: following in-suit point card that LOSES (low pWin) → score near 0.5+0.45=0.95.
+    // Use 2♥ following a hearts trick where K♥ is already winning — 2♥ cannot win.
+    const trick = [tc("hearts", 13, 3)]; // K♥ leading / winning
+    const hand = [c("hearts", 2)]; // 2♥ cannot beat K♥
+    const state = mkState({ handScores: [0, 6, 0, 0], currentTrick: trick, heartsBroken: true });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    // 2♥: pWin=0 (beaten by K♥) → score = 0.5 + (1-0)*0.45 = 0.95
+    const score = rateMoonThreat(info, c("hearts", 2));
+    expect(score).toBeCloseTo(0.95, 2);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -363,21 +384,13 @@ describe("rateMoonAttemptProgress", () => {
   });
 
   it("scores following in-suit point card proportional to P_win", () => {
-    // Hearts led; we have A♥ (certain win since all higher hearts gone)
+    // Hearts led; we have A♥. A♥ (rank=1, ace-high=14) is the highest card in
+    // any suit — nothing beats it → P_win = 1.0 → score = 1 * 0.95 = 0.95
     const trick = [tc("hearts", 3, 3)];
-    const won = [
-      [c("hearts", 1)], // A♥ in seenKeys (in our wonCards)
-      [],
-      [],
-      [],
-    ];
-    // Actually A is rank 1 = ace-high=14 = highest → if A is seen, K♥ wins
-    // Let's use A♥ where all higher are seen. A♥ rank=1 is the highest → P_win=1
-    const hand = [c("hearts", 1)]; // A♥ not seen yet
+    const hand = [c("hearts", 1)];
     const state = mkState({ wonCards: [[], [], [], []], currentTrick: trick, heartsBroken: true });
     const info = buildHeartsInfoSet(hand, trick, state, 0);
     const score = rateMoonAttemptProgress(info, c("hearts", 1));
-    // A♥ wins for sure (nothing beats it) → P_win=1 → 1*0.95 = 0.95
     expect(score).toBeCloseTo(0.95, 2);
   });
 
@@ -463,6 +476,18 @@ describe("ratePassingQuality", () => {
     const lowScore = ratePassingQuality(info, c("clubs", 6));
     expect(aScore).toBeGreaterThan(lowScore);
     expect(kScore).toBeGreaterThan(lowScore);
+  });
+
+  it("Q♠ with passDirection=none: protected only when holding both A♠ and K♠", () => {
+    const handBoth = [c("spades", 12), c("spades", 1), c("spades", 13)];
+    const handOne = [c("spades", 12), c("spades", 1)]; // A♠ but no K♠
+    const stateNone = mkState({ passDirection: "none" });
+    const infoBoth = buildHeartsInfoSet(handBoth, [], stateNone, 0);
+    const infoOne = buildHeartsInfoSet(handOne, [], stateNone, 0);
+    // With both covers: fullyProtected=true → low score (keep Q♠)
+    expect(ratePassingQuality(infoBoth, c("spades", 12))).toBeLessThan(0.3);
+    // With only A♠: fullyProtected=false → high score (pass Q♠)
+    expect(ratePassingQuality(infoOne, c("spades", 12))).toBeGreaterThan(0.9);
   });
 });
 

--- a/frontend/src/game/hearts/__tests__/aiConsiderations.test.ts
+++ b/frontend/src/game/hearts/__tests__/aiConsiderations.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Hearts consideration evaluator unit tests (#2030, story A6).
+ *
+ * Coverage:
+ *   computePWin      — certain-to-win, following loses, P_win vs hand-computed
+ *   rateMinimizeImmediatePoints
+ *   rateSuitVoidingUtility
+ *   rateQueenSpadesRisk
+ *   rateMoonThreat
+ *   rateMoonAttemptProgress
+ *   ratePassingQuality
+ *   Range invariants — all considerations return [0,1] on randomised states
+ */
+
+import {
+  computePWin,
+  rateMinimizeImmediatePoints,
+  rateMoonAttemptProgress,
+  rateMoonThreat,
+  ratePassingQuality,
+  rateQueenSpadesRisk,
+  rateSuitVoidingUtility,
+} from "../aiConsiderations";
+import { buildHeartsInfoSet } from "../aiInfoSet";
+import { createSeededRng, dealGame, getValidPlays, playCard, setRng } from "../engine";
+import type { Card, HeartsState, Rank, Suit, TrickCard } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function c(suit: Suit, rank: Rank): Card {
+  return { suit, rank };
+}
+
+function tc(suit: Suit, rank: Rank, playerIndex: number): TrickCard {
+  return { card: c(suit, rank), playerIndex };
+}
+
+function mkState(overrides: Partial<HeartsState> = {}): HeartsState {
+  return {
+    _v: 3,
+    aiDifficulty: "schemer",
+    phase: "playing",
+    handNumber: 1,
+    passDirection: "left",
+    playerHands: [[], [], [], []],
+    cumulativeScores: [0, 0, 0, 0],
+    handScores: [0, 0, 0, 0],
+    scoreHistory: [],
+    passSelections: [[], [], [], []],
+    passingComplete: true,
+    currentTrick: [],
+    currentLeaderIndex: 0,
+    currentPlayerIndex: 0,
+    wonCards: [[], [], [], []],
+    heartsBroken: false,
+    tricksPlayedInHand: 1,
+    isComplete: false,
+    winnerIndex: null,
+    knownVoids: [[], [], [], []],
+    ...overrides,
+  };
+}
+
+function mkInfo(
+  hand: Card[],
+  trick: TrickCard[],
+  stateOverrides: Partial<HeartsState> = {},
+  playerIndex = 0
+) {
+  return buildHeartsInfoSet(hand, trick, mkState(stateOverrides), playerIndex);
+}
+
+afterEach(() => {
+  setRng(Math.random);
+});
+
+// ---------------------------------------------------------------------------
+// computePWin
+// ---------------------------------------------------------------------------
+
+describe("computePWin — certain-to-win invariant", () => {
+  it("returns 1.0 when all higher cards in led suit are in seenKeys (following)", () => {
+    // Holding K♠ (rank 13). Only A♠ is higher. A♠ is in seenKeys → P_win = 1.
+    const seenCards = [c("spades", 1)]; // A♠ seen
+    const wonCards = [[...seenCards], [], [], []];
+    const trick = [tc("spades", 5, 3)]; // spades led
+    const hand = [c("spades", 13)];
+    const state = mkState({ wonCards, currentTrick: trick });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    expect(computePWin(c("spades", 13), info)).toBe(1.0);
+  });
+
+  it("returns 1.0 when Ace leads (nothing beats A)", () => {
+    const hand = [c("hearts", 1)];
+    const info = mkInfo(hand, []);
+    expect(computePWin(c("hearts", 1), info)).toBe(1.0);
+  });
+
+  it("returns 0 when card is off-suit while following", () => {
+    const trick = [tc("clubs", 5, 3)]; // clubs led
+    const info = mkInfo([c("hearts", 1)], trick, { currentTrick: trick });
+    expect(computePWin(c("hearts", 1), info)).toBe(0);
+  });
+
+  it("returns 0 when card already beaten by current trick winner", () => {
+    const trick = [tc("spades", 10, 3)]; // 10♠ winning
+    const info = mkInfo([c("spades", 7)], trick, { currentTrick: trick });
+    expect(computePWin(c("spades", 7), info)).toBe(0); // 7 < 10
+  });
+
+  it("returns value between 0 and 1 when some (not all) higher cards outstanding", () => {
+    // 9♣ following 3♣ lead. Higher clubs: T,J,Q,K,A = 5 cards max (maxHigher=14-9=5).
+    // Put 3 of them in seenKeys (collected), leaving 2 outstanding.
+    // P_win = 1 - 2/5 = 0.6 — between 0 and 1.
+    const trick = [tc("clubs", 3, 3)];
+    const won = [[c("clubs", 10), c("clubs", 11), c("clubs", 12)], [], [], []]; // T,J,Q gone
+    const hand = [c("clubs", 9)];
+    const state = mkState({ wonCards: won, currentTrick: trick });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const p = computePWin(c("clubs", 9), info);
+    expect(p).toBeGreaterThan(0);
+    expect(p).toBeLessThan(1);
+  });
+
+  it("void-ledger bonus: known-void opponents raise P_win when leading", () => {
+    // Leading 9♦ — some higher diamonds outstanding, but all opponents known void in diamonds
+    const hand = [c("diamonds", 9)];
+    const info = buildHeartsInfoSet(
+      hand,
+      [],
+      mkState({
+        knownVoids: [[], ["diamonds"], ["diamonds"], ["diamonds"]],
+      }),
+      0
+    );
+    const pWithVoids = computePWin(c("diamonds", 9), info);
+
+    // Without voids
+    const infoNoVoids = mkInfo(hand, []);
+    const pNoVoids = computePWin(c("diamonds", 9), infoNoVoids);
+
+    expect(pWithVoids).toBeGreaterThanOrEqual(pNoVoids);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateMinimizeImmediatePoints
+// ---------------------------------------------------------------------------
+
+describe("rateMinimizeImmediatePoints", () => {
+  it("returns 1.0 when the card cannot win the trick (off-suit discard)", () => {
+    const trick = [tc("clubs", 5, 3)];
+    // Discarding A♥ — void in clubs — cannot win
+    const info = mkInfo([c("hearts", 1)], trick, { currentTrick: trick });
+    expect(rateMinimizeImmediatePoints(info, c("hearts", 1))).toBe(1.0);
+  });
+
+  it("returns 1.0 when the trick contains zero points", () => {
+    // Trick with only non-point cards; leading a non-point card
+    const trick = [tc("clubs", 5, 3), tc("clubs", 7, 1)];
+    const hand = [c("clubs", 9)];
+    const info = mkInfo(hand, trick, { currentTrick: trick });
+    // No points in the trick, card has 0 points
+    expect(rateMinimizeImmediatePoints(info, c("clubs", 9))).toBe(1.0);
+  });
+
+  it("returns < 1.0 when card would likely win a trick with hearts", () => {
+    // A♥ leads; opponent played 2♥; we follow with K♥ — high chance of winning 2 pts
+    const trick = [tc("hearts", 2, 3), tc("hearts", 5, 1)];
+    const hand = [c("hearts", 13)]; // K♥
+    // Seed known-voids so A♥ is in seenKeys (A♥ already played → K♥ becomes top)
+    const won = [[c("hearts", 1)], [], [], []];
+    const state = mkState({ wonCards: won, currentTrick: trick, heartsBroken: true });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const score = rateMinimizeImmediatePoints(info, c("hearts", 13));
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(1.0);
+  });
+
+  it("returns a lower score for Q♠ certain to win than for a 2♠ that loses", () => {
+    // 3♠ led. K♠ and A♠ are both in seenKeys, so Q♠ (rank 12) is the highest
+    // outstanding spade and will win. 2♠ is beaten by the current 3♠ → P_win=0.
+    const trick = [tc("spades", 3, 3)];
+    const won = [[c("spades", 1), c("spades", 13)], [], [], []]; // A♠, K♠ gone
+    const hand = [c("spades", 12), c("spades", 2)];
+    const state = mkState({ wonCards: won, currentTrick: trick });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const qScore = rateMinimizeImmediatePoints(info, c("spades", 12)); // certain win, 13 pts
+    const lowScore = rateMinimizeImmediatePoints(info, c("spades", 2)); // P_win=0 → score=1.0
+    expect(qScore).toBeLessThan(lowScore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateSuitVoidingUtility
+// ---------------------------------------------------------------------------
+
+describe("rateSuitVoidingUtility", () => {
+  it("returns 1.0 when playing the card creates an immediate void", () => {
+    const hand = [c("diamonds", 7)]; // only diamond
+    const info = mkInfo(hand, []);
+    expect(rateSuitVoidingUtility(info, c("diamonds", 7))).toBe(1.0);
+  });
+
+  it("returns ~0.67 with 2 cards remaining in suit", () => {
+    const hand = [c("diamonds", 7), c("diamonds", 9)];
+    const info = mkInfo(hand, []);
+    expect(rateSuitVoidingUtility(info, c("diamonds", 7))).toBeCloseTo(0.667, 2);
+  });
+
+  it("returns 0.33 with 3 cards remaining in suit", () => {
+    const hand = [c("diamonds", 5), c("diamonds", 7), c("diamonds", 9)];
+    const info = mkInfo(hand, []);
+    expect(rateSuitVoidingUtility(info, c("diamonds", 5))).toBeCloseTo(0.333, 2);
+  });
+
+  it("returns 0 with 4+ cards remaining in suit", () => {
+    const hand = [c("clubs", 6), c("clubs", 7), c("clubs", 8), c("clubs", 9)];
+    const info = mkInfo(hand, []);
+    expect(rateSuitVoidingUtility(info, c("clubs", 6))).toBe(0);
+  });
+
+  it("a singleton produces higher void utility than a doubleton", () => {
+    const handSingle = [c("spades", 5)];
+    const handDouble = [c("spades", 5), c("spades", 7)];
+    const infoS = mkInfo(handSingle, []);
+    const infoD = mkInfo(handDouble, []);
+    expect(rateSuitVoidingUtility(infoS, c("spades", 5))).toBeGreaterThan(
+      rateSuitVoidingUtility(infoD, c("spades", 5))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateQueenSpadesRisk
+// ---------------------------------------------------------------------------
+
+describe("rateQueenSpadesRisk", () => {
+  it("returns 1.0 when Q♠ is already gone (in seenKeys)", () => {
+    const won = [[c("spades", 12)], [], [], []];
+    const info = mkInfo([c("hearts", 5)], [], { wonCards: won });
+    expect(rateQueenSpadesRisk(info, c("hearts", 5))).toBe(1.0);
+  });
+
+  it("returns 1.0 for Q♠ as off-suit void discard (safe dump)", () => {
+    // Clubs led; we're void in clubs; discarding Q♠ safely
+    const trick = [tc("clubs", 5, 3)];
+    const hand = [c("spades", 12)];
+    const info = mkInfo(hand, trick, { currentTrick: trick });
+    expect(rateQueenSpadesRisk(info, c("spades", 12))).toBe(1.0);
+  });
+
+  it("returns very low for leading Q♠ (near-certain self-take)", () => {
+    const hand = [c("spades", 12), c("spades", 3)];
+    const info = mkInfo(hand, []);
+    expect(rateQueenSpadesRisk(info, c("spades", 12))).toBeLessThanOrEqual(0.1);
+  });
+
+  it("score for Q♠ following spades: inversely proportional to win chance", () => {
+    // Spades led; A♠ and K♠ already seen → Q♠ wins the trick (highest remaining)
+    const trick = [tc("spades", 5, 3)];
+    const won = [[c("spades", 1), c("spades", 13)], [], [], []]; // A♠,K♠ gone
+    const hand = [c("spades", 12)];
+    const state = mkState({ wonCards: won, currentTrick: trick });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    // Q♠ will win (nothing higher outstanding) → high self-take risk → low score
+    expect(rateQueenSpadesRisk(info, c("spades", 12))).toBeLessThan(0.2);
+  });
+
+  it("returns low when winning a trick containing Q♠", () => {
+    // Q♠ is in the trick; we're following with a high spade that beats it
+    const trick = [tc("spades", 3, 3), tc("spades", 12, 1)]; // Q♠ played by P1
+    const hand = [c("spades", 1)]; // A♠ will win this trick
+    const info = mkInfo(hand, trick, { currentTrick: trick });
+    const score = rateQueenSpadesRisk(info, c("spades", 1));
+    expect(score).toBeLessThan(0.5);
+  });
+
+  it("penalises leading A♠/K♠ while holding Q♠", () => {
+    const hand = [c("spades", 12), c("spades", 1), c("spades", 13)];
+    const info = mkInfo(hand, []);
+    const aScore = rateQueenSpadesRisk(info, c("spades", 1));
+    const kScore = rateQueenSpadesRisk(info, c("spades", 13));
+    // Leading cover cards while holding Q♠ should score poorly
+    expect(aScore).toBeLessThan(0.5);
+    expect(kScore).toBeLessThan(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateMoonThreat
+// ---------------------------------------------------------------------------
+
+describe("rateMoonThreat", () => {
+  it("returns 0.5 when there is no moon threat (no points taken)", () => {
+    const info = mkInfo([c("clubs", 5)], []);
+    expect(rateMoonThreat(info, c("clubs", 5))).toBe(0.5);
+  });
+
+  it("returns 0.5 when points are spread across multiple players", () => {
+    const state = mkState({ handScores: [5, 3, 0, 0] });
+    const info = buildHeartsInfoSet([c("clubs", 5)], [], state, 0);
+    expect(rateMoonThreat(info, c("clubs", 5))).toBe(0.5);
+  });
+
+  it("returns > 0.5 for off-suit point dump onto shooter's trick", () => {
+    // P1 has all 6 points (moon threat). We're void in clubs, discarding Q♠.
+    const trick = [tc("clubs", 5, 1)]; // shooter is winning
+    const hand = [c("spades", 12)]; // Q♠ to dump
+    const state = mkState({
+      handScores: [0, 6, 0, 0],
+      currentTrick: trick,
+    });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const score = rateMoonThreat(info, c("spades", 12)); // off-suit Q♠ dump
+    expect(score).toBeGreaterThan(0.7);
+  });
+
+  it("returns < 0.5 for leading hearts during a moon threat (feeds the shooter)", () => {
+    const hand = [c("hearts", 10)];
+    const state = mkState({ handScores: [0, 6, 0, 0] });
+    const info = buildHeartsInfoSet(hand, [], state, 0);
+    expect(rateMoonThreat(info, c("hearts", 10))).toBeLessThan(0.5);
+  });
+
+  it("Q♠ dump scores higher than a single heart dump", () => {
+    const trick = [tc("clubs", 5, 1)]; // shooter winning
+    const hand = [c("spades", 12), c("hearts", 3)];
+    const state = mkState({ handScores: [0, 4, 0, 0], currentTrick: trick });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const qScore = rateMoonThreat(info, c("spades", 12));
+    const hScore = rateMoonThreat(info, c("hearts", 3));
+    expect(qScore).toBeGreaterThan(hScore);
+  });
+
+  it("does not misidentify self as threat (uses playerIndex)", () => {
+    // We (P0) have all points — we're not a threat to ourselves
+    const state = mkState({ handScores: [6, 0, 0, 0] });
+    const info = buildHeartsInfoSet([c("clubs", 5)], [], state, 0);
+    expect(rateMoonThreat(info, c("clubs", 5))).toBe(0.5); // no opponent threat
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rateMoonAttemptProgress
+// ---------------------------------------------------------------------------
+
+describe("rateMoonAttemptProgress", () => {
+  it("returns 0.9 for dumping junk (non-point) when void", () => {
+    const trick = [tc("clubs", 5, 1)]; // clubs led
+    const hand = [c("diamonds", 3)]; // void in clubs, diamond discard
+    const info = mkInfo(hand, trick, { currentTrick: trick });
+    expect(rateMoonAttemptProgress(info, c("diamonds", 3))).toBeCloseTo(0.9, 5);
+  });
+
+  it("returns ~0.05 for discarding a heart when void (fatal for moon run)", () => {
+    const trick = [tc("clubs", 5, 1)];
+    const hand = [c("hearts", 7)];
+    const info = mkInfo(hand, trick, { currentTrick: trick });
+    expect(rateMoonAttemptProgress(info, c("hearts", 7))).toBeCloseTo(0.05, 5);
+  });
+
+  it("scores following in-suit point card proportional to P_win", () => {
+    // Hearts led; we have A♥ (certain win since all higher hearts gone)
+    const trick = [tc("hearts", 3, 3)];
+    const won = [
+      [c("hearts", 1)], // A♥ in seenKeys (in our wonCards)
+      [],
+      [],
+      [],
+    ];
+    // Actually A is rank 1 = ace-high=14 = highest → if A is seen, K♥ wins
+    // Let's use A♥ where all higher are seen. A♥ rank=1 is the highest → P_win=1
+    const hand = [c("hearts", 1)]; // A♥ not seen yet
+    const state = mkState({ wonCards: [[], [], [], []], currentTrick: trick, heartsBroken: true });
+    const info = buildHeartsInfoSet(hand, trick, state, 0);
+    const score = rateMoonAttemptProgress(info, c("hearts", 1));
+    // A♥ wins for sure (nothing beats it) → P_win=1 → 1*0.95 = 0.95
+    expect(score).toBeCloseTo(0.95, 2);
+  });
+
+  it("non-heart lead: higher P_win yields higher score", () => {
+    // Leading 2♣ (low, many higher outstanding) vs A♣ (certain win)
+    const hand2 = [c("clubs", 2)];
+    const handA = [c("clubs", 1)];
+    const info2 = mkInfo(hand2, []);
+    const infoA = mkInfo(handA, []);
+    const s2 = rateMoonAttemptProgress(info2, c("clubs", 2));
+    const sA = rateMoonAttemptProgress(infoA, c("clubs", 1));
+    expect(sA).toBeGreaterThan(s2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ratePassingQuality
+// ---------------------------------------------------------------------------
+
+describe("ratePassingQuality", () => {
+  it("returns 0.0 for 2♣ (must never be passed)", () => {
+    const info = mkInfo([c("clubs", 2), c("clubs", 5)], []);
+    expect(ratePassingQuality(info, c("clubs", 2))).toBe(0.0);
+  });
+
+  it("returns 0.9 for A♥ (always wins heart tricks)", () => {
+    const info = mkInfo([c("hearts", 1)], []);
+    expect(ratePassingQuality(info, c("hearts", 1))).toBe(0.9);
+  });
+
+  it("danger hearts descend: A♥ > K♥ > Q♥ > J♥", () => {
+    const hand = [c("hearts", 1), c("hearts", 13), c("hearts", 12), c("hearts", 11)];
+    const info = mkInfo(hand, []);
+    const [aH, kH, qH, jH] = hand.map((cd) => ratePassingQuality(info, cd));
+    expect(aH).toBeGreaterThan(kH!);
+    expect(kH!).toBeGreaterThan(qH!);
+    expect(qH!).toBeGreaterThan(jH!);
+  });
+
+  it("Q♠ scores high when passing right (no protection needed)", () => {
+    const hand = [c("spades", 12), c("spades", 1), c("spades", 13)];
+    const state = mkState({ passDirection: "right" });
+    const info = buildHeartsInfoSet(hand, [], state, 0);
+    expect(ratePassingQuality(info, c("spades", 12))).toBeGreaterThan(0.9);
+  });
+
+  it("Q♠ scores low when passing left and holding A♠ + K♠ (fully protected)", () => {
+    const hand = [c("spades", 12), c("spades", 1), c("spades", 13)];
+    const state = mkState({ passDirection: "left" });
+    const info = buildHeartsInfoSet(hand, [], state, 0);
+    // left + A♠ cover → protected → should not pass Q♠
+    expect(ratePassingQuality(info, c("spades", 12))).toBeLessThan(0.3);
+  });
+
+  it("K♠ scores low when holding Q♠ (needed as cover)", () => {
+    const hand = [c("spades", 12), c("spades", 13)];
+    const info = mkInfo(hand, []);
+    expect(ratePassingQuality(info, c("spades", 13))).toBeLessThan(0.3);
+  });
+
+  it("K♠ scores moderately high without Q♠ in hand", () => {
+    const hand = [c("spades", 13), c("clubs", 5)];
+    const info = mkInfo(hand, []);
+    expect(ratePassingQuality(info, c("spades", 13))).toBeGreaterThan(0.5);
+  });
+
+  it("10♥ scores higher when passing right vs left", () => {
+    const hand = [c("hearts", 10)];
+    const stateRight = mkState({ passDirection: "right" });
+    const stateLeft = mkState({ passDirection: "left" });
+    const infoR = buildHeartsInfoSet(hand, [], stateRight, 0);
+    const infoL = buildHeartsInfoSet(hand, [], stateLeft, 0);
+    expect(ratePassingQuality(infoR, c("hearts", 10))).toBeGreaterThan(
+      ratePassingQuality(infoL, c("hearts", 10))
+    );
+  });
+
+  it("A♣/K♣ score higher than low clubs (danger early cycle)", () => {
+    const hand = [c("clubs", 1), c("clubs", 13), c("clubs", 6)];
+    const info = mkInfo(hand, []);
+    const aScore = ratePassingQuality(info, c("clubs", 1));
+    const kScore = ratePassingQuality(info, c("clubs", 13));
+    const lowScore = ratePassingQuality(info, c("clubs", 6));
+    expect(aScore).toBeGreaterThan(lowScore);
+    expect(kScore).toBeGreaterThan(lowScore);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Range invariants — all considerations must return [0, 1] on arbitrary states
+// ---------------------------------------------------------------------------
+
+describe("Range invariants — all considerations in [0, 1]", () => {
+  const CONSIDERATIONS = [
+    rateMinimizeImmediatePoints,
+    rateSuitVoidingUtility,
+    rateQueenSpadesRisk,
+    rateMoonThreat,
+    rateMoonAttemptProgress,
+    ratePassingQuality,
+  ] as const;
+
+  it("all return [0,1] for every valid play in 30 seeded games", () => {
+    for (let seed = 0; seed < 30; seed++) {
+      setRng(createSeededRng(seed));
+      let state = dealGame();
+
+      // Fast-forward to trick 3 (past first-trick restrictions) by playing first tricks
+      for (let t = 0; t < 3; t++) {
+        for (let p = 0; p < 4; p++) {
+          const player = state.currentPlayerIndex;
+          const valid = getValidPlays(state, player);
+          if (valid.length === 0) break;
+          state = playCard(state, player, valid[0]!);
+          if (state.phase !== "playing") break;
+        }
+        if (state.phase !== "playing") break;
+      }
+
+      if (state.phase !== "playing") continue;
+
+      const player = state.currentPlayerIndex;
+      const hand = state.playerHands[player] ?? [];
+      const trick = state.currentTrick;
+      const info = buildHeartsInfoSet([...hand], [...trick], state, player);
+      const valid = getValidPlays(state, player);
+
+      for (const card of valid) {
+        for (const fn of CONSIDERATIONS) {
+          const score = fn(info, card);
+          expect(score).toBeGreaterThanOrEqual(0);
+          expect(score).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
+});

--- a/frontend/src/game/hearts/aiConsiderations.ts
+++ b/frontend/src/game/hearts/aiConsiderations.ts
@@ -1,0 +1,423 @@
+/**
+ * Hearts consideration evaluators for the utility AI (#2030, story A6).
+ *
+ * Pure functions — no React, no IO, no Math.random, no Date.now.
+ * Each accepts a HeartsInfoSet plus a candidate Card and returns a normalized
+ * score in [0.0, 1.0]:  0.0 = highly undesirable, 1.0 = highly desirable.
+ *
+ * All six functions are decomposed from the existing rule chains in ai.ts.
+ * Strategy knowledge is preserved; branching priority structure is discarded.
+ *
+ * Play considerations (action = Card to play):
+ *   rateMinimizeImmediatePoints — avoid winning point-laden tricks
+ *   rateQueenSpadesRisk         — avoid self-taking Q♠ (13 pts)
+ *   rateMoonThreat              — block an opponent's moon attempt
+ *   rateMoonAttemptProgress     — advance our own moon run (Daring)
+ *
+ * Pass considerations (action = Card to include in the pass selection):
+ *   rateSuitVoidingUtility      — progress toward a useful suit void
+ *   ratePassingQuality          — composite danger-card / void priority
+ */
+
+import type { Consideration } from "../_shared/utilityAi/types";
+import type { HeartsInfoSet } from "./aiInfoSet";
+import type { Card, Rank, Suit } from "./types";
+
+// ---------------------------------------------------------------------------
+// Internal helpers (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+const aceHigh = (rank: number): number => (rank === 1 ? 14 : rank);
+
+function isQueenOfSpades(c: Card): boolean {
+  return c.suit === "spades" && c.rank === 12;
+}
+
+function cardPoints(c: Card): number {
+  if (c.suit === "hearts") return 1;
+  if (isQueenOfSpades(c)) return 13;
+  return 0;
+}
+
+const ALL_RANKS: readonly Rank[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+/** Count cards in `suit` with strictly higher rank than `card` that are not yet
+ *  seen and not currently in the acting player's hand. */
+function countHigherOutstanding(
+  card: Card,
+  suit: Suit,
+  seenKeys: ReadonlySet<string>,
+  hand: readonly Card[]
+): number {
+  const cardRank = aceHigh(card.rank);
+  const handKeys = new Set(hand.map((c) => `${c.suit}:${c.rank}`));
+  let count = 0;
+  for (const rank of ALL_RANKS) {
+    if (aceHigh(rank) <= cardRank) continue;
+    const key = `${suit}:${rank}`;
+    if (!seenKeys.has(key) && !handKeys.has(key)) count++;
+  }
+  return count;
+}
+
+/** Highest ace-high rank currently winning the trick in `ledSuit`. */
+function currentTrickWinRank(trick: HeartsInfoSet["currentTrick"], ledSuit: Suit): number {
+  let best = 0;
+  for (const tc of trick) {
+    if (tc.card.suit === ledSuit) {
+      const r = aceHigh(tc.card.rank);
+      if (r > best) best = r;
+    }
+  }
+  return best;
+}
+
+/**
+ * Estimated probability that `card` wins the current trick.
+ *
+ * When following: card must be in led suit and beat the current winner;
+ * score decreases linearly with outstanding higher cards.
+ *
+ * When leading: score decreases linearly with outstanding higher cards in
+ * the led suit, then increases with the fraction of opponents known void
+ * (void opponents cannot follow, so they cannot beat us in that suit).
+ *
+ * Invariant: returns 1.0 when all higher cards in the relevant suit are
+ * accounted for (in seenKeys or in hand).  Returns 0.0 when the card
+ * cannot possibly win (wrong suit when following, or already beaten).
+ */
+export function computePWin(card: Card, infoSet: HeartsInfoSet): number {
+  const { seenKeys, hand, currentTrick, ledSuit, voidLedger } = infoSet;
+
+  if (ledSuit !== null) {
+    if (card.suit !== ledSuit) return 0; // off-suit never wins
+
+    const winRank = currentTrickWinRank(currentTrick, ledSuit);
+    if (aceHigh(card.rank) <= winRank) return 0; // already beaten by current winner
+
+    const higher = countHigherOutstanding(card, ledSuit, seenKeys, hand);
+    if (higher === 0) return 1.0;
+
+    const maxHigher = 14 - aceHigh(card.rank); // ranks strictly above this card (up to A=14)
+    return Math.max(0, 1.0 - higher / Math.max(1, maxHigher));
+  }
+
+  // Leading
+  const higher = countHigherOutstanding(card, card.suit, seenKeys, hand);
+  if (higher === 0) return 1.0;
+
+  const maxHigher = 14 - aceHigh(card.rank);
+  const basePWin = Math.max(0, 1.0 - higher / Math.max(1, maxHigher));
+
+  // Void bonus: void opponents cannot follow suit and therefore cannot beat us
+  const knownVoidCount = [0, 1, 2, 3].filter(
+    (p) => voidLedger[p]?.[card.suit]
+  ).length;
+  const voidFraction = knownVoidCount / 3;
+  return Math.min(1.0, basePWin + voidFraction * (1.0 - basePWin));
+}
+
+// ---------------------------------------------------------------------------
+// rateMinimizeImmediatePoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Score = how well this card avoids capturing points in the current trick.
+ *
+ * Decomposed from: chooseFollow tries-to-lose-on-point-tricks, chooseDiscard
+ * dumps highest heart / Q♠, chooseLead / chooseLeadHard avoid leading hearts.
+ *
+ * 1.0: card cannot win the trick, or the trick contains zero points.
+ * 0.0: card is certain to win a trick worth 26 pts (maximum danger).
+ */
+export const rateMinimizeImmediatePoints: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const pWin = computePWin(card, infoSet);
+  if (pWin === 0) return 1.0;
+
+  const trickPts = infoSet.currentTrick.reduce(
+    (s, tc) => s + cardPoints(tc.card),
+    0
+  );
+  const totalPts = trickPts + cardPoints(card);
+  if (totalPts === 0) return 1.0;
+
+  // Expected points captured, normalised by the theoretical max of 26
+  const danger = (pWin * totalPts) / 26;
+  return Math.max(0, 1.0 - danger);
+};
+
+// ---------------------------------------------------------------------------
+// rateSuitVoidingUtility
+// ---------------------------------------------------------------------------
+
+/**
+ * Score = how much playing/passing this card advances a void in its suit.
+ *
+ * Decomposed from: voidOneSuit (pass logic) and the shortest-suit discard
+ * preference in chooseDiscard / chooseLead (holding Q♠).
+ *
+ * 1.0: card is the last of its suit in hand — playing it creates an immediate void.
+ * 0.0: suit has ≥4 remaining cards — voiding is not achievable in the near term.
+ */
+export const rateSuitVoidingUtility: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const suitCount = infoSet.hand.filter((c) => c.suit === card.suit).length;
+  if (suitCount === 1) return 1.0; // immediate void
+  // Linear: 2 remaining → 0.67, 3 → 0.33, 4+ → 0
+  return Math.max(0, 1.0 - (suitCount - 1) / 3);
+};
+
+// ---------------------------------------------------------------------------
+// rateQueenSpadesRisk
+// ---------------------------------------------------------------------------
+
+/**
+ * Score = how safe this card is with respect to self-taking Q♠ (13 pts).
+ *
+ * Decomposed from: qSpadeProtected direction thresholds (all three pass modes),
+ * the "dump Q♠ on void discard" path in chooseFollow, the endgame Q♠ guard in
+ * selectCardToPlayHard, and the lead guard (never lead K♠/A♠ while Q♠ is out).
+ *
+ * 1.0: no Q♠ risk (Q♠ already gone, or this card cannot cause self-take).
+ * 0.0: near-certain Q♠ self-take (e.g. leading Q♠ into an active spade suit).
+ */
+export const rateQueenSpadesRisk: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const { hand, seenKeys, currentTrick, ledSuit } = infoSet;
+
+  // Q♠ is "gone" only when it has been collected into a completed trick (wonCards),
+  // not when it is merely in the current (still-active) trick.
+  const qInCurrentTrick = currentTrick.some((tc) => isQueenOfSpades(tc.card));
+  const qGone = seenKeys.has("spades:12") && !qInCurrentTrick;
+  if (qGone) return 1.0; // Q♠ safely collected — no further Q♠ risk
+
+  const holdingQ = hand.some(isQueenOfSpades);
+
+  if (isQueenOfSpades(card)) {
+    if (ledSuit === null) {
+      // Leading Q♠: starts a spade trick — almost certain self-take
+      return 0.05;
+    }
+    if (card.suit !== ledSuit) {
+      // Off-suit void discard of Q♠: safe dump → excellent
+      return 1.0;
+    }
+    // In-suit spade follow: good only when Q♠ loses
+    const pWin = computePWin(card, infoSet);
+    return Math.max(0, 1.0 - pWin);
+  }
+
+  // Q♠ is in the current trick — winning it costs us 13 pts
+  const qInTrick = currentTrick.some((tc) => isQueenOfSpades(tc.card));
+  if (qInTrick) {
+    const pWin = computePWin(card, infoSet);
+    return Math.max(0, 1.0 - pWin);
+  }
+
+  if (holdingQ) {
+    // Holding Q♠: assess whether this play creates exposure
+    if (card.suit === "spades" && ledSuit === null) {
+      // Leading spades with Q♠ in hand risks forced spade leads that trap Q♠.
+      // Decomposed from chooseLeadHard: avoid leading K♠/A♠ while Q♠ outstanding.
+      if (card.rank === 1 || card.rank === 13) return 0.25; // burns Q♠ cover
+      return 0.5;
+    }
+    return 0.8; // holding Q♠ but this play doesn't directly expose it
+  }
+
+  return 1.0; // Q♠ outstanding but we don't hold it and it's not in the trick
+};
+
+// ---------------------------------------------------------------------------
+// rateMoonThreat
+// ---------------------------------------------------------------------------
+
+/**
+ * Score = how effectively this card blocks an opponent's moon attempt.
+ *
+ * Decomposed from: the moon-blocking dump sequences in selectCardToPlayMedium /
+ * selectCardToPlayHard — dump highest safe point card on the moon-shooter's trick
+ * when following, prefer low leads that won't feed the shooter when leading.
+ *
+ * 1.0: optimal block (safe high-value point dump onto the shooter's winning trick).
+ * 0.5: neutral (no moon threat, or card has no blocking effect).
+ * 0.0: counter-productive (would win back a point trick, helping the shooter).
+ */
+export const rateMoonThreat: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const { pointsPerPlayer, playerIndex, ledSuit } = infoSet;
+
+  const totalPts = pointsPerPlayer.reduce((s, v) => s + v, 0);
+  if (totalPts < 4) return 0.5; // insufficient signal for a moon threat
+
+  // Moon threat: exactly one opponent holds all points taken so far
+  let threatFound = false;
+  for (let i = 0; i < 4; i++) {
+    if (i === playerIndex) continue;
+    const pts = pointsPerPlayer[i] ?? 0;
+    if (pts > 0 && pts === totalPts) {
+      threatFound = true;
+      break;
+    }
+  }
+  if (!threatFound) return 0.5;
+
+  const pts = cardPoints(card);
+  const pWin = computePWin(card, infoSet);
+  const isVoid = ledSuit !== null && card.suit !== ledSuit;
+
+  if (ledSuit === null) {
+    // Leading during a moon threat: avoid starting point tricks the shooter can take
+    return pts > 0 ? 0.2 : 0.6;
+  }
+
+  if (isVoid) {
+    // Off-suit discard onto the shooter's trick: dumping points is ideal blocking
+    // Q♠ (13 pts) is worth maximally dumping; each heart (1 pt) is still useful
+    if (pts > 0) return 0.7 + (pts / 26) * 0.3;
+    return 0.5; // non-point discard: neutral
+  }
+
+  // Following in led suit: dump points only when we won't win the trick back
+  if (pts > 0) {
+    return 0.5 + (1.0 - pWin) * 0.45; // safe dump → up to 0.95; self-win → ~0.5
+  }
+  return 0.5;
+};
+
+// ---------------------------------------------------------------------------
+// rateMoonAttemptProgress
+// ---------------------------------------------------------------------------
+
+/**
+ * Score = how well this card advances collecting all 26 points (moon run).
+ *
+ * Decomposed from: the earlyMoon / midMoon play sequences in selectCardToPlayHard
+ * — lead highest non-hearts for trick control, win every point trick, dump junk
+ * when void, protect hearts/Q♠ from being discarded.
+ *
+ * The weight broker (A7) applies this consideration only for Daring persona and
+ * when moon-attempt mode is active.  Here we rate the card's raw moon-run value
+ * without gating on whether the player is actually in moon mode.
+ *
+ * 1.0: perfect moon-run move (win a fully point-laden trick).
+ * 0.5: neutral (e.g. winning a 0-pt trick for board control).
+ * 0.05: catastrophic (discarding a heart/Q♠ during a void, losing it forever).
+ */
+export const rateMoonAttemptProgress: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const pts = cardPoints(card);
+  const pWin = computePWin(card, infoSet);
+  const { ledSuit } = infoSet;
+  const isVoid = ledSuit !== null && card.suit !== ledSuit;
+
+  if (isVoid) {
+    // Off-suit void discard: dump non-point junk; losing a heart/Q♠ kills a moon run
+    if (pts === 0) return 0.9;
+    return 0.05;
+  }
+
+  if (ledSuit === null) {
+    // Leading: want to win and maintain trick control
+    if (card.suit === "hearts" || isQueenOfSpades(card)) {
+      // Lead hearts/Q♠ only when necessary; prefer winning if forced
+      return pWin * 0.75;
+    }
+    // Non-heart lead for trick control: high pWin = high desirability
+    return 0.3 + pWin * 0.65;
+  }
+
+  // Following in led suit
+  if (pts > 0) return pWin * 0.95; // win point tricks to collect all 26
+  return pWin * 0.65; // win 0-pt tricks for board control
+};
+
+// ---------------------------------------------------------------------------
+// ratePassingQuality
+// ---------------------------------------------------------------------------
+
+/**
+ * Composite pass quality score for a single candidate card.
+ *
+ * Decomposed from all three pass-strategy implementations (selectCardsToPassEasy /
+ * Medium / Hard): Q♠ direction-aware thresholds, danger-heart ranking,
+ * first-trick club safety, A♣/K♣ danger, short-suit priority, cover-card
+ * preservation when keeping Q♠.
+ *
+ * 1.0: ideal pass candidate (unprotected Q♠, A♥, high danger heart).
+ * 0.0: must never pass (2♣).
+ */
+export const ratePassingQuality: Consideration<HeartsInfoSet, Card> = (
+  infoSet,
+  card
+) => {
+  const { hand, passDirection } = infoSet;
+
+  // 2♣ must never be passed — engine requires it to open the first trick
+  if (card.suit === "clubs" && card.rank === 2) return 0.0;
+
+  // Low clubs (3♣–5♣): safe early leads; low pass priority
+  if (card.suit === "clubs" && card.rank >= 3 && card.rank <= 5) return 0.35;
+
+  const spades = hand.filter((c) => c.suit === "spades");
+  const hasQSpades = spades.some(isQueenOfSpades);
+  const hasASpades = spades.some((c) => c.rank === 1);
+  const hasKSpades = spades.some((c) => c.rank === 13);
+  const voidInSpades = spades.length === 0;
+
+  if (isQueenOfSpades(card)) {
+    if (voidInSpades) return 0.5; // void in spades — Q♠ pass is moot but not dangerous
+    // Direction-aware protection thresholds (decomposed from Medium/Hard pass logic)
+    const fullyProtected =
+      passDirection === "left"
+        ? hasASpades || hasKSpades // keep Q♠ with any cover when passing left
+        : passDirection === "none"
+          ? hasASpades && hasKSpades // baseline: need both covers to keep Q♠
+          : false; // right/across: always pass Q♠ (travels safely)
+    return fullyProtected ? 0.2 : 0.95;
+  }
+
+  if (card.suit === "hearts") {
+    // Danger hearts ranked by win probability — A♥ always wins heart tricks
+    if (card.rank === 1) return 0.9;
+    if (card.rank === 13) return 0.8;
+    if (card.rank === 12) return 0.75;
+    if (card.rank === 11) return 0.7;
+    if (card.rank === 10) {
+      // 10♥ is an extra danger card when passing right (decomposed from Hard's heartDangerThreshold)
+      return passDirection === "right" ? 0.65 : 0.4;
+    }
+    return 0.3; // lower hearts: not especially dangerous
+  }
+
+  if (card.suit === "spades") {
+    if (hasQSpades) {
+      // Holding Q♠: K♠ and A♠ are cover cards — keeping them is the entire point
+      if (card.rank === 1 || card.rank === 13) return 0.15;
+    }
+    // Without Q♠: A♠/K♠ can win dangerous spade tricks themselves
+    if (card.rank === 1 || card.rank === 13) return 0.65;
+    return 0.3;
+  }
+
+  if (card.suit === "clubs") {
+    // A♣/K♣ are dangerous — clubs cycle early and high clubs often take point tricks
+    if (card.rank === 1 || card.rank === 13) return 0.6;
+    // Mid clubs: filler material; scaled slightly by rank
+    return Math.min(0.45, 0.2 + aceHigh(card.rank) / 28);
+  }
+
+  // Diamonds: generally safe; scale lightly by rank
+  return Math.min(0.55, 0.1 + aceHigh(card.rank) / 28);
+};

--- a/frontend/src/game/hearts/aiConsiderations.ts
+++ b/frontend/src/game/hearts/aiConsiderations.ts
@@ -109,11 +109,12 @@ export function computePWin(card: Card, infoSet: HeartsInfoSet): number {
   const maxHigher = 14 - aceHigh(card.rank);
   const basePWin = Math.max(0, 1.0 - higher / Math.max(1, maxHigher));
 
-  // Void bonus: void opponents cannot follow suit and therefore cannot beat us
+  // Void bonus: void opponents cannot follow suit and therefore cannot beat us.
+  // Exclude self (playerIndex) — the engine never marks the acting player void.
   const knownVoidCount = [0, 1, 2, 3].filter(
-    (p) => voidLedger[p]?.[card.suit]
+    (p) => p !== infoSet.playerIndex && voidLedger[p]?.[card.suit]
   ).length;
-  const voidFraction = knownVoidCount / 3;
+  const voidFraction = knownVoidCount / 3; // at most 3 opponents
   return Math.min(1.0, basePWin + voidFraction * (1.0 - basePWin));
 }
 
@@ -130,17 +131,11 @@ export function computePWin(card: Card, infoSet: HeartsInfoSet): number {
  * 1.0: card cannot win the trick, or the trick contains zero points.
  * 0.0: card is certain to win a trick worth 26 pts (maximum danger).
  */
-export const rateMinimizeImmediatePoints: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const rateMinimizeImmediatePoints: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const pWin = computePWin(card, infoSet);
   if (pWin === 0) return 1.0;
 
-  const trickPts = infoSet.currentTrick.reduce(
-    (s, tc) => s + cardPoints(tc.card),
-    0
-  );
+  const trickPts = infoSet.currentTrick.reduce((s, tc) => s + cardPoints(tc.card), 0);
   const totalPts = trickPts + cardPoints(card);
   if (totalPts === 0) return 1.0;
 
@@ -162,10 +157,7 @@ export const rateMinimizeImmediatePoints: Consideration<HeartsInfoSet, Card> = (
  * 1.0: card is the last of its suit in hand — playing it creates an immediate void.
  * 0.0: suit has ≥4 remaining cards — voiding is not achievable in the near term.
  */
-export const rateSuitVoidingUtility: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const rateSuitVoidingUtility: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const suitCount = infoSet.hand.filter((c) => c.suit === card.suit).length;
   if (suitCount === 1) return 1.0; // immediate void
   // Linear: 2 remaining → 0.67, 3 → 0.33, 4+ → 0
@@ -186,10 +178,7 @@ export const rateSuitVoidingUtility: Consideration<HeartsInfoSet, Card> = (
  * 1.0: no Q♠ risk (Q♠ already gone, or this card cannot cause self-take).
  * 0.0: near-certain Q♠ self-take (e.g. leading Q♠ into an active spade suit).
  */
-export const rateQueenSpadesRisk: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const rateQueenSpadesRisk: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const { hand, seenKeys, currentTrick, ledSuit } = infoSet;
 
   // Q♠ is "gone" only when it has been collected into a completed trick (wonCards),
@@ -215,8 +204,7 @@ export const rateQueenSpadesRisk: Consideration<HeartsInfoSet, Card> = (
   }
 
   // Q♠ is in the current trick — winning it costs us 13 pts
-  const qInTrick = currentTrick.some((tc) => isQueenOfSpades(tc.card));
-  if (qInTrick) {
+  if (qInCurrentTrick) {
     const pWin = computePWin(card, infoSet);
     return Math.max(0, 1.0 - pWin);
   }
@@ -250,10 +238,7 @@ export const rateQueenSpadesRisk: Consideration<HeartsInfoSet, Card> = (
  * 0.5: neutral (no moon threat, or card has no blocking effect).
  * 0.0: counter-productive (would win back a point trick, helping the shooter).
  */
-export const rateMoonThreat: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const rateMoonThreat: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const { pointsPerPlayer, playerIndex, ledSuit } = infoSet;
 
   const totalPts = pointsPerPlayer.reduce((s, v) => s + v, 0);
@@ -313,10 +298,7 @@ export const rateMoonThreat: Consideration<HeartsInfoSet, Card> = (
  * 0.5: neutral (e.g. winning a 0-pt trick for board control).
  * 0.05: catastrophic (discarding a heart/Q♠ during a void, losing it forever).
  */
-export const rateMoonAttemptProgress: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const rateMoonAttemptProgress: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const pts = cardPoints(card);
   const pWin = computePWin(card, infoSet);
   const { ledSuit } = infoSet;
@@ -357,11 +339,11 @@ export const rateMoonAttemptProgress: Consideration<HeartsInfoSet, Card> = (
  *
  * 1.0: ideal pass candidate (unprotected Q♠, A♥, high danger heart).
  * 0.0: must never pass (2♣).
+ *
+ * Callers must weight this consideration at 0 during `passDirection === "none"`
+ * hands — no pass occurs, so any non-zero weight would incorrectly influence play.
  */
-export const ratePassingQuality: Consideration<HeartsInfoSet, Card> = (
-  infoSet,
-  card
-) => {
+export const ratePassingQuality: Consideration<HeartsInfoSet, Card> = (infoSet, card) => {
   const { hand, passDirection } = infoSet;
 
   // 2♣ must never be passed — engine requires it to open the first trick

--- a/frontend/src/game/hearts/aiInfoSet.ts
+++ b/frontend/src/game/hearts/aiInfoSet.ts
@@ -29,6 +29,9 @@ export type VoidLedger = Readonly<Record<number, Readonly<Partial<Record<Suit, b
 export interface HeartsInfoSet extends InformationSet {
   readonly kind: "hearts";
 
+  /** Seat index (0–3) of the player for whom this snapshot was built. */
+  readonly playerIndex: number;
+
   /** The requesting player's current hand. */
   readonly hand: readonly Card[];
 
@@ -92,7 +95,7 @@ export function buildHeartsInfoSet(
   hand: readonly Card[],
   trick: readonly TrickCard[],
   state: HeartsState,
-  _playerIndex: number
+  playerIndex: number
 ): HeartsInfoSet {
   // ------------------------------------------------------------------
   // ledSuit: null when leading (trick is empty), otherwise the first card's suit.
@@ -168,6 +171,7 @@ export function buildHeartsInfoSet(
 
   return Object.freeze({
     kind: "hearts" as const,
+    playerIndex,
     hand,
     currentTrick: trick,
     ledSuit,


### PR DESCRIPTION
## Summary

- Adds `aiConsiderations.ts` with six pure `Consideration<HeartsInfoSet, Card>` functions (all returning `[0.0, 1.0]`), decomposed from the existing `ai.ts` heuristics rather than discarding them
- Exports `computePWin` — probability a candidate card wins the current trick, using `seenKeys` + `voidLedger` from the info set; returns `1.0` when all higher cards in the relevant suit are accounted for
- Adds `playerIndex` to `HeartsInfoSet` (was `_playerIndex`, previously unused) so moon-threat and self-vs-opponent logic has a seat anchor

**Considerations:**
| Function | Decomposed from |
|---|---|
| `rateMinimizeImmediatePoints` | `chooseFollow` point-avoidance, `chooseDiscard` heart dump |
| `rateSuitVoidingUtility` | `voidOneSuit`, shortest-suit discard preference |
| `rateQueenSpadesRisk` | direction-aware Q♠ thresholds (all three pass modes), endgame Q♠ guard, lead guard |
| `rateMoonThreat` | `detectPotentialMoon` blocking sequences in Medium/Hard |
| `rateMoonAttemptProgress` | `earlyMoon`/`midMoon` play sequences in Hard |
| `ratePassingQuality` | All three pass strategies unified into a continuous score |

## Test plan

- [x] 41 unit tests: per-function edge cases, `computePWin` hand-computed sanity checks, range invariants on 30 seeded games
- [x] Existing `aiInfoSet` tests (34) — all green after `playerIndex` addition
- [ ] Playwright `hearts-*.spec.ts` — nothing wired in yet (`USE_UTILITY_AI` flag off); no behaviour change expected
- [ ] Maestro `flows/hearts/smoke.yaml` — no behaviour change expected

Closes #2030. Part of epic #2022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)