### PR TITLE
fix(daily-word): render tile letter "I" by correcting fontWeight to 700

### DIFF
--- a/frontend/src/screens/DailyWordScreen.tsx
+++ b/frontend/src/screens/DailyWordScreen.tsx
@@ -237,7 +237,8 @@ const tileStyles = StyleSheet.create({
   letter: {
     fontFamily: typography.heading,
     fontSize: 22,
-    fontWeight: "900",
+    fontWeight: "700",
+    textAlign: "center",
   },
 });
 


### PR DESCRIPTION
## Summary

- Fixes the capital "I" not appearing in game tiles when typed in Daily Word
- `tileStyles.letter` had `fontWeight: "900"` but `SpaceGrotesk_700Bold` only goes up to weight 700
- On iOS, CoreText attempts a 900-weight SpaceGrotesk lookup, fails, and falls back inconsistently — producing a broken/invisible render for the narrow "I" glyph
- Changed `fontWeight` to `"700"` (matches the loaded font) and added `textAlign: "center"` for extra safety

## Root cause vs. previous fix

PR #2082 fixed the keyboard *key* "I" (Manrope at small font size → increased to 13px). This PR fixes the *tile* "I" — a separate issue caused by a mismatched `fontWeight` that triggers bad font resolution on iOS.

## Test plan

- [ ] Open Daily Word and type any word containing "I" (e.g. GIFTS, PINTS, FINES)
- [ ] Confirm the "I" tile letter is visible while typing (tbd/grey state)
- [ ] Confirm the "I" tile flips and shows the correct color (green/yellow/grey) after submitting
- [ ] Spot-check other letters (G, O, W) look unchanged in tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUi6jvm4qv8KiM4XB73PgH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUi6jvm4qv8KiM4XB73PgH)_