### PR TITLE
test(hearts): fix sim calibration metrics and --count semantics (#2204)

### DIFF
--- a/frontend/src/game/hearts/__tests__/ai.calibrate.test.ts
+++ b/frontend/src/game/hearts/__tests__/ai.calibrate.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Hearts AI calibration gate (GH #2204, HRT-1/HRT-3).
+ *
+ * Full N-game validation of persona calibration bands, mirroring the Yacht
+ * gate (yacht/__tests__/ai.calibrate.test.ts). Skipped by default; enable
+ * with HEARTS_SIM_FULL=<N> (e.g. HEARTS_SIM_FULL=3000).
+ *
+ * Acceptance bands (measured on an instrumented 3,000-game / 33,325-hand run,
+ * see #2204):
+ *   Cautious baseline win rate (uniform Cautious field):    20–30%
+ *   Daring moon attempt rate (Daring seat 0 vs S/C/C):      8–16% of hands
+ *   Daring PAIRED moon success (completions ÷ activations): 2–10% of attempts
+ *
+ * The paired-success band replaces the old unpaired ratio (all completions ÷
+ * trick-0-only attempt count), which reported 48–80% against a true paired
+ * rate of ~4.9%. #2234 (rank-aware attempts) is expected to raise this band
+ * deliberately; update the numbers there, with sim evidence, when it lands.
+ */
+
+import { detectMoonAttempt, selectCardToPlay, selectCardsToPass } from "../ai";
+import {
+  commitPass,
+  createSeededRng,
+  dealGame,
+  dealNextHand,
+  playCard,
+  selectPassCard,
+  setRng,
+} from "../engine";
+import type { AiPersona, HeartsState } from "../types";
+
+const RUN = !!process.env.HEARTS_SIM_FULL;
+const N = process.env.HEARTS_SIM_FULL ? parseInt(process.env.HEARTS_SIM_FULL, 10) : 3000;
+
+const itFull = (RUN ? it : it.skip) as jest.It;
+
+type Difficulties = [AiPersona, AiPersona, AiPersona, AiPersona];
+
+// ---------------------------------------------------------------------------
+// Simulator (trimmed from scripts/simulate-hearts.ts — win + paired moon only)
+// ---------------------------------------------------------------------------
+
+interface SimResult {
+  win: boolean;
+  handsPlayed: number;
+  moonAttemptsBySeat0: number;
+  pairedMoonSuccessBySeat0: number;
+}
+
+function simulateGame(difficulties: Difficulties, seed: number): SimResult {
+  setRng(createSeededRng(seed));
+  let state: HeartsState = dealGame(difficulties[0]); // aiDifficulty field is informational
+
+  // Paired moon instrumentation (#2204): a hand counts as "attempted" for seat 0
+  // the first time the real earlyMoon/midMoon trigger (detectMoonAttempt — the
+  // same check ai.ts uses to activate DARING_MOON_PLAY_WEIGHTS) fires, and as a
+  // paired success only when that SAME hand ends with seat 0 shooting the moon.
+  let attemptedThisHand = false;
+  let moonAttempts = 0;
+  let pairedSuccesses = 0;
+
+  function collectHandEvents(s: HeartsState) {
+    for (const e of s.events ?? []) {
+      if (e.type === "moonShot" && e.shooter === 0 && attemptedThisHand) {
+        pairedSuccesses++;
+      }
+    }
+  }
+
+  while (state.phase !== "game_over") {
+    if (state.phase === "passing") {
+      for (let i = 0; i < 4; i++) {
+        const hand = [...(state.playerHands[i] ?? [])];
+        const cards = selectCardsToPass(hand, state.passDirection, difficulties[i]!, i);
+        for (const card of cards) {
+          state = selectPassCard(state, i, card);
+        }
+      }
+      state = commitPass(state);
+    } else if (state.phase === "playing") {
+      const playerIndex = state.currentPlayerIndex;
+      const hand = [...(state.playerHands[playerIndex] ?? [])];
+      if (
+        playerIndex === 0 &&
+        !attemptedThisHand &&
+        detectMoonAttempt(hand, state, playerIndex, difficulties[0]!)
+      ) {
+        attemptedThisHand = true;
+        moonAttempts++;
+      }
+      const card = selectCardToPlay(
+        hand,
+        [...state.currentTrick],
+        state,
+        playerIndex,
+        difficulties[playerIndex]!
+      );
+      state = playCard(state, playerIndex, card);
+    } else if (state.phase === "dealing") {
+      collectHandEvents(state);
+      attemptedThisHand = false;
+      state = dealNextHand(state);
+    }
+  }
+  collectHandEvents(state);
+
+  return {
+    win: state.winnerIndex === 0,
+    handsPlayed: state.handNumber,
+    moonAttemptsBySeat0: moonAttempts,
+    pairedMoonSuccessBySeat0: pairedSuccesses,
+  };
+}
+
+interface BatchResult {
+  winRate: number;
+  totalHands: number;
+  moonAttemptRate: number;
+  pairedMoonSuccessRate: number;
+}
+
+function runBatch(difficulties: Difficulties, n: number, seedOffset: number): BatchResult {
+  let wins = 0;
+  let hands = 0;
+  let attempts = 0;
+  let successes = 0;
+  for (let i = 0; i < n; i++) {
+    const r = simulateGame(difficulties, seedOffset + i);
+    if (r.win) wins++;
+    hands += r.handsPlayed;
+    attempts += r.moonAttemptsBySeat0;
+    successes += r.pairedMoonSuccessBySeat0;
+  }
+  return {
+    winRate: wins / n,
+    totalHands: hands,
+    moonAttemptRate: hands > 0 ? attempts / hands : 0,
+    pairedMoonSuccessRate: attempts > 0 ? successes / attempts : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => setRng(Math.random));
+
+describe("Hearts calibration — persona bands (#2204)", () => {
+  itFull("Cautious baseline: seat 0 win rate 20–30% in a uniform Cautious field", () => {
+    const r = runBatch(["cautious", "cautious", "cautious", "cautious"], N, 0);
+    expect(r.winRate).toBeGreaterThanOrEqual(0.2);
+    expect(r.winRate).toBeLessThanOrEqual(0.3);
+  });
+
+  itFull("Daring moon calibration: paired attempt→outcome bands (seat 0 Daring vs S/C/C)", () => {
+    // Same lineup as simulate-hearts.ts batch 5 for comparability.
+    const r = runBatch(["daring", "schemer", "cautious", "cautious"], N, 100000);
+
+    // Attempt rate: hands where the real trigger activated / hands played.
+    expect(r.moonAttemptRate).toBeGreaterThanOrEqual(0.08);
+    expect(r.moonAttemptRate).toBeLessThanOrEqual(0.16);
+
+    // PAIRED success: completions in attempted hands / attempted hands (HRT-1).
+    expect(r.pairedMoonSuccessRate).toBeGreaterThanOrEqual(0.02);
+    expect(r.pairedMoonSuccessRate).toBeLessThanOrEqual(0.1);
+  });
+});

--- a/frontend/src/game/hearts/ai.ts
+++ b/frontend/src/game/hearts/ai.ts
@@ -192,6 +192,38 @@ export function selectCardsToPassUtility(
  *
  * Noise: Cautious 25 %, Schemer 10 %, Daring 0 % (seeded RNG via getRng()).
  */
+/**
+ * Returns true when `playerIndex` is in an active moon attempt this trick,
+ * per the Daring earlyMoon/midMoon thresholds (exact thresholds from the
+ * legacy selectCardToPlayHard). Exported so simulation/calibration tooling
+ * (scripts/simulate-hearts.ts, ai.calibrate.test.ts) can instrument real
+ * trigger activations instead of re-implementing — and drifting from —
+ * these thresholds (#2204).
+ */
+export function detectMoonAttempt(
+  hand: Card[],
+  state: HeartsState,
+  playerIndex: number,
+  difficulty: AiPersona
+): boolean {
+  if (difficulty !== "daring") return false;
+  const heartsInHand = hand.filter((c) => c.suit === "hearts").length;
+  const heartsWon = (state.wonCards[playerIndex] ?? []).filter((c) => c.suit === "hearts").length;
+  const totalHearts = heartsInHand + heartsWon;
+  const myHasQ =
+    hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
+  const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
+  const myPoints = state.handScores[playerIndex] ?? 0;
+  // earlyMoon: 7+ hearts + Q♠ at trick start (hand.length ≥ 8)
+  const earlyMoon = heartsInHand >= 7 && myHasQ && heartsWon === 0 && hand.length >= 8;
+  // midMoon: 6+ hearts total + Q♠ + we hold all points taken so far.
+  // NOTE: fires trivially when totalPointsTaken === 0 — myPoints(0) === 0 always.
+  // This is intentional (matching selectCardToPlayHard): a player with 6+ hearts + Q♠
+  // should play moon-attempt mode from trick 1, even before earlyMoon's 7+ threshold.
+  const midMoon = totalHearts >= 6 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
+  return earlyMoon || midMoon;
+}
+
 export function selectCardToPlayUtility(
   hand: Card[],
   trick: TrickCard[],
@@ -205,24 +237,7 @@ export function selectCardToPlayUtility(
   const infoSet = buildHeartsInfoSet(hand, trick, state, playerIndex);
 
   // ── Moon-attempt detection (exact thresholds from selectCardToPlayHard) ──
-  let isMoonAttempt = false;
-  if (difficulty === "daring") {
-    const heartsInHand = hand.filter((c) => c.suit === "hearts").length;
-    const heartsWon = (state.wonCards[playerIndex] ?? []).filter((c) => c.suit === "hearts").length;
-    const totalHearts = heartsInHand + heartsWon;
-    const myHasQ =
-      hand.some(isQueenOfSpades) || (state.wonCards[playerIndex] ?? []).some(isQueenOfSpades);
-    const totalPointsTaken = state.handScores.reduce((s, v) => s + (v ?? 0), 0);
-    const myPoints = state.handScores[playerIndex] ?? 0;
-    // earlyMoon: 7+ hearts + Q♠ at trick start (hand.length ≥ 8)
-    const earlyMoon = heartsInHand >= 7 && myHasQ && heartsWon === 0 && hand.length >= 8;
-    // midMoon: 6+ hearts total + Q♠ + we hold all points taken so far.
-    // NOTE: fires trivially when totalPointsTaken === 0 — myPoints(0) === 0 always.
-    // This is intentional (matching selectCardToPlayHard): a player with 6+ hearts + Q♠
-    // should play moon-attempt mode from trick 1, even before earlyMoon's 7+ threshold.
-    const midMoon = totalHearts >= 6 && myHasQ && myPoints === totalPointsTaken && hand.length >= 5;
-    isMoonAttempt = earlyMoon || midMoon;
-  }
+  const isMoonAttempt = detectMoonAttempt(hand, state, playerIndex, difficulty);
 
   // ── Endgame detection (Daring only) ──────────────────────────────────────
   // Mirrors the inEndgame guard in selectCardToPlayHard (maxScore ≥ 65).

--- a/hearts-analysis/main.py
+++ b/hearts-analysis/main.py
@@ -115,7 +115,7 @@ async def simulate(req: SimulateRequest) -> dict:
     safe_diffs = [d for d in req.difficulties if d in {"easy", "medium", "hard"}]
     cmd = [
         "npx", "tsx", "scripts/simulate-hearts.ts",
-        "--count", str(safe_count),
+        "--log-games", str(safe_count),
         "--difficulties", ",".join(safe_diffs),
     ]
     games_file = DATA_DIR / "games.json"

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -593,7 +593,7 @@ console.log(
 // avoid flagging the correct direction as a failure on ordinary sampling noise.
 const csDelta = cautiousVsSchemerWr - cautiousWr;
 console.log(
-  `  ${check(csDelta > -0.01)} Cautious vs Schemer: win rate rises (Δ${csDelta >= 0 ? "+" : ""}${(csDelta * 100).toFixed(1)}pp, expected ~1-3pp rise, ${sigLabel(zCS)})`,
+  `  ${check(csDelta > -0.01)} Cautious vs Schemer: win rate does not drop (Δ${csDelta >= 0 ? "+" : ""}${(csDelta * 100).toFixed(1)}pp, expected ~1-3pp rise, ${sigLabel(zCS)})`,
 );
 // Removed: "Cautious vs Daring drops further" check is structurally flawed.
 // Daring's high-variance failed moon attempts self-punish Daring, so Cautious

--- a/scripts/simulate-hearts.ts
+++ b/scripts/simulate-hearts.ts
@@ -1,12 +1,19 @@
 /**
  * Hearts AI difficulty simulation (#1273).
  *
- * Runs batches of 3,000 games. Each batch specifies all 4 player difficulties
- * individually. Player 0's stats are tracked and reported.
+ * Runs batches of games (3,000/batch by default). Each batch specifies all 4
+ * player difficulties individually. Player 0's stats are tracked and reported.
+ *
+ * `--count` semantics are aligned with scripts/simulate-yacht.ts: it sets the
+ * number of games per batch in aggregate-stats mode. NDJSON game-log dumping
+ * (a distinct mode, also used by hearts-analysis/main.py's /api/simulate) is
+ * triggered by `--log-games` instead (#2204).
  *
  * Usage:
- *   npx tsx scripts/simulate-hearts.ts                  # aggregate stats
- *   npx tsx scripts/simulate-hearts.ts --log-games 10   # 10 fully-logged games (NDJSON)
+ *   npx tsx scripts/simulate-hearts.ts                       # aggregate stats (3000 games/batch)
+ *   npx tsx scripts/simulate-hearts.ts --count 500            # 500 games per batch
+ *   npx tsx scripts/simulate-hearts.ts --log-games 10         # 10 fully-logged games (NDJSON)
+ *   npx tsx scripts/simulate-hearts.ts --log-games 10 --difficulties cautious,schemer,daring,schemer
  */
 
 import {
@@ -19,6 +26,7 @@ import {
   setRng,
 } from "../frontend/src/game/hearts/engine";
 import {
+  detectMoonAttempt,
   selectCardToPlay,
   selectCardsToPass,
 } from "../frontend/src/game/hearts/ai";
@@ -46,8 +54,13 @@ interface GameResult {
   passingRounds: number; // total non-"none" passing rounds
   moonShotsByPlayer: [number, number, number, number]; // rounds each seat shot the moon
   handScoreSumByPlayer: [number, number, number, number]; // sum of per-hand scores
-  // Moon attempt instrumentation (#1895): earlyMoon triggers (7+ hearts + Q♠ at hand start)
+  // Moon attempt instrumentation (#2204, replacing the unpaired #1895 version):
+  // moonAttemptsByPlayer counts hands where the real earlyMoon/midMoon trigger
+  // (detectMoonAttempt, mirroring ai.ts's own activation check) fired for that
+  // seat. pairedMoonSuccessByPlayer counts, of those same hands, how many that
+  // SAME seat went on to complete the moon in — a true paired attempt→outcome rate.
   moonAttemptsByPlayer: [number, number, number, number];
+  pairedMoonSuccessByPlayer: [number, number, number, number];
 }
 
 function simulateGame(difficulties: Difficulties, seed: number): GameResult {
@@ -60,6 +73,19 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
   const qSpadeByPlayer: [number, number, number, number] = [0, 0, 0, 0];
   const moonShotsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
   const handScoreSumByPlayer: [number, number, number, number] = [0, 0, 0, 0];
+  // Moon attempt pairing (#2204): whether each seat's earlyMoon/midMoon trigger
+  // has activated at least once *this hand*. Reset at every hand boundary (the
+  // "dealing" branch below) so a moonShot event can be paired against the
+  // attempt state of the hand that produced it, not a later hand.
+  const attemptedThisHand: [boolean, boolean, boolean, boolean] = [
+    false,
+    false,
+    false,
+    false,
+  ];
+  const pairedMoonSuccessByPlayer: [number, number, number, number] = [
+    0, 0, 0, 0,
+  ];
 
   function collectHandEvents(s: HeartsState) {
     const ev = s.events ?? [];
@@ -67,6 +93,9 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
       if (e.type === "moonShot") {
         totalMoonShots++;
         moonShotsByPlayer[e.shooter]++;
+        if (attemptedThisHand[e.shooter]) {
+          pairedMoonSuccessByPlayer[e.shooter]++;
+        }
       }
       if (e.type === "queenOfSpades") {
         qSpadeByPlayer[e.takerSeat]++;
@@ -80,9 +109,10 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
 
   const voidsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
   let passingRounds = 0;
-  // earlyMoon attempt tracking (#1895): record triggers at hand start, compare to moonShots.
+  // Moon attempt tracking (#2204): count a hand as "attempted" for a seat the
+  // first time detectMoonAttempt — the actual trigger used by ai.ts to select
+  // DARING_MOON_PLAY_WEIGHTS — fires for that seat during the hand.
   const moonAttemptsByPlayer: [number, number, number, number] = [0, 0, 0, 0];
-  let lastAttemptCheckHand = -1;
 
   while (state.phase !== "game_over") {
     if (state.phase === "passing") {
@@ -106,32 +136,25 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
         }
       }
     } else if (state.phase === "playing") {
-      // Detect earlyMoon triggers once per hand, at trick 0.
-      if (
-        state.tricksPlayedInHand === 0 &&
-        state.handNumber !== lastAttemptCheckHand
-      ) {
-        lastAttemptCheckHand = state.handNumber;
-        for (let i = 0; i < 4; i++) {
-          if (difficulties[i] === "daring") {
-            const h = state.playerHands[i] ?? [];
-            const heartsCount = h.filter((c) => c.suit === "hearts").length;
-            const hasQ = h.some((c) => c.suit === "spades" && c.rank === 12);
-            // earlyMoon: 7+ hearts + Q♠, no hearts yet won, enough cards remaining.
-            if (heartsCount >= 7 && hasQ && h.length >= 8) {
-              moonAttemptsByPlayer[i]++;
-            }
-          }
-        }
-      }
       const playerIndex = state.currentPlayerIndex;
       const diff = difficulties[playerIndex]!;
       const hand = [...(state.playerHands[playerIndex] ?? [])];
+      if (
+        !attemptedThisHand[playerIndex] &&
+        detectMoonAttempt(hand, state, playerIndex, diff)
+      ) {
+        attemptedThisHand[playerIndex] = true;
+        moonAttemptsByPlayer[playerIndex]++;
+      }
       const trick = [...state.currentTrick];
       const card = selectCardToPlay(hand, trick, state, playerIndex, diff);
       state = playCard(state, playerIndex, card);
     } else if (state.phase === "dealing") {
-      collectHandEvents(state);
+      collectHandEvents(state); // pairs this hand's moonShot (if any) against attemptedThisHand
+      attemptedThisHand[0] = false;
+      attemptedThisHand[1] = false;
+      attemptedThisHand[2] = false;
+      attemptedThisHand[3] = false;
       state = dealNextHand(state);
     }
   }
@@ -149,6 +172,7 @@ function simulateGame(difficulties: Difficulties, seed: number): GameResult {
     moonShotsByPlayer,
     handScoreSumByPlayer,
     moonAttemptsByPlayer,
+    pairedMoonSuccessByPlayer,
   };
 }
 
@@ -332,13 +356,17 @@ function parseDifficulties(args: string[]): Difficulties | null {
   return parts as unknown as Difficulties;
 }
 
-// --count N is the primary flag; --log-games N is a deprecated alias
-const count =
-  parseCount(process.argv, "--count") ??
-  parseCount(process.argv, "--log-games");
-if (count !== null) {
-  if (count < 1) {
-    process.stderr.write("Error: count must be a positive integer\n");
+// --log-games N: emit N NDJSON game logs and exit (optionally with --difficulties).
+// This is a distinct mode from aggregate-stats --count below (#2204) — it is used
+// by hearts-analysis/main.py's /api/simulate endpoint, so the flag name and the
+// NDJSON-per-line output format must stay stable even though --count no longer
+// triggers it.
+const logCount = parseCount(process.argv, "--log-games");
+if (logCount !== null) {
+  if (logCount < 1) {
+    process.stderr.write(
+      "Error: --log-games count must be a positive integer\n",
+    );
     process.exit(1);
   }
   const difficultiesArg = parseDifficulties(process.argv);
@@ -355,7 +383,7 @@ if (count !== null) {
     "schemer",
     "schemer",
   ];
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < logCount; i++) {
     const log = simulateGameLogged(logDifficulties, i);
     process.stdout.write(JSON.stringify(log) + "\n");
   }
@@ -381,7 +409,15 @@ function fmt4score(vals: number[], denom: number): string {
 // Batches
 // ---------------------------------------------------------------------------
 
-const GAMES_PER_BATCH = 3000;
+// --count N: games per batch in aggregate-stats mode, aligned with
+// scripts/simulate-yacht.ts's --count semantics (#2204). Previously this flag
+// triggered NDJSON dump mode here; that behavior now lives under --log-games.
+const GAMES_PER_BATCH = parseCount(process.argv, "--count") ?? 3000;
+
+if (GAMES_PER_BATCH < 1) {
+  process.stderr.write("Error: --count must be a positive integer\n");
+  process.exit(1);
+}
 
 const batches: Array<{ label: string; difficulties: Difficulties }> = [
   {
@@ -418,8 +454,9 @@ console.log("Hearts AI Persona Simulation Results");
 console.log("=======================================\n");
 
 const batchWinRates: number[] = [];
-// earlyMoon success rate from batch 5 (Daring at seat 0) for Interpretation check.
-let daringEarlyMoonSuccessRate = 0;
+// Paired moon-attempt metrics from batch 5 (Daring at seat 0) for Interpretation check (#2204).
+let daringMoonAttemptRate = 0;
+let daringPairedMoonSuccessRate = 0;
 
 for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const { label, difficulties } = batches[batchIndex]!;
@@ -462,6 +499,9 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   const moonAttemptsAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.moonAttemptsByPlayer[i]!, 0),
   );
+  const pairedMoonSuccessAgg = [0, 1, 2, 3].map((i) =>
+    results.reduce((s, r) => s + r.pairedMoonSuccessByPlayer[i]!, 0),
+  );
   const handScoreAgg = [0, 1, 2, 3].map((i) =>
     results.reduce((s, r) => s + r.handScoreSumByPlayer[i]!, 0),
   );
@@ -486,21 +526,35 @@ for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
   console.log(`  Void Rate by Seat:  ${fmt4pct(voidsAgg, totalPassRounds)}`);
   console.log(`  Moon Shots/Round:   ${fmt4pct(moonAgg, totalHands)}`);
   console.log(`  Avg Hand Score:     ${fmt4score(handScoreAgg, totalHands)}`);
-  // earlyMoon success rate: shots / attempts per seat (n/a when no Daring at that seat).
-  // Values >100% mean midMoon completions in that hand exceeded earlyMoon triggers —
-  // moonShotsByPlayer counts all moon completions, not just earlyMoon-initiated ones.
-  const moonSuccessRate = moonAttemptsAgg.map((attempts, i) =>
+  // Moon attempt rate (#2204): hands per seat where the real earlyMoon/midMoon
+  // trigger activated, over hands played (n/a for non-Daring seats — the trigger
+  // never fires for them).
+  const moonAttemptRate = moonAttemptsAgg.map((attempts) =>
+    totalHands === 0
+      ? "    n/a"
+      : `${((attempts / totalHands) * 100).toFixed(1)}%`.padStart(7),
+  );
+  // Paired moon success rate (#2204 — fixes HRT-1): of the hands where a seat's
+  // trigger activated, the fraction where that SAME seat completed the moon in
+  // that SAME hand. This replaces the old unpaired ratio (all moon completions
+  // for a seat / narrow trick-0-only attempt count), which mismatched
+  // denominators and reported 48-80% against a true paired rate of ~4.9%.
+  const pairedMoonSuccessRate = moonAttemptsAgg.map((attempts, i) =>
     attempts === 0
       ? "    n/a"
-      : `${(((moonAgg[i] ?? 0) / attempts) * 100).toFixed(1)}%`.padStart(7),
+      : `${(((pairedMoonSuccessAgg[i] ?? 0) / attempts) * 100).toFixed(1)}%`.padStart(
+          7,
+        ),
   );
-  console.log(`  earlyMoon Success:  ${moonSuccessRate.join(" ")}`);
+  console.log(`  Moon Attempt Rate:  ${moonAttemptRate.join(" ")}`);
+  console.log(`  Paired Moon Success:${pairedMoonSuccessRate.join(" ")}`);
   console.log();
-  // Store Daring seat-0 earlyMoon success rate (batch 5, batchIndex=4) for Interpretation.
+  // Store Daring seat-0 attempt/paired-success rates (batch 5, batchIndex=4) for Interpretation.
   if (batchIndex === 4) {
     const attempts = moonAttemptsAgg[0] ?? 0;
-    const shots = moonAgg[0] ?? 0;
-    daringEarlyMoonSuccessRate = attempts > 0 ? shots / attempts : 0;
+    const paired = pairedMoonSuccessAgg[0] ?? 0;
+    daringMoonAttemptRate = totalHands > 0 ? attempts / totalHands : 0;
+    daringPairedMoonSuccessRate = attempts > 0 ? paired / attempts : 0;
   }
 }
 
@@ -531,8 +585,15 @@ console.log("Interpretation:");
 console.log(
   `  ${check(cautiousWr > 0.2 && cautiousWr < 0.3)} Cautious baseline win rate near 25% (got ${(cautiousWr * 100).toFixed(1)}%)`,
 );
+// HRT-3 fix: empirically (pooled 9,000-game reproduction across 3 disjoint seeds,
+// z≈2.9, p<0.01), Cautious's win rate RISES ~1-3pp against 3 Schemers rather than
+// dropping — the original check had the expected direction backwards. A single
+// 3,000-game batch is noisier than the pooled reproduction, so this check uses a
+// tolerant band (allow up to -1pp) rather than requiring strict positivity, to
+// avoid flagging the correct direction as a failure on ordinary sampling noise.
+const csDelta = cautiousVsSchemerWr - cautiousWr;
 console.log(
-  `  ${check(cautiousVsSchemerWr < cautiousWr)} Cautious vs Schemer: win rate drops (${sigLabel(zCS)})`,
+  `  ${check(csDelta > -0.01)} Cautious vs Schemer: win rate rises (Δ${csDelta >= 0 ? "+" : ""}${(csDelta * 100).toFixed(1)}pp, expected ~1-3pp rise, ${sigLabel(zCS)})`,
 );
 // Removed: "Cautious vs Daring drops further" check is structurally flawed.
 // Daring's high-variance failed moon attempts self-punish Daring, so Cautious
@@ -545,6 +606,15 @@ console.log(
 console.log(
   `  ${check(daringVsSchemerNeutralWr > schemerVsDaringNeutralWr)} Daring vs Schemer (neutral field): Daring ${(daringVsSchemerNeutralWr * 100).toFixed(1)}% vs Schemer ${(schemerVsDaringNeutralWr * 100).toFixed(1)}% (${sigLabel(zDvS_direct)})`,
 );
+// HRT-1 fix: the old "earlyMoon success ≥ 15%" gate consumed the unpaired ratio
+// (all completions / trick-0-only attempt count), which reported 48-80% while the
+// true paired attempt→outcome rate is ~4.9% (instrumented rerun, 3,000 games /
+// 33,325 hands: attempt rate 12.0%, paired success 4.9%). The gates below hold
+// the paired metrics inside tolerant bands around those measured values; #2234
+// (rank-aware attempts) is expected to raise the success band deliberately.
 console.log(
-  `  ${check(daringEarlyMoonSuccessRate >= 0.15)} earlyMoon success rate ≥ 15% (got ${(daringEarlyMoonSuccessRate * 100).toFixed(1)}%)`,
+  `  ${check(daringMoonAttemptRate >= 0.08 && daringMoonAttemptRate <= 0.16)} Daring moon attempt rate in [8%, 16%] of hands (got ${(daringMoonAttemptRate * 100).toFixed(1)}%)`,
+);
+console.log(
+  `  ${check(daringPairedMoonSuccessRate >= 0.02 && daringPairedMoonSuccessRate <= 0.1)} Daring paired moon success in [2%, 10%] of attempts (got ${(daringPairedMoonSuccessRate * 100).toFixed(1)}%)`,
 );


### PR DESCRIPTION
Closes #2204. QA findings HRT-1, HRT-2, HRT-3 (`docs/hearts-qa-report-2026-07.md`, branch `review/qa-2026-07`).

## What changed

**HRT-1 — unpaired moon-success metric (the 48–80% fiction).** The old "earlyMoon Success" divided *all* moon completions by a narrow trick-0-only attempt count — mismatched denominators. The sim now instruments the real trigger: `ai.ts`'s moon-attempt check is extracted as exported `detectMoonAttempt()` (pure refactor, behavior identical) and the sim counts a hand as *attempted* when that trigger actually fires for a seat, and a *paired success* only when that same seat completes the moon in that same hand. Reported as two separate metrics (attempt rate over hands; success rate over attempts), never blended.

**HRT-3 — reversed direction check.** "Cautious vs Schemer: win rate drops" was empirically backwards (pooled 9,000 games: rises ~1–3pp, z≈2.9, p<0.01). The check now expects a rise, with a −1pp tolerance so ordinary batch noise doesn't flag the correct direction.

**HRT-2 — `--count` semantics.** `--count N` now sets games-per-batch (aligned with `simulate-yacht.ts`); NDJSON dump mode moves to `--log-games N` (flag name and output format kept stable for `hearts-analysis`'s `/api/simulate`).

**New calibration gate**: `frontend/src/game/hearts/__tests__/ai.calibrate.test.ts`, mirroring the yacht gate — skipped by default, enabled with `HEARTS_SIM_FULL=<N>`, seeded. Asserts Cautious baseline win rate 20–30% and Daring paired moon bands (attempt 8–16%, paired success 2–10%). #2234 is expected to raise the success band deliberately, with sim evidence.

## Verification

- `npx jest src/game/hearts`: 7 suites / 332 tests pass; calibrate suite self-skips without the env flag.
- `HEARTS_SIM_FULL=500 npx jest …ai.calibrate.test.ts`: both calibration tests pass on live sim data.
- Full default gate (`npx tsx scripts/simulate-hearts.ts`, 6 batches × 3,000 games) — all 6 interpretation checks pass:
  - Cautious baseline 26.3% ✓
  - Cautious vs Schemer Δ+2.3pp rise, p<0.05 ✓ (direction fix confirmed)
  - Daring moon attempt rate 9.8% ✓, paired success 7.7% ✓ (vs old metric's 48–80%)
- eslint + prettier clean on touched files; `tsc` shows no new errors (the new test file inherits the same pre-existing jest-types config errors as the yacht calibrate test, tracked in #2211).

Part of the measurement-first track for epic #2233 (next: #2238 sim gate v2, which builds on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNjGcMZkrPPbXQDmpFCaUe