### PR TITLE
feat(deps): add expo-dev-client; switch iOS dev to development build (fixes #2146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ npx expo start --web   # http://localhost:8081
 
 The frontend points at `http://localhost:8000` by default. Override with `EXPO_PUBLIC_API_URL` if the backend is elsewhere.
 
+### Terminal 2 — Frontend (iOS simulator)
+
+The app uses native modules (`@react-native-async-storage/async-storage`, gesture handler, etc.) that are not bundled in Expo Go. Use a development build instead of `npx expo start`:
+
+```bash
+cd frontend
+npm install                # first time or when package.json changes
+npm run ios                # builds native app + starts Metro (first run ~5 min)
+```
+
+Subsequent runs after the initial build: `npm run ios` again, or just `npx expo start` and open the installed dev client on the simulator.
+
+> **Note:** After changing native dependencies (e.g. adding a new package with native code), run `pod install` in `frontend/ios/` and rebuild with `npm run ios`.
+
 ## Testing
 
 ```bash

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "expo": "^56.0.9",
         "expo-audio": "~56.0.12",
         "expo-blur": "~56.0.3",
+        "expo-dev-client": "~56.0.20",
         "expo-haptics": "~56.0.3",
         "expo-linear-gradient": "~56.0.4",
         "expo-localization": "~56.0.6",
@@ -8825,6 +8826,59 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "56.0.20",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-56.0.20.tgz",
+      "integrity": "sha512-KebW4r8HhIiRrPzs6ZqVhp/so8buyglAO1h4No0Ibr5C2XRnlIoGWCN4zC6rW7IsI3iKUXcofLAQV9OjoxjiwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "~56.0.20",
+        "expo-dev-menu": "~56.0.17",
+        "expo-dev-menu-interface": "~56.0.0",
+        "expo-manifests": "~56.0.4",
+        "expo-updates-interface": "~56.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "56.0.20",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-56.0.20.tgz",
+      "integrity": "sha512-cTuC3GkPl9CTwO3CKnVmEm9qoQ0WairhwvTh6qMlg+zr/QU/tdiU++uDBX67hf9+FuxQOkWGp5khFNosT+0cIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^56.0.0",
+        "expo-dev-menu": "~56.0.17",
+        "expo-manifests": "~56.0.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "56.0.17",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-56.0.17.tgz",
+      "integrity": "sha512-OofRkOOZnaDriSav3JDN4NP2lsLt2eOa/Ryptr5nMD62SwnFyK4R6n6PkPVaDU3LSsZqndAJHmN6inS+oziayQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-56.0.1.tgz",
+      "integrity": "sha512-odATx0ZL/Kis10sKSBiKiGQxAB6coSi/KQtKcMhnQVNno6FkRh5/4e5BqcEvpq2rNMTiQp4ytNAQHtdwbPXvGA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-file-system": {
       "version": "56.0.8",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-56.0.8.tgz",
@@ -8858,6 +8912,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "56.0.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-56.0.0.tgz",
+      "integrity": "sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "56.0.3",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-56.0.3.tgz",
@@ -8890,6 +8950,18 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "56.0.4",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-56.0.4.tgz",
+      "integrity": "sha512-Fokawl2UkiExIF0bqGoblRFA8lYpROVD+EpvDwSW4LgqQyPwNua1gLSgHZjdl5GsVugfRMMWE3LHaibDyX93hw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~56.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -8965,6 +9037,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "56.0.2",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-56.0.2.tgz",
+      "integrity": "sha512-eWTwSZ9y8vrULG2oBn2TQSSIwBGSq/TxGJ3jY6tuVS2FWH/ASRIiKs3zkUZTRoC3ZuV2alz0mUClYV7nNrFx8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,6 +73,7 @@
     "expo": "^56.0.9",
     "expo-audio": "~56.0.12",
     "expo-blur": "~56.0.3",
+    "expo-dev-client": "~56.0.20",
     "expo-haptics": "~56.0.3",
     "expo-linear-gradient": "~56.0.4",
     "expo-localization": "~56.0.6",


### PR DESCRIPTION
## Summary

Fixes the AsyncStorage `"Native module is null"` crash that floods Sentry during every Expo Go dev session (BC_GAMES-4A through BC_GAMES-4R, ~150 events per session, 14 grouped issues).

**Root cause:** Expo Go SDK 56 does not bundle `RNAsyncStorage` — the TurboModule that `@react-native-async-storage/async-storage@3.1.1` requires. All 75+ files that import `AsyncStorage` fail immediately. A development build compiles the native module in, fixing the issue with zero app code changes.

**Changes:**
- Add `expo-dev-client@~56.0.20` (SDK 56-compatible) to `dependencies`
- Update `package-lock.json`
- Document `npm run ios` as the iOS simulator dev workflow in README (`npm run ios` script already existed and maps to `expo run:ios`)

## After merging — required local steps (macOS only)

```bash
cd frontend
npm install
npx pod-install          # or: cd ios && pod install
npm run ios              # first build ~5 min, then hot-reloads like Expo Go
```

> yarn.lock also needs syncing on macOS after the pod install — Windows yarn swaps platform binaries (see fdf8700b for precedent).

## What changes in the dev workflow

| Before | After |
|---|---|
| `npx expo start` → scan QR with Expo Go | `npm run ios` → installs dev client on simulator |
| AsyncStorage broken in Expo Go SDK 56 | All native modules compile in and work |
| Rebuild needed: never (Expo Go handles it) | Rebuild needed: only when native deps change |

## Test plan

- [ ] `npm run ios` in `frontend/` builds and installs without error
- [ ] App launches in simulator via the development build (not Expo Go)
- [ ] Open any game — no AsyncStorage errors in Metro logs or Sentry
- [ ] Sentry: BC_GAMES-4A through BC_GAMES-4R stop generating new events
- [ ] Hot reload still works after initial build (edit a `.tsx` file, save, see update in simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)