### PR TITLE
feat(freecell): smart single-tap auto-move + supermove pre-check (#2037)

### DIFF
--- a/e2e/tests/freecell-accessibility.spec.ts
+++ b/e2e/tests/freecell-accessibility.spec.ts
@@ -12,7 +12,11 @@
 
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { mockFreecellApi, gotoFreecell, injectFreecellState } from "./helpers/freecell";
+import {
+  mockFreecellApi,
+  gotoFreecell,
+  injectFreecellState,
+} from "./helpers/freecell";
 
 async function assertNoA11yViolations(
   axeBuilder: InstanceType<typeof AxeBuilder>,
@@ -32,10 +36,7 @@ async function assertNoA11yViolations(
 
 const SINGLE_CARD_STATE = {
   _v: 1,
-  tableau: [
-    [{ suit: "hearts", rank: 5 }],
-    [], [], [], [], [], [], [],
-  ],
+  tableau: [[{ suit: "hearts", rank: 5 }], [], [], [], [], [], [], []],
   freeCells: [null, null, null, null],
   foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
   undoStack: [],
@@ -47,34 +48,42 @@ test.describe("FreeCell — accessibility", () => {
   test("board region has accessible label", async ({ page }) => {
     await mockFreecellApi(page);
     await gotoFreecell(page);
-    await expect(
-      page.getByLabel("FreeCell board").first(),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
-  test("cards in tableau have descriptive accessible labels", async ({ page }) => {
+  test("cards in tableau have descriptive accessible labels", async ({
+    page,
+  }) => {
     await mockFreecellApi(page);
     await injectFreecellState(page, SINGLE_CARD_STATE);
     await page.getByRole("button", { name: "Play FreeCell" }).click();
-    await page.getByRole("heading", { name: "FreeCell", exact: true }).waitFor({ timeout: 10_000 });
-    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByLabel("5 of Hearts")).toBeVisible({ timeout: 5_000 });
+    await page
+      .getByRole("heading", { name: "FreeCell", exact: true })
+      .waitFor({ timeout: 10_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByLabel("5 of Hearts")).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("empty free cell slots have accessible labels", async ({ page }) => {
     await mockFreecellApi(page);
     await gotoFreecell(page);
-    await expect(
-      page.getByLabel("Empty free cell 1"),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByLabel("Empty free cell 1")).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("foundation slots have accessible labels", async ({ page }) => {
     await mockFreecellApi(page);
     await gotoFreecell(page);
-    await expect(
-      page.getByLabel(/foundation/i).first(),
-    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByLabel(/foundation/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
   });
 
   test("keyboard Tab navigates through interactive controls without trapping focus", async ({
@@ -84,30 +93,38 @@ test.describe("FreeCell — accessibility", () => {
     await gotoFreecell(page);
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
-    await expect(
-      page.getByLabel("FreeCell board").first(),
-    ).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 3_000,
+    });
   });
 
-  test("focus is not lost after selecting and moving a card", async ({ page }) => {
+  test("focus is not lost after selecting and moving a card", async ({
+    page,
+  }) => {
     await mockFreecellApi(page);
     await injectFreecellState(page, SINGLE_CARD_STATE);
     await page.getByRole("button", { name: "Play FreeCell" }).click();
-    await page.getByRole("heading", { name: "FreeCell", exact: true }).waitFor({ timeout: 10_000 });
-    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({ timeout: 5_000 });
+    await page
+      .getByRole("heading", { name: "FreeCell", exact: true })
+      .waitFor({ timeout: 10_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 5_000,
+    });
 
+    // Single tap auto-moves 5♥ to the first free cell — no second tap required.
     await page.getByLabel("5 of Hearts").click();
-    await page.getByLabel("Empty free cell 1").click();
 
-    await expect(
-      page.getByLabel("FreeCell board").first(),
-    ).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 3_000,
+    });
   });
 
   test("game screen passes axe-core WCAG 2.2 AA scan", async ({ page }) => {
     await mockFreecellApi(page);
     await gotoFreecell(page);
-    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByLabel("FreeCell board").first()).toBeVisible({
+      timeout: 5_000,
+    });
     await assertNoA11yViolations(
       new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa", "wcag21aa"]),
     );

--- a/e2e/tests/freecell-card-move.spec.ts
+++ b/e2e/tests/freecell-card-move.spec.ts
@@ -1,15 +1,20 @@
 /**
- * freecell-card-move.spec.ts — GH #1145
+ * freecell-card-move.spec.ts — GH #1145, updated for smart single-tap (#2037)
  *
- * Card-move mechanic: tap a tableau card to select it, tap an empty free cell
- * slot, and confirm the move counter increments to 1.
+ * Single-tap smart auto-move: tapping a card with exactly one best destination
+ * on the priority ladder (foundation > non-empty tableau > empty col > free cell)
+ * executes the move immediately without a second tap.
+ *
  * All backend calls are intercepted — no running backend needed.
  */
 
 import { test, expect } from "@playwright/test";
 import { mockFreecellApi, injectFreecellState } from "./helpers/freecell";
 
-// One card (5♥) in tableau column 0; free cells and foundations empty.
+// One card (5♥) in tableau column 0; all free cells empty; no valid non-empty
+// tableau or empty-column destination (rank 5 ≠ 13).
+// Priority ladder: foundation (no), non-empty tableau (none), empty col (no —
+// rank 5), free cell (yes — first available) → auto-moves to free cell 1.
 const CARD_MOVE_STATE = {
   _v: 1,
   tableau: [[{ suit: "hearts", rank: 5 }], [], [], [], [], [], [], []],
@@ -20,7 +25,7 @@ const CARD_MOVE_STATE = {
   moveCount: 0,
 };
 
-test("tap tableau card then tap free cell: card moves and counter increments", async ({
+test("single tap on a tableau card auto-moves it via the priority ladder", async ({
   page,
 }) => {
   await mockFreecellApi(page);
@@ -35,12 +40,9 @@ test("tap tableau card then tap free cell: card moves and counter increments", a
     timeout: 5_000,
   });
 
-  // Tap 5♥ in the tableau to select it.
+  // Single tap on 5♥ → auto-move to first free cell (no second tap needed).
   await page.getByLabel("5 of Hearts").click();
 
-  // Tap the empty free cell slot (cell 1 = index 0).
-  await page.getByLabel("Empty free cell 1").click();
-
-  // Move counter increments to 1.
+  // Move counter increments immediately — no second tap required.
   await expect(page.getByText("Moves: 1")).toBeVisible({ timeout: 3_000 });
 });

--- a/e2e/tests/freecell-errors.spec.ts
+++ b/e2e/tests/freecell-errors.spec.ts
@@ -21,17 +21,23 @@ import {
 
 const API_BASE = "http://localhost:8000";
 
-// Board: 5♥ in column 0, 3♣ in column 1, free cells empty.
-// FreeCell rule: a card may only be placed on a card that is one rank higher
-// and the opposite colour. 5♥ (red) needs a black 6; placing it on 3♣
-// (wrong rank) is illegal.
+// Board designed for two-tap error coverage (#2037 smart-tap rework).
+//
+// 2♠ (col 0) has two equally-ranked destinations (3♥ col 1, 3♦ col 2) so the
+// first tap enters selection state instead of auto-moving.  4♠ (col 3) is an
+// invalid destination for 2♠ (same colour — black on black).
+//
+// Error test flow:
+//   tap 2♠ → ambiguous → selection
+//   tap 4♠ → invalid (same colour) → counter stays 0, selection preserved
+//   tap 3♥  → valid move → counter becomes 1
 const BOARD_STATE = {
   _v: 1,
   tableau: [
-    [{ suit: "hearts", rank: 5 }],
-    [{ suit: "clubs", rank: 3 }],
-    [],
-    [],
+    [{ suit: "spades", rank: 2 }],
+    [{ suit: "hearts", rank: 3 }],
+    [{ suit: "diamonds", rank: 3 }],
+    [{ suit: "spades", rank: 4 }],
     [],
     [],
     [],
@@ -75,9 +81,10 @@ test.describe("FreeCell — error paths", () => {
       .waitFor({ timeout: 10_000 });
     await page.getByLabel("FreeCell board").first().waitFor({ timeout: 5_000 });
 
-    // Select 5♥ then attempt to place it on 3♣ (wrong rank — illegal)
-    await page.getByLabel("5 of Hearts").click();
-    await page.getByLabel("3 of Clubs").click();
+    // 2♠ has two equal-priority destinations → first tap enters selection.
+    // 4♠ is an invalid destination (same colour — black on black).
+    await page.getByLabel("2 of Spades").click();
+    await page.getByLabel("4 of Spades").click();
 
     // Move counter must remain at 0 — illegal move was rejected
     await expect(page.getByText("Moves: 0")).toBeVisible({ timeout: 3_000 });
@@ -116,13 +123,13 @@ test.describe("FreeCell — error paths", () => {
       .waitFor({ timeout: 10_000 });
     await page.getByLabel("FreeCell board").first().waitFor({ timeout: 5_000 });
 
-    // Attempt an invalid move (wrong rank)
-    await page.getByLabel("5 of Hearts").click();
-    await page.getByLabel("3 of Clubs").click();
+    // 2♠ ambiguous → selection; 4♠ is invalid (same colour) → counter stays 0.
+    await page.getByLabel("2 of Spades").click();
+    await page.getByLabel("4 of Spades").click();
     await expect(page.getByText("Moves: 0")).toBeVisible({ timeout: 3_000 });
 
-    // 5♥ remains selected after the failed move — go straight to the free cell
-    await page.getByLabel("Empty free cell 1").click();
+    // 2♠ remains selected — tap a valid destination to confirm recovery.
+    await page.getByLabel("3 of Hearts").click();
 
     // Move counter increments — game recovered from the failed attempt
     await expect(page.getByText("Moves: 1")).toBeVisible({ timeout: 3_000 });

--- a/frontend/src/components/freecell/FreeCellBoard.tsx
+++ b/frontend/src/components/freecell/FreeCellBoard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "../../theme/ThemeContext";
 
 import { SUITS } from "../../game/freecell/types";
-import { validateMove } from "../../game/freecell/engine";
+import { validateMove, resolveAutoMove } from "../../game/freecell/engine";
 import type { FreeCellState, Move, Suit } from "../../game/freecell/types";
 import FreeCellSlot from "./FreeCellSlot";
 import FoundationPile from "./FoundationPile";
@@ -34,9 +34,10 @@ type Selection =
 export interface FreeCellBoardProps {
   readonly state: FreeCellState;
   readonly onMove: (move: Move) => void;
+  readonly onSupermoveRejected?: () => void;
 }
 
-export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
+export default function FreeCellBoard({ state, onMove, onSupermoveRejected }: FreeCellBoardProps) {
   const { t } = useTranslation("freecell");
   const { colors } = useTheme();
   const { cardWidth } = useCardSize();
@@ -75,7 +76,15 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
     }
 
     if (selection === null) {
-      setSelection({ kind: "tableau", col, index });
+      const result = resolveAutoMove(state, { type: "tableau", col, index });
+      if (result.kind === "execute") {
+        tryMove(result.move);
+      } else if (result.kind === "supermove-rejected") {
+        triggerIllegal();
+        onSupermoveRejected?.();
+      } else {
+        setSelection({ kind: "tableau", col, index });
+      }
       return;
     }
     if (selection.kind === "tableau" && selection.col === col && selection.index === index) {
@@ -126,7 +135,12 @@ export default function FreeCellBoard({ state, onMove }: FreeCellBoardProps) {
 
     if (selection === null) {
       if (state.freeCells[cell] !== null) {
-        setSelection({ kind: "freecell", cell });
+        const result = resolveAutoMove(state, { type: "freecell", cell });
+        if (result.kind === "execute") {
+          tryMove(result.move);
+        } else {
+          setSelection({ kind: "freecell", cell });
+        }
       }
       return;
     }

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.smartTap.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.smartTap.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Smart single-tap auto-move tests — supermove pre-check + priority ladder
+ * edge cases (#2037).
+ *
+ * Focused on the supermove-rejected path and `onSupermoveRejected` callback,
+ * which FreeCellBoard.test.tsx doesn't cover.
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider } from "../../../theme/ThemeContext";
+import FreeCellBoard from "../FreeCellBoard";
+import type { FreeCellState } from "../../../game/freecell/types";
+
+async function renderBoard(
+  state: FreeCellState,
+  onMove = jest.fn(),
+  onSupermoveRejected?: () => void
+) {
+  const utils = await render(
+    <ThemeProvider>
+      <FreeCellBoard state={state} onMove={onMove} onSupermoveRejected={onSupermoveRejected} />
+    </ThemeProvider>
+  );
+  return { ...utils, onMove };
+}
+
+// ---------------------------------------------------------------------------
+// Supermove pre-check
+// ---------------------------------------------------------------------------
+
+describe("FreeCellBoard — supermove pre-check (#2037)", () => {
+  it("calls onSupermoveRejected and does NOT call onMove when run exceeds capacity", async () => {
+    // Run of 3 (5♥→4♠→3♥ from index 0, alternating-color descending).
+    // All 4 free cells occupied; 1 empty column (col 7, excluding source col 0).
+    // maxCapacity = (1 + 0) × 2^1 = 2  →  run length 3 > 2 → rejected.
+    const state: FreeCellState = {
+      _v: 1,
+      tableau: [
+        [
+          { suit: "hearts", rank: 5 },
+          { suit: "spades", rank: 4 },
+          { suit: "hearts", rank: 3 },
+        ],
+        [{ suit: "clubs", rank: 6 }],
+        [{ suit: "spades", rank: 7 }],
+        [{ suit: "diamonds", rank: 8 }],
+        [{ suit: "clubs", rank: 9 }],
+        [{ suit: "spades", rank: 10 }],
+        [{ suit: "diamonds", rank: 11 }],
+        [],
+      ],
+      freeCells: [
+        { suit: "clubs", rank: 1 },
+        { suit: "spades", rank: 1 },
+        { suit: "diamonds", rank: 1 },
+        { suit: "hearts", rank: 1 },
+      ],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+
+    const onMove = jest.fn();
+    const onSupermoveRejected = jest.fn();
+    const { getByLabelText } = await renderBoard(state, onMove, onSupermoveRejected);
+
+    // Tapping the run root (5♥ at index 0 of col 0)
+    await fireEvent.press(getByLabelText("5 of Hearts"));
+
+    expect(onMove).not.toHaveBeenCalled();
+    expect(onSupermoveRejected).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reject when run length equals the supermove capacity", async () => {
+    // Run of 2 (5♥→4♠ from index 0).
+    // All 4 free cells occupied; 1 empty column.
+    // maxCapacity = (1 + 0) × 2^1 = 2  →  run length 2 = 2 → allowed.
+    // The 6♦ in col 1 is the valid destination (red, rank 6 → 5♥ black rank 5).
+    // Wait: 5♥ is red, 4♠ is black; the run head is 5♥ (red).
+    // Destination needs to be black rank 6 for 5♥ to stack.
+    // 6♣ (black, rank 6) in col 1 → canStackOnTableau(5♥, 6♣) ✓.
+    const state: FreeCellState = {
+      _v: 1,
+      tableau: [
+        [
+          { suit: "hearts", rank: 5 },
+          { suit: "spades", rank: 4 },
+        ],
+        [{ suit: "clubs", rank: 6 }],
+        [],
+        [{ suit: "spades", rank: 7 }],
+        [{ suit: "diamonds", rank: 8 }],
+        [{ suit: "clubs", rank: 9 }],
+        [{ suit: "spades", rank: 10 }],
+        [{ suit: "diamonds", rank: 11 }],
+      ],
+      freeCells: [
+        { suit: "clubs", rank: 1 },
+        { suit: "spades", rank: 1 },
+        { suit: "diamonds", rank: 1 },
+        { suit: "hearts", rank: 1 },
+      ],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+
+    const onMove = jest.fn();
+    const onSupermoveRejected = jest.fn();
+    const { getByLabelText } = await renderBoard(state, onMove, onSupermoveRejected);
+
+    await fireEvent.press(getByLabelText("5 of Hearts"));
+
+    expect(onSupermoveRejected).not.toHaveBeenCalled();
+    expect(onMove).toHaveBeenCalledWith({
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Priority ladder: destination-quality preference
+// ---------------------------------------------------------------------------
+
+describe("FreeCellBoard — priority ladder destination preference (#2037)", () => {
+  it("prefers the destination with the longer existing run over a shorter one", async () => {
+    // Col 0: [2♣] — source.
+    // Col 1: [4♠, 3♥] — top is 3♥ (red, rank 3); existing run length = 2.
+    // Col 2: [3♦]     — top is 3♦ (red, rank 3); existing run length = 1.
+    // 2♣ can go on either 3♥ or 3♦, but col 1's run is longer → execute col 1.
+    const state: FreeCellState = {
+      _v: 1,
+      tableau: [
+        [{ suit: "clubs", rank: 2 }],
+        [{ suit: "spades", rank: 4 }, { suit: "hearts", rank: 3 }],
+        [{ suit: "diamonds", rank: 3 }],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [null, null, null, null],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(state, onMove);
+    await fireEvent.press(getByLabelText("2 of Clubs"));
+
+    expect(onMove).toHaveBeenCalledWith({
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    });
+  });
+});

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.smartTap.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.smartTap.test.tsx
@@ -78,7 +78,7 @@ describe("FreeCellBoard — supermove pre-check (#2037)", () => {
     // Run of 2 (5♥→4♠ from index 0).
     // All 4 free cells occupied; 1 empty column.
     // maxCapacity = (1 + 0) × 2^1 = 2  →  run length 2 = 2 → allowed.
-    // The 6♦ in col 1 is the valid destination (red, rank 6 → 5♥ black rank 5).
+    // The 6♣ in col 1 is the valid destination (black, rank 6 → 5♥ red rank 5).
     // Wait: 5♥ is red, 4♠ is black; the run head is 5♥ (red).
     // Destination needs to be black rank 6 for 5♥ to stack.
     // 6♣ (black, rank 6) in col 1 → canStackOnTableau(5♥, 6♣) ✓.
@@ -139,7 +139,10 @@ describe("FreeCellBoard — priority ladder destination preference (#2037)", () 
       _v: 1,
       tableau: [
         [{ suit: "clubs", rank: 2 }],
-        [{ suit: "spades", rank: 4 }, { suit: "hearts", rank: 3 }],
+        [
+          { suit: "spades", rank: 4 },
+          { suit: "hearts", rank: 3 },
+        ],
         [{ suit: "diamonds", rank: 3 }],
         [],
         [],

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
@@ -1,24 +1,19 @@
 /**
- * Interaction tests for FreeCellBoard — tap-to-move state machine (#990).
+ * Interaction tests for FreeCellBoard — tap-to-move state machine (#990, #2037).
  *
- * Controlled state layout:
- *   Col 0: [2♣]   Col 1: [3♥]   Col 2: [K♦]   Cols 3–7: empty
- *   freeCells[0]: A♠   freeCells[1]: K♠   freeCells[2–3]: null
- *   All foundations empty
+ * Smart single-tap (#2037): when a card has exactly one best destination on the
+ * priority ladder (foundation > non-empty tableau > empty col > free cell), the
+ * first tap executes the move directly.  When multiple equal-priority
+ * destinations exist the board enters selection state (two-tap fallback).
  *
- * Engine rule: only Kings may move to an empty tableau column.
- * (canStackOnTableau returns false for non-kings on an empty destination.)
- *
- * Valid tap-to-move paths exercised:
- *   2♣ → 3♥               (tableau-to-tableau, black rank 2 onto red rank 3)
- *   K♦ → empty col        (tableau-to-tableau, king onto empty column)
- *   2♣ → empty freecell   (tableau-to-freecell)
- *   A♠ → spades foundation (freecell-to-foundation, ace starts a foundation)
- *   K♠ → empty col        (freecell-to-tableau, king onto empty column)
- *
- * Drag-and-drop coverage: the drop handlers in FreeCellBoard exercise
- * the same validateMove paths as tap-to-move. Full gesture simulation
- * (pan → overlay → drop) requires a device-level harness (Maestro E2E, #990).
+ * Test state glossary:
+ *   AMBIGUOUS_2C  — 2♣ has two equally-ranked red-3 dests → first tap is
+ *                   ambiguous → enters selection for two-tap coverage.
+ *   AMBIGUOUS_3H  — 3♥ has two black-4 dests → ambiguous; 5♦ is invalid.
+ *   AMBIGUOUS_FC  — freeCells[0]=2♠ with two red-3 tableau dests → ambiguous
+ *                   freecell first tap; freeCells[1]=2♥ for second-cell test.
+ *   ACE_TABLEAU   — A♦ in col 0, foundations empty → auto-moves to foundation.
+ *   TWO_FOUNDATIONS — A♠ + A♥ in foundations for re-select test.
  */
 
 import React from "react";
@@ -28,30 +23,97 @@ import { ThemeProvider } from "../../../theme/ThemeContext";
 import FreeCellBoard from "../FreeCellBoard";
 import type { FreeCellState } from "../../../game/freecell/types";
 
-// Col 0: 2♣   Col 1: 3♥   Col 2: K♦   Cols 3–7: empty
-// freeCells[0]: A♠   [1]: K♠   [2–3]: null
-// All foundations empty
-const BASE_STATE: FreeCellState = {
+// ---------------------------------------------------------------------------
+// Shared states
+// ---------------------------------------------------------------------------
+
+// 2♣ (col 0) has two valid red-3 destinations (3♥ col 1, 3♦ col 2) — tied →
+// first tap enters selection.  4♣ (col 3) is an invalid same-color destination.
+const AMBIGUOUS_2C: FreeCellState = {
   _v: 1,
   tableau: [
     [{ suit: "clubs", rank: 2 }],
     [{ suit: "hearts", rank: 3 }],
-    [{ suit: "diamonds", rank: 13 }],
-    [],
+    [{ suit: "diamonds", rank: 3 }],
+    [{ suit: "clubs", rank: 4 }],
     [],
     [],
     [],
     [],
   ],
-  freeCells: [{ suit: "spades", rank: 1 }, { suit: "spades", rank: 13 }, null, null],
+  freeCells: [null, null, null, null],
   foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
   undoStack: [],
   isComplete: false,
   moveCount: 0,
 };
 
-// State with two non-empty foundations for Story 9 re-select test.
-const STATE_WITH_TWO_FOUNDATIONS: FreeCellState = {
+// 3♥ (col 0) has two valid black-4 destinations (4♣ col 1, 4♠ col 2) — tied →
+// first tap enters selection.  5♦ (col 3) is invalid for 3♥.
+const AMBIGUOUS_3H: FreeCellState = {
+  _v: 1,
+  tableau: [
+    [{ suit: "hearts", rank: 3 }],
+    [{ suit: "clubs", rank: 4 }],
+    [{ suit: "spades", rank: 4 }],
+    [{ suit: "diamonds", rank: 5 }],
+    [],
+    [],
+    [],
+    [],
+  ],
+  freeCells: [null, null, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+// freeCells[0]=2♠ has two valid red-3 destinations (3♥ col 0, 3♦ col 1) — tied
+// → first tap on 2♠ enters selection.  freeCells[1]=2♥ for second-cell tests.
+const AMBIGUOUS_FC: FreeCellState = {
+  _v: 1,
+  tableau: [
+    [{ suit: "hearts", rank: 3 }],
+    [{ suit: "diamonds", rank: 3 }],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+  ],
+  freeCells: [{ suit: "spades", rank: 2 }, { suit: "hearts", rank: 2 }, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+// A♦ in col 0 — single tap auto-moves to diamonds foundation.
+const ACE_TABLEAU: FreeCellState = {
+  _v: 1,
+  tableau: [[{ suit: "diamonds", rank: 1 }], [], [], [], [], [], [], []],
+  freeCells: [null, null, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+// A♠ in freecell[0] — single tap auto-moves to spades foundation.
+const ACE_FREECELL: FreeCellState = {
+  _v: 1,
+  tableau: [[], [], [], [], [], [], [], []],
+  freeCells: [{ suit: "spades", rank: 1 }, null, null, null],
+  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+  undoStack: [],
+  isComplete: false,
+  moveCount: 0,
+};
+
+// A♠ + A♥ in foundations for the re-select test.
+const TWO_FOUNDATIONS: FreeCellState = {
   _v: 1,
   tableau: [[], [], [], [], [], [], [], []],
   freeCells: [null, null, null, null],
@@ -66,18 +128,7 @@ const STATE_WITH_TWO_FOUNDATIONS: FreeCellState = {
   moveCount: 0,
 };
 
-// State with an Ace in tableau col 0 for Story 10 double-tap test.
-const STATE_WITH_ACE_TABLEAU: FreeCellState = {
-  _v: 1,
-  tableau: [[{ suit: "diamonds", rank: 1 }], [], [], [], [], [], [], []],
-  freeCells: [null, null, null, null],
-  foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
-  undoStack: [],
-  isComplete: false,
-  moveCount: 0,
-};
-
-async function renderBoard(state = BASE_STATE, onMove = jest.fn()) {
+async function renderBoard(state: FreeCellState, onMove = jest.fn()) {
   const utils = await render(
     <ThemeProvider>
       <FreeCellBoard state={state} onMove={onMove} />
@@ -88,70 +139,83 @@ async function renderBoard(state = BASE_STATE, onMove = jest.fn()) {
 
 afterEach(() => jest.useRealTimers());
 
-// ── Selection ────────────────────────────────────────────────────────────────
+// ── Selection (two-tap flow via ambiguous first tap) ─────────────────────────
 
 describe("FreeCellBoard — selection", () => {
-  it("selects a tableau card on first tap", async () => {
-    const { getByLabelText } = await renderBoard();
+  it("enters selection when first tap is ambiguous (two valid equal-priority destinations)", async () => {
+    const { getByLabelText } = await renderBoard(AMBIGUOUS_2C);
     await fireEvent.press(getByLabelText("2 of Clubs"));
     expect(getByLabelText("2 of Clubs (selected)")).toBeTruthy();
   });
 
-  it("deselects a tableau card when tapped after the double-tap window", async () => {
+  it("deselects a tableau card when tapped again after the double-tap window", async () => {
     jest.useFakeTimers();
-    const { getByLabelText } = await renderBoard();
+    const { getByLabelText } = await renderBoard(AMBIGUOUS_2C);
     await fireEvent.press(getByLabelText("2 of Clubs"));
-    jest.advanceTimersByTime(301); // past DOUBLE_TAP_MS=300
+    jest.advanceTimersByTime(301);
     await fireEvent.press(getByLabelText("2 of Clubs (selected)"));
     expect(getByLabelText("2 of Clubs")).toBeTruthy();
   });
 
-  it("selects a freecell card on first tap", async () => {
-    const { getByLabelText } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades"));
-    expect(getByLabelText("A of Spades (selected)")).toBeTruthy();
+  it("enters selection when freecell first tap is ambiguous", async () => {
+    const { getByLabelText } = await renderBoard(AMBIGUOUS_FC);
+    await fireEvent.press(getByLabelText("2 of Spades"));
+    expect(getByLabelText("2 of Spades (selected)")).toBeTruthy();
   });
 
-  it("deselects a freecell card when tapped after the double-tap window", async () => {
+  it("deselects a freecell card when tapped again after the double-tap window", async () => {
     jest.useFakeTimers();
-    const { getByLabelText } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades"));
-    jest.advanceTimersByTime(301); // past DOUBLE_TAP_MS=300 — prevents freecell-to-foundation double-tap
-    await fireEvent.press(getByLabelText("A of Spades (selected)"));
-    expect(getByLabelText("A of Spades")).toBeTruthy();
+    const { getByLabelText } = await renderBoard(AMBIGUOUS_FC);
+    await fireEvent.press(getByLabelText("2 of Spades"));
+    jest.advanceTimersByTime(301);
+    await fireEvent.press(getByLabelText("2 of Spades (selected)"));
+    expect(getByLabelText("2 of Spades")).toBeTruthy();
   });
 
   it("does not select an empty freecell slot", async () => {
-    const { getByLabelText, queryByLabelText } = await renderBoard();
-    // freeCells[2] is null → "Empty free cell 3" (1-indexed)
-    await fireEvent.press(getByLabelText("Empty free cell 3"));
+    const { getByLabelText, queryByLabelText } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("Empty free cell 1"));
     expect(queryByLabelText(/\(selected\)/)).toBeNull();
   });
 
-  it("clears selection after a valid move", async () => {
-    const { getByLabelText, queryByLabelText } = await renderBoard();
-    await fireEvent.press(getByLabelText("2 of Clubs")); // select
-    await fireEvent.press(getByLabelText("3 of Hearts")); // valid move → clears selection
+  it("clears selection after a valid move (two-tap flow)", async () => {
+    const { getByLabelText, queryByLabelText } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("2 of Clubs")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("3 of Hearts")); // valid dest → move + deselect
     expect(queryByLabelText(/\(selected\)/)).toBeNull();
   });
 
-  it("preserves selection after an invalid move attempt", async () => {
+  it("preserves selection after an invalid move attempt (two-tap flow)", async () => {
     jest.useFakeTimers();
-    const { getByLabelText, queryByLabelText } = await renderBoard();
-    await fireEvent.press(getByLabelText("3 of Hearts")); // select col 1
-    jest.advanceTimersByTime(301); // past double-tap window so second tap is not a double-tap
-    await fireEvent.press(getByLabelText("2 of Clubs")); // invalid destination → re-select col 0
+    const { getByLabelText, queryByLabelText } = await renderBoard(AMBIGUOUS_3H);
+    await fireEvent.press(getByLabelText("3 of Hearts")); // ambiguous → selects
+    jest.advanceTimersByTime(301);
+    await fireEvent.press(getByLabelText("5 of Diamonds")); // invalid (rank 5, same color)
     expect(queryByLabelText(/\(selected\)/)).toBeTruthy();
   });
 });
 
-// ── Valid moves ──────────────────────────────────────────────────────────────
+// ── Auto-move (single-tap smart tap) ─────────────────────────────────────────
 
-describe("FreeCellBoard — valid moves", () => {
-  it("tableau-to-tableau: moves a card onto a valid destination", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("2 of Clubs")); // select col 0
-    await fireEvent.press(getByLabelText("3 of Hearts")); // col 1
+describe("FreeCellBoard — smart single-tap auto-move", () => {
+  it("auto-moves to the sole valid non-empty tableau destination", async () => {
+    // 2♣ has only one valid dest: 3♥ in col 1 (3♦ absent in this state).
+    const oneDestState: FreeCellState = {
+      ...AMBIGUOUS_2C,
+      tableau: [
+        [{ suit: "clubs", rank: 2 }],
+        [{ suit: "hearts", rank: 3 }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+    };
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(oneDestState, onMove);
+    await fireEvent.press(getByLabelText("2 of Clubs"));
     expect(onMove).toHaveBeenCalledWith({
       type: "tableau-to-tableau",
       fromCol: 0,
@@ -160,97 +224,186 @@ describe("FreeCellBoard — valid moves", () => {
     });
   });
 
-  it("tableau-to-tableau: moves a King onto an empty column", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("K of Diamonds")); // select col 2 (K♦)
-    // col index 3 → "Empty tableau column 4" (1-indexed)
-    await fireEvent.press(getByLabelText("Empty tableau column 4"));
+  it("auto-moves a King to the first empty column", async () => {
+    const kingState: FreeCellState = {
+      _v: 1,
+      tableau: [
+        [{ suit: "diamonds", rank: 13 }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [null, null, null, null],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(kingState, onMove);
+    await fireEvent.press(getByLabelText("K of Diamonds"));
     expect(onMove).toHaveBeenCalledWith({
       type: "tableau-to-tableau",
-      fromCol: 2,
+      fromCol: 0,
       fromIndex: 0,
-      toCol: 3,
+      toCol: 1,
     });
   });
 
-  it("tableau-to-freecell: parks a card in an empty freecell slot", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("2 of Clubs")); // select col 0
-    // freeCells[2] → "Empty free cell 3" (1-indexed)
-    await fireEvent.press(getByLabelText("Empty free cell 3"));
+  it("auto-moves to free cell when no non-empty or empty-column destination exists", async () => {
+    // 5♥ cannot go to foundation, empty col (rank ≠ 13), or non-empty tableau;
+    // only free cell remains.
+    const state: FreeCellState = {
+      _v: 1,
+      tableau: [[{ suit: "hearts", rank: 5 }], [], [], [], [], [], [], []],
+      freeCells: [null, null, null, null],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(state, onMove);
+    await fireEvent.press(getByLabelText("5 of Hearts"));
     expect(onMove).toHaveBeenCalledWith({
       type: "tableau-to-freecell",
       fromCol: 0,
-      toCell: 2,
+      toCell: 0,
     });
   });
 
-  it("freecell-to-foundation: moves an ace to the matching foundation", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades")); // select freecell 0
-    await fireEvent.press(getByLabelText("Empty Spades foundation"));
-    expect(onMove).toHaveBeenCalledWith({
-      type: "freecell-to-foundation",
-      fromCell: 0,
-    });
+  it("auto-moves tableau card to foundation (highest priority)", async () => {
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(ACE_TABLEAU, onMove);
+    await fireEvent.press(getByLabelText("A of Diamonds"));
+    expect(onMove).toHaveBeenCalledWith({ type: "tableau-to-foundation", fromCol: 0 });
   });
 
-  it("freecell-to-tableau: moves a King freecell card onto an empty column", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("K of Spades")); // select freecell 1 (K♠)
-    // col index 3 → "Empty tableau column 4" (1-indexed)
-    await fireEvent.press(getByLabelText("Empty tableau column 4"));
+  it("auto-moves freecell card to foundation (highest priority)", async () => {
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(ACE_FREECELL, onMove);
+    await fireEvent.press(getByLabelText("A of Spades"));
+    expect(onMove).toHaveBeenCalledWith({ type: "freecell-to-foundation", fromCell: 0 });
+  });
+
+  it("auto-moves freecell card to the best non-empty tableau destination", async () => {
+    // freeCells[0]=2♠ with only one valid tableau dest (3♥ col 0); no tie.
+    const state: FreeCellState = {
+      _v: 1,
+      tableau: [
+        [{ suit: "hearts", rank: 3 }],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+      ],
+      freeCells: [{ suit: "spades", rank: 2 }, null, null, null],
+      foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
+      undoStack: [],
+      isComplete: false,
+      moveCount: 0,
+    };
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(state, onMove);
+    await fireEvent.press(getByLabelText("2 of Spades"));
     expect(onMove).toHaveBeenCalledWith({
       type: "freecell-to-tableau",
-      fromCell: 1,
-      toCol: 3,
+      fromCell: 0,
+      toCol: 0,
     });
   });
 });
 
-// ── Invalid moves ────────────────────────────────────────────────────────────
+// ── Two-tap valid moves (selection → destination) ────────────────────────────
+
+describe("FreeCellBoard — two-tap valid moves", () => {
+  it("tableau-to-tableau via two-tap (ambiguous first tap)", async () => {
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("2 of Clubs")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("3 of Hearts")); // second tap → move
+    expect(onMove).toHaveBeenCalledWith({
+      type: "tableau-to-tableau",
+      fromCol: 0,
+      fromIndex: 0,
+      toCol: 1,
+    });
+  });
+
+  it("tableau-to-freecell via two-tap (ambiguous first tap)", async () => {
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("2 of Clubs")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("Empty free cell 1")); // cell 0
+    expect(onMove).toHaveBeenCalledWith({
+      type: "tableau-to-freecell",
+      fromCol: 0,
+      toCell: 0,
+    });
+  });
+
+  it("freecell-to-tableau via two-tap (ambiguous first tap)", async () => {
+    // AMBIGUOUS_FC: 2♠ in cell 0 — ambiguous (3♥ col 0, 3♦ col 1 tied).
+    // Second tap picks col 0 (3♥).
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_FC);
+    await fireEvent.press(getByLabelText("2 of Spades")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("3 of Hearts")); // second tap → move
+    expect(onMove).toHaveBeenCalledWith({
+      type: "freecell-to-tableau",
+      fromCell: 0,
+      toCol: 0,
+    });
+  });
+});
+
+// ── Invalid moves ─────────────────────────────────────────────────────────────
 
 describe("FreeCellBoard — invalid moves", () => {
-  it("does not call onMove when a higher-rank card is placed on a lower-rank card", async () => {
-    // 3♥ (rank 3) cannot go on top of 2♣ (rank 2).
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("3 of Hearts")); // select col 1
-    await fireEvent.press(getByLabelText("2 of Clubs")); // invalid destination
+  it("does not call onMove when the destination is invalid (same-color card)", async () => {
+    // AMBIGUOUS_2C: 2♣ (col 0) → selection via ambiguity, then tap 4♣ (same color).
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("2 of Clubs")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("4 of Clubs")); // same color → invalid
     expect(onMove).not.toHaveBeenCalled();
   });
 
-  it("does not call onMove when a non-king is placed on an empty column", async () => {
-    // Engine rule: only Kings may go to empty tableau columns.
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("2 of Clubs")); // rank 2 — not a king
-    await fireEvent.press(getByLabelText("Empty tableau column 4"));
+  it("does not call onMove when a non-king is dragged to an empty column", async () => {
+    // AMBIGUOUS_2C: 2♣ (rank 2) selected, then tap an empty column.
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("2 of Clubs")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("Empty tableau column 5")); // rank 2 ≠ 13 → invalid
     expect(onMove).not.toHaveBeenCalled();
   });
 
   it("does not call onMove when no card is selected and an empty column is tapped", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("Empty tableau column 4")); // no prior selection
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("Empty tableau column 5")); // no prior selection
     expect(onMove).not.toHaveBeenCalled();
   });
 
   it("does not call onMove when no card is selected and a foundation is tapped", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
     await fireEvent.press(getByLabelText("Empty Spades foundation")); // no prior selection
     expect(onMove).not.toHaveBeenCalled();
   });
 
   it("does not call onMove when no card is selected and an empty freecell is tapped", async () => {
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("Empty free cell 3")); // no prior selection
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_2C);
+    await fireEvent.press(getByLabelText("Empty free cell 1")); // no prior selection
     expect(onMove).not.toHaveBeenCalled();
   });
 
   it("does not call onMove when a second occupied freecell is tapped while another is selected", async () => {
-    // freecell-to-freecell is not a legal move; board just deselects.
-    // A♠ (cell 0) selected, then tap K♠ (cell 1) → deselect only.
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades")); // select freecell 0
-    await fireEvent.press(getByLabelText("K of Spades")); // tap freecell 1 → deselect
+    // AMBIGUOUS_FC: tap 2♠ (cell 0, ambiguous → selects), then tap 2♥ (cell 1).
+    // freecell-to-freecell is not a legal move — board just deselects.
+    const { getByLabelText, onMove } = await renderBoard(AMBIGUOUS_FC);
+    await fireEvent.press(getByLabelText("2 of Spades")); // ambiguous → selects
+    await fireEvent.press(getByLabelText("2 of Hearts")); // second freecell → deselect only
     expect(onMove).not.toHaveBeenCalled();
   });
 });
@@ -259,7 +412,7 @@ describe("FreeCellBoard — invalid moves", () => {
 
 describe("FreeCellBoard — foundation re-select (Story 9)", () => {
   it("re-selects to a different non-empty foundation when one is already selected", async () => {
-    const { getByLabelText, queryByLabelText } = await renderBoard(STATE_WITH_TWO_FOUNDATIONS);
+    const { getByLabelText, queryByLabelText } = await renderBoard(TWO_FOUNDATIONS);
     await fireEvent.press(getByLabelText("A of Spades")); // select spades foundation
     expect(getByLabelText("A of Spades (selected)")).toBeTruthy();
     await fireEvent.press(getByLabelText("A of Hearts")); // tap hearts foundation → re-select
@@ -268,32 +421,24 @@ describe("FreeCellBoard — foundation re-select (Story 9)", () => {
   });
 });
 
-// ── Story 10: double-tap ──────────────────────────────────────────────────────
+// ── Double-tap → foundation (legacy path still reachable) ────────────────────
 
-describe("FreeCellBoard — double-tap (Story 10)", () => {
-  it("freecell: two taps within 300ms → freecell-to-foundation", async () => {
-    jest.useFakeTimers();
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades")); // first tap: selects
-    await fireEvent.press(getByLabelText("A of Spades (selected)")); // second tap within 300ms → foundation
+describe("FreeCellBoard — double-tap to foundation", () => {
+  it("freecell double-tap within 300ms skips selection and sends to foundation", async () => {
+    // With smart tap the first tap already auto-moves A♠ to foundation.
+    // The double-tap code path is effectively bypassed in production but the
+    // net observable result is the same: onMove fires with freecell-to-foundation.
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(ACE_FREECELL, onMove);
+    await fireEvent.press(getByLabelText("A of Spades"));
     expect(onMove).toHaveBeenCalledWith({ type: "freecell-to-foundation", fromCell: 0 });
   });
 
-  it("tableau: two taps within 300ms on top card → tableau-to-foundation", async () => {
-    jest.useFakeTimers();
-    const { getByLabelText, onMove } = await renderBoard(STATE_WITH_ACE_TABLEAU);
-    await fireEvent.press(getByLabelText("A of Diamonds")); // first tap: selects
-    await fireEvent.press(getByLabelText("A of Diamonds (selected)")); // second tap within 300ms → foundation
+  it("tableau double-tap within 300ms sends top card to foundation", async () => {
+    const onMove = jest.fn();
+    const { getByLabelText } = await renderBoard(ACE_TABLEAU, onMove);
+    await fireEvent.press(getByLabelText("A of Diamonds"));
     expect(onMove).toHaveBeenCalledWith({ type: "tableau-to-foundation", fromCol: 0 });
-  });
-
-  it("freecell: two taps separated by >300ms do NOT trigger a foundation move", async () => {
-    jest.useFakeTimers();
-    const { getByLabelText, onMove } = await renderBoard();
-    await fireEvent.press(getByLabelText("A of Spades")); // first tap: selects
-    jest.advanceTimersByTime(301); // past double-tap window
-    await fireEvent.press(getByLabelText("A of Spades (selected)")); // second tap: deselects
-    expect(onMove).not.toHaveBeenCalled();
   });
 });
 
@@ -301,26 +446,17 @@ describe("FreeCellBoard — double-tap (Story 10)", () => {
 
 describe("FreeCellBoard — DragProvider tree shape", () => {
   it("all DraggableCard instances have a DragProvider ancestor (no missing provider)", async () => {
-    // If DragProvider were absent or misplaced, DraggableCard.useDragContext would
-    // throw on mount — the render itself is the assertion.
-    const { getAllByTestId } = await renderBoard();
+    const { getAllByTestId } = await renderBoard(AMBIGUOUS_2C);
     expect(getAllByTestId(/^freecell-col-/).length).toBeGreaterThan(0);
   });
 
   it("DragProvider is rendered exactly once in FreeCellBoard", async () => {
-    // v14: composite components are not visible in the host tree. Verified
-    // structurally: DraggableCard.useDragContext throws if DragProvider is
-    // absent; duplicate providers would shadow silently, caught by code review.
-    const { getAllByTestId } = await renderBoard();
+    const { getAllByTestId } = await renderBoard(AMBIGUOUS_2C);
     expect(getAllByTestId(/^freecell-col-/).length).toBeGreaterThan(0);
   });
 
   it("DragProvider has no ancestor with a transform style", async () => {
-    // v14: composite-level tree walking is unavailable. This guard is preserved
-    // structurally: DragProvider must remain a direct child of the board root
-    // (not inside any animated/transformed container) per the architecture note
-    // in DragContext.tsx. Verified by visual inspection and Maestro E2E (#1249).
-    const { getAllByTestId } = await renderBoard();
+    const { getAllByTestId } = await renderBoard(AMBIGUOUS_2C);
     expect(getAllByTestId(/^freecell-col-/).length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
+++ b/frontend/src/components/freecell/__tests__/FreeCellBoard.test.tsx
@@ -73,16 +73,7 @@ const AMBIGUOUS_3H: FreeCellState = {
 // → first tap on 2♠ enters selection.  freeCells[1]=2♥ for second-cell tests.
 const AMBIGUOUS_FC: FreeCellState = {
   _v: 1,
-  tableau: [
-    [{ suit: "hearts", rank: 3 }],
-    [{ suit: "diamonds", rank: 3 }],
-    [],
-    [],
-    [],
-    [],
-    [],
-    [],
-  ],
+  tableau: [[{ suit: "hearts", rank: 3 }], [{ suit: "diamonds", rank: 3 }], [], [], [], [], [], []],
   freeCells: [{ suit: "spades", rank: 2 }, { suit: "hearts", rank: 2 }, null, null],
   foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
   undoStack: [],
@@ -227,16 +218,7 @@ describe("FreeCellBoard — smart single-tap auto-move", () => {
   it("auto-moves a King to the first empty column", async () => {
     const kingState: FreeCellState = {
       _v: 1,
-      tableau: [
-        [{ suit: "diamonds", rank: 13 }],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-      ],
+      tableau: [[{ suit: "diamonds", rank: 13 }], [], [], [], [], [], [], []],
       freeCells: [null, null, null, null],
       foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
       undoStack: [],
@@ -294,16 +276,7 @@ describe("FreeCellBoard — smart single-tap auto-move", () => {
     // freeCells[0]=2♠ with only one valid tableau dest (3♥ col 0); no tie.
     const state: FreeCellState = {
       _v: 1,
-      tableau: [
-        [{ suit: "hearts", rank: 3 }],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-        [],
-      ],
+      tableau: [[{ suit: "hearts", rank: 3 }], [], [], [], [], [], [], []],
       freeCells: [{ suit: "spades", rank: 2 }, null, null, null],
       foundations: { spades: [], hearts: [], diamonds: [], clubs: [] },
       undoStack: [],
@@ -424,10 +397,9 @@ describe("FreeCellBoard — foundation re-select (Story 9)", () => {
 // ── Double-tap → foundation (legacy path still reachable) ────────────────────
 
 describe("FreeCellBoard — double-tap to foundation", () => {
-  it("freecell double-tap within 300ms skips selection and sends to foundation", async () => {
-    // With smart tap the first tap already auto-moves A♠ to foundation.
-    // The double-tap code path is effectively bypassed in production but the
-    // net observable result is the same: onMove fires with freecell-to-foundation.
+  it("freecell single tap on an ace auto-moves to foundation (smart tap path)", async () => {
+    // A♠ has a unique foundation destination → resolveAutoMove executes immediately
+    // on the first tap; the double-tap code path is never reached.
     const onMove = jest.fn();
     const { getByLabelText } = await renderBoard(ACE_FREECELL, onMove);
     await fireEvent.press(getByLabelText("A of Spades"));

--- a/frontend/src/game/freecell/engine.ts
+++ b/frontend/src/game/freecell/engine.ts
@@ -430,6 +430,135 @@ export function applyMove(state: FreeCellState, move: Move): FreeCellState {
 // Hint / legal-move enumeration
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Smart single-tap auto-move (#2037)
+// ---------------------------------------------------------------------------
+
+export type AutoMoveResult =
+  | { kind: "execute"; move: Move }
+  | { kind: "ambiguous" }
+  | { kind: "supermove-rejected" }
+  | { kind: "no-move" };
+
+function runLengthAt(state: FreeCellState, col: number): number {
+  const pile = state.tableau[col];
+  if (!pile || pile.length === 0) return 0;
+  let len = 1;
+  for (let i = pile.length - 1; i > 0; i--) {
+    const top = pile[i]!;
+    const below = pile[i - 1]!;
+    if (cardColor(top) !== cardColor(below) && top.rank === below.rank - 1) {
+      len++;
+    } else {
+      break;
+    }
+  }
+  return len;
+}
+
+/**
+ * Given a tap source, resolves the smart auto-move priority ladder (#2037):
+ *   1. Foundation — unambiguous when valid
+ *   2. Non-empty tableau — prefer the destination building the longest run;
+ *      if multiple tie, caller enters two-tap selection flow
+ *   3. Empty tableau column — execute first available (interchangeable)
+ *   4. Free cell — execute first available (tableau source, single card only)
+ *
+ * Returns "supermove-rejected" when a multi-card run exceeds the maximum
+ * supermove capacity for any destination — caller should shake + toast.
+ */
+export function resolveAutoMove(
+  state: FreeCellState,
+  source: { type: "tableau"; col: number; index: number } | { type: "freecell"; cell: number }
+): AutoMoveResult {
+  if (source.type === "freecell") {
+    const { cell } = source;
+
+    // 1. Foundation
+    const foundMove: Move = { type: "freecell-to-foundation", fromCell: cell };
+    if (validateMove(state, foundMove)) return { kind: "execute", move: foundMove };
+
+    // 2. Non-empty tableau — prefer longest resulting run
+    const nonEmpty: Array<{ move: Move; score: number }> = [];
+    for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+      const pile = state.tableau[toCol];
+      if (!pile || pile.length === 0) continue;
+      const m: Move = { type: "freecell-to-tableau", fromCell: cell, toCol };
+      if (validateMove(state, m)) nonEmpty.push({ move: m, score: runLengthAt(state, toCol) });
+    }
+    if (nonEmpty.length > 0) {
+      const best = Math.max(...nonEmpty.map((s) => s.score));
+      const bestMoves = nonEmpty.filter((s) => s.score === best);
+      if (bestMoves.length === 1) return { kind: "execute", move: bestMoves[0]!.move };
+      return { kind: "ambiguous" };
+    }
+
+    // 3. Empty tableau column — first available
+    for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+      const pile = state.tableau[toCol];
+      if (!pile || pile.length > 0) continue;
+      const m: Move = { type: "freecell-to-tableau", fromCell: cell, toCol };
+      if (validateMove(state, m)) return { kind: "execute", move: m };
+    }
+
+    return { kind: "no-move" };
+  }
+
+  // Tableau source
+  const { col, index } = source;
+  const pile = state.tableau[col];
+  if (!pile || index < 0 || index >= pile.length) return { kind: "no-move" };
+  const run = pile.slice(index);
+
+  // Supermove pre-check for multi-card runs
+  if (run.length > 1) {
+    const emptyCells = state.freeCells.filter((c) => c === null).length;
+    const emptyColumns = state.tableau.filter((c, idx) => idx !== col && c.length === 0).length;
+    if (run.length > (1 + emptyCells) * Math.pow(2, emptyColumns)) {
+      return { kind: "supermove-rejected" };
+    }
+  }
+
+  // 1. Foundation (top card only)
+  if (index === pile.length - 1) {
+    const foundMove: Move = { type: "tableau-to-foundation", fromCol: col };
+    if (validateMove(state, foundMove)) return { kind: "execute", move: foundMove };
+  }
+
+  // 2. Non-empty tableau — prefer longest resulting run
+  const nonEmpty: Array<{ move: Move; score: number }> = [];
+  for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+    const dest = state.tableau[toCol];
+    if (!dest || dest.length === 0) continue;
+    const m: Move = { type: "tableau-to-tableau", fromCol: col, fromIndex: index, toCol };
+    if (validateMove(state, m)) nonEmpty.push({ move: m, score: runLengthAt(state, toCol) });
+  }
+  if (nonEmpty.length > 0) {
+    const best = Math.max(...nonEmpty.map((s) => s.score));
+    const bestMoves = nonEmpty.filter((s) => s.score === best);
+    if (bestMoves.length === 1) return { kind: "execute", move: bestMoves[0]!.move };
+    return { kind: "ambiguous" };
+  }
+
+  // 3. Empty tableau column — first available
+  for (let toCol = 0; toCol < TABLEAU_COLUMNS; toCol++) {
+    const dest = state.tableau[toCol];
+    if (!dest || dest.length > 0) continue;
+    const m: Move = { type: "tableau-to-tableau", fromCol: col, fromIndex: index, toCol };
+    if (validateMove(state, m)) return { kind: "execute", move: m };
+  }
+
+  // 4. Free cell — first available (single card only)
+  if (run.length === 1) {
+    for (let toCell = 0; toCell < FREE_CELL_COUNT; toCell++) {
+      const m: Move = { type: "tableau-to-freecell", fromCol: col, toCell };
+      if (validateMove(state, m)) return { kind: "execute", move: m };
+    }
+  }
+
+  return { kind: "no-move" };
+}
+
 /**
  * Returns false when a tableau-to-tableau move is a pure oscillation: the
  * moving run's parent card is color-rank-equivalent to the destination card

--- a/frontend/src/i18n/locales/en/freecell.json
+++ b/frontend/src/i18n/locales/en/freecell.json
@@ -30,5 +30,6 @@
   "action.submitScore": "Submit Score",
   "action.goHome": "Go Home",
   "error.submitFailed": "Submission failed — try again",
-  "error.submitRetry": "Try Again"
+  "error.submitRetry": "Try Again",
+  "error.supermoveRejected": "Not enough free spaces to move this stack"
 }

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -226,6 +226,13 @@ export default function FreeCellScreen() {
     setState(applyHint(state));
   }, [state]);
 
+  useEffect(
+    () => () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    },
+    []
+  );
+
   const showToast = useCallback((message: string) => {
     setToast(message);
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);

--- a/frontend/src/screens/FreeCellScreen.tsx
+++ b/frontend/src/screens/FreeCellScreen.tsx
@@ -50,6 +50,7 @@ import { useNetwork } from "../game/_shared/NetworkContext";
 import { OfflineBanner } from "../components/shared/OfflineBanner";
 
 const AUTO_STEP_MS = 120;
+const TOAST_DURATION_MS = 2500;
 const TABLEAU_COLS = 8;
 const COL_GAP = 2;
 const SCREEN_H_PADDING = 24;
@@ -77,6 +78,8 @@ export default function FreeCellScreen() {
   const [showFoundation, setShowFoundation] = useState(false);
   const [showGameWin, setShowGameWin] = useState(false);
   const [showNoMovesBanner, setShowNoMovesBanner] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { play: playCardPlace } = useSound("freecell.cardPlace", FREECELL_SOUNDS, 0.4);
   const { play: playSupermove } = useSound("freecell.supermove", FREECELL_SOUNDS, 0.5);
@@ -223,6 +226,12 @@ export default function FreeCellScreen() {
     setState(applyHint(state));
   }, [state]);
 
+  const showToast = useCallback((message: string) => {
+    setToast(message);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToast(null), TOAST_DURATION_MS);
+  }, []);
+
   const handleNewGame = useCallback(() => {
     clearGame().catch(() => {});
     setState(dealGame());
@@ -311,7 +320,11 @@ export default function FreeCellScreen() {
               style={styles.boardWrap}
               accessibilityLabel={t("freecell:a11y.boardRegion")}
             >
-              <FreeCellBoard state={state} onMove={handleMove} />
+              <FreeCellBoard
+                state={state}
+                onMove={handleMove}
+                onSupermoveRejected={() => showToast(t("freecell:error.supermoveRejected"))}
+              />
             </View>
 
             {showNoMovesBanner && (
@@ -359,6 +372,7 @@ export default function FreeCellScreen() {
         onAnimationEnd={() => setShowFoundation(false)}
       />
       <FreeCellGameWinAnimation visible={showGameWin} onDismiss={() => setShowGameWin(false)} />
+      {toast !== null && <SupermoveToast message={toast} colors={colors} />}
     </GameShell>
   );
 }
@@ -520,6 +534,28 @@ function WinModal({
 }
 
 // ---------------------------------------------------------------------------
+// Supermove rejection toast
+// ---------------------------------------------------------------------------
+
+function SupermoveToast({
+  message,
+  colors,
+}: {
+  readonly message: string;
+  readonly colors: { text: string; background: string };
+}) {
+  return (
+    <View
+      style={[styles.supermoveToast, { backgroundColor: colors.text }]}
+      accessibilityRole="alert"
+      accessibilityLiveRegion="assertive"
+    >
+      <Text style={[styles.supermoveToastText, { color: colors.background }]}>{message}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Styles
 // ---------------------------------------------------------------------------
 
@@ -664,5 +700,19 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "700",
     marginBottom: 12,
+  },
+  supermoveToast: {
+    position: "absolute",
+    bottom: 80,
+    alignSelf: "center",
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 24,
+    maxWidth: 280,
+  },
+  supermoveToastText: {
+    fontSize: 13,
+    fontWeight: "700",
+    textAlign: "center",
   },
 });


### PR DESCRIPTION
## Summary

- Adds `resolveAutoMove` to `engine.ts`: walks the priority ladder (foundation → best non-empty tableau run → first empty column → first free cell) and returns `execute | ambiguous | supermove-rejected | no-move`
- Updates `FreeCellBoard` so the first tap on any card calls `resolveAutoMove`; unambiguous results execute immediately, ties fall through to the existing two-tap selection flow
- Multi-card runs exceeding `(1 + emptyCells) × 2^emptyColumns` trigger `triggerIllegal()` + a 2.5 s "Not enough free spaces to move this stack" toast via a new `onSupermoveRejected` prop

## Test plan

- [x] `FreeCellBoard.test.tsx` rebuilt with ambiguous board states — 28 tests green
- [x] `FreeCellBoard.smartTap.test.tsx` (new) — supermove pre-check, boundary, run-length preference — 3 tests green
- [x] `freecell-card-move.spec.ts` updated: single tap now suffices (no second tap)
- [x] `freecell-errors.spec.ts` updated: BOARD_STATE replaced with ambiguous 2♠ state so two-tap error flow is preserved
- [x] All 156 FreeCell Jest tests pass; prettier clean

Closes #2037. Part of epic #2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)