### PR TITLE
ci(android): enable Gradle caching in android-release-smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,7 +689,11 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: [test-python, test-frontend]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 30 min gives headroom for a cold Gradle cache (~20 min); once the cache
+    # is warm, runs finish well under that. A job killed by this timeout is
+    # cancelled before its own post-job step runs, so the cache never saves —
+    # too tight a limit here is self-perpetuating.
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,6 +714,8 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+          cache: gradle
+          cache-dependency-path: frontend/android/**/*.gradle*
 
       - uses: actions/setup-node@v7
         if: steps.changes.outputs.should_run == 'true'

--- a/frontend/android/gradle.properties
+++ b/frontend/android/gradle.properties
@@ -16,6 +16,10 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1024m -XX:+UseG1GC
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
+# Enable the Gradle build cache so unchanged task outputs (e.g. compilation,
+# R8 minification) are reused across builds instead of recomputed.
+org.gradle.caching=true
+
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
## Summary
- The `android-release-smoke` job had no Gradle dependency or build-output caching, so every run did a fully cold build + R8 minification.
- This ran marginal against the job's 20-minute timeout and was recently cancelled mid-build (`:app:minifyReleaseWithR8`) on two separate dependency-bump PRs (#2256, #2258) — neither touched any Android/Gradle files, so this looks like general CI slowness, not anything caused by those bumps.
- Adds `cache: gradle` to the `setup-java` step (keyed on `android/**/*.gradle*`) and enables `org.gradle.caching=true` so unchanged task outputs are reused across runs.

## Test plan
- [ ] CI on this PR (android-release-smoke, android-build-check, etc.) passes
- [ ] Verify a subsequent PR's android-release-smoke run is meaningfully faster with a warm cache