### PR TITLE
chore(hearts-ai): fix stale qSpadeProtected reference in docstring (#2280)

### DIFF
--- a/frontend/src/game/hearts/aiConsiderations.ts
+++ b/frontend/src/game/hearts/aiConsiderations.ts
@@ -171,9 +171,10 @@ export const rateSuitVoidingUtility: Consideration<HeartsInfoSet, Card> = (infoS
 /**
  * Score = how safe this card is with respect to self-taking Q♠ (13 pts).
  *
- * Decomposed from: qSpadeProtected direction thresholds (all three pass modes),
- * the "dump Q♠ on void discard" follow path, the endgame Q♠ guard in the
- * legacy Hard AI, and the lead guard (never lead K♠/A♠ while Q♠ is out).
+ * Decomposed from: the legacy rule-based Q♠-protection thresholds across all
+ * three pass modes, the "dump Q♠ on void discard" follow path, the endgame
+ * Q♠ guard in the legacy Hard AI, and the lead guard (never lead K♠/A♠ while
+ * Q♠ is out).
  *
  * 1.0: no Q♠ risk (Q♠ already gone, or this card cannot cause self-take).
  * 0.0: near-certain Q♠ self-take (e.g. leading Q♠ into an active spade suit).


### PR DESCRIPTION
## Summary

Closes #2280. Follow-up from the #2268 dead-code sweep (PR #2279 review) — `rateQueenSpadesRisk`'s docstring in `frontend/src/game/hearts/aiConsiderations.ts` referenced `qSpadeProtected`, a function that no longer exists anywhere in the codebase. Missed by the original sweep since it wasn't in the identified list, but same class of issue as the other three stale references #2268 fixed in this same file.

Rewrote the docstring to describe the source logic (Q♠-protection thresholds across all three pass modes) without naming a dead symbol. No code/behavior change.

## Type of change

- [x] `chore` — tooling, deps, config

## Testing done

- [x] All tests pass locally — `npx jest src/game/hearts` green (332 passed, 2 skipped, 0 failed)
- [x] No new lint errors — `eslint` clean on the changed file

## Security checklist

- [x] No secrets committed (gitleaks passes)
- [x] Dependencies reviewed if new ones added — none added
- [x] OWASP considerations addressed if auth or data handling was touched — n/a, comment-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2Bv711tR7EPbWw1hH9M31)_